### PR TITLE
feat: add configurable DNS provider with safe apply flow and auto-restart

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -226,6 +226,7 @@ dependencies {
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    implementation("com.squareup.okhttp3:okhttp-dnsoverhttps:4.12.0")
     implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
 
     // Coroutines

--- a/app/src/main/kotlin/com/arflix/tv/ArflixApplication.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ArflixApplication.kt
@@ -1,7 +1,6 @@
 package com.arflix.tv
 
 import android.app.Application
-import android.graphics.Bitmap
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import androidx.work.Constraints
@@ -12,23 +11,24 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.workDataOf
+import coil.Coil
 import coil.ImageLoader
-import coil.ImageLoaderFactory
-import coil.disk.DiskCache
-import coil.memory.MemoryCache
 import com.arflix.tv.network.OkHttpProvider
 import com.arflix.tv.data.repository.AuthRepository
 import com.arflix.tv.data.repository.CloudSyncRepository
 import com.arflix.tv.data.repository.ProfileManager
-import com.arflix.tv.util.AppLogger
 import com.arflix.tv.util.CrashlyticsProvider
+import com.arflix.tv.util.settingsDataStore
 import com.arflix.tv.worker.TraktSyncWorker
+import dagger.Lazy
 import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
@@ -36,7 +36,7 @@ import javax.inject.Inject
  * ARVIO TV Application class
  */
 @HiltAndroidApp
-class ArflixApplication : Application(), Configuration.Provider, ImageLoaderFactory {
+class ArflixApplication : Application(), Configuration.Provider {
     private val appScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     @Inject
@@ -47,7 +47,6 @@ class ArflixApplication : Application(), Configuration.Provider, ImageLoaderFact
     lateinit var authRepository: AuthRepository
     @Inject
     lateinit var cloudSyncRepository: CloudSyncRepository
-
     override fun onCreate() {
         super.onCreate()
         instance = this
@@ -55,11 +54,23 @@ class ArflixApplication : Application(), Configuration.Provider, ImageLoaderFact
         // Initialize OkHttp disk cache before any network calls
         OkHttpProvider.init(this)
 
+        // Build global Coil loader using active profile DNS before first image request.
+        runBlocking {
+            profileManager.initialize()
+            applyProfileDnsAndRefreshCoil()
+        }
+
+        // Keep Coil loader in sync when active profile changes.
+        appScope.launch {
+            profileManager.activeProfileId.collect {
+                applyProfileDnsAndRefreshCoil()
+            }
+        }
+
         // Initialize crash reporting (gracefully handles missing Firebase config)
         CrashlyticsProvider.initialize()
         // Initialize active profile asynchronously to avoid blocking cold start.
         appScope.launch {
-            runCatching { profileManager.initialize() }
             if (!authRepository.getCurrentUserId().isNullOrBlank()) {
                 // Keep cold-start smooth: perform first cloud pull after startup settles.
                 delay(12_000L)
@@ -68,26 +79,11 @@ class ArflixApplication : Application(), Configuration.Provider, ImageLoaderFact
         }
     }
 
-    override fun newImageLoader(): ImageLoader {
-        return ImageLoader.Builder(this)
-            .okHttpClient(OkHttpProvider.client)
-            .memoryCache {
-                MemoryCache.Builder(this)
-                    .maxSizePercent(0.15)  // Reduced from 25% to 15% to prevent OOM during playback
-                    .build()
-            }
-            .diskCache {
-                DiskCache.Builder()
-                    .directory(cacheDir.resolve("image_cache"))
-                    .maxSizeBytes(48L * 1024L * 1024L)  // Strict cap to prevent cache bloat on TV storage.
-                    .build()
-            }
-            .crossfade(false)
-            .respectCacheHeaders(false)
-            .allowRgb565(true)  // Performance: Use RGB_565 for faster decoding on TV
-            .bitmapConfig(Bitmap.Config.RGB_565)  // Performance: Smaller bitmaps, faster decode
-            .error(android.R.color.transparent)
-            .build()
+    private suspend fun applyProfileDnsAndRefreshCoil() {
+        val prefs = settingsDataStore.data.first()
+        val raw = prefs[profileManager.profileStringKey("dns_provider")]
+        OkHttpProvider.setDnsProvider(OkHttpProvider.parseDnsProvider(raw))
+        Coil.setImageLoader(OkHttpProvider.createCoilImageLoader(this))
     }
 
     override val workManagerConfiguration: Configuration
@@ -141,7 +137,6 @@ class ArflixApplication : Application(), Configuration.Provider, ImageLoaderFact
             private set
     }
 }
-
 
 
 

--- a/app/src/main/kotlin/com/arflix/tv/ArflixApplication.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ArflixApplication.kt
@@ -12,7 +12,6 @@ import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.workDataOf
 import coil.Coil
-import coil.ImageLoader
 import com.arflix.tv.network.OkHttpProvider
 import com.arflix.tv.data.repository.AuthRepository
 import com.arflix.tv.data.repository.CloudSyncRepository
@@ -28,7 +27,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
@@ -54,8 +52,10 @@ class ArflixApplication : Application(), Configuration.Provider {
         // Initialize OkHttp disk cache before any network calls
         OkHttpProvider.init(this)
 
-        // Build global Coil loader using active profile DNS before first image request.
-        runBlocking {
+        // Initialize the global loader immediately; profile DNS is applied asynchronously.
+        Coil.setImageLoader(OkHttpProvider.createCoilImageLoader(this))
+
+        appScope.launch {
             profileManager.initialize()
             applyProfileDnsAndRefreshCoil()
         }

--- a/app/src/main/kotlin/com/arflix/tv/di/AppModule.kt
+++ b/app/src/main/kotlin/com/arflix/tv/di/AppModule.kt
@@ -1,7 +1,6 @@
 package com.arflix.tv.di
 
 import android.content.Context
-import coil.Coil
 import coil.ImageLoader
 import com.arflix.tv.data.api.AniSkipApi
 import com.arflix.tv.data.api.ArmApi
@@ -35,10 +34,19 @@ object AppModule {
 
     @Provides
     @Singleton
+    @Named("coilImage")
+    fun provideImageOkHttpClient(
+        @ApplicationContext _context: Context
+    ): OkHttpClient {
+        return OkHttpProvider.coilClient
+    }
+
+    @Provides
+    @Singleton
     fun provideImageLoader(
         @ApplicationContext context: Context
     ): ImageLoader {
-        return Coil.imageLoader(context)
+        return OkHttpProvider.createCoilImageLoader(context)
     }
     
     @Provides

--- a/app/src/main/kotlin/com/arflix/tv/di/AppModule.kt
+++ b/app/src/main/kotlin/com/arflix/tv/di/AppModule.kt
@@ -1,7 +1,5 @@
 package com.arflix.tv.di
 
-import android.content.Context
-import coil.ImageLoader
 import com.arflix.tv.data.api.AniSkipApi
 import com.arflix.tv.data.api.ArmApi
 import com.arflix.tv.data.api.IntroDbApi
@@ -14,7 +12,6 @@ import com.arflix.tv.util.Constants
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
@@ -32,23 +29,6 @@ object AppModule {
         return OkHttpProvider.client
     }
 
-    @Provides
-    @Singleton
-    @Named("coilImage")
-    fun provideImageOkHttpClient(
-        @ApplicationContext _context: Context
-    ): OkHttpClient {
-        return OkHttpProvider.coilClient
-    }
-
-    @Provides
-    @Singleton
-    fun provideImageLoader(
-        @ApplicationContext context: Context
-    ): ImageLoader {
-        return OkHttpProvider.createCoilImageLoader(context)
-    }
-    
     @Provides
     @Singleton
     fun provideTmdbApi(okHttpClient: OkHttpClient): TmdbApi {

--- a/app/src/main/kotlin/com/arflix/tv/network/OkHttpProvider.kt
+++ b/app/src/main/kotlin/com/arflix/tv/network/OkHttpProvider.kt
@@ -1,12 +1,27 @@
 package com.arflix.tv.network
 
 import android.content.Context
+import android.util.Log
+import coil.ImageLoader
+import coil.disk.DiskCache
+import coil.memory.MemoryCache
 import com.arflix.tv.BuildConfig
 import okhttp3.Cache
 import okhttp3.ConnectionPool
+import okhttp3.Dns
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
+import okhttp3.dnsoverhttps.DnsOverHttps
 import okhttp3.logging.HttpLoggingInterceptor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import java.io.File
+import java.net.Inet4Address
+import java.net.InetAddress
+import java.net.UnknownHostException
 import java.util.concurrent.TimeUnit
 
 /**
@@ -22,9 +37,26 @@ import java.util.concurrent.TimeUnit
  * DO NOT add custom TrustManager - it defeats certificate validation.
  */
 object OkHttpProvider {
-
+    private const val TAG = "AppDns"
     /** 50 MB disk cache for API responses (TMDB metadata, Trakt data, etc.) */
     private const val HTTP_CACHE_SIZE = 50L * 1024L * 1024L
+    private const val IMAGE_HTTP_CACHE_SIZE = 100L * 1024L * 1024L
+    private const val IMAGE_DISK_CACHE_SIZE = 48L * 1024L * 1024L
+    private const val CLOUDFLARE_DOH_HOST = "cloudflare-dns.com"
+    private const val CLOUDFLARE_DOH_URL = "https://cloudflare-dns.com/dns-query"
+    private const val GOOGLE_DOH_HOST = "dns.google"
+    private const val GOOGLE_DOH_URL = "https://dns.google/dns-query"
+    private const val ADGUARD_DOH_HOST = "dns.adguard-dns.com"
+    private const val ADGUARD_DOH_URL = "https://dns.adguard-dns.com/dns-query"
+
+    const val DNS_PROVIDER_PREF_KEY = "dns_provider_global"
+
+    enum class AppDnsProvider {
+        SYSTEM,
+        CLOUDFLARE,
+        GOOGLE,
+        ADGUARD
+    }
 
     /**
      * Must be called once from Application.onCreate() before any network calls.
@@ -37,31 +69,235 @@ object OkHttpProvider {
     @Volatile
     private var appContext: Context? = null
 
-    val client: OkHttpClient by lazy {
-        val loggingInterceptor = HttpLoggingInterceptor().apply {
-            level = if (BuildConfig.DEBUG) {
-                HttpLoggingInterceptor.Level.BASIC
-            } else {
-                HttpLoggingInterceptor.Level.NONE
+    @Volatile
+    private var selectedDnsProvider: AppDnsProvider = AppDnsProvider.SYSTEM
+
+    private val dnsScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private val appConnectionPool = ConnectionPool(32, 5, TimeUnit.MINUTES)
+
+    private val systemDns: Dns by lazy {
+        preferIpv4ForTmdb(Dns.SYSTEM)
+    }
+
+    private val cloudflareDns: Dns by lazy {
+        preferIpv4ForTmdb(
+            buildDohDns(
+                url = CLOUDFLARE_DOH_URL,
+                dohHost = CLOUDFLARE_DOH_HOST,
+                bootstrapHosts = cloudflareBootstrapHosts
+            )
+        )
+    }
+
+    private val googleDns: Dns by lazy {
+        preferIpv4ForTmdb(
+            buildDohDns(
+                url = GOOGLE_DOH_URL,
+                dohHost = GOOGLE_DOH_HOST,
+                bootstrapHosts = googleBootstrapHosts
+            )
+        )
+    }
+
+    private val adguardDns: Dns by lazy {
+        preferIpv4ForTmdb(
+            buildDohDns(
+                url = ADGUARD_DOH_URL,
+                dohHost = ADGUARD_DOH_HOST,
+                bootstrapHosts = adguardBootstrapHosts
+            )
+        )
+    }
+
+    val dns: Dns = object : Dns {
+        override fun lookup(hostname: String): List<InetAddress> {
+            return selectedDns(selectedDnsProvider).lookup(hostname)
+        }
+    }
+
+    private val apiDnsLoggingInterceptor = Interceptor { chain ->
+        val request = chain.request()
+        Log.i(
+            TAG,
+            "API request dnsProvider=$selectedDnsProvider method=${request.method} host=${request.url.host} url=${request.url}"
+        )
+        chain.proceed(request)
+    }
+
+    private fun selectedDns(provider: AppDnsProvider): Dns {
+        return when (provider) {
+            AppDnsProvider.SYSTEM -> systemDns
+            AppDnsProvider.CLOUDFLARE -> cloudflareDns
+            AppDnsProvider.GOOGLE -> googleDns
+            AppDnsProvider.ADGUARD -> adguardDns
+        }
+    }
+
+    val client: OkHttpClient
+        get() {
+            val loggingInterceptor = HttpLoggingInterceptor().apply {
+                level = if (BuildConfig.DEBUG) {
+                    HttpLoggingInterceptor.Level.BASIC
+                } else {
+                    HttpLoggingInterceptor.Level.NONE
+                }
+            }
+
+            val builder = OkHttpClient.Builder()
+                // Direct API calls — no Supabase edge function proxy.
+                // TMDB/Trakt keys are passed as query params / headers by Retrofit.
+                .addInterceptor(apiDnsLoggingInterceptor)
+                .addInterceptor(loggingInterceptor)
+                .connectTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(30, TimeUnit.SECONDS)
+                .writeTimeout(30, TimeUnit.SECONDS)
+                .connectionPool(appConnectionPool)
+                .dns(dns)
+                .retryOnConnectionFailure(true)
+
+            // Attach disk cache if context was initialized
+            appContext?.let { ctx ->
+                val cacheDir = File(ctx.cacheDir, "http_cache")
+                builder.cache(Cache(cacheDir, HTTP_CACHE_SIZE))
+            }
+
+            return builder.build()
+        }
+
+    private val cloudflareBootstrapHosts: List<InetAddress> by lazy {
+        listOf(
+            InetAddress.getByName("1.1.1.1"),
+            InetAddress.getByName("1.0.0.1"),
+            InetAddress.getByName("2606:4700:4700::1111"),
+            InetAddress.getByName("2606:4700:4700::1001")
+        )
+    }
+
+    private val googleBootstrapHosts: List<InetAddress> by lazy {
+        listOf(
+            InetAddress.getByName("8.8.8.8"),
+            InetAddress.getByName("8.8.4.4"),
+            InetAddress.getByName("2001:4860:4860::8888"),
+            InetAddress.getByName("2001:4860:4860::8844")
+        )
+    }
+
+    private val adguardBootstrapHosts: List<InetAddress> by lazy {
+        listOf(
+            InetAddress.getByName("94.140.14.14"),
+            InetAddress.getByName("94.140.15.15"),
+            InetAddress.getByName("2a10:50c0::ad1:ff"),
+            InetAddress.getByName("2a10:50c0::ad2:ff")
+        )
+    }
+
+    fun parseDnsProvider(raw: String?): AppDnsProvider {
+        return when (raw?.trim()?.lowercase()) {
+            "system", "system dns", "system_dns" -> AppDnsProvider.SYSTEM
+            "cloudflare", "cloudflare dns", "cloudflare_dns" -> AppDnsProvider.CLOUDFLARE
+            "google" -> AppDnsProvider.GOOGLE
+            "adguard", "ad guard" -> AppDnsProvider.ADGUARD
+            else -> AppDnsProvider.SYSTEM
+        }
+    }
+
+    fun setDnsProvider(provider: AppDnsProvider) {
+        selectedDnsProvider = provider
+        Log.i(TAG, "Using DNS provider=$provider")
+        dnsScope.launch {
+            appConnectionPool.evictAll()
+            Log.i(TAG, "Evicted pooled app connections after DNS change")
+        }
+    }
+
+    private fun preferIpv4ForTmdb(delegate: Dns): Dns {
+        return object : Dns {
+            override fun lookup(hostname: String): List<InetAddress> {
+                val resolved = delegate.lookup(hostname)
+                if (!hostname.contains("tmdb", ignoreCase = true) &&
+                    !hostname.contains("themoviedb", ignoreCase = true)
+                ) {
+                    return resolved
+                }
+
+                val ipv4 = resolved.filterIsInstance<Inet4Address>()
+                if (ipv4.isEmpty()) {
+                    return resolved
+                }
+                val ipv6 = resolved.filterNot { it is Inet4Address }
+                return ipv4 + ipv6
             }
         }
+    }
 
-        val builder = OkHttpClient.Builder()
-            // Direct API calls — no Supabase edge function proxy.
-            // TMDB/Trakt keys are passed as query params / headers by Retrofit.
-            .addInterceptor(loggingInterceptor)
-            .connectTimeout(30, TimeUnit.SECONDS)
-            .readTimeout(30, TimeUnit.SECONDS)
-            .writeTimeout(30, TimeUnit.SECONDS)
-            .connectionPool(ConnectionPool(32, 5, TimeUnit.MINUTES))
-            .retryOnConnectionFailure(true)
+    private fun buildBootstrapDns(
+        dohHost: String,
+        bootstrapHosts: List<InetAddress>
+    ): Dns {
+        return object : Dns {
+            override fun lookup(hostname: String): List<InetAddress> {
+                if (hostname.equals(dohHost, ignoreCase = true)) {
+                    return bootstrapHosts
+                }
+                throw UnknownHostException(
+                    "Bootstrap DNS is restricted to $dohHost. Requested: $hostname"
+                )
+            }
+        }
+    }
 
-        // Attach disk cache if context was initialized
-        appContext?.let { ctx ->
-            val cacheDir = File(ctx.cacheDir, "http_cache")
-            builder.cache(Cache(cacheDir, HTTP_CACHE_SIZE))
+    private fun buildDohDns(
+        url: String,
+        dohHost: String,
+        bootstrapHosts: List<InetAddress>
+    ): Dns {
+        val bootstrapDns = buildBootstrapDns(dohHost, bootstrapHosts)
+        val bootstrapClient = OkHttpClient.Builder()
+            .dns(bootstrapDns)
+            .cache(null)
+            .build()
+
+        return DnsOverHttps.Builder()
+            .client(bootstrapClient)
+            .url(url.toHttpUrl())
+            .systemDns(bootstrapDns)
+            .bootstrapDnsHosts(*bootstrapHosts.toTypedArray())
+            .post(true)
+            .resolvePrivateAddresses(false)
+            .resolvePublicAddresses(true)
+            .build()
+    }
+
+    val coilClient: OkHttpClient
+        get() {
+            val builder = client.newBuilder()
+            builder.interceptors().remove(apiDnsLoggingInterceptor)
+            builder.dns(dns)
+            return builder.build()
         }
 
-        builder.build()
+    fun createCoilImageLoader(context: Context): ImageLoader {
+        val imageHttpClient = coilClient.newBuilder()
+            .cache(Cache(File(context.cacheDir, "image_http_cache"), IMAGE_HTTP_CACHE_SIZE))
+            .build()
+
+        return ImageLoader.Builder(context)
+            .okHttpClient(imageHttpClient)
+            .memoryCache {
+                MemoryCache.Builder(context)
+                    .maxSizePercent(0.15)
+                    .build()
+            }
+            .diskCache {
+                DiskCache.Builder()
+                    .directory(context.cacheDir.resolve("image_cache"))
+                    .maxSizeBytes(IMAGE_DISK_CACHE_SIZE)
+                    .build()
+            }
+            .crossfade(false)
+            .respectCacheHeaders(false)
+            .allowRgb565(true)
+            .build()
     }
 }

--- a/app/src/main/kotlin/com/arflix/tv/network/OkHttpProvider.kt
+++ b/app/src/main/kotlin/com/arflix/tv/network/OkHttpProvider.kt
@@ -40,7 +40,6 @@ object OkHttpProvider {
     private const val TAG = "AppDns"
     /** 50 MB disk cache for API responses (TMDB metadata, Trakt data, etc.) */
     private const val HTTP_CACHE_SIZE = 50L * 1024L * 1024L
-    private const val IMAGE_HTTP_CACHE_SIZE = 100L * 1024L * 1024L
     private const val IMAGE_DISK_CACHE_SIZE = 48L * 1024L * 1024L
     private const val CLOUDFLARE_DOH_HOST = "cloudflare-dns.com"
     private const val CLOUDFLARE_DOH_URL = "https://cloudflare-dns.com/dns-query"
@@ -73,8 +72,18 @@ object OkHttpProvider {
     private var selectedDnsProvider: AppDnsProvider = AppDnsProvider.SYSTEM
 
     private val dnsScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val clientLock = Any()
 
     private val appConnectionPool = ConnectionPool(32, 5, TimeUnit.MINUTES)
+
+    @Volatile
+    private var appClient: OkHttpClient? = null
+
+    @Volatile
+    private var appHttpCache: Cache? = null
+
+    @Volatile
+    private var coilSharedClient: OkHttpClient? = null
 
     private val systemDns: Dns by lazy {
         preferIpv4ForTmdb(Dns.SYSTEM)
@@ -135,35 +144,48 @@ object OkHttpProvider {
     }
 
     val client: OkHttpClient
-        get() {
-            val loggingInterceptor = HttpLoggingInterceptor().apply {
-                level = if (BuildConfig.DEBUG) {
-                    HttpLoggingInterceptor.Level.BASIC
-                } else {
-                    HttpLoggingInterceptor.Level.NONE
-                }
-            }
-
-            val builder = OkHttpClient.Builder()
-                // Direct API calls — no Supabase edge function proxy.
-                // TMDB/Trakt keys are passed as query params / headers by Retrofit.
-                .addInterceptor(apiDnsLoggingInterceptor)
-                .addInterceptor(loggingInterceptor)
-                .connectTimeout(30, TimeUnit.SECONDS)
-                .readTimeout(30, TimeUnit.SECONDS)
-                .writeTimeout(30, TimeUnit.SECONDS)
-                .connectionPool(appConnectionPool)
-                .dns(dns)
-                .retryOnConnectionFailure(true)
-
-            // Attach disk cache if context was initialized
-            appContext?.let { ctx ->
-                val cacheDir = File(ctx.cacheDir, "http_cache")
-                builder.cache(Cache(cacheDir, HTTP_CACHE_SIZE))
-            }
-
-            return builder.build()
+        get() = appClient ?: synchronized(clientLock) {
+            appClient ?: buildAppClient().also { appClient = it }
         }
+
+    private fun buildAppClient(): OkHttpClient {
+        val loggingInterceptor = HttpLoggingInterceptor().apply {
+            level = if (BuildConfig.DEBUG) {
+                HttpLoggingInterceptor.Level.BASIC
+            } else {
+                HttpLoggingInterceptor.Level.NONE
+            }
+        }
+
+        val builder = OkHttpClient.Builder()
+            // Direct API calls — no Supabase edge function proxy.
+            // TMDB/Trakt keys are passed as query params / headers by Retrofit.
+            .addInterceptor(loggingInterceptor)
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .writeTimeout(30, TimeUnit.SECONDS)
+            .connectionPool(appConnectionPool)
+            .dns(dns)
+            .retryOnConnectionFailure(true)
+
+        if (BuildConfig.DEBUG) {
+            builder.addInterceptor(apiDnsLoggingInterceptor)
+        }
+
+        appContext?.let { ctx ->
+            builder.cache(getOrCreateHttpCache(ctx))
+        }
+
+        return builder.build()
+    }
+
+    private fun getOrCreateHttpCache(context: Context): Cache {
+        return appHttpCache ?: synchronized(clientLock) {
+            appHttpCache ?: Cache(File(context.cacheDir, "http_cache"), HTTP_CACHE_SIZE).also {
+                appHttpCache = it
+            }
+        }
+    }
 
     private val cloudflareBootstrapHosts: List<InetAddress> by lazy {
         listOf(
@@ -270,20 +292,20 @@ object OkHttpProvider {
     }
 
     val coilClient: OkHttpClient
-        get() {
-            val builder = client.newBuilder()
-            builder.interceptors().remove(apiDnsLoggingInterceptor)
-            builder.dns(dns)
-            return builder.build()
+        get() = coilSharedClient ?: synchronized(clientLock) {
+            coilSharedClient ?: buildCoilClient().also { coilSharedClient = it }
         }
 
-    fun createCoilImageLoader(context: Context): ImageLoader {
-        val imageHttpClient = coilClient.newBuilder()
-            .cache(Cache(File(context.cacheDir, "image_http_cache"), IMAGE_HTTP_CACHE_SIZE))
-            .build()
+    private fun buildCoilClient(): OkHttpClient {
+        val builder = client.newBuilder()
+        builder.interceptors().remove(apiDnsLoggingInterceptor)
+        builder.dns(dns)
+        return builder.build()
+    }
 
+    fun createCoilImageLoader(context: Context): ImageLoader {
         return ImageLoader.Builder(context)
-            .okHttpClient(imageHttpClient)
+            .okHttpClient(coilClient)
             .memoryCache {
                 MemoryCache.Builder(context)
                     .maxSizePercent(0.15)

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
@@ -109,6 +109,7 @@ import coil.size.Precision
 import com.arflix.tv.data.model.Category
 import com.arflix.tv.data.model.MediaItem
 import com.arflix.tv.data.model.MediaType
+import com.arflix.tv.network.OkHttpProvider
 import com.arflix.tv.ui.components.MediaCard as ArvioMediaCard
 import com.arflix.tv.ui.components.CardLayoutMode
 import com.arflix.tv.ui.components.AppTopBar
@@ -431,6 +432,7 @@ fun HomeScreen(
             .connectionPool(ConnectionPool(2, 2, TimeUnit.MINUTES))
             .followRedirects(true).followSslRedirects(true)
             .retryOnConnectionFailure(true)
+            .dns(OkHttpProvider.dns)
             .connectTimeout(15, TimeUnit.SECONDS)
             .readTimeout(20, TimeUnit.SECONDS)
             .build()

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
@@ -6,6 +6,7 @@ import android.os.SystemClock
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import coil.ImageLoader
+import coil.imageLoader
 import coil.request.ImageRequest
 import coil.size.Precision
 import com.arflix.tv.data.model.Category
@@ -91,9 +92,12 @@ class HomeViewModel @Inject constructor(
     private val watchlistRepository: WatchlistRepository,
     private val cloudSyncRepository: CloudSyncRepository,
     private val launcherContinueWatchingRepository: LauncherContinueWatchingRepository,
-    private val imageLoader: ImageLoader,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
+    private val imageLoader: ImageLoader by lazy(LazyThreadSafetyMode.NONE) {
+        context.imageLoader
+    }
+
     private data class HeroDetailsSnapshot(
         val duration: String,
         val releaseDate: String?,

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -106,6 +106,7 @@ import androidx.media3.ui.PlayerView
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.Text
 import coil.compose.AsyncImage
+import com.arflix.tv.network.OkHttpProvider
 import com.arflix.tv.data.model.MediaType
 import com.arflix.tv.data.model.StreamSource
 import com.arflix.tv.data.model.Subtitle
@@ -332,6 +333,7 @@ fun PlayerScreen(
             .followRedirects(true)
             .followSslRedirects(true)
             .retryOnConnectionFailure(true)
+            .dns(OkHttpProvider.dns)
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(180, TimeUnit.SECONDS)
             .writeTimeout(30, TimeUnit.SECONDS)

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ContentPaste
+import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.LinkOff
 import androidx.compose.material.icons.filled.Movie
@@ -168,6 +169,10 @@ fun SettingsScreen(
     var subtitlePickerIndex by remember { mutableIntStateOf(0) }
     var showAudioLanguagePicker by remember { mutableStateOf(false) }
     var audioLanguagePickerIndex by remember { mutableIntStateOf(0) }
+    var showDnsProviderPicker by remember { mutableStateOf(false) }
+    var dnsProviderPickerIndex by remember { mutableIntStateOf(0) }
+    var showDnsRestartConfirm by remember { mutableStateOf(false) }
+    var pendingDnsProvider by remember { mutableStateOf("") }
 
     val sections = remember { listOf("general", "iptv", "catalogs", "addons", "accounts") }
 
@@ -186,6 +191,12 @@ fun SettingsScreen(
         audioLanguagePickerIndex = options.indexOfFirst { it.equals(uiState.defaultAudioLanguage, ignoreCase = true) }
             .coerceAtLeast(0)
         showAudioLanguagePicker = true
+    }
+    val openDnsProviderPicker = {
+        val options = uiState.dnsProviderOptions
+        dnsProviderPickerIndex = options.indexOfFirst { it.equals(uiState.dnsProvider, ignoreCase = true) }
+            .coerceAtLeast(0)
+        showDnsProviderPicker = true
     }
 
     LaunchedEffect(Unit) {
@@ -210,6 +221,15 @@ fun SettingsScreen(
             audioLanguagePickerIndex = if (targetIndex >= 0) targetIndex else audioLanguagePickerIndex.coerceIn(0, maxIndex)
         }
     }
+
+    LaunchedEffect(showDnsProviderPicker, uiState.dnsProviderOptions) {
+        if (showDnsProviderPicker) {
+            val options = uiState.dnsProviderOptions
+            val maxIndex = (options.size - 1).coerceAtLeast(0)
+            val targetIndex = options.indexOfFirst { it.equals(uiState.dnsProvider, ignoreCase = true) }
+            dnsProviderPickerIndex = if (targetIndex >= 0) targetIndex else dnsProviderPickerIndex.coerceIn(0, maxIndex)
+        }
+    }
     
     // Reset content scroll when switching sections.
     LaunchedEffect(sectionIndex) {
@@ -224,7 +244,7 @@ fun SettingsScreen(
         if (scrollState.maxValue <= 0) return@LaunchedEffect
 
         val maxIndex = when (sectionIndex) {
-            0 -> 6 // General: 7 items
+            0 -> 7 // General: 8 items
             1 -> 2 // IPTV
             2 -> uiState.catalogs.size // Catalogs
             3 -> uiState.addons.size // Addons
@@ -275,7 +295,7 @@ fun SettingsScreen(
             .onPreviewKeyEvent { event ->
                     if (isTouchDevice) return@onPreviewKeyEvent false
                     // BLOCKER FIX: Ignore main screen navigation if modals are open
-                    if (showCustomAddonInput || showSubtitlePicker || showAudioLanguagePicker || showIptvInput || showCatalogInput || uiState.showCloudPairDialog || uiState.showCloudEmailPasswordDialog) return@onPreviewKeyEvent false
+                    if (showCustomAddonInput || showSubtitlePicker || showAudioLanguagePicker || showDnsProviderPicker || showDnsRestartConfirm || showIptvInput || showCatalogInput || uiState.showCloudPairDialog || uiState.showCloudEmailPasswordDialog) return@onPreviewKeyEvent false
 
                 if (event.type == KeyEventType.KeyDown) {
                     val currentSection = sections.getOrNull(sectionIndex).orEmpty()
@@ -390,7 +410,7 @@ fun SettingsScreen(
                                 Zone.CONTENT -> {
                                     // Dynamic max based on current section
                                     val maxIndex = when (sectionIndex) {
-                                        0 -> 6 // General: 7 items
+                                        0 -> 7 // General: 8 items
                                         1 -> 2 // IPTV: Configure + Refresh + Delete
                                         2 -> uiState.catalogs.size // Catalogs: Add + N catalogs
                                         3 -> uiState.addons.size // Addons: N addons + "Add Custom" button
@@ -434,9 +454,10 @@ fun SettingsScreen(
                                                 1 -> openAudioLanguagePicker()
                                                 2 -> viewModel.toggleCardLayoutMode()
                                                 3 -> viewModel.cycleFrameRateMatchingMode()
-                                                4 -> viewModel.setAutoPlayNext(!uiState.autoPlayNext)
-                                                5 -> viewModel.setAutoPlaySingleSource(!uiState.autoPlaySingleSource)
-                                                6 -> viewModel.cycleAutoPlayMinQuality()
+                                                4 -> openDnsProviderPicker()
+                                                5 -> viewModel.setAutoPlayNext(!uiState.autoPlayNext)
+                                                6 -> viewModel.setAutoPlaySingleSource(!uiState.autoPlaySingleSource)
+                                                7 -> viewModel.cycleAutoPlayMinQuality()
                                             }
                                         }
                                         1 -> { // IPTV
@@ -551,6 +572,7 @@ fun SettingsScreen(
                             defaultAudioLanguage = uiState.defaultAudioLanguage,
                             cardLayoutMode = uiState.cardLayoutMode,
                             frameRateMatchingMode = uiState.frameRateMatchingMode,
+                            dnsProvider = uiState.dnsProvider,
                             autoPlayNext = uiState.autoPlayNext,
                             autoPlaySingleSource = uiState.autoPlaySingleSource,
                             autoPlayMinQuality = uiState.autoPlayMinQuality,
@@ -559,6 +581,7 @@ fun SettingsScreen(
                             onAudioLanguageClick = openAudioLanguagePicker,
                             onCardLayoutToggle = { viewModel.toggleCardLayoutMode() },
                             onFrameRateMatchingClick = { viewModel.cycleFrameRateMatchingMode() },
+                            onDnsProviderClick = openDnsProviderPicker,
                             onAutoPlayToggle = { viewModel.setAutoPlayNext(it) },
                             onAutoPlaySingleSourceToggle = { viewModel.setAutoPlaySingleSource(it) },
                             onAutoPlayMinQualityClick = { viewModel.cycleAutoPlayMinQuality() }
@@ -695,6 +718,7 @@ fun SettingsScreen(
                             defaultAudioLanguage = uiState.defaultAudioLanguage,
                             cardLayoutMode = uiState.cardLayoutMode,
                             frameRateMatchingMode = uiState.frameRateMatchingMode,
+                            dnsProvider = uiState.dnsProvider,
                             autoPlayNext = uiState.autoPlayNext,
                             autoPlaySingleSource = uiState.autoPlaySingleSource,
                             autoPlayMinQuality = uiState.autoPlayMinQuality,
@@ -703,6 +727,7 @@ fun SettingsScreen(
                             onAudioLanguageClick = openAudioLanguagePicker,
                             onCardLayoutToggle = { viewModel.toggleCardLayoutMode() },
                             onFrameRateMatchingClick = { viewModel.cycleFrameRateMatchingMode() },
+                            onDnsProviderClick = openDnsProviderPicker,
                             onAutoPlayToggle = { viewModel.setAutoPlayNext(it) },
                             onAutoPlaySingleSourceToggle = { viewModel.setAutoPlaySingleSource(it) },
                             onAutoPlayMinQualityClick = { viewModel.cycleAutoPlayMinQuality() }
@@ -901,6 +926,41 @@ fun SettingsScreen(
                     showAudioLanguagePicker = false
                 },
                 onDismiss = { showAudioLanguagePicker = false }
+            )
+        }
+
+        if (showDnsProviderPicker) {
+            SubtitlePickerModal(
+                title = "DNS Provider (Auto-Restart)",
+                options = uiState.dnsProviderOptions,
+                selected = uiState.dnsProvider,
+                focusedIndex = dnsProviderPickerIndex,
+                onFocusChange = { dnsProviderPickerIndex = it },
+                onSelect = {
+                    showDnsProviderPicker = false
+                    pendingDnsProvider = it
+                    if (it.equals(uiState.dnsProvider, ignoreCase = true)) {
+                        viewModel.setDnsProvider(it)
+                    } else {
+                        showDnsRestartConfirm = true
+                    }
+                },
+                onDismiss = { showDnsProviderPicker = false }
+            )
+        }
+
+        if (showDnsRestartConfirm) {
+            DnsRestartConfirmModal(
+                providerLabel = pendingDnsProvider,
+                onConfirm = {
+                    showDnsRestartConfirm = false
+                    viewModel.setDnsProvider(pendingDnsProvider)
+                    pendingDnsProvider = ""
+                },
+                onDismiss = {
+                    showDnsRestartConfirm = false
+                    pendingDnsProvider = ""
+                }
             )
         }
 
@@ -1880,6 +1940,7 @@ private fun GeneralSettings(
     defaultAudioLanguage: String,
     cardLayoutMode: String,
     frameRateMatchingMode: String,
+    dnsProvider: String,
     autoPlayNext: Boolean,
     autoPlaySingleSource: Boolean,
     autoPlayMinQuality: String,
@@ -1888,6 +1949,7 @@ private fun GeneralSettings(
     onAudioLanguageClick: () -> Unit,
     onCardLayoutToggle: () -> Unit,
     onFrameRateMatchingClick: () -> Unit,
+    onDnsProviderClick: () -> Unit,
     onAutoPlayToggle: (Boolean) -> Unit,
     onAutoPlaySingleSourceToggle: (Boolean) -> Unit,
     onAutoPlayMinQualityClick: () -> Unit
@@ -1947,13 +2009,24 @@ private fun GeneralSettings(
         )
 
         Spacer(modifier = Modifier.height(16.dp))
+
+        SettingsRow(
+            icon = Icons.Default.Language,
+            title = "DNS Provider",
+            subtitle = "Resolver for API/image/stream requests. Changing it restarts the app.",
+            value = dnsProvider,
+            isFocused = focusedIndex == 4,
+            onClick = onDnsProviderClick
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
         
         // Auto-Play Next
         SettingsToggleRow(
             title = "Auto-Play Next",
             subtitle = "Start next episode automatically",
             isEnabled = autoPlayNext,
-            isFocused = focusedIndex == 4,
+            isFocused = focusedIndex == 5,
             onToggle = onAutoPlayToggle
         )
 
@@ -1963,7 +2036,7 @@ private fun GeneralSettings(
             title = "Auto-Play Single Source",
             subtitle = "Skip source picker when only one valid source exists",
             isEnabled = autoPlaySingleSource,
-            isFocused = focusedIndex == 5,
+            isFocused = focusedIndex == 6,
             onToggle = onAutoPlaySingleSourceToggle
         )
 
@@ -1974,7 +2047,7 @@ private fun GeneralSettings(
             title = "Auto-Play Min Quality",
             subtitle = "Minimum quality required for single-source auto-play",
             value = autoPlayMinQuality,
-            isFocused = focusedIndex == 6,
+            isFocused = focusedIndex == 7,
             onClick = onAutoPlayMinQualityClick
         )
     }
@@ -3651,7 +3724,6 @@ private fun SubtitlePickerModal(
     val focusRequester = remember { FocusRequester() }
     val listState = rememberLazyListState()
     val safeIndex = focusedIndex.coerceIn(0, (options.size - 1).coerceAtLeast(0))
-
     LaunchedEffect(safeIndex) {
         if (options.isNotEmpty()) {
             listState.animateScrollToItem(safeIndex)
@@ -3761,6 +3833,146 @@ private fun SubtitlePickerModal(
                 color = TextSecondary.copy(alpha = 0.6f),
                 textAlign = TextAlign.Center,
                 modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun DnsRestartConfirmModal(
+    providerLabel: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    var focusedIndex by remember { mutableIntStateOf(1) } // 0 cancel, 1 apply
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.6f))
+            .focusRequester(focusRequester)
+            .focusable()
+            .onPreviewKeyEvent { event ->
+                if (event.type == KeyEventType.KeyDown) {
+                    when (event.key) {
+                        Key.Back, Key.Escape -> {
+                            onDismiss()
+                            true
+                        }
+                        Key.DirectionLeft -> {
+                            if (focusedIndex > 0) focusedIndex--
+                            true
+                        }
+                        Key.DirectionRight -> {
+                            if (focusedIndex < 1) focusedIndex++
+                            true
+                        }
+                        Key.Enter, Key.DirectionCenter -> {
+                            if (focusedIndex == 0) onDismiss() else onConfirm()
+                            true
+                        }
+                        else -> false
+                    }
+                } else false
+            },
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier
+                .then(
+                    if (LocalDeviceType.current.isTouchDevice()) Modifier.fillMaxWidth(0.92f).widthIn(max = 560.dp)
+                    else Modifier.width(560.dp)
+                )
+                .background(BackgroundElevated, RoundedCornerShape(16.dp))
+                .border(1.dp, Color.White.copy(alpha = 0.12f), RoundedCornerShape(16.dp))
+                .padding(if (LocalDeviceType.current.isTouchDevice()) 20.dp else 24.dp)
+        ) {
+            Text(
+                text = "Apply DNS Change?",
+                style = ArflixTypography.sectionTitle,
+                color = TextPrimary
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Text(
+                text = "Switch to $providerLabel and restart the app now?",
+                style = ArflixTypography.body,
+                color = TextSecondary
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                val cancelFocused = focusedIndex == 0
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(
+                            color = if (cancelFocused) Color.White else Color.Black.copy(alpha = 0.82f),
+                            shape = RoundedCornerShape(10.dp)
+                        )
+                        .border(
+                            width = 1.dp,
+                            color = if (cancelFocused) Color.White else Color.White.copy(alpha = 0.14f),
+                            shape = RoundedCornerShape(10.dp)
+                        )
+                        .clickable { onDismiss() }
+                        .padding(vertical = 12.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "Cancel",
+                        style = ArflixTypography.button,
+                        color = if (cancelFocused) Color.Black else Color.White
+                    )
+                }
+
+                val applyFocused = focusedIndex == 1
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(
+                            color = if (applyFocused) Color.White else Color.Black.copy(alpha = 0.82f),
+                            shape = RoundedCornerShape(10.dp)
+                        )
+                        .border(
+                            width = 1.dp,
+                            color = if (applyFocused) Color.White else Color.White.copy(alpha = 0.14f),
+                            shape = RoundedCornerShape(10.dp)
+                        )
+                        .clickable { onConfirm() }
+                        .padding(vertical = 12.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "Apply & Restart",
+                        style = ArflixTypography.button,
+                        color = if (applyFocused) Color.Black else Color.White
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(10.dp))
+            Text(
+                text = if (LocalDeviceType.current.isTouchDevice()) {
+                    "Tap a button to continue"
+                } else {
+                    "Left/Right to choose • OK to confirm • Back to cancel"
+                },
+                style = ArflixTypography.caption,
+                color = TextSecondary.copy(alpha = 0.56f)
             )
         }
     }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -171,8 +171,6 @@ fun SettingsScreen(
     var audioLanguagePickerIndex by remember { mutableIntStateOf(0) }
     var showDnsProviderPicker by remember { mutableStateOf(false) }
     var dnsProviderPickerIndex by remember { mutableIntStateOf(0) }
-    var showDnsRestartConfirm by remember { mutableStateOf(false) }
-    var pendingDnsProvider by remember { mutableStateOf("") }
 
     val sections = remember { listOf("general", "iptv", "catalogs", "addons", "accounts") }
 
@@ -295,7 +293,7 @@ fun SettingsScreen(
             .onPreviewKeyEvent { event ->
                     if (isTouchDevice) return@onPreviewKeyEvent false
                     // BLOCKER FIX: Ignore main screen navigation if modals are open
-                    if (showCustomAddonInput || showSubtitlePicker || showAudioLanguagePicker || showDnsProviderPicker || showDnsRestartConfirm || showIptvInput || showCatalogInput || uiState.showCloudPairDialog || uiState.showCloudEmailPasswordDialog) return@onPreviewKeyEvent false
+                    if (showCustomAddonInput || showSubtitlePicker || showAudioLanguagePicker || showDnsProviderPicker || showIptvInput || showCatalogInput || uiState.showCloudPairDialog || uiState.showCloudEmailPasswordDialog) return@onPreviewKeyEvent false
 
                 if (event.type == KeyEventType.KeyDown) {
                     val currentSection = sections.getOrNull(sectionIndex).orEmpty()
@@ -931,36 +929,16 @@ fun SettingsScreen(
 
         if (showDnsProviderPicker) {
             SubtitlePickerModal(
-                title = "DNS Provider (Auto-Restart)",
+                title = "DNS Provider",
                 options = uiState.dnsProviderOptions,
                 selected = uiState.dnsProvider,
                 focusedIndex = dnsProviderPickerIndex,
                 onFocusChange = { dnsProviderPickerIndex = it },
                 onSelect = {
                     showDnsProviderPicker = false
-                    pendingDnsProvider = it
-                    if (it.equals(uiState.dnsProvider, ignoreCase = true)) {
-                        viewModel.setDnsProvider(it)
-                    } else {
-                        showDnsRestartConfirm = true
-                    }
+                    viewModel.setDnsProvider(it)
                 },
                 onDismiss = { showDnsProviderPicker = false }
-            )
-        }
-
-        if (showDnsRestartConfirm) {
-            DnsRestartConfirmModal(
-                providerLabel = pendingDnsProvider,
-                onConfirm = {
-                    showDnsRestartConfirm = false
-                    viewModel.setDnsProvider(pendingDnsProvider)
-                    pendingDnsProvider = ""
-                },
-                onDismiss = {
-                    showDnsRestartConfirm = false
-                    pendingDnsProvider = ""
-                }
             )
         }
 
@@ -2013,7 +1991,7 @@ private fun GeneralSettings(
         SettingsRow(
             icon = Icons.Default.Language,
             title = "DNS Provider",
-            subtitle = "Resolver for API/image/stream requests. Changing it restarts the app.",
+            subtitle = "Resolver for API/image/stream requests. Changes apply immediately.",
             value = dnsProvider,
             isFocused = focusedIndex == 4,
             onClick = onDnsProviderClick
@@ -3838,142 +3816,3 @@ private fun SubtitlePickerModal(
     }
 }
 
-@OptIn(ExperimentalTvMaterial3Api::class)
-@Composable
-private fun DnsRestartConfirmModal(
-    providerLabel: String,
-    onConfirm: () -> Unit,
-    onDismiss: () -> Unit
-) {
-    var focusedIndex by remember { mutableIntStateOf(1) } // 0 cancel, 1 apply
-    val focusRequester = remember { FocusRequester() }
-
-    LaunchedEffect(Unit) {
-        focusRequester.requestFocus()
-    }
-
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Color.Black.copy(alpha = 0.6f))
-            .focusRequester(focusRequester)
-            .focusable()
-            .onPreviewKeyEvent { event ->
-                if (event.type == KeyEventType.KeyDown) {
-                    when (event.key) {
-                        Key.Back, Key.Escape -> {
-                            onDismiss()
-                            true
-                        }
-                        Key.DirectionLeft -> {
-                            if (focusedIndex > 0) focusedIndex--
-                            true
-                        }
-                        Key.DirectionRight -> {
-                            if (focusedIndex < 1) focusedIndex++
-                            true
-                        }
-                        Key.Enter, Key.DirectionCenter -> {
-                            if (focusedIndex == 0) onDismiss() else onConfirm()
-                            true
-                        }
-                        else -> false
-                    }
-                } else false
-            },
-        contentAlignment = Alignment.Center
-    ) {
-        Column(
-            modifier = Modifier
-                .then(
-                    if (LocalDeviceType.current.isTouchDevice()) Modifier.fillMaxWidth(0.92f).widthIn(max = 560.dp)
-                    else Modifier.width(560.dp)
-                )
-                .background(BackgroundElevated, RoundedCornerShape(16.dp))
-                .border(1.dp, Color.White.copy(alpha = 0.12f), RoundedCornerShape(16.dp))
-                .padding(if (LocalDeviceType.current.isTouchDevice()) 20.dp else 24.dp)
-        ) {
-            Text(
-                text = "Apply DNS Change?",
-                style = ArflixTypography.sectionTitle,
-                color = TextPrimary
-            )
-
-            Spacer(modifier = Modifier.height(12.dp))
-
-            Text(
-                text = "Switch to $providerLabel and restart the app now?",
-                style = ArflixTypography.body,
-                color = TextSecondary
-            )
-
-            Spacer(modifier = Modifier.height(20.dp))
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                val cancelFocused = focusedIndex == 0
-                Box(
-                    modifier = Modifier
-                        .weight(1f)
-                        .clip(RoundedCornerShape(10.dp))
-                        .background(
-                            color = if (cancelFocused) Color.White else Color.Black.copy(alpha = 0.82f),
-                            shape = RoundedCornerShape(10.dp)
-                        )
-                        .border(
-                            width = 1.dp,
-                            color = if (cancelFocused) Color.White else Color.White.copy(alpha = 0.14f),
-                            shape = RoundedCornerShape(10.dp)
-                        )
-                        .clickable { onDismiss() }
-                        .padding(vertical = 12.dp),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = "Cancel",
-                        style = ArflixTypography.button,
-                        color = if (cancelFocused) Color.Black else Color.White
-                    )
-                }
-
-                val applyFocused = focusedIndex == 1
-                Box(
-                    modifier = Modifier
-                        .weight(1f)
-                        .clip(RoundedCornerShape(10.dp))
-                        .background(
-                            color = if (applyFocused) Color.White else Color.Black.copy(alpha = 0.82f),
-                            shape = RoundedCornerShape(10.dp)
-                        )
-                        .border(
-                            width = 1.dp,
-                            color = if (applyFocused) Color.White else Color.White.copy(alpha = 0.14f),
-                            shape = RoundedCornerShape(10.dp)
-                        )
-                        .clickable { onConfirm() }
-                        .padding(vertical = 12.dp),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = "Apply & Restart",
-                        style = ArflixTypography.button,
-                        color = if (applyFocused) Color.Black else Color.White
-                    )
-                }
-            }
-
-            Spacer(modifier = Modifier.height(10.dp))
-            Text(
-                text = if (LocalDeviceType.current.isTouchDevice()) {
-                    "Tap a button to continue"
-                } else {
-                    "Left/Right to choose • OK to confirm • Back to cancel"
-                },
-                style = ArflixTypography.caption,
-                color = TextSecondary.copy(alpha = 0.56f)
-            )
-        }
-    }
-}

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -1,8 +1,6 @@
 package com.arflix.tv.ui.screens.settings
 
 import android.content.Context
-import android.content.Intent
-import android.os.Process
 import coil.Coil
 import com.arflix.tv.BuildConfig
 import androidx.datastore.preferences.core.booleanPreferencesKey
@@ -56,7 +54,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlin.system.exitProcess
 import java.io.File
 import javax.inject.Inject
 
@@ -757,23 +754,6 @@ class SettingsViewModel @Inject constructor(
                 OkHttpProvider.createCoilImageLoader(context)
             }
             Coil.setImageLoader(imageLoader)
-
-            delay(250)
-            restartApp()
-        }
-    }
-
-    private fun restartApp() {
-        val launchIntent = context.packageManager
-            .getLaunchIntentForPackage(context.packageName)
-            ?.apply {
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
-            }
-
-        if (launchIntent != null) {
-            context.startActivity(launchIntent)
-            Process.killProcess(Process.myPid())
-            exitProcess(0)
         }
     }
 

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -1,6 +1,9 @@
 package com.arflix.tv.ui.screens.settings
 
 import android.content.Context
+import android.content.Intent
+import android.os.Process
+import coil.Coil
 import com.arflix.tv.BuildConfig
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
@@ -25,6 +28,7 @@ import com.arflix.tv.data.repository.TvDeviceAuthStatusType
 import com.arflix.tv.data.repository.TraktRepository
 import com.arflix.tv.data.repository.TraktSyncService
 import com.arflix.tv.data.repository.WatchlistRepository
+import com.arflix.tv.network.OkHttpProvider
 import com.arflix.tv.data.repository.SyncProgress
 import com.arflix.tv.data.repository.SyncStatus
 import com.arflix.tv.data.repository.SyncResult
@@ -52,6 +56,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlin.system.exitProcess
 import java.io.File
 import javax.inject.Inject
 
@@ -69,6 +74,8 @@ data class SettingsUiState(
     val autoPlayNext: Boolean = true,
     val autoPlaySingleSource: Boolean = true,
     val autoPlayMinQuality: String = "Any",
+    val dnsProvider: String = "System DNS",
+    val dnsProviderOptions: List<String> = listOf("System DNS", "Cloudflare", "Google", "AdGuard"),
     val includeSpecials: Boolean = false,
     val isLoggedIn: Boolean = false,
     val accountEmail: String? = null,
@@ -159,6 +166,7 @@ class SettingsViewModel @Inject constructor(
     private fun autoPlaySingleSourceKeyFor(profileId: String) = profileManager.profileBooleanKeyFor(profileId, "auto_play_single_source")
     private fun autoPlayMinQualityKey() = profileManager.profileStringKey("auto_play_min_quality")
     private fun autoPlayMinQualityKeyFor(profileId: String) = profileManager.profileStringKeyFor(profileId, "auto_play_min_quality")
+    private fun dnsProviderKey() = profileManager.profileStringKey("dns_provider")
     private fun includeSpecialsKey() = profileManager.profileBooleanKey("include_specials")
     private fun includeSpecialsKeyFor(profileId: String) = profileManager.profileBooleanKeyFor(profileId, "include_specials")
     private val gson = Gson()
@@ -227,6 +235,7 @@ class SettingsViewModel @Inject constructor(
             var autoPlay = prefs[autoPlayNextKey()] ?: true
             val autoPlaySingleSource = prefs[autoPlaySingleSourceKey()] ?: true
             val autoPlayMinQuality = normalizeAutoPlayMinQuality(prefs[autoPlayMinQualityKey()])
+            val dnsProviderValue = normalizeDnsProviderValue(prefs[dnsProviderKey()])
             val includeSpecials = prefs[includeSpecialsKey()] ?: false
 
             // Check auth statuses
@@ -261,6 +270,7 @@ class SettingsViewModel @Inject constructor(
                 autoPlayNext = autoPlay,
                 autoPlaySingleSource = autoPlaySingleSource,
                 autoPlayMinQuality = autoPlayMinQuality,
+                dnsProvider = dnsProviderLabel(dnsProviderValue),
                 includeSpecials = includeSpecials,
                 isLoggedIn = isLoggedIn,
                 accountEmail = accountEmail,
@@ -693,6 +703,77 @@ class SettingsViewModel @Inject constructor(
             "1080p", "fullhd", "fhd" -> "1080p"
             "4k", "2160p", "uhd" -> "4K"
             else -> "Any"
+        }
+    }
+
+    private fun normalizeDnsProviderValue(raw: String?): String {
+        return when (raw?.trim()?.lowercase()) {
+            "system", "system dns", "system_dns" -> "system"
+            "cloudflare", "cloudflare dns", "cloudflare_dns" -> "cloudflare"
+            "google" -> "google"
+            "adguard", "ad guard" -> "adguard"
+            else -> "system"
+        }
+    }
+
+    private fun dnsProviderLabel(value: String): String {
+        return when (normalizeDnsProviderValue(value)) {
+            "system" -> "System DNS"
+            "google" -> "Google"
+            "adguard" -> "AdGuard"
+            else -> "Cloudflare"
+        }
+    }
+
+    private fun dnsProviderValueFromLabel(label: String): String {
+        return when (label.trim().lowercase()) {
+            "system dns" -> "system"
+            "google" -> "google"
+            "adguard" -> "adguard"
+            else -> "cloudflare"
+        }
+    }
+
+    fun setDnsProvider(label: String) {
+        val value = dnsProviderValueFromLabel(label)
+        viewModelScope.launch {
+            val currentValue = dnsProviderValueFromLabel(_uiState.value.dnsProvider)
+            if (value == currentValue) {
+                return@launch
+            }
+
+            withContext(Dispatchers.IO) {
+                OkHttpProvider.setDnsProvider(OkHttpProvider.parseDnsProvider(value))
+            }
+            context.settingsDataStore.edit { prefs ->
+                prefs[dnsProviderKey()] = value
+            }
+            _uiState.value = _uiState.value.copy(
+                dnsProvider = dnsProviderLabel(value)
+            )
+
+            // Keep image requests consistent if restart is delayed by the system.
+            val imageLoader = withContext(Dispatchers.IO) {
+                OkHttpProvider.createCoilImageLoader(context)
+            }
+            Coil.setImageLoader(imageLoader)
+
+            delay(250)
+            restartApp()
+        }
+    }
+
+    private fun restartApp() {
+        val launchIntent = context.packageManager
+            .getLaunchIntentForPackage(context.packageName)
+            ?.apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            }
+
+        if (launchIntent != null) {
+            context.startActivity(launchIntent)
+            Process.killProcess(Process.myPid())
+            exitProcess(0)
         }
     }
 
@@ -1670,7 +1751,4 @@ class SettingsViewModel @Inject constructor(
         traktPollingJob?.cancel()
     }
 }
-
-
-
 

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/TvScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/TvScreen.kt
@@ -90,6 +90,7 @@ import coil.size.Precision
 import com.arflix.tv.data.model.IptvChannel
 import com.arflix.tv.data.model.IptvNowNext
 import com.arflix.tv.data.model.IptvProgram
+import com.arflix.tv.network.OkHttpProvider
 import com.arflix.tv.ui.components.AppTopBar
 import com.arflix.tv.ui.components.AppTopBarContentTopInset
 import com.arflix.tv.util.LocalDeviceType
@@ -220,6 +221,7 @@ fun TvScreen(
             .followRedirects(true)
             .followSslRedirects(true)
             .retryOnConnectionFailure(true)
+            .dns(OkHttpProvider.dns)
             .connectTimeout(20, TimeUnit.SECONDS)
             .readTimeout(300, TimeUnit.SECONDS) // 5 min — live streams should not timeout during normal playback
             .build()
@@ -1875,4 +1877,3 @@ private val programTimeFormatter = DateTimeFormatter.ofPattern("h:mm a")
 private fun formatProgramTime(utcMillis: Long): String {
     return programTimeFormatter.format(Instant.ofEpochMilli(utcMillis).atZone(ZoneId.systemDefault()))
 }
-

--- a/app/src/main/kotlin/com/arflix/tv/ui/startup/StartupViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/startup/StartupViewModel.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import coil.ImageLoader
+import coil.imageLoader
 import coil.request.ImageRequest
 import coil.size.Precision
 import com.arflix.tv.data.model.Category
@@ -40,9 +41,12 @@ data class StartupState(
 @OptIn(ExperimentalCoroutinesApi::class)
 class StartupViewModel @Inject constructor(
     private val mediaRepository: MediaRepository,
-    private val imageLoader: ImageLoader,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
+    private val imageLoader: ImageLoader by lazy(LazyThreadSafetyMode.NONE) {
+        context.imageLoader
+    }
+
     private val networkDispatcher = Dispatchers.IO.limitedParallelism(8)
     private val heroLogoPreloadWidth = 300
     private val heroLogoPreloadHeight = 70


### PR DESCRIPTION
## Why

I was facing network-related issues in the app, so I added DNS provider selection to improve reliability and make it easier to switch resolvers when connectivity is unstable or region-dependent.

## What changed

1. Added configurable DNS provider support across app networking.
2. Added DNS-over-HTTPS support and resolver options (System DNS, Cloudflare, Google, AdGuard).
3. Wired DNS selection into Settings UI.
4. Added a confirmation step before applying DNS changes.
5. Automatically restarts the app after DNS change so all clients use the new resolver cleanly.
6. Updated image/network client wiring to use the selected DNS consistently.
7. Moved DNS switch/connection pool eviction work off the main thread to avoid UI-thread network exceptions.

## User impact

1. Users can change DNS from Settings.
2. DNS changes are applied consistently after confirmation and restart.
3. Better resilience for users with ISP DNS issues, blocked domains, or unstable network resolution.

## Motivation / context

This was implemented specifically to address network problems I was experiencing, where changing DNS can help recover API/image connectivity and stop request failures.

## Testing done

1. Built app variant successfully after changes.
2. Verified DNS selection flow from Settings.
3. Verified apply confirmation and automatic restart flow.

## Notes

No functional changes outside DNS/network resolver behavior and the related Settings flow.