### PR TITLE
feat: post-episode Up Next prompt + honor autoPlayNext setting (#86)

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -128,6 +128,7 @@ import com.arflix.tv.data.model.MediaType
 import com.arflix.tv.data.model.StreamSource
 import com.arflix.tv.data.model.Subtitle
 import com.arflix.tv.ui.components.LoadingIndicator
+import com.arflix.tv.ui.components.NextEpisodeOverlay
 import com.arflix.tv.ui.components.StreamSelector
 import com.arflix.tv.ui.components.WaveLoadingDots
 import androidx.compose.ui.text.style.TextOverflow
@@ -244,6 +245,16 @@ fun PlayerScreen(
     var focusedButton by remember { mutableIntStateOf(0) }
     var showSubtitleMenu by remember { mutableStateOf(false) }
     var showSourceMenu by remember { mutableStateOf(false) }
+    // Post-episode "Up Next" prompt (issue #86). Shown on STATE_ENDED for TV shows:
+    // a 10-second countdown lets the user Cancel or immediately Continue. On timeout we
+    // advance to the next episode. Gated on the existing autoPlayNext profile setting —
+    // when disabled we simply stay on the ended frame rather than advancing silently.
+    var showNextEpisodePrompt by remember { mutableStateOf(false) }
+    var pendingNextSeason by remember { mutableIntStateOf(0) }
+    var pendingNextEpisode by remember { mutableIntStateOf(0) }
+    var pendingNextAddonId by remember { mutableStateOf<String?>(null) }
+    var pendingNextSourceName by remember { mutableStateOf<String?>(null) }
+    var pendingNextBingeGroup by remember { mutableStateOf<String?>(null) }
     var playerResizeMode by remember { mutableIntStateOf(AspectRatioFrameLayout.RESIZE_MODE_FIT) }
     var subtitleMenuIndex by remember { mutableIntStateOf(0) }
     var subtitleMenuTab by remember { mutableIntStateOf(0) } // 0 = Subtitles, 1 = Audio
@@ -1247,17 +1258,26 @@ fun PlayerScreen(
 
             }
 
-            // Auto-play next episode when current one ends
-            if (exoPlayer.playbackState == Player.STATE_ENDED && mediaType == MediaType.TV) {
-                if (seasonNumber != null && episodeNumber != null) {
+            // Post-episode prompt: when a TV episode ends, show the "Up Next" overlay with a
+            // 10-second countdown that auto-advances (or lets the user cancel / continue
+            // immediately). Gated on the profile's autoPlayNext setting — when disabled we
+            // stay on the ended frame rather than silently advancing. Only trigger once per
+            // session (showNextEpisodePrompt guard) to avoid re-triggering on tick loops.
+            if (exoPlayer.playbackState == Player.STATE_ENDED &&
+                mediaType == MediaType.TV &&
+                !showNextEpisodePrompt &&
+                !showSourceMenu &&
+                !showSubtitleMenu &&
+                uiState.error == null
+            ) {
+                if (seasonNumber != null && episodeNumber != null && uiState.autoPlayNext) {
                     val selected = uiState.selectedStream
-                    onPlayNext(
-                        seasonNumber,
-                        episodeNumber + 1,
-                        selected?.addonId?.takeIf { it.isNotBlank() },
-                        selected?.source?.takeIf { it.isNotBlank() },
-                        selected?.behaviorHints?.bingeGroup?.takeIf { it.isNotBlank() }
-                    )
+                    pendingNextSeason = seasonNumber
+                    pendingNextEpisode = episodeNumber + 1
+                    pendingNextAddonId = selected?.addonId?.takeIf { it.isNotBlank() }
+                    pendingNextSourceName = selected?.source?.takeIf { it.isNotBlank() }
+                    pendingNextBingeGroup = selected?.behaviorHints?.bingeGroup?.takeIf { it.isNotBlank() }
+                    showNextEpisodePrompt = true
                 }
             }
 
@@ -1305,8 +1325,8 @@ fun PlayerScreen(
     }
 
     // Request focus on the container when not showing controls
-    LaunchedEffect(showControls, showSubtitleMenu, showSourceMenu, uiState.error) {
-        if (!showControls && !showSubtitleMenu && !showSourceMenu && uiState.error == null) {
+    LaunchedEffect(showControls, showSubtitleMenu, showSourceMenu, showNextEpisodePrompt, uiState.error) {
+        if (!showControls && !showSubtitleMenu && !showSourceMenu && !showNextEpisodePrompt && uiState.error == null) {
             delay(100)
             try {
                 containerFocusRequester.requestFocus()
@@ -2148,6 +2168,39 @@ fun PlayerScreen(
                     delay(150)
                     runCatching { sourceButtonFocusRequester.requestFocus() }
                 }
+            }
+        )
+
+        // Post-episode "Up Next" prompt (issue #86). Shown when a TV episode ends and
+        // autoPlayNext is enabled. 10-second countdown auto-advances, or the user can
+        // hit Enter to continue immediately or Back/Escape/Close to cancel and stay on
+        // the ended frame. Placed after StreamSelector so it renders above the player
+        // but below any error/source overlays that might appear simultaneously.
+        NextEpisodeOverlay(
+            isVisible = showNextEpisodePrompt,
+            showTitle = uiState.title,
+            // We only know the current episode's title at this point; fetching the next
+            // episode's metadata would require an extra TMDB round-trip during playback.
+            // Fall back to a generic "Episode N" label — the show title, S/E number, and
+            // backdrop image still give users enough context to decide Continue/Cancel.
+            episodeTitle = "Episode $pendingNextEpisode",
+            seasonNumber = pendingNextSeason,
+            episodeNumber = pendingNextEpisode,
+            episodeImage = uiState.backdropUrl,
+            countdownSeconds = 10,
+            onPlayNext = {
+                showNextEpisodePrompt = false
+                onPlayNext(
+                    pendingNextSeason,
+                    pendingNextEpisode,
+                    pendingNextAddonId,
+                    pendingNextSourceName,
+                    pendingNextBingeGroup
+                )
+            },
+            onCancel = {
+                showNextEpisodePrompt = false
+                // Stay on the ended frame — user can hit Back to leave the player.
             }
         )
 

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
@@ -60,6 +60,10 @@ data class PlayerUiState(
     val subtitleColor: String = "White",
     val error: String? = null,
     val isSetupError: Boolean = false, // true when error is due to missing addons (shows friendly guide instead of red error)
+    // Auto-play next episode at end of current one. Mirrors the profile-scoped
+    // "auto_play_next" DataStore setting so the player can respect the toggle
+    // and so the post-episode overlay can show a Continue/Cancel prompt.
+    val autoPlayNext: Boolean = true,
     // Skip intro/recap
     val activeSkipInterval: SkipInterval? = null,
     val skipIntervalDismissed: Boolean = false
@@ -177,13 +181,15 @@ class PlayerViewModel @Inject constructor(
             val frameRateMatchingMode = resolveFrameRateMatchingMode()
             val subSize = context.settingsDataStore.data.first()[profileManager.profileStringKey("subtitle_size")] ?: "Medium"
             val subColor = context.settingsDataStore.data.first()[profileManager.profileStringKey("subtitle_color")] ?: "White"
+            val autoPlayNext = context.settingsDataStore.data.first()[profileManager.profileBooleanKey("auto_play_next")] ?: true
             _uiState.value = PlayerUiState(
                 isLoading = true,
                 isLoadingStreams = true,
                 preferredAudioLanguage = preferredAudioLanguage,
                 frameRateMatchingMode = frameRateMatchingMode,
                 subtitleSize = subSize,
-                subtitleColor = subColor
+                subtitleColor = subColor,
+                autoPlayNext = autoPlayNext
             )
 
             // If stream URL provided, use it directly (except magnet links, which require resolution).


### PR DESCRIPTION
## Summary

Closes #86.

Adds the post-episode "Up Next" prompt with Continue / Cancel buttons and a 10-second countdown at the end of every TV episode. Also fixes a long-standing bug where the player ignored the `autoPlayNext` profile setting entirely.

## Root cause

Two separate bugs, both in `PlayerScreen.kt:1251-1262`:

1. When a TV episode ended, `onPlayNext()` was called immediately with zero UI feedback. Users were abruptly dropped into the next episode with no way to cancel except by hitting back.
2. The handler didn't check the profile's `autoPlayNext` setting at all — users who disabled auto-advance in Settings still got silently advanced at the end of every episode.

`NextEpisodeOverlay.kt` has been fully implemented for a while (~260 LOC, countdown, focus handling, Back/Escape cancel, Enter confirm) but **was never invoked anywhere** — confirmed by grep across the entire project. This PR finally wires it up.

## Changes

### 1. Player respects the autoPlayNext setting

- New `autoPlayNext: Boolean = true` field on `PlayerUiState`.
- `PlayerViewModel.loadDetails()` loads it from DataStore via `profileManager.profileBooleanKey("auto_play_next")` — the same key `SettingsViewModel` already uses to persist the toggle. This was the missing link that made the setting a no-op for the player.

### 2. Overlay state machine in PlayerScreen

- Added `showNextEpisodePrompt` + `pendingNextSeason` / `pendingNextEpisode` / `pendingNextAddonId` / `pendingNextSourceName` / `pendingNextBingeGroup` state vars.
- Replaced the unconditional `onPlayNext(...)` call in the `STATE_ENDED` branch with a state transition that captures the next-episode parameters and shows the overlay.
- Guards:
  - Only fires when `mediaType == TV` (unchanged).
  - Gated on `uiState.autoPlayNext` — when disabled we stay on the ended frame.
  - Re-entry guard `!showNextEpisodePrompt` prevents the tick loop (200-500ms) from re-triggering.
  - Doesn't fire while `showSourceMenu`, `showSubtitleMenu`, or `uiState.error != null`.
- Added `showNextEpisodePrompt` to the container-focus `LaunchedEffect` key set so the overlay's own `onKeyEvent` handler receives D-pad input without the background container stealing focus.

### 3. Render the overlay

Placed after `StreamSelector` in the UI tree. Uses:

- `showTitle` → `uiState.title` (show name)
- `episodeTitle` → generic `"Episode N"` for the upcoming episode (see note below)
- `seasonNumber` / `episodeNumber` → `pendingNextSeason` / `pendingNextEpisode`
- `episodeImage` → `uiState.backdropUrl` (show backdrop — we don't have the next episode's still)
- `countdownSeconds` → 10
- `onPlayNext` → hide overlay + call the existing `onPlayNext(...)` lambda with the pending parameters
- `onCancel` → hide overlay, stay on the ended frame

### Why a generic "Episode N" label instead of the next episode's title

Fetching the upcoming episode's metadata (name, overview, still image) would require an extra TMDB `/tv/{id}/season/{n}/episode/{m}` round-trip at end-of-episode time. For this PR I'm keeping the scope tight and using a generic label — the show title, S/E number, and show backdrop still give users enough context to decide Continue / Cancel. A follow-up PR could prefetch the next episode's still during playback if we want the richer preview.

## Test plan

1. Enable auto-play next in Settings (it's the default, `true`).
2. Play an episode near the end and let it finish.
3. Verify the "Up Next" overlay slides in from the right with a 10-second countdown.
4. Verify Left/Right moves focus between Play Now and Cancel.
5. Verify Enter on Play Now advances immediately.
6. Verify Enter on Cancel hides the overlay and stays on the frame.
7. Verify Back/Escape cancels.
8. Verify the countdown auto-advances at 0.
9. Disable auto-play next in Settings.
10. Play an episode to the end.
11. Verify the player stays on the ended frame with no advance and no overlay.

## Risk

Low. The existing STATE_ENDED path was unconditional and ignored the setting — this PR strictly adds behavior (setting gate + overlay UI) and replaces the auto-advance with an overlay-gated advance. When autoPlayNext is true and the user takes no action, the net behavior is the same as before plus a 10-second countdown UI. When autoPlayNext is false, the new behavior (stay on frame) is what users who disabled the setting were expecting all along.
