### PR TITLE
fix: focus first unwatched episode in details view (#117)

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
@@ -490,10 +490,20 @@ class DetailsViewModel @Inject constructor(
                         }
 
                         val targetEpisodeForRow = if (initialSeason == seasonToLoad) initialEpisode else null
-                        val initialEpisodeIndex = if (targetEpisodeForRow != null) {
-                            decoratedEpisodes.indexOfFirst { it.episodeNumber == targetEpisodeForRow }.coerceAtLeast(0)
-                        } else 0
                         val nextUnwatchedEpisode = decoratedEpisodes.firstOrNull { !it.isWatched }
+                        // Focus the explicit target episode if the caller passed one (deeplink /
+                        // Continue Watching tile), otherwise focus the first unwatched episode so
+                        // users don't have to scroll past every episode they've already seen.
+                        // When every episode in the current season is watched we fall back to
+                        // the first episode (index 0) — from there the user can jump to the next
+                        // season via the season selector. See issue #117.
+                        val initialEpisodeIndex = when {
+                            targetEpisodeForRow != null ->
+                                decoratedEpisodes.indexOfFirst { it.episodeNumber == targetEpisodeForRow }.coerceAtLeast(0)
+                            nextUnwatchedEpisode != null ->
+                                decoratedEpisodes.indexOf(nextUnwatchedEpisode).coerceAtLeast(0)
+                            else -> 0
+                        }
                         val hasWatchedEpisodes = decoratedEpisodes.any { it.isWatched }
                         updateState { state ->
                             val shouldUseEpisodeTarget = !hasExplicitEpisodeTarget &&


### PR DESCRIPTION
## Summary

Closes #117.

In the episode list on the details screen, the first unwatched episode is now focused by default instead of always focusing episode 1. Particularly valuable for long-running shows/anime where users had to scroll past everything they had already watched.

## Root cause

`DetailsViewModel.loadDetails()` computes `nextUnwatchedEpisode` on line 496 and uses it for the play button label ("Continue S1E3"), but `initialEpisodeIndex` at line 493-495 always defaulted to `0` when the caller did not pass an explicit episode target (which is the normal case for navigation from the home grid, search, catalogs, etc. — only Continue Watching tiles pass a target episode).

## Fix

Replaced the `if/else 0` with a three-way `when`:

```kotlin
val initialEpisodeIndex = when {
    targetEpisodeForRow != null ->
        decoratedEpisodes.indexOfFirst { it.episodeNumber == targetEpisodeForRow }.coerceAtLeast(0)
    nextUnwatchedEpisode != null ->
        decoratedEpisodes.indexOf(nextUnwatchedEpisode).coerceAtLeast(0)
    else -> 0
}
```

The watched-status decoration already runs a few lines earlier (pulls from Trakt for linked users via `traktRepository.getWatchedEpisodesForShow(mediaId)`, falls back to local season progress otherwise), so this reuses existing data with zero extra network calls or work.

## Edge cases handled

- **Explicit target from Continue Watching**: unchanged behavior — the user still lands on the exact episode they were watching.
- **Fully watched season**: `nextUnwatchedEpisode` is `null`, falls back to index 0 (episode 1). User can use the season selector to jump forward.
- **Brand new show (nothing watched)**: `nextUnwatchedEpisode` is episode 1, `indexOf(...)` returns 0, same as the old default.
- **Switching seasons on an already-loaded show**: the `LaunchedEffect` in `DetailsScreen.kt:268` keys on `(initialEpisodeIndex, episodes)` — both change when a new season loads, so the new focus index is picked up correctly.
- **Index-0 re-sync guard**: `DetailsScreen.kt:269` only re-syncs when `initialEpisodeIndex > 0`. When my fix returns 0, the screen-level `episodeIndex` default is also 0, so no re-sync is needed. No behavior change for shows where episode 1 is unwatched.

## Risk

Minimal. Single-file, 13-line change. Reuses existing watched-episode data. No new network calls, no new allocations on a hot path.
