### PR TITLE
feat: add toggle for trailer banner audio

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncRepository.kt
@@ -57,8 +57,8 @@ class CloudSyncRepository @Inject constructor(
         val frameRateMatchingMode: String = "Off",
         val autoPlayNext: Boolean = true,
         val autoPlaySingleSource: Boolean = true,
-        val autoPlayMinQuality: String = "Any",
         val trailerAutoPlay: Boolean = false,
+        val trailerAudioEnabled: Boolean = false,
         val includeSpecials: Boolean = false,
         val iptvHiddenGroups: String = "",
         val iptvGroupOrder: String = ""
@@ -70,6 +70,8 @@ class CloudSyncRepository @Inject constructor(
         profileManager.profileStringKeyFor(profileId, "content_language")
     private fun trailerAutoPlayKeyFor(profileId: String) =
         profileManager.profileBooleanKeyFor(profileId, "trailer_auto_play")
+    private fun trailerAudioEnabledKeyFor(profileId: String) =
+        profileManager.profileBooleanKeyFor(profileId, "trailer_audio_enabled")
 
     private fun subtitleSizeKeyFor(profileId: String) =
         profileManager.profileStringKeyFor(profileId, "subtitle_size")
@@ -151,6 +153,7 @@ class CloudSyncRepository @Inject constructor(
                         contentLanguage = prefs[contentLanguageKeyFor(profile.id)] ?: "en-US",
 
                         trailerAutoPlay = prefs[trailerAutoPlayKeyFor(profile.id)] ?: false,
+                        trailerAudioEnabled = prefs[trailerAudioEnabledKeyFor(profile.id)] ?: false,
                         subtitleSize = prefs[subtitleSizeKeyFor(profile.id)] ?: "Medium",
                         subtitleColor = prefs[subtitleColorKeyFor(profile.id)] ?: "White",
                         iptvHiddenGroups = prefs[iptvHiddenGroupsKeyFor(profile.id)] ?: "",
@@ -370,6 +373,7 @@ class CloudSyncRepository @Inject constructor(
                         prefs[contentLanguageKeyFor(profileId)] = state.contentLanguage
 
                         prefs[trailerAutoPlayKeyFor(profileId)] = state.trailerAutoPlay
+                        prefs[trailerAudioEnabledKeyFor(profileId)] = state.trailerAudioEnabled
                         prefs[subtitleSizeKeyFor(profileId)] = state.subtitleSize
                         prefs[subtitleColorKeyFor(profileId)] = state.subtitleColor
                         if (state.iptvHiddenGroups.isNotBlank()) prefs[iptvHiddenGroupsKeyFor(profileId)] = state.iptvHiddenGroups

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncRepository.kt
@@ -57,6 +57,7 @@ class CloudSyncRepository @Inject constructor(
         val frameRateMatchingMode: String = "Off",
         val autoPlayNext: Boolean = true,
         val autoPlaySingleSource: Boolean = true,
+        val autoPlayMinQuality: String = "Any", // Ensure this name is exact
         val trailerAutoPlay: Boolean = false,
         val trailerAudioEnabled: Boolean = false,
         val includeSpecials: Boolean = false,
@@ -151,7 +152,6 @@ class CloudSyncRepository @Inject constructor(
                         defaultSubtitle = prefs[defaultSubtitleKeyFor(profile.id)] ?: "Off",
                         defaultAudioLanguage = prefs[defaultAudioLanguageKeyFor(profile.id)] ?: "Auto (Original)",
                         contentLanguage = prefs[contentLanguageKeyFor(profile.id)] ?: "en-US",
-
                         trailerAutoPlay = prefs[trailerAutoPlayKeyFor(profile.id)] ?: false,
                         trailerAudioEnabled = prefs[trailerAudioEnabledKeyFor(profile.id)] ?: false,
                         subtitleSize = prefs[subtitleSizeKeyFor(profile.id)] ?: "Medium",
@@ -371,7 +371,6 @@ class CloudSyncRepository @Inject constructor(
                         prefs[defaultSubtitleKeyFor(profileId)] = state.defaultSubtitle
                         prefs[defaultAudioLanguageKeyFor(profileId)] = state.defaultAudioLanguage
                         prefs[contentLanguageKeyFor(profileId)] = state.contentLanguage
-
                         prefs[trailerAutoPlayKeyFor(profileId)] = state.trailerAutoPlay
                         prefs[trailerAudioEnabledKeyFor(profileId)] = state.trailerAudioEnabled
                         prefs[subtitleSizeKeyFor(profileId)] = state.subtitleSize

--- a/app/src/main/kotlin/com/arflix/tv/ui/components/TrailerPlayer.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/TrailerPlayer.kt
@@ -38,7 +38,8 @@ import kotlinx.coroutines.withContext
 fun TrailerPlayer(
     youtubeKey: String,
     modifier: Modifier = Modifier,
-    delayMs: Long = 3000L
+    delayMs: Long = 3000L,
+    isMuted: Boolean = true
 ) {
     val context = LocalContext.current
     var shouldPlay by remember { mutableStateOf(false) }
@@ -72,7 +73,7 @@ fun TrailerPlayer(
     ) {
         val player = remember(youtubeKey) {
             ExoPlayer.Builder(context).build().apply {
-                volume = 0.5f // Half volume for background trailer
+                volume = if (isMuted) 0f else 0.5f // Muted or half volume for background trailer
                 repeatMode = Player.REPEAT_MODE_ONE
                 playWhenReady = true
             }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
@@ -556,6 +556,7 @@ fun HomeScreen(
             if (heroVideoUrl == null && uiState.trailerAutoPlay && uiState.heroTrailerKey != null) {
                 TrailerPlayer(
                     youtubeKey = uiState.heroTrailerKey!!,
+                    isMuted = !uiState.trailerAudioEnabled,
                     modifier = Modifier.fillMaxSize()
                 )
             }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
@@ -66,6 +66,7 @@ data class HomeUiState(
     val heroLogoUrl: String? = null,
     val heroTrailerKey: String? = null,
     val trailerAutoPlay: Boolean = false,
+    val trailerAudioEnabled: Boolean = false,
     val heroOverviewOverride: String? = null,
     val cardLogoUrls: Map<String, String> = emptyMap(),
     // Previous hero for crossfade (Phase 2.1)
@@ -96,6 +97,7 @@ class HomeViewModel @Inject constructor(
     private val watchlistRepository: WatchlistRepository,
     private val cloudSyncRepository: CloudSyncRepository,
     private val launcherContinueWatchingRepository: LauncherContinueWatchingRepository,
+    private val profileManager: ProfileManager,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
     private val imageLoader: ImageLoader by lazy(LazyThreadSafetyMode.NONE) {
@@ -648,7 +650,14 @@ class HomeViewModel @Inject constructor(
                 val trailerEnabled = prefs.asMap().any { (key, value) ->
                     key.name.endsWith("_trailer_auto_play") && value == true
                 }
-                _uiState.value = _uiState.value.copy(trailerAutoPlay = trailerEnabled)
+                
+                // Scope trailer audio strictly to the active profile
+                val trailerAudio = prefs[profileManager.profileBooleanKey("trailer_audio_enabled")] ?: false
+                
+                _uiState.value = _uiState.value.copy(
+                    trailerAutoPlay = trailerEnabled,
+                    trailerAudioEnabled = trailerAudio
+                )
             } catch (_: Exception) {}
         }
         // Restore logo URL cache from disk for instant clearlogos on cold start

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
@@ -1,5 +1,6 @@
 package com.arflix.tv.ui.screens.home
 
+import com.arflix.tv.data.repository.ProfileManager
 import android.app.ActivityManager
 import android.content.Context
 import com.arflix.tv.util.settingsDataStore

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -253,7 +253,7 @@ fun SettingsScreen(
         if (scrollState.maxValue <= 0) return@LaunchedEffect
 
         val maxIndex = when (sectionIndex) {
-            0 -> 13 // General: 14 items
+            0 -> 14 // General: 15 items
             1 -> 3 // IPTV: Configure + Refresh + Delete + Stalker
             2 -> uiState.catalogs.size // Catalogs
             3 -> uiState.addons.size // Addons
@@ -433,7 +433,7 @@ fun SettingsScreen(
                                 Zone.CONTENT -> {
                                     // Dynamic max based on current section
                                     val maxIndex = when (sectionIndex) {
-                                        0 -> 13 // General: 14 items
+                                        0 -> 14 // General: 15 items
                                         1 -> 3 // IPTV: Configure + Refresh + Delete + Stalker
                                         2 -> uiState.catalogs.size // Catalogs: Add + N catalogs
                                         3 -> uiState.addons.size // Addons: N addons + "Add Custom" button
@@ -482,11 +482,12 @@ fun SettingsScreen(
                                                 6 -> viewModel.setAutoPlaySingleSource(!uiState.autoPlaySingleSource)
                                                 7 -> viewModel.cycleAutoPlayMinQuality()
                                                 8 -> viewModel.setTrailerAutoPlay(!uiState.trailerAutoPlay)
-                                                9 -> viewModel.cycleFrameRateMatchingMode()
-                                                10 -> viewModel.toggleCardLayoutMode()
-                                                11 -> { val next = when (uiState.deviceModeOverride) { "auto" -> "tv"; "tv" -> "tablet"; "tablet" -> "phone"; else -> "auto" }; viewModel.setDeviceModeOverride(next) }
-                                                12 -> viewModel.setSkipProfileSelection(!uiState.skipProfileSelection)
-                                                13 -> openDnsProviderPicker()
+                                                9 -> viewModel.setTrailerAudioEnabled(!uiState.trailerAudioEnabled)
+                                                10 -> viewModel.cycleFrameRateMatchingMode()
+                                                11 -> viewModel.toggleCardLayoutMode()
+                                                12 -> { val next = when (uiState.deviceModeOverride) { "auto" -> "tv"; "tv" -> "tablet"; "tablet" -> "phone"; else -> "auto" }; viewModel.setDeviceModeOverride(next) }
+                                                13 -> viewModel.setSkipProfileSelection(!uiState.skipProfileSelection)
+                                                14 -> openDnsProviderPicker()
                                             }
                                         }
                                         1 -> { // IPTV
@@ -625,7 +626,9 @@ fun SettingsScreen(
                             onAutoPlaySingleSourceToggle = { viewModel.setAutoPlaySingleSource(it) },
                             onAutoPlayMinQualityClick = { viewModel.cycleAutoPlayMinQuality() },
                             trailerAutoPlay = uiState.trailerAutoPlay,
+                            trailerAudioEnabled = uiState.trailerAudioEnabled,
                             onTrailerAutoPlayToggle = { viewModel.setTrailerAutoPlay(it) },
+                            onTrailerAudioToggle = { viewModel.setTrailerAudioEnabled(it) },
                             onDeviceModeClick = {
                                 val next = when (uiState.deviceModeOverride) { "auto" -> "tv"; "tv" -> "tablet"; "tablet" -> "phone"; else -> "auto" }
                                 viewModel.setDeviceModeOverride(next)
@@ -797,7 +800,9 @@ fun SettingsScreen(
                             onAutoPlaySingleSourceToggle = { viewModel.setAutoPlaySingleSource(it) },
                             onAutoPlayMinQualityClick = { viewModel.cycleAutoPlayMinQuality() },
                             trailerAutoPlay = uiState.trailerAutoPlay,
+                            trailerAudioEnabled = uiState.trailerAudioEnabled,
                             onTrailerAutoPlayToggle = { viewModel.setTrailerAutoPlay(it) },
+                            onTrailerAudioToggle = { viewModel.setTrailerAudioEnabled(it) },
                             onDeviceModeClick = {
                                 val next = when (uiState.deviceModeOverride) { "auto" -> "tv"; "tv" -> "tablet"; "tablet" -> "phone"; else -> "auto" }
                                 viewModel.setDeviceModeOverride(next)
@@ -2127,9 +2132,11 @@ private fun GeneralSettings(
     onContentLanguageClick: () -> Unit = {},
     onSkipProfileSelectionToggle: (Boolean) -> Unit = {},
     trailerAutoPlay: Boolean = false,
+    trailerAudioEnabled: Boolean = false,
     onSubtitleSizeClick: () -> Unit = {},
     onSubtitleColorClick: () -> Unit = {},
-    onTrailerAutoPlayToggle: (Boolean) -> Unit = {}
+    onTrailerAutoPlayToggle: (Boolean) -> Unit = {},
+    onTrailerAudioToggle: (Boolean) -> Unit = {}
 ) {
     Column {
         // ── Language & Subtitles ──
@@ -2227,12 +2234,20 @@ private fun GeneralSettings(
             onToggle = onTrailerAutoPlayToggle
         )
         Spacer(modifier = Modifier.height(10.dp))
+        SettingsToggleRow(
+            title = "Trailer Audio",
+            subtitle = "Enable sound for banners",
+            isEnabled = trailerAudioEnabled,
+            isFocused = focusedIndex == 9,
+            onToggle = onTrailerAudioToggle
+        )
+        Spacer(modifier = Modifier.height(10.dp))
         SettingsRow(
             icon = Icons.Default.Movie,
             title = "Match Frame Rate",
             subtitle = "Off, Seamless, or Always",
             value = frameRateMatchingMode,
-            isFocused = focusedIndex == 9,
+            isFocused = focusedIndex == 10,
             onClick = onFrameRateMatchingClick
         )
 
@@ -2250,7 +2265,7 @@ private fun GeneralSettings(
             title = "Card Layout",
             subtitle = "Landscape or poster cards",
             value = cardLayoutMode,
-            isFocused = focusedIndex == 10,
+            isFocused = focusedIndex == 11,
             onClick = onCardLayoutToggle
         )
         Spacer(modifier = Modifier.height(10.dp))
@@ -2264,7 +2279,7 @@ private fun GeneralSettings(
                 "phone" -> "Phone"
                 else -> "Auto"
             },
-            isFocused = focusedIndex == 11,
+            isFocused = focusedIndex == 12,
             onClick = onDeviceModeClick
         )
         Spacer(modifier = Modifier.height(10.dp))
@@ -2272,7 +2287,7 @@ private fun GeneralSettings(
             title = "Skip Profile Selection",
             subtitle = "Auto-load last used profile",
             isEnabled = skipProfileSelection,
-            isFocused = focusedIndex == 12,
+            isFocused = focusedIndex == 13,
             onToggle = onSkipProfileSelectionToggle
         )
 
@@ -2290,7 +2305,7 @@ private fun GeneralSettings(
             title = "DNS Provider",
             subtitle = "Resolve API and stream requests",
             value = dnsProvider,
-            isFocused = focusedIndex == 13,
+            isFocused = focusedIndex == 14,
             onClick = onDnsProviderClick
         )
     }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -76,6 +76,7 @@ data class SettingsUiState(
     val subtitleSize: String = "Medium",
     val subtitleColor: String = "White",
     val trailerAutoPlay: Boolean = false,
+    val trailerAudioEnabled: Boolean = false,
     val includeSpecials: Boolean = false,
     val isLoggedIn: Boolean = false,
     val accountEmail: String? = null,
@@ -177,6 +178,7 @@ class SettingsViewModel @Inject constructor(
     private fun autoPlayMinQualityKey() = profileManager.profileStringKey("auto_play_min_quality")
     private fun autoPlayMinQualityKeyFor(profileId: String) = profileManager.profileStringKeyFor(profileId, "auto_play_min_quality")
     private fun trailerAutoPlayKey() = profileManager.profileBooleanKey("trailer_auto_play")
+    private fun trailerAudioEnabledKey() = profileManager.profileBooleanKey("trailer_audio_enabled")
 
     private fun subtitleSizeKey() = profileManager.profileStringKey("subtitle_size")
     private fun subtitleColorKey() = profileManager.profileStringKey("subtitle_color")
@@ -264,6 +266,7 @@ class SettingsViewModel @Inject constructor(
             }
             val autoPlayMinQuality = normalizeAutoPlayMinQuality(prefs[autoPlayMinQualityKey()])
             val trailerAutoPlay = prefs[trailerAutoPlayKey()] ?: false
+            val trailerAudioEnabled = prefs[trailerAudioEnabledKey()] ?: false
 
             val subtitleSize = prefs[subtitleSizeKey()] ?: "Medium"
             val subtitleColor = prefs[subtitleColorKey()] ?: "White"
@@ -303,6 +306,7 @@ class SettingsViewModel @Inject constructor(
                 autoPlaySingleSource = autoPlaySingleSource,
                 autoPlayMinQuality = autoPlayMinQuality,
                 trailerAutoPlay = trailerAutoPlay,
+                trailerAudioEnabled = trailerAudioEnabled,
 
                 subtitleSize = subtitleSize,
                 subtitleColor = subtitleColor,
@@ -781,6 +785,10 @@ class SettingsViewModel @Inject constructor(
 
     fun setTrailerAutoPlay(enabled: Boolean) {
         viewModelScope.launch { context.settingsDataStore.edit { it[trailerAutoPlayKey()] = enabled }; _uiState.value = _uiState.value.copy(trailerAutoPlay = enabled); syncLocalStateToCloud(silent = true) }
+    }
+
+    fun setTrailerAudioEnabled(enabled: Boolean) {
+        viewModelScope.launch { context.settingsDataStore.edit { it[trailerAudioEnabledKey()] = enabled }; _uiState.value = _uiState.value.copy(trailerAudioEnabled = enabled); syncLocalStateToCloud(silent = true) }
     }
 
     fun cycleSubtitleSize() {


### PR DESCRIPTION
This PR introduces a new user preference that allows users to toggle the audio for trailers playing in the Home Screen Hero Banner.

By default, trailers will remain muted to ensure a non-intrusive experience, but users can now choose to enable sound via the settings menu.

Key Changes:

New Preference: Added trailer_audio_enabled to the local DataStore. This setting is profile-specific.
Settings UI: Added a new "Trailer Audio" toggle in the General Settings > Playback section.
Audio Control: Updated the TrailerPlayer component to support an isMuted parameter. When unmuted, the trailer plays at a comfortable 50% volume (0.5f).
State Propagation: Updated HomeViewModel to load the current audio preference and pass it through to the TrailerPlayer on the Home screen.
Files Modified:

SettingsViewModel.kt: Added logic to manage and persist the new setting.
SettingsScreen.kt: Added the toggle UI row and updated the GeneralSettings layout.
HomeViewModel.kt: Updated to load the setting for the home screen UI state.
HomeScreen.kt: Passes the user's preference down to the banner player.
TrailerPlayer.kt: Added support for muting/unmuting the background video.