### PR TITLE
Add toggle to skip profile selection on startup

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/MainActivity.kt
+++ b/app/src/main/kotlin/com/arflix/tv/MainActivity.kt
@@ -56,6 +56,7 @@ import androidx.core.view.WindowInsetsControllerCompat
 import android.content.pm.ActivityInfo
 import com.arflix.tv.util.DeviceType
 import com.arflix.tv.util.DEVICE_MODE_OVERRIDE_KEY
+import com.arflix.tv.util.SKIP_PROFILE_SELECTION_KEY
 import com.arflix.tv.util.LocalDeviceType
 import com.arflix.tv.util.LocalHasTouchScreen
 import com.arflix.tv.util.detectDeviceType
@@ -157,6 +158,7 @@ class MainActivity : ComponentActivity() {
         setContent {
             // Observe device mode override changes live from DataStore
             val deviceModeOverride by remember { this@MainActivity.settingsDataStore.data.map { it[DEVICE_MODE_OVERRIDE_KEY] } }.collectAsState(initial = null)
+            val skipProfileSelection by remember { this@MainActivity.settingsDataStore.data.map { it[SKIP_PROFILE_SELECTION_KEY] ?: false } }.collectAsState(initial = false)
             val deviceType = when (deviceModeOverride) {
                 "tv" -> DeviceType.TV
                 "tablet" -> DeviceType.TABLET
@@ -178,6 +180,7 @@ class MainActivity : ComponentActivity() {
                         profileRepository = profileRepository.get(),
                         traktRepository = traktRepository.get(),
                         launcherContinueWatchingRepository = launcherContinueWatchingRepository.get(),
+                        skipProfileSelection = skipProfileSelection,
                         pendingLauncherRequest = pendingLauncherRequest,
                         onConsumeLauncherRequest = { pendingLauncherRequest = null },
                         preloadedCategories = startupState.categories,
@@ -348,6 +351,7 @@ fun ArflixApp(
     profileRepository: ProfileRepository,
     traktRepository: TraktRepository,
     launcherContinueWatchingRepository: LauncherContinueWatchingRepository,
+    skipProfileSelection: Boolean = false,
     pendingLauncherRequest: LauncherContinueWatchingRequest? = null,
     onConsumeLauncherRequest: () -> Unit = {},
     preloadedCategories: List<com.arflix.tv.data.model.Category> = emptyList(),
@@ -375,7 +379,11 @@ fun ArflixApp(
     }
 
     // Always show profile selection on startup - user must manually choose a profile
-    val startDestination = Screen.ProfileSelection.route
+    val startDestination = if (skipProfileSelection && activeProfile != null) {
+        Screen.Home.route
+    } else {
+        Screen.ProfileSelection.route
+    }
 
     val deviceType = LocalDeviceType.current
     val isMobile = deviceType.isTouchDevice()

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -251,7 +251,7 @@ fun SettingsScreen(
         if (scrollState.maxValue <= 0) return@LaunchedEffect
 
         val maxIndex = when (sectionIndex) {
-            0 -> 11 // General: 12 items
+            0 -> 12 // General: 13 items
             1 -> 3 // IPTV: Configure + Refresh + Delete + Stalker
             2 -> uiState.catalogs.size // Catalogs
             3 -> uiState.addons.size // Addons
@@ -469,7 +469,8 @@ fun SettingsScreen(
                                                 9 -> viewModel.cycleFrameRateMatchingMode()
                                                 10 -> viewModel.toggleCardLayoutMode()
                                                 11 -> { val next = when (uiState.deviceModeOverride) { "auto" -> "tv"; "tv" -> "tablet"; "tablet" -> "phone"; else -> "auto" }; viewModel.setDeviceModeOverride(next) }
-                                                12 -> openDnsProviderPicker()
+                                                12 -> viewModel.setSkipProfileSelection(!uiState.skipProfileSelection)
+                                                13 -> openDnsProviderPicker()
                                             }
                                         }
                                         1 -> { // IPTV
@@ -597,6 +598,7 @@ fun SettingsScreen(
                             subtitleSize = uiState.subtitleSize,
                             subtitleColor = uiState.subtitleColor,
                             deviceModeOverride = uiState.deviceModeOverride,
+                            skipProfileSelection = uiState.skipProfileSelection,
                             focusedIndex = -1,
                             onSubtitleClick = openSubtitlePicker,
                             onAudioLanguageClick = openAudioLanguagePicker,
@@ -614,6 +616,7 @@ fun SettingsScreen(
                             },
                             onContentLanguageClick = openContentLanguagePicker,
                             onSubtitleSizeClick = { viewModel.cycleSubtitleSize() },
+                            onSkipProfileSelectionToggle = { viewModel.setSkipProfileSelection(it) },
                             onSubtitleColorClick = { viewModel.cycleSubtitleColor() }
                         )
                         "iptv" -> IptvSettings(
@@ -767,6 +770,7 @@ fun SettingsScreen(
                             subtitleSize = uiState.subtitleSize,
                             subtitleColor = uiState.subtitleColor,
                             deviceModeOverride = uiState.deviceModeOverride,
+                            skipProfileSelection = uiState.skipProfileSelection,
                             focusedIndex = if (activeZone == Zone.CONTENT) contentFocusIndex else -1,
                             onSubtitleClick = openSubtitlePicker,
                             onAudioLanguageClick = openAudioLanguagePicker,
@@ -783,6 +787,7 @@ fun SettingsScreen(
                                 viewModel.setDeviceModeOverride(next)
                             },
                             onContentLanguageClick = openContentLanguagePicker,
+                            onSkipProfileSelectionToggle = { viewModel.setSkipProfileSelection(it) },
                             onSubtitleSizeClick = { viewModel.cycleSubtitleSize() },
                             onSubtitleColorClick = { viewModel.cycleSubtitleColor() }
                         )
@@ -2034,6 +2039,7 @@ private fun GeneralSettings(
     subtitleSize: String = "Medium",
     subtitleColor: String = "White",
     deviceModeOverride: String = "auto",
+    skipProfileSelection: Boolean = false,
     focusedIndex: Int,
     onSubtitleClick: () -> Unit,
     onAudioLanguageClick: () -> Unit,
@@ -2045,6 +2051,7 @@ private fun GeneralSettings(
     onAutoPlayMinQualityClick: () -> Unit,
     onDeviceModeClick: () -> Unit = {},
     onContentLanguageClick: () -> Unit = {},
+    onSkipProfileSelectionToggle: (Boolean) -> Unit = {},
     trailerAutoPlay: Boolean = false,
     onSubtitleSizeClick: () -> Unit = {},
     onSubtitleColorClick: () -> Unit = {},
@@ -2185,6 +2192,14 @@ private fun GeneralSettings(
             },
             isFocused = focusedIndex == 11,
             onClick = onDeviceModeClick
+        )
+        Spacer(modifier = Modifier.height(10.dp))
+        SettingsToggleRow(
+            title = "Skip Profile Selection",
+            subtitle = "Auto-load last used profile",
+            isEnabled = skipProfileSelection,
+            isFocused = focusedIndex == 12,
+            onToggle = onSkipProfileSelectionToggle
         )
 
         // ── Network ──

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -128,6 +128,8 @@ data class SettingsUiState(
     val contentLanguage: String = "en-US",
     // Device mode override
     val deviceModeOverride: String = "auto",
+    // Skip profile selection
+    val skipProfileSelection: Boolean = false,
     // Toast
     val toastMessage: String? = null,
     val toastType: ToastType = ToastType.INFO
@@ -245,6 +247,7 @@ class SettingsViewModel @Inject constructor(
             val cardLayoutMode = normalizeCardLayoutMode(prefs[cardLayoutModeKey()])
             val frameRateMode = normalizeFrameRateMode(prefs[frameRateMatchingModeKey()])
             val deviceModeOverride = prefs[com.arflix.tv.util.DEVICE_MODE_OVERRIDE_KEY] ?: "auto"
+            val skipProfileSelection = prefs[com.arflix.tv.util.SKIP_PROFILE_SELECTION_KEY] ?: false
             val contentLang = prefs[contentLanguageKey()] ?: "en-US"
             // Apply content language to MediaRepository immediately
             mediaRepository.contentLanguage = if (contentLang == "en-US") null else contentLang
@@ -325,7 +328,8 @@ class SettingsViewModel @Inject constructor(
                 catalogs = existingCatalogs,
                 addons = addons,
                 contentLanguage = contentLang,
-                deviceModeOverride = deviceModeOverride
+                deviceModeOverride = deviceModeOverride,
+                skipProfileSelection = skipProfileSelection
             )
         }
     }
@@ -722,6 +726,15 @@ class SettingsViewModel @Inject constructor(
                 prefs[com.arflix.tv.util.DEVICE_MODE_OVERRIDE_KEY] = mode
             }
             _uiState.value = _uiState.value.copy(deviceModeOverride = mode)
+        }
+    }
+
+    fun setSkipProfileSelection(skip: Boolean) {
+        viewModelScope.launch {
+            context.settingsDataStore.edit { prefs ->
+                prefs[com.arflix.tv.util.SKIP_PROFILE_SELECTION_KEY] = skip
+            }
+            _uiState.value = _uiState.value.copy(skipProfileSelection = skip)
         }
     }
 

--- a/app/src/main/kotlin/com/arflix/tv/util/DeviceType.kt
+++ b/app/src/main/kotlin/com/arflix/tv/util/DeviceType.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.content.res.Configuration
 import androidx.compose.runtime.compositionLocalOf
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
@@ -29,6 +30,9 @@ fun deviceHasTouchScreen(context: Context): Boolean {
 
 /** Key for the user's UI mode override in settingsDataStore */
 val DEVICE_MODE_OVERRIDE_KEY = stringPreferencesKey("device_mode_override")
+
+/** Key for skipping profile selection on startup */
+val SKIP_PROFILE_SELECTION_KEY = booleanPreferencesKey("skip_profile_selection")
 
 /** Values: "auto" (default), "tv", "tablet", "phone" */
 fun detectDeviceType(context: Context): DeviceType {


### PR DESCRIPTION
## Description
Users reported they don't want to see the 'Who's watching' profile selection screen on every startup.

## Changes
- Add toggle in Settings > Interface > 'Skip Profile Selection'
- When enabled, the app automatically loads the last used profile
- When disabled (default), app shows the profile selection screen as before

## Implementation Details
- New preference key: SKIP_PROFILE_SELECTION_KEY
- Updated MainActivity to conditionally skip profile selection screen
- Added setting to SettingsViewModel for persistence
- New UI toggle in GeneralSettings composable

## Testing
- Toggle the setting on/off
- Verify last used profile loads when enabled
- Verify profile selection screen shows when disabled