### PR TITLE
feat: sync app clock format with device settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.configuration.updateBuildConfiguration": "interactive"
-}

--- a/app/src/main/kotlin/com/arflix/tv/ui/components/TopBarClock.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/TopBarClock.kt
@@ -31,9 +31,7 @@ import kotlinx.coroutines.delay
 import android.content.Context
 import android.text.format.DateFormat
 import androidx.compose.ui.platform.LocalContext
-import java.text.SimpleDateFormat
 import java.util.Date
-import java.util.Locale
 
 /**
  * Top bar clock display with optional profile indicator
@@ -139,9 +137,6 @@ private fun ProfileIndicator(
 }
 
 private fun getCurrentTime(context: Context): String {
-    val pattern = if (DateFormat.is24HourFormat(context)) "HH:mm" else "h:mm a"
-    val sdf = SimpleDateFormat(pattern, Locale.getDefault())
-    return sdf.format(Date())
+    val timeFormat = DateFormat.getTimeFormat(context)
+    return timeFormat.format(Date())
 }
-
-

--- a/app/src/main/kotlin/com/arflix/tv/ui/components/TopBarClock.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/TopBarClock.kt
@@ -28,6 +28,9 @@ import androidx.tv.material3.Text
 import com.arflix.tv.data.model.Profile
 import com.arflix.tv.ui.theme.ArflixTypography
 import kotlinx.coroutines.delay
+import android.content.Context
+import android.text.format.DateFormat
+import androidx.compose.ui.platform.LocalContext
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -41,11 +44,12 @@ fun TopBarClock(
     modifier: Modifier = Modifier,
     profile: Profile? = null
 ) {
-    var currentTime by remember { mutableStateOf(getCurrentTime()) }
+    val context = LocalContext.current
+    var currentTime by remember { mutableStateOf(getCurrentTime(context)) }
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(context) {
         while (true) {
-            currentTime = getCurrentTime()
+            currentTime = getCurrentTime(context)
             val now = System.currentTimeMillis()
             val delayToNextMinute = 60_000L - (now % 60_000L)
             delay(delayToNextMinute.coerceIn(1_000L, 60_000L))
@@ -134,8 +138,9 @@ private fun ProfileIndicator(
     }
 }
 
-private fun getCurrentTime(): String {
-    val sdf = SimpleDateFormat("HH:mm", Locale.getDefault())
+private fun getCurrentTime(context: Context): String {
+    val pattern = if (DateFormat.is24HourFormat(context)) "HH:mm" else "h:mm a"
+    val sdf = SimpleDateFormat(pattern, Locale.getDefault())
     return sdf.format(Date())
 }
 


### PR DESCRIPTION
This PR updates the top bar clock to respect the user's Android device time setting, automatically switching between 12-hour and 24-hour formats accordingly.