### PR TITLE
feat: add launcher channel thumbnails

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/LauncherContinueWatchingRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/LauncherContinueWatchingRepository.kt
@@ -164,6 +164,7 @@ class LauncherContinueWatchingRepository @Inject constructor(
             .setDescription(item.buildSubtitle())
             .setInternalProviderId(item.previewProgramId())
             .setPosterArtUri(item.posterPath?.takeIf { it.isNotBlank() }?.let(Uri::parse))
+            .setThumbnailUri(item.backdropPath?.takeIf { it.isNotBlank() }?.let(Uri::parse))
             .setIntentUri(buildLaunchIntent(item).toUri(Intent.URI_INTENT_SCHEME).let(Uri::parse))
             .setWeight((Constants.MAX_CONTINUE_WATCHING - index).coerceAtLeast(1))
             .build()
@@ -180,6 +181,7 @@ class LauncherContinueWatchingRepository @Inject constructor(
             .setInternalProviderId(item.watchNextProgramId())
             .setIntentUri(buildLaunchIntent(item).toUri(Intent.URI_INTENT_SCHEME).let(Uri::parse))
             .setPosterArtUri(item.posterPath?.takeIf { it.isNotBlank() }?.let(Uri::parse))
+            .setThumbnailUri(item.backdropPath?.takeIf { it.isNotBlank() }?.let(Uri::parse))
             .setWatchNextType(TvContractCompat.WatchNextPrograms.WATCH_NEXT_TYPE_CONTINUE)
             .setLastEngagementTimeUtcMillis(System.currentTimeMillis() - index)
 


### PR DESCRIPTION
It appears that only posters are provided for google tv launchers to use, meaning they get cropped for launchers that use landscape views (e.g. projectivy)

this PR attempts to add thumbnail art alongside the poster art to allow the launcher to use whichever is appropriate

Please note I havent tested this as I don't have an android dev setup. It's based on using codex and checking against the api docs / source code. So if anyone is able to test this works that would great

https://developer.android.com/reference/android/media/tv/TvContract.WatchNextPrograms#COLUMN_THUMBNAIL_URI

https://android.googlesource.com/platform/prebuilts/fullsdk/sources/android-28/+/refs/heads/androidx-enterprise-release/androidx/tvprovider/media/tv/BaseProgram.java#393

Many thanks
