### PR TITLE
Feature/adaptive card layout

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/components/AdaptiveMediaCard.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/AdaptiveMediaCard.kt
@@ -1,0 +1,181 @@
+package com.arflix.tv.ui.components
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.zIndex
+import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.Text
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import coil.size.Precision
+import com.arflix.tv.data.model.MediaItem
+import com.arflix.tv.ui.skin.ArvioFocusableSurface
+import com.arflix.tv.ui.skin.ArvioSkin
+import com.arflix.tv.ui.skin.rememberArvioCardShape
+import androidx.compose.animation.Crossfade
+import androidx.compose.foundation.layout.Spacer
+
+/**
+ * A hybrid card that expand from Poster to Landscape when focused.
+ * Mimics high-end streaming apps (like Netflix or Prime Video updates).
+ */
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+fun AdaptiveMediaCard(
+    item: MediaItem,
+    height: Dp = 190.dp, // Height is fixed to keep row steady
+    isFocusedOverride: Boolean = false,
+    onFocused: () -> Unit = {},
+    onClick: () -> Unit = {},
+    onLongClick: (() -> Unit)? = null,
+    modifier: Modifier = Modifier,
+) {
+    if (item.isPlaceholder) {
+        // Fallback to static placeholder for simplicity
+        Box(modifier = modifier.height(height).width(height * 0.66f).background(ArvioSkin.colors.surface))
+        return
+    }
+
+    val posterWidth = height * 0.68f // ~2:3 aspect
+    val landscapeWidth = height * 1.6f // ~16:10 aspect for better push effect
+
+    val width by animateDpAsState(
+        targetValue = if (isFocusedOverride) landscapeWidth else posterWidth,
+        animationSpec = tween(durationMillis = 350),
+        label = "adaptiveWidth"
+    )
+
+    val shape = rememberArvioCardShape(ArvioSkin.radius.md)
+    val context = LocalContext.current
+    val density = LocalDensity.current
+
+    // Pre-calculate image requests for both poster and backdrop
+    val posterRequest = remember(item.image, posterWidth) {
+        val wPx = with(density) { posterWidth.roundToPx() }
+        val hPx = with(density) { height.roundToPx() }
+        ImageRequest.Builder(context)
+            .data(item.image)
+            .size(wPx, hPx)
+            .precision(Precision.INEXACT)
+            .allowHardware(true)
+            .build()
+    }
+
+    val backdropRequest = remember(item.backdrop ?: item.image, landscapeWidth) {
+        val wPx = with(density) { landscapeWidth.roundToPx() }
+        val hPx = with(density) { height.roundToPx() }
+        ImageRequest.Builder(context)
+            .data(item.backdrop ?: item.image)
+            .size(wPx, hPx)
+            .precision(Precision.INEXACT)
+            .allowHardware(true)
+            .build()
+    }
+
+    Column(
+        modifier = modifier
+            .width(width)
+            .zIndex(if (isFocusedOverride) 10f else 1f)
+    ) {
+        ArvioFocusableSurface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(height),
+            shape = shape,
+            backgroundColor = ArvioSkin.colors.surface,
+            outlineColor = if (isFocusedOverride) ArvioSkin.colors.focusOutline else Color.Transparent,
+            outlineWidth = if (isFocusedOverride) 3.dp else 0.dp,
+            focusedScale = 1.0f, // Width animation handles the "expansion" feel
+            pressedScale = 0.98f,
+            isFocusedOverride = isFocusedOverride,
+            onClick = onClick,
+            onLongClick = onLongClick,
+            onFocusChanged = { if (it) onFocused() },
+        ) { _ ->
+            Box(modifier = Modifier.fillMaxSize()) {
+                // Crossfade between poster and landscape art based on focus
+                Crossfade(targetState = isFocusedOverride, label = "AdaptiveImage") { focused ->
+                    AsyncImage(
+                        model = if (focused) backdropRequest else posterRequest,
+                        contentDescription = item.title,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(ArvioSkin.colors.surface),
+                    )
+                }
+
+                // Gradient Overlay
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(
+                            Brush.verticalGradient(
+                                listOf(Color.Transparent, Color.Black.copy(alpha = 0.7f))
+                            )
+                        )
+                )
+
+                // Title overlay (only visible in landscape/focused state)
+                if (isFocusedOverride) {
+                    Column(
+                        modifier = Modifier
+                            .align(Alignment.BottomStart)
+                            .padding(12.dp)
+                    ) {
+                        Text(
+                            text = item.title,
+                            style = ArvioSkin.typography.cardTitle.copy(fontSize = 14.sp),
+                            color = Color.White,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        if (item.year.isNotBlank()) {
+                            Text(
+                                text = item.year,
+                                style = ArvioSkin.typography.caption.copy(fontSize = 10.sp),
+                                color = Color.White.copy(alpha = 0.7f)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        
+        // External label (fallback if not focused or if preferred)
+        if (!isFocusedOverride) {
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = item.title,
+                style = ArvioSkin.typography.caption.copy(fontSize = 11.sp),
+                color = ArvioSkin.colors.textMuted,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(horizontal = 4.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/arflix/tv/ui/components/CardLayoutMode.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/CardLayoutMode.kt
@@ -14,11 +14,13 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 
 enum class CardLayoutMode {
     LANDSCAPE,
-    POSTER
+    POSTER,
+    ADAPTIVE
 }
 
 const val CARD_LAYOUT_MODE_LANDSCAPE = "Landscape"
 const val CARD_LAYOUT_MODE_POSTER = "Poster"
+const val CARD_LAYOUT_MODE_ADAPTIVE = "Adaptive"
 
 private val cardLayoutModeKey = stringPreferencesKey("card_layout_mode")
 private val activeProfileIdKey = stringPreferencesKey("active_profile_id")
@@ -28,18 +30,19 @@ private fun profileCardLayoutModeKey(profileId: String): Preferences.Key<String>
 }
 
 fun normalizeCardLayoutMode(raw: String?): String {
-    return if (raw?.trim()?.equals(CARD_LAYOUT_MODE_POSTER, ignoreCase = true) == true) {
-        CARD_LAYOUT_MODE_POSTER
-    } else {
-        CARD_LAYOUT_MODE_LANDSCAPE
+    val r = raw?.trim()?.lowercase() ?: return CARD_LAYOUT_MODE_LANDSCAPE
+    return when (r) {
+        "poster" -> CARD_LAYOUT_MODE_POSTER
+        "adaptive" -> CARD_LAYOUT_MODE_ADAPTIVE
+        else -> CARD_LAYOUT_MODE_LANDSCAPE
     }
 }
 
 fun parseCardLayoutMode(raw: String?): CardLayoutMode {
-    return if (normalizeCardLayoutMode(raw) == CARD_LAYOUT_MODE_POSTER) {
-        CardLayoutMode.POSTER
-    } else {
-        CardLayoutMode.LANDSCAPE
+    return when (normalizeCardLayoutMode(raw)) {
+        CARD_LAYOUT_MODE_POSTER -> CardLayoutMode.POSTER
+        CARD_LAYOUT_MODE_ADAPTIVE -> CardLayoutMode.ADAPTIVE
+        else -> CardLayoutMode.LANDSCAPE
     }
 }
 

--- a/app/src/main/kotlin/com/arflix/tv/ui/components/TrailerPlayer.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/TrailerPlayer.kt
@@ -38,7 +38,8 @@ import kotlinx.coroutines.withContext
 fun TrailerPlayer(
     youtubeKey: String,
     modifier: Modifier = Modifier,
-    delayMs: Long = 3000L
+    delayMs: Long = 3000L,
+    isMuted: Boolean = true
 ) {
     val context = LocalContext.current
     var shouldPlay by remember { mutableStateOf(false) }
@@ -72,7 +73,7 @@ fun TrailerPlayer(
     ) {
         val player = remember(youtubeKey) {
             ExoPlayer.Builder(context).build().apply {
-                volume = 0.5f // Half volume for background trailer
+                volume = if (isMuted) 0f else 0.5f // Muted or half volume for background trailer
                 repeatMode = Player.REPEAT_MODE_ONE
                 playWhenReady = true
             }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
@@ -1922,7 +1922,7 @@ private fun HomeRowsLayer(
             focusState = focusState,
             contentStartPadding = contentStartPadding,
             fastScrollThresholdMs = fastScrollThresholdMs,
-            cardLayoutMode = cardLayoutModeState,
+            cardLayoutMode = cardLayoutMode,
             onItemClick = onItemClick
         )
     }
@@ -2315,6 +2315,7 @@ private fun ContentRow(
     val configuration = LocalConfiguration.current
     val density = LocalDensity.current
     val isContinueWatching = category.id == "continue_watching"
+    val usePosterCards = cardLayoutMode == CardLayoutMode.POSTER
     val itemWidth = when (cardLayoutMode) {
         CardLayoutMode.POSTER -> 125.dp
         CardLayoutMode.ADAPTIVE -> 125.dp // Base width is poster
@@ -2537,7 +2538,7 @@ private fun ContentRow(
                             ArvioMediaCard(
                                 item = item,
                                 width = rankedCardWidth,
-                                isLandscape = !usePosterCards,
+                                isLandscape = cardLayoutMode == CardLayoutMode.LANDSCAPE,
                                 logoImageUrl = cardLogoUrl,
                                 showProgress = false,
                                 showTitle = false,

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
@@ -556,6 +556,7 @@ fun HomeScreen(
             if (heroVideoUrl == null && uiState.trailerAutoPlay && uiState.heroTrailerKey != null) {
                 TrailerPlayer(
                     youtubeKey = uiState.heroTrailerKey!!,
+                    isMuted = !uiState.trailerAudioEnabled,
                     modifier = Modifier.fillMaxSize()
                 )
             }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
@@ -1864,7 +1864,6 @@ private fun HomeInputLayer(
             contentStartPadding = contentStartPadding,
             fastScrollThresholdMs = fastScrollThresholdMs,
             cardLayoutMode = cardLayoutMode,
-            usePosterCards = usePosterCards,
             isMobile = isMobile,
             heroItem = heroItem,
             heroOverviewOverride = heroOverviewOverride,

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
@@ -113,6 +113,7 @@ import com.arflix.tv.network.OkHttpProvider
 import com.arflix.tv.ui.components.MediaCard as ArvioMediaCard
 import com.arflix.tv.ui.components.TrailerPlayer
 import com.arflix.tv.ui.components.CardLayoutMode
+import com.arflix.tv.ui.components.AdaptiveMediaCard
 import com.arflix.tv.ui.components.AppTopBar
 import com.arflix.tv.ui.components.AppTopBarContentTopInset
 import com.arflix.tv.util.LocalDeviceType
@@ -249,7 +250,8 @@ fun HomeScreen(
     // Performance: Directly collect StateFlow instead of syncing to mutableStateMapOf
     // This avoids O(n) iteration on every logo cache update
     val cardLogoUrls by viewModel.cardLogoUrls.collectAsState()
-    val usePosterCards = rememberCardLayoutMode() == CardLayoutMode.POSTER
+    val cardLayoutMode = rememberCardLayoutMode()
+    val usePosterCards = cardLayoutMode == CardLayoutMode.POSTER
     val lifecycleOwner = LocalLifecycleOwner.current
     var suppressSelectUntilMs by remember { mutableLongStateOf(0L) }
 
@@ -581,6 +583,7 @@ fun HomeScreen(
             suppressSelectUntilMs = suppressSelectUntilMs,
             contentStartPadding = contentStartPadding,
             fastScrollThresholdMs = fastScrollThresholdMs,
+            cardLayoutMode = cardLayoutMode,
             usePosterCards = usePosterCards,
             isContextMenuOpen = showContextMenu,
             isMobile = isMobile,
@@ -1598,6 +1601,7 @@ private fun HomeInputLayer(
     suppressSelectUntilMs: Long,
     contentStartPadding: androidx.compose.ui.unit.Dp,
     fastScrollThresholdMs: Long,
+    cardLayoutMode: CardLayoutMode,
     usePosterCards: Boolean,
     isContextMenuOpen: Boolean,
     isMobile: Boolean = false,
@@ -1859,6 +1863,7 @@ private fun HomeInputLayer(
             focusState = focusState,
             contentStartPadding = contentStartPadding,
             fastScrollThresholdMs = fastScrollThresholdMs,
+            cardLayoutMode = cardLayoutMode,
             usePosterCards = usePosterCards,
             isMobile = isMobile,
             heroItem = heroItem,
@@ -1889,7 +1894,7 @@ private fun HomeRowsLayer(
     focusState: HomeFocusState,
     contentStartPadding: androidx.compose.ui.unit.Dp,
     fastScrollThresholdMs: Long,
-    usePosterCards: Boolean,
+    cardLayoutMode: CardLayoutMode,
     isMobile: Boolean = false,
     heroItem: MediaItem? = null,
     heroOverviewOverride: String? = null,
@@ -1899,6 +1904,7 @@ private fun HomeRowsLayer(
     onItemClick: (MediaItem) -> Unit,
     onItemLongClick: ((MediaItem, Boolean) -> Unit)? = null
 ) {
+    val usePosterCards = cardLayoutMode == CardLayoutMode.POSTER
     if (isMobile) {
         MobileHomeRowsLayer(
             categories = categories,
@@ -1916,7 +1922,7 @@ private fun HomeRowsLayer(
             focusState = focusState,
             contentStartPadding = contentStartPadding,
             fastScrollThresholdMs = fastScrollThresholdMs,
-            usePosterCards = usePosterCards,
+            cardLayoutMode = cardLayoutModeState,
             onItemClick = onItemClick
         )
     }
@@ -2058,7 +2064,7 @@ private fun TvHomeRowsLayer(
     focusState: HomeFocusState,
     contentStartPadding: androidx.compose.ui.unit.Dp,
     fastScrollThresholdMs: Long,
-    usePosterCards: Boolean,
+    cardLayoutMode: CardLayoutMode,
     onItemClick: (MediaItem) -> Unit
 ) {
     val currentRowIndex = focusState.currentRowIndex
@@ -2120,32 +2126,38 @@ private fun TvHomeRowsLayer(
                         animationSpec = tween(durationMillis = 300),
                         label = "homeRowAlpha"
                     ).value
-                    val rowHeight = if (usePosterCards) 240.dp else 190.dp
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(rowHeight)
-                            .clipToBounds()
-                            .graphicsLayer { alpha = rowAlpha }
-                    ) {
-                        ContentRow(
-                            category = category,
-                            cardLogoUrls = cardLogoUrls,
-                            isCurrentRow = !focusState.isSidebarFocused && index == focusState.currentRowIndex,
-                            isRanked = category.title.contains("Top 10", ignoreCase = true),
-                            usePosterCards = usePosterCards,
-                            startPadding = contentStartPadding,
-                            focusedItemIndex = if (!focusState.isSidebarFocused && index == focusState.currentRowIndex) focusState.currentItemIndex else -1,
-                            isFastScrolling = isFastScrolling,
-                            onItemClick = onItemClick,
-                            onItemFocused = { _, itemIdx ->
-                                focusState.currentRowIndex = index
-                                focusState.currentItemIndex = itemIdx
-                                focusState.isSidebarFocused = false
-                                focusState.lastNavEventTime = SystemClock.elapsedRealtime()
-                            }
-                        )
-                    }
+    val isAdaptive = cardLayoutMode == CardLayoutMode.ADAPTIVE
+    val usePosterCards = cardLayoutMode == CardLayoutMode.POSTER
+    val rowHeight = when {
+        isAdaptive -> 210.dp // Slightly taller for Adaptive titles
+        usePosterCards -> 240.dp 
+        else -> 190.dp
+    }
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(rowHeight)
+            .clipToBounds()
+            .graphicsLayer { alpha = rowAlpha }
+    ) {
+        ContentRow(
+            category = category,
+            cardLogoUrls = cardLogoUrls,
+            isCurrentRow = !focusState.isSidebarFocused && index == focusState.currentRowIndex,
+            isRanked = category.title.contains("Top 10", ignoreCase = true),
+            cardLayoutMode = cardLayoutMode,
+            startPadding = contentStartPadding,
+            focusedItemIndex = if (!focusState.isSidebarFocused && index == focusState.currentRowIndex) focusState.currentItemIndex else -1,
+            isFastScrolling = isFastScrolling,
+            onItemClick = onItemClick,
+            onItemFocused = { _, itemIdx ->
+                focusState.currentRowIndex = index
+                focusState.currentItemIndex = itemIdx
+                focusState.isSidebarFocused = false
+                focusState.lastNavEventTime = SystemClock.elapsedRealtime()
+            }
+        )
+    }
             }
             }
         }
@@ -2292,7 +2304,7 @@ private fun ContentRow(
     cardLogoUrls: Map<String, String>,
     isCurrentRow: Boolean,
     isRanked: Boolean = false,
-    usePosterCards: Boolean = false,
+    cardLayoutMode: CardLayoutMode = CardLayoutMode.LANDSCAPE,
     startPadding: androidx.compose.ui.unit.Dp = 12.dp,
     focusedItemIndex: Int,
     isFastScrolling: Boolean,
@@ -2303,7 +2315,11 @@ private fun ContentRow(
     val configuration = LocalConfiguration.current
     val density = LocalDensity.current
     val isContinueWatching = category.id == "continue_watching"
-    val itemWidth = if (usePosterCards) 125.dp else 210.dp
+    val itemWidth = when (cardLayoutMode) {
+        CardLayoutMode.POSTER -> 125.dp
+        CardLayoutMode.ADAPTIVE -> 125.dp // Base width is poster
+        else -> 210.dp
+    }
     val itemSpacing = 14.dp
     val availableWidthDp = configuration.screenWidthDp.dp - 56.dp - 12.dp
     val fallbackItemsPerPage = remember(configuration, density, itemWidth, itemSpacing) {
@@ -2532,13 +2548,22 @@ private fun ContentRow(
                             )
                         }
                     }
+                } else if (cardLayoutMode == CardLayoutMode.ADAPTIVE) {
+                    val cardLogoUrl = cardLogoUrls["${item.mediaType}_${item.id}"]
+                    AdaptiveMediaCard(
+                        item = item,
+                        height = 180.dp, // Matches base poster height well
+                        isFocusedOverride = itemIsFocused,
+                        onFocused = { onItemFocused(item, index) },
+                        onClick = { onItemClick(item) },
+                    )
                 } else {
                     // Standard Card - keep width aligned with scroll math
                     val cardLogoUrl = cardLogoUrls["${item.mediaType}_${item.id}"]
                     ArvioMediaCard(
                         item = item,
                         width = itemWidth,
-                        isLandscape = !usePosterCards,
+                        isLandscape = cardLayoutMode == CardLayoutMode.LANDSCAPE,
                         logoImageUrl = cardLogoUrl,
                         showProgress = isContinueWatching,
                         showTitle = false,

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
@@ -66,6 +66,7 @@ data class HomeUiState(
     val heroLogoUrl: String? = null,
     val heroTrailerKey: String? = null,
     val trailerAutoPlay: Boolean = false,
+    val trailerAudioEnabled: Boolean = false,
     val heroOverviewOverride: String? = null,
     val cardLogoUrls: Map<String, String> = emptyMap(),
     // Previous hero for crossfade (Phase 2.1)
@@ -648,7 +649,13 @@ class HomeViewModel @Inject constructor(
                 val trailerEnabled = prefs.asMap().any { (key, value) ->
                     key.name.endsWith("_trailer_auto_play") && value == true
                 }
-                _uiState.value = _uiState.value.copy(trailerAutoPlay = trailerEnabled)
+                val trailerAudio = prefs.asMap().any { (key, value) ->
+                    key.name.endsWith("_trailer_audio_enabled") && value == true
+                }
+                _uiState.value = _uiState.value.copy(
+                    trailerAutoPlay = trailerEnabled,
+                    trailerAudioEnabled = trailerAudio
+                )
             } catch (_: Exception) {}
         }
         // Restore logo URL cache from disk for instant clearlogos on cold start

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -2262,9 +2262,9 @@ private fun GeneralSettings(
         SettingsRow(
             icon = Icons.Default.Widgets,
             title = "Card Layout",
-            subtitle = "Landscape or poster cards",
+            subtitle = "Landscape, Poster, or Adaptive",
             value = cardLayoutMode,
-            isFocused = focusedIndex == 10,
+            isFocused = focusedIndex == 11,
             onClick = onCardLayoutToggle
         )
         Spacer(modifier = Modifier.height(10.dp))
@@ -2278,7 +2278,7 @@ private fun GeneralSettings(
                 "phone" -> "Phone"
                 else -> "Auto"
             },
-            isFocused = focusedIndex == 11,
+            isFocused = focusedIndex == 12,
             onClick = onDeviceModeClick
         )
         Spacer(modifier = Modifier.height(10.dp))
@@ -2286,7 +2286,7 @@ private fun GeneralSettings(
             title = "Skip Profile Selection",
             subtitle = "Auto-load last used profile",
             isEnabled = skipProfileSelection,
-            isFocused = focusedIndex == 12,
+            isFocused = focusedIndex == 13,
             onToggle = onSkipProfileSelectionToggle
         )
 
@@ -2304,7 +2304,7 @@ private fun GeneralSettings(
             title = "DNS Provider",
             subtitle = "Resolve API and stream requests",
             value = dnsProvider,
-            isFocused = focusedIndex == 13,
+            isFocused = focusedIndex == 14,
             onClick = onDnsProviderClick
         )
     }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -625,7 +625,9 @@ fun SettingsScreen(
                             onAutoPlaySingleSourceToggle = { viewModel.setAutoPlaySingleSource(it) },
                             onAutoPlayMinQualityClick = { viewModel.cycleAutoPlayMinQuality() },
                             trailerAutoPlay = uiState.trailerAutoPlay,
+                            trailerAudioEnabled = uiState.trailerAudioEnabled,
                             onTrailerAutoPlayToggle = { viewModel.setTrailerAutoPlay(it) },
+                            onTrailerAudioToggle = { viewModel.setTrailerAudioEnabled(it) },
                             onDeviceModeClick = {
                                 val next = when (uiState.deviceModeOverride) { "auto" -> "tv"; "tv" -> "tablet"; "tablet" -> "phone"; else -> "auto" }
                                 viewModel.setDeviceModeOverride(next)
@@ -797,7 +799,9 @@ fun SettingsScreen(
                             onAutoPlaySingleSourceToggle = { viewModel.setAutoPlaySingleSource(it) },
                             onAutoPlayMinQualityClick = { viewModel.cycleAutoPlayMinQuality() },
                             trailerAutoPlay = uiState.trailerAutoPlay,
+                            trailerAudioEnabled = uiState.trailerAudioEnabled,
                             onTrailerAutoPlayToggle = { viewModel.setTrailerAutoPlay(it) },
+                            onTrailerAudioToggle = { viewModel.setTrailerAudioEnabled(it) },
                             onDeviceModeClick = {
                                 val next = when (uiState.deviceModeOverride) { "auto" -> "tv"; "tv" -> "tablet"; "tablet" -> "phone"; else -> "auto" }
                                 viewModel.setDeviceModeOverride(next)
@@ -2127,9 +2131,11 @@ private fun GeneralSettings(
     onContentLanguageClick: () -> Unit = {},
     onSkipProfileSelectionToggle: (Boolean) -> Unit = {},
     trailerAutoPlay: Boolean = false,
+    trailerAudioEnabled: Boolean = false,
     onSubtitleSizeClick: () -> Unit = {},
     onSubtitleColorClick: () -> Unit = {},
-    onTrailerAutoPlayToggle: (Boolean) -> Unit = {}
+    onTrailerAutoPlayToggle: (Boolean) -> Unit = {},
+    onTrailerAudioToggle: (Boolean) -> Unit = {}
 ) {
     Column {
         // ── Language & Subtitles ──
@@ -2227,12 +2233,20 @@ private fun GeneralSettings(
             onToggle = onTrailerAutoPlayToggle
         )
         Spacer(modifier = Modifier.height(10.dp))
+        SettingsToggleRow(
+            title = "Trailer Audio",
+            subtitle = "Enable sound for banners",
+            isEnabled = trailerAudioEnabled,
+            isFocused = focusedIndex == 9,
+            onToggle = onTrailerAudioToggle
+        )
+        Spacer(modifier = Modifier.height(10.dp))
         SettingsRow(
             icon = Icons.Default.Movie,
             title = "Match Frame Rate",
             subtitle = "Off, Seamless, or Always",
             value = frameRateMatchingMode,
-            isFocused = focusedIndex == 9,
+            isFocused = focusedIndex == 10,
             onClick = onFrameRateMatchingClick
         )
 

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -31,6 +31,8 @@ import com.arflix.tv.data.repository.SyncProgress
 import com.arflix.tv.data.repository.SyncStatus
 import com.arflix.tv.data.repository.SyncResult
 import com.arflix.tv.ui.components.CARD_LAYOUT_MODE_LANDSCAPE
+import com.arflix.tv.ui.components.CARD_LAYOUT_MODE_POSTER
+import com.arflix.tv.ui.components.CARD_LAYOUT_MODE_ADAPTIVE
 import com.arflix.tv.ui.components.normalizeCardLayoutMode
 import com.arflix.tv.updater.ApkDownloader
 import com.arflix.tv.updater.ApkInstaller

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -693,10 +693,11 @@ class SettingsViewModel @Inject constructor(
     }
 
     fun toggleCardLayoutMode() {
-        val next = if (_uiState.value.cardLayoutMode.equals("Poster", ignoreCase = true)) {
-            CARD_LAYOUT_MODE_LANDSCAPE
-        } else {
-            "Poster"
+        val current = normalizeCardLayoutMode(_uiState.value.cardLayoutMode)
+        val next = when (current) {
+            CARD_LAYOUT_MODE_LANDSCAPE -> CARD_LAYOUT_MODE_POSTER
+            CARD_LAYOUT_MODE_POSTER -> CARD_LAYOUT_MODE_ADAPTIVE
+            else -> CARD_LAYOUT_MODE_LANDSCAPE
         }
         setCardLayoutMode(next)
     }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -76,6 +76,7 @@ data class SettingsUiState(
     val subtitleSize: String = "Medium",
     val subtitleColor: String = "White",
     val trailerAutoPlay: Boolean = false,
+    val trailerAudioEnabled: Boolean = false,
     val includeSpecials: Boolean = false,
     val isLoggedIn: Boolean = false,
     val accountEmail: String? = null,
@@ -177,6 +178,7 @@ class SettingsViewModel @Inject constructor(
     private fun autoPlayMinQualityKey() = profileManager.profileStringKey("auto_play_min_quality")
     private fun autoPlayMinQualityKeyFor(profileId: String) = profileManager.profileStringKeyFor(profileId, "auto_play_min_quality")
     private fun trailerAutoPlayKey() = profileManager.profileBooleanKey("trailer_auto_play")
+    private fun trailerAudioEnabledKey() = profileManager.profileBooleanKey("trailer_audio_enabled")
 
     private fun subtitleSizeKey() = profileManager.profileStringKey("subtitle_size")
     private fun subtitleColorKey() = profileManager.profileStringKey("subtitle_color")
@@ -264,6 +266,7 @@ class SettingsViewModel @Inject constructor(
             }
             val autoPlayMinQuality = normalizeAutoPlayMinQuality(prefs[autoPlayMinQualityKey()])
             val trailerAutoPlay = prefs[trailerAutoPlayKey()] ?: false
+            val trailerAudioEnabled = prefs[trailerAudioEnabledKey()] ?: false
 
             val subtitleSize = prefs[subtitleSizeKey()] ?: "Medium"
             val subtitleColor = prefs[subtitleColorKey()] ?: "White"
@@ -303,6 +306,7 @@ class SettingsViewModel @Inject constructor(
                 autoPlaySingleSource = autoPlaySingleSource,
                 autoPlayMinQuality = autoPlayMinQuality,
                 trailerAutoPlay = trailerAutoPlay,
+                trailerAudioEnabled = trailerAudioEnabled,
 
                 subtitleSize = subtitleSize,
                 subtitleColor = subtitleColor,
@@ -781,6 +785,10 @@ class SettingsViewModel @Inject constructor(
 
     fun setTrailerAutoPlay(enabled: Boolean) {
         viewModelScope.launch { context.settingsDataStore.edit { it[trailerAutoPlayKey()] = enabled }; _uiState.value = _uiState.value.copy(trailerAutoPlay = enabled); syncLocalStateToCloud(silent = true) }
+    }
+
+    fun setTrailerAudioEnabled(enabled: Boolean) {
+        viewModelScope.launch { context.settingsDataStore.edit { it[trailerAudioEnabledKey()] = enabled }; _uiState.value = _uiState.value.copy(trailerAudioEnabled = enabled); syncLocalStateToCloud(silent = true) }
     }
 
     fun cycleSubtitleSize() {


### PR DESCRIPTION
Description: This PR introduces a premium "Adaptive" card layout mode for the Android TV home screen.

Adaptive Expansion: Posters (2:3) smoothly expand into Landscape (16:9) backdrops when focused.
Asset Logic: Implements crossfade between Poster and Backdrop art during expansion.
UI UX: Adds contextual metadata (title/year) that appears only on the focused card.
Settings: Integrates a new toggle choice in Interface settings and fixes D-pad navigation indices.