### PR TITLE
Fix watchlist navigation bug - prevent getting stuck on last item

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/watchlist/WatchlistScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/watchlist/WatchlistScreen.kt
@@ -183,7 +183,17 @@ fun WatchlistScreen(
                         Key.DirectionUp -> {
                             if (isSidebarFocused) {
                                 true
-                            } else false
+                            } else {
+                                // When in grid and Up is pressed, allow native focus to handle it
+                                // If at first visible item, transition to sidebar
+                                val firstVisibleIndex = gridState.firstVisibleItemIndex
+                                if (firstVisibleIndex == 0 && focusedGridIndex < gridColumns) {
+                                    isSidebarFocused = true
+                                    true
+                                } else {
+                                    false
+                                }
+                            }
                         }
                         Key.DirectionDown -> {
                             if (isSidebarFocused) {
@@ -195,7 +205,15 @@ fun WatchlistScreen(
                                     }
                                 }
                                 true
-                            } else false
+                            } else {
+                                // When in grid and Down is pressed, allow native focus to handle it
+                                // Only consume if we're at the last item (prevent getting stuck)
+                                if (focusedGridIndex >= uiState.items.size - 1) {
+                                    true // Consume to prevent focus loss
+                                } else {
+                                    false
+                                }
+                            }
                         }
                         Key.Enter, Key.DirectionCenter -> {
                             if (isSidebarFocused) {
@@ -306,6 +324,21 @@ fun WatchlistScreen(
                                     if (it.hasFocus) {
                                         isSidebarFocused = false
                                     }
+                                }
+                                .onKeyEvent { event ->
+                                    if (event.type == KeyEventType.KeyDown) {
+                                        when (event.key) {
+                                            Key.Back, Key.Escape -> {
+                                                isSidebarFocused = true
+                                                scope.launch {
+                                                    delay(40)
+                                                    runCatching { rootFocusRequester.requestFocus() }
+                                                }
+                                                true
+                                            }
+                                            else -> false
+                                        }
+                                    } else false
                                 }
                         ) {
                             itemsIndexed(uiState.items) { index, item ->


### PR DESCRIPTION
## Bug Description
When you add more than two items to the watchlist and navigate to the last item, navigation can get stuck. The user cannot navigate anywhere else and must press back, reselect the watchlist tab, and manually go to home.

## Root Cause
The Up/Down key handlers in the grid were not properly handling focus transitions, especially at the boundaries (first and last items). When at the last item:
- Pressing Down caused focus loss since there was nowhere to go
- The Back key from the grid wasn't properly handled
- Focus management between grid and sidebar was broken

## Solution
- Enhanced Up key handling: now transitions to sidebar when user presses Up at the first row
- Enhanced Down key handling: consumes the event at the last item to prevent focus loss
- Added explicit Back/Escape key handler on the grid to ensure proper transition to sidebar
- Improved focus management to prevent grid from becoming unfocused

## Testing Steps
1. Add 3+ movies/shows to watchlist
2. Go to Watchlist and navigate to the last item
3. Try pressing Up - should transition to sidebar
4. Try pressing Down at last item - should not get stuck
5. Try pressing Back at any item - should return to sidebar