### PR TITLE
fix: in-app updater downloads but never installs (#116, #99, #75)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -99,6 +99,22 @@
                 android:resource="@xml/file_paths" />
         </provider>
 
+        <!--
+          PackageInstaller session callback receiver for the in-app APK updater.
+          Without this receiver, STATUS_PENDING_USER_ACTION callbacks from the system
+          installer are dropped and the install never actually happens — which was the
+          root cause of issues #116, #99, #75 where the updater downloaded but never
+          installed the APK on Android 7+ devices.
+          The action is scoped to ${applicationId} so it's unique per flavor/install.
+        -->
+        <receiver
+            android:name=".updater.ApkInstallReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="${applicationId}.INSTALL_COMPLETE" />
+            </intent-filter>
+        </receiver>
+
     </application>
 
 </manifest>

--- a/app/src/main/kotlin/com/arflix/tv/updater/ApkInstallReceiver.kt
+++ b/app/src/main/kotlin/com/arflix/tv/updater/ApkInstallReceiver.kt
@@ -1,0 +1,110 @@
+package com.arflix.tv.updater
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageInstaller
+import android.os.Build
+import android.util.Log
+import android.widget.Toast
+
+/**
+ * Handles PackageInstaller session callbacks for the in-app APK updater.
+ *
+ * The Android [PackageInstaller] session API requires user confirmation for non-privileged
+ * apps. It delivers the result by firing the supplied PendingIntent with
+ * [PackageInstaller.EXTRA_STATUS] == [PackageInstaller.STATUS_PENDING_USER_ACTION] and an
+ * [Intent.EXTRA_INTENT] containing the system install-confirmation Activity. Without a
+ * receiver to pick that up and start the confirm Activity, the "Installing update..." flow
+ * hangs forever and no install ever happens — which is exactly what was reported in
+ * issues #116, #99, and #75 for versions 1.9.3 through 1.9.73.
+ */
+class ApkInstallReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val status = intent.getIntExtra(PackageInstaller.EXTRA_STATUS, -999)
+        val message = intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE)
+
+        when (status) {
+            PackageInstaller.STATUS_PENDING_USER_ACTION -> {
+                // The system needs user confirmation — launch the confirm Activity.
+                val confirmIntent: Intent? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    intent.getParcelableExtra(Intent.EXTRA_INTENT, Intent::class.java)
+                } else {
+                    @Suppress("DEPRECATION")
+                    intent.getParcelableExtra(Intent.EXTRA_INTENT)
+                }
+
+                if (confirmIntent == null) {
+                    Log.e(TAG, "STATUS_PENDING_USER_ACTION without EXTRA_INTENT — cannot prompt user.")
+                    return
+                }
+
+                confirmIntent.addFlags(
+                    Intent.FLAG_ACTIVITY_NEW_TASK or
+                        Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                        Intent.FLAG_GRANT_READ_URI_PERMISSION
+                )
+
+                try {
+                    context.startActivity(confirmIntent)
+                } catch (e: Exception) {
+                    // Some Android TV forks (particularly Chinese AOSP variants) don't
+                    // handle the system confirm intent correctly. Log but don't crash.
+                    Log.e(TAG, "Failed to launch install confirmation Activity: ${e.message}", e)
+                    showToast(context, "Update install requires manual confirmation. Please install from Downloads.")
+                }
+            }
+
+            PackageInstaller.STATUS_SUCCESS -> {
+                Log.i(TAG, "Update installed successfully.")
+                // No toast needed — the new APK is installing/replacing the running process.
+            }
+
+            PackageInstaller.STATUS_FAILURE,
+            PackageInstaller.STATUS_FAILURE_ABORTED,
+            PackageInstaller.STATUS_FAILURE_BLOCKED,
+            PackageInstaller.STATUS_FAILURE_CONFLICT,
+            PackageInstaller.STATUS_FAILURE_INCOMPATIBLE,
+            PackageInstaller.STATUS_FAILURE_INVALID,
+            PackageInstaller.STATUS_FAILURE_STORAGE -> {
+                Log.e(TAG, "Update install failed: status=$status message=$message")
+                val userMessage = when (status) {
+                    PackageInstaller.STATUS_FAILURE_ABORTED -> "Update cancelled."
+                    PackageInstaller.STATUS_FAILURE_BLOCKED -> "Update blocked by system policy."
+                    PackageInstaller.STATUS_FAILURE_CONFLICT -> "Update conflicts with installed version. Try uninstalling first."
+                    PackageInstaller.STATUS_FAILURE_INCOMPATIBLE -> "Update not compatible with this device."
+                    PackageInstaller.STATUS_FAILURE_INVALID -> "Update package is invalid or corrupted."
+                    PackageInstaller.STATUS_FAILURE_STORAGE -> "Not enough storage to install update."
+                    else -> message ?: "Update install failed."
+                }
+                showToast(context, userMessage)
+            }
+
+            else -> {
+                Log.w(TAG, "Unexpected PackageInstaller status=$status message=$message")
+            }
+        }
+    }
+
+    private fun showToast(context: Context, text: String) {
+        try {
+            Toast.makeText(context.applicationContext, text, Toast.LENGTH_LONG).show()
+        } catch (_: Exception) {
+            // Receiver may not have a main looper in some paths; swallow silently.
+        }
+    }
+
+    companion object {
+        private const val TAG = "ApkInstallReceiver"
+
+        /**
+         * The broadcast action used for PackageInstaller session callbacks. Derived from the
+         * applicationId at runtime so it's unique per build flavor (e.g. `.staging`) and
+         * cannot collide with other installs of ARVIO on the same device.
+         */
+        fun actionFor(context: Context): String {
+            return "${context.packageName}.INSTALL_COMPLETE"
+        }
+    }
+}

--- a/app/src/main/kotlin/com/arflix/tv/updater/ApkInstaller.kt
+++ b/app/src/main/kotlin/com/arflix/tv/updater/ApkInstaller.kt
@@ -120,11 +120,19 @@ object ApkInstaller {
 
                 // Use a broadcast PendingIntent instead of activity — works reliably
                 // on Android TV where the Application context isn't an Activity.
-                val intent = Intent("com.arvio.tv.INSTALL_COMPLETE")
+                // The action is per-applicationId so it's unique per flavor / install.
+                // ApkInstallReceiver (registered in the manifest) picks up the callback and
+                // launches the system install-confirmation Activity on STATUS_PENDING_USER_ACTION,
+                // without which the session commit succeeds silently but no install ever happens.
+                val intent = Intent(ApkInstallReceiver.actionFor(context))
                     .setPackage(context.packageName)
-                val pendingIntent = PendingIntent.getBroadcast(
-                    context, sessionId, intent,
+                val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                     PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+                } else {
+                    PendingIntent.FLAG_UPDATE_CURRENT
+                }
+                val pendingIntent = PendingIntent.getBroadcast(
+                    context.applicationContext, sessionId, intent, flags
                 )
 
                 session.commit(pendingIntent.intentSender)
@@ -135,13 +143,17 @@ object ApkInstaller {
             }
         }
 
-        // Fallback: classic ACTION_VIEW install
-        val uri = FileProvider.getUriForFile(context, "${BuildConfig.APPLICATION_ID}.fileprovider", apkFile)
-        val intent = Intent(Intent.ACTION_VIEW)
-            .setDataAndType(uri, "application/vnd.android.package-archive")
-            .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        // Fallback: classic ACTION_VIEW install (used when the session path throws OR on API < 21).
+        try {
+            val uri = FileProvider.getUriForFile(context, "${BuildConfig.APPLICATION_ID}.fileprovider", apkFile)
+            val intent = Intent(Intent.ACTION_VIEW)
+                .setDataAndType(uri, "application/vnd.android.package-archive")
+                .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
 
-        context.startActivity(intent)
+            context.startActivity(intent)
+        } catch (e: Exception) {
+            System.err.println("[ApkInstaller] Fallback ACTION_VIEW install failed: ${e.message}")
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the long-standing in-app updater bug where the APK downloads successfully but the install screen never appears. Reported multiple times across versions 1.9.3 - 1.9.73:

- Closes #116 (Still broken on 1.9.73)
- Closes #99 (In app updater does not work)
- Closes #75 (Still Exists In-App Updater Issue)

## Root cause

PR #95 switched the `PackageInstaller` session callback from `getActivity` to `getBroadcast` against the action `com.arvio.tv.INSTALL_COMPLETE`, but **no `BroadcastReceiver` was ever registered for that action** anywhere in the project (verified by grep — the only reference was the `Intent(...)` construction in `ApkInstaller.kt:123`).

On Android 7+ the `PackageInstaller` session API requires user confirmation for non-privileged apps. It delivers the result by firing the supplied `PendingIntent` with:

- `EXTRA_STATUS` == `STATUS_PENDING_USER_ACTION`, and
- `EXTRA_INTENT` containing the system install-confirmation `Activity` the app **must** `startActivity()` to actually show the "Install?" screen.

With no receiver, the session commit succeeded silently, the callback went nowhere, and users saw the "Installing update..." toast followed by nothing. The APK sat in cache and the old process kept running.

## Changes

1. **New `ApkInstallReceiver`** (`app/src/main/kotlin/com/arflix/tv/updater/ApkInstallReceiver.kt`) that handles:
   - `STATUS_PENDING_USER_ACTION` → extracts `EXTRA_INTENT`, adds `FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_CLEAR_TOP | FLAG_GRANT_READ_URI_PERMISSION`, and `startActivity()`s the confirm screen.
   - `STATUS_SUCCESS` → logs (no toast, the new APK is replacing the running process).
   - All `STATUS_FAILURE_*` values → logs and shows a user-friendly toast explaining what went wrong (storage, conflict, incompatible, blocked, aborted, invalid, etc.).
   - Wraps `startActivity` in `try/catch` so Chinese Android TV forks whose non-AOSP installer doesn't handle the standard confirm intent degrade gracefully with a user message instead of crashing.

2. **Register the receiver in `AndroidManifest.xml`** with `android:exported="false"` and an intent filter using `${applicationId}.INSTALL_COMPLETE`. The `${applicationId}` template variable means the action is unique per build flavor (`play`, `sideload`, `.staging`), so the receiver can't collide with other ARVIO installs on the same device.

3. **Fix `ApkInstaller.launchInstall`**:
   - Derive the broadcast action from `context.packageName` at runtime via `ApkInstallReceiver.actionFor(context)`, replacing the hard-coded `com.arvio.tv.INSTALL_COMPLETE` string that was wrong for the `.staging` build flavor.
   - Use `context.applicationContext` when constructing the `PendingIntent` so it outlives the calling Activity.
   - Only set `PendingIntent.FLAG_MUTABLE` on API 31+ (has no effect on older APIs but avoids the lint warning and documents intent).
   - Wrap the `ACTION_VIEW` fallback path in `try/catch` so it no longer crashes on forks that reject the `application/vnd.android.package-archive` mime type.

## Testing

- Unit-testable paths: all new logic is in `ApkInstallReceiver.onReceive`, which can be driven by constructing `Intent` fixtures with each status value.
- Manual test plan (requires two sideload-flavor APK builds on a real Android TV device or phone):
  1. Install the older version.
  2. Install this build as the "current" version.
  3. Publish a newer sideload APK.
  4. Trigger the in-app update from Settings.
  5. Verify the system "Install?" confirmation dialog actually appears.
  6. Tap Install and verify the app updates.

## Risk

Low. The session-based path was already the default; this PR only fixes its broken callback handling. The fallback `ACTION_VIEW` path is unchanged except for defensive `try/catch` wrapping. No behavior change for users on Android <7 (where `PackageInstaller` session path is already skipped).

The action rename from `com.arvio.tv.INSTALL_COMPLETE` → `${applicationId}.INSTALL_COMPLETE` is safe because the only sender (`ApkInstaller.launchInstall`) and the only receiver (`ApkInstallReceiver`) are both updated in lockstep in this PR.
