### PR TITLE
Fix stream quality badges - prioritize filename over metadata

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
@@ -1030,11 +1030,14 @@ class StreamRepository @Inject constructor(
                     )
                 } ?: emptyList()
 
+                val torrentName = stream.getTorrentName()
+                val qualityFromTorrent = parseQuality(torrentName)
+
                 StreamSource(
-                    source = stream.getTorrentName(),
+                    source = torrentName,
                     addonName = addon.name + " - " + stream.getSourceName(),
                     addonId = addon.id,
-                    quality = stream.getQuality(),
+                    quality = if (qualityFromTorrent != "Unknown") qualityFromTorrent else stream.getQuality(),
                     size = stream.getSize(),
                     sizeBytes = parseSizeToBytes(stream.getSize()),
                     url = streamUrl,
@@ -1748,6 +1751,16 @@ class StreamRepository @Inject constructor(
             quality.contains("720p", ignoreCase = true) -> 60
             quality.contains("480p", ignoreCase = true) -> 40
             else -> 20
+        }
+    }
+
+    private fun parseQuality(text: String): String {
+        return when {
+            text.contains("2160p", ignoreCase = true) || text.contains("4K", ignoreCase = true) -> "4K"
+            text.contains("1080p", ignoreCase = true) -> "1080p"
+            text.contains("720p", ignoreCase = true) -> "720p"
+            text.contains("480p", ignoreCase = true) -> "480p"
+            else -> "Unknown"
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes incorrect quality badges on streams where metadata provider reports wrong quality (e.g., labeled as 4K but description indicates 1080p/720p).

## Changes
- Modified  to parse quality from torrent filename first, then fallback to addon metadata.
- Added  helper function for consistent quality parsing.
- Quality determination now prioritizes filename (torrent name) over potentially incorrect metadata.

## Why
Metadata providers can have inaccurate quality information in stream descriptions/titles. Torrent filenames are more reliable indicators of actual video quality.

## Testing
1. Search for a show/movie with available streams.
2. Check stream quality badges in source selection.
3. Verify badges match the torrent filename quality rather than metadata description.
4. Ensure no regressions for streams without explicit quality in filename.

## Notes
- Low-priority optimization as requested.
- IPTV streams unchanged (uses metadata as no filename available).
- Build tested in compatible environments (Java 17/21).