### PR TITLE
fix: in-app updater stalling at 99%

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/updater/ApkDownloader.kt
+++ b/app/src/main/kotlin/com/arflix/tv/updater/ApkDownloader.kt
@@ -20,8 +20,14 @@ class ApkDownloader @Inject constructor(
             destinationFile.parentFile?.mkdirs()
             if (destinationFile.exists()) destinationFile.delete()
 
+            // Use a dedicated client with longer timeouts for large APK downloads
+            val downloadClient = okHttpClient.newBuilder()
+                .connectTimeout(60, java.util.concurrent.TimeUnit.SECONDS)
+                .readTimeout(120, java.util.concurrent.TimeUnit.SECONDS)
+                .build()
+
             val request = Request.Builder().url(url).build()
-            okHttpClient.newCall(request).execute().use { response ->
+            downloadClient.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
                     error("Download failed: HTTP ${response.code}")
                 }

--- a/app/src/main/kotlin/com/arflix/tv/updater/ApkInstaller.kt
+++ b/app/src/main/kotlin/com/arflix/tv/updater/ApkInstaller.kt
@@ -118,11 +118,12 @@ object ApkInstaller {
                     session.fsync(out)
                 }
 
-                val intent = Intent(context, context.javaClass).apply {
-                    action = "com.arvio.tv.INSTALL_COMPLETE"
-                }
-                val pendingIntent = PendingIntent.getActivity(
-                    context, 0, intent,
+                // Use a broadcast PendingIntent instead of activity — works reliably
+                // on Android TV where the Application context isn't an Activity.
+                val intent = Intent("com.arvio.tv.INSTALL_COMPLETE")
+                    .setPackage(context.packageName)
+                val pendingIntent = PendingIntent.getBroadcast(
+                    context, sessionId, intent,
                     PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
                 )
 


### PR DESCRIPTION
Fixes download timeout and install PendingIntent for Android TV.