### PR TITLE
Fix subtitle mime-type fallback and OpenSubtitles language handling

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
@@ -19,6 +19,7 @@ import com.arflix.tv.data.model.StreamSource
 import com.arflix.tv.data.model.Subtitle
 import com.arflix.tv.util.AnimeMapper
 import com.arflix.tv.util.Constants
+import java.util.Locale
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -1338,7 +1339,7 @@ class StreamRepository @Inject constructor(
         val videoHash = stream?.behaviorHints?.videoHash?.trim().takeUnless { it.isNullOrBlank() }
         val videoSize = stream?.behaviorHints?.videoSize?.takeIf { it != null && it > 0L }
 
-        val contentId = when (mediaType) {
+        val rawContentId = when (mediaType) {
             MediaType.MOVIE -> imdbId
             MediaType.TV -> {
                 val s = season ?: return@withContext emptyList()
@@ -1347,12 +1348,14 @@ class StreamRepository @Inject constructor(
             }
             else -> return@withContext emptyList()
         }
+        val contentId = rawContentId
         val type = when (mediaType) {
             MediaType.MOVIE -> "movie"
             MediaType.TV -> "series"
             else -> ""
         }
 
+        val localeLanguage = Locale.getDefault().language
         subtitleAddons.flatMap { addon ->
             runCatching {
                 withTimeout(SUBTITLE_TIMEOUT_MS) {
@@ -1364,7 +1367,8 @@ class StreamRepository @Inject constructor(
                         id = contentId,
                         addonQueryParams = queryParams,
                         videoHash = videoHash,
-                        videoSize = videoSize
+                        videoSize = videoSize,
+                        language = localeLanguage
                     )
                     val response = streamApi.getSubtitles(url)
                     response.subtitles?.mapIndexed { index, sub ->
@@ -1388,7 +1392,8 @@ class StreamRepository @Inject constructor(
         id: String,
         addonQueryParams: String?,
         videoHash: String?,
-        videoSize: Long?
+        videoSize: Long?,
+        language: String? = null
     ): String {
         val base = baseUrl.trimEnd('/')
         val subtitleBase = if (base.endsWith("/subtitles", ignoreCase = true)) {
@@ -1406,10 +1411,12 @@ class StreamRepository @Inject constructor(
             hints.takeIf { it.isNotBlank() }
         ).joinToString("&")
 
+        val contentId = if (!language.isNullOrBlank()) "$id:lang=${language.trim().lowercase()}" else id
+
         return if (mergedQuery.isNotBlank()) {
-            "$subtitleBase/$type/$id.json?$mergedQuery"
+            "$subtitleBase/$type/$contentId.json?$mergedQuery"
         } else {
-            "$subtitleBase/$type/$id.json"
+            "$subtitleBase/$type/$contentId.json"
         }
     }
 

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -3090,11 +3090,11 @@ private fun subtitleMimeTypeFromUrl(url: String): String {
         cleanUrl.endsWith(".srt") || cleanUrl.endsWith(".srt.gz") -> MimeTypes.APPLICATION_SUBRIP
         cleanUrl.endsWith(".ass") || cleanUrl.endsWith(".ssa") -> MimeTypes.TEXT_SSA
         cleanUrl.endsWith(".ttml") || cleanUrl.endsWith(".dfxp") -> MimeTypes.APPLICATION_TTML
-        // Extensionless URLs from addons (Comet, OpenSubtitles, etc.) - default to
-        // WebVTT which is the most common format served by subtitle addons.
-        // ExoPlayer handles VTT more gracefully than SRT when there's a format mismatch.
-        cleanUrl.contains("/subtitles/") || cleanUrl.contains("/subs/") || !cleanUrl.substringAfterLast('/').contains('.') -> MimeTypes.TEXT_VTT
-        else -> MimeTypes.TEXT_VTT  // Safe fallback - VTT parser is more lenient
+        // Extensionless URLs (e.g., OpenSubtitles stream URL) should prefer SRT behavior,
+        // because OpenSubtitles often serves SRT/SRT.GZ there. VTT fallback is still used
+        // for explicit .vtt URLs.
+        cleanUrl.contains("/subtitles/") || cleanUrl.contains("/subs/") || !cleanUrl.substringAfterLast('/').contains('.') -> MimeTypes.APPLICATION_SUBRIP
+        else -> MimeTypes.APPLICATION_SUBRIP  // Safer fallback for unknown subtitle URLs
     }
 }
 


### PR DESCRIPTION
Title
Fix subtitle mime-type fallback and OpenSubtitles language handling

Summary
This PR fixes OpenSubtitles subtitle playback reliability by improving subtitle mime-type inference and adding locale-aware subtitle query behavior.

What changed
PlayerScreen.subtitleMimeTypeFromUrl(url)

For ambiguous or extensionless subtitle URLs (e.g., OpenSubtitles /subtitles/, /subs/, no extension), prefer:
MimeTypes.APPLICATION_SUBRIP
Fallback changed from TEXT_VTT to APPLICATION_SUBRIP.
StreamRepository.buildSubtitlesUrl(...)

New param: language: String? = null
If language exists, include in generated content ID:
contentId = "$id:lang=$lang"
Ensures subtitle provider selection can use localization hint.
fetchSubtitlesForSelectedStream(...)

Passes Locale.getDefault().language into buildSubtitlesUrl.
Supports better matching for locale-specific subtitle sets.

Why
OpenSubtitles often returns subtitle URLs without extension; those are usually SRT-based.
Existing VTT fallback caused incorrect parsing or failure in ExoPlayer when actual stream is SRT.
Language tag in subtitle queries improves probability of matching user language content.

Testing
Playback sample with OpenSubtitles source, verify subtitles appear with no extension URLs.
Validate regular extension URLs still load (VTT/SRT/ASS).
Confirm the request URL now uses :lang=xx contentId for local language, e.g. .../subtitles/movie/tt123456:lang=en.json?....

Notes
Local container build currently fails due host Java/Gradle environment (25.0.1 versus required 17/21), unrelated to change.
Should be CI-ready in supported environment.