### PR TITLE
fix: recognize custom subtitle addons like Wizdom and Ktuvit (#80)

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
@@ -249,6 +249,25 @@ class StreamRepository @Inject constructor(
             val resolvedName = customName?.trim()?.takeIf { it.isNotBlank() } ?: manifest.name
             val addonId = buildAddonInstanceId(manifest.id, normalizedUrl)
 
+            // Classify the addon based on the resources its manifest declares.
+            // - If it declares `subtitles` but NOT `stream`, it's a pure subtitle addon
+            //   (e.g. Wizdom, Ktuvit) and gets AddonType.SUBTITLE so the subtitle fetcher
+            //   picks it up and the stream resolver correctly ignores it.
+            // - If it declares `stream` (with or without subtitles), keep it as CUSTOM so
+            //   the stream resolver queries it. The subtitle fetcher has been updated
+            //   separately to also include CUSTOM addons whose manifest declares a
+            //   subtitles resource, so hybrid addons still get queried for both.
+            // - Everything else stays CUSTOM, matching the previous default.
+            // Fixes issue #80 where Wizdom/Ktuvit were installed but never queried because
+            // every user-added addon was hardcoded to CUSTOM regardless of its manifest.
+            val resourceNames = addonManifest.resources.map { it.name }.toSet()
+            val hasSubtitles = "subtitles" in resourceNames
+            val hasStream = "stream" in resourceNames
+            val addonType = when {
+                hasSubtitles && !hasStream -> AddonType.SUBTITLE
+                else -> AddonType.CUSTOM
+            }
+
             val newAddon = Addon(
                 id = addonId,
                 name = resolvedName,
@@ -256,7 +275,7 @@ class StreamRepository @Inject constructor(
                 description = manifest.description ?: "",
                 isInstalled = true,
                 isEnabled = true,
-                type = AddonType.CUSTOM,
+                type = addonType,
                 url = normalizedUrl,
                 logo = manifest.logo,
                 manifest = addonManifest,
@@ -1336,7 +1355,26 @@ class StreamRepository @Inject constructor(
         stream: StreamSource?
     ): List<Subtitle> = withContext(Dispatchers.IO) {
         val allAddons = installedAddons.first()
-        val subtitleAddons = allAddons.filter { it.isInstalled && it.isEnabled && it.type == AddonType.SUBTITLE }
+        // Include:
+        // - Addons classified as AddonType.SUBTITLE (OpenSubtitles and, going forward,
+        //   any user-added pure-subtitle addon like Wizdom/Ktuvit now that addCustomAddon
+        //   classifies them correctly).
+        // - Addons classified as CUSTOM whose manifest declares a `subtitles` resource.
+        //   This covers two cases: (a) addons installed before the classification fix
+        //   landed, which are still stored as CUSTOM; (b) hybrid addons that provide
+        //   both streams and subtitles. Both should be queried for subtitles.
+        // Fixes issue #80.
+        val subtitleAddons = allAddons.filter { addon ->
+            if (!addon.isInstalled || !addon.isEnabled) return@filter false
+            if (addon.type == AddonType.SUBTITLE) return@filter true
+            if (addon.type == AddonType.CUSTOM) {
+                val declaresSubtitles = addon.manifest?.resources?.any { res ->
+                    res.name.equals("subtitles", ignoreCase = true)
+                } == true
+                return@filter declaresSubtitles
+            }
+            false
+        }
 
         val videoHash = stream?.behaviorHints?.videoHash?.trim().takeUnless { it.isNullOrBlank() }
         val videoSize = stream?.behaviorHints?.videoSize?.takeIf { it != null && it > 0L }


### PR DESCRIPTION
## Summary

Closes #80.

User-added Stremio subtitle addons like **Wizdom** and **Ktuvit** (the primary Hebrew subtitle providers for Israeli users) were installed successfully but were functionally inert — they showed up in Settings → Addons, could be enabled/disabled, but were never queried during playback. No Hebrew subtitles ever appeared in the player.

## Root cause

Two sequential bugs:

1. **`StreamRepository.addCustomAddon`** at line 259 hardcoded `type = AddonType.CUSTOM` for every user-added addon, regardless of what resources the manifest declared. So a pure-subtitle addon (manifest `resources: ["subtitles"]`) ended up in the same bucket as a pure-stream addon (manifest `resources: ["stream"]`).

2. **`fetchSubtitlesForSelectedStream`** at line 1339 filtered strictly on `type == AddonType.SUBTITLE`, which only matched the built-in OpenSubtitles addon. Pure-subtitle addons stored as CUSTOM were **never queried for subtitles**.

The result: the addon was installed, the toggle worked, the stream resolver correctly ignored it (because `getStreamAddons` requires a `stream` resource in the manifest), but no code path ever actually fetched subtitles from it.

## Fix

### 1. Classify addons by manifest resources at install time

`addCustomAddon` now inspects the parsed manifest's resources:

```kotlin
val resourceNames = addonManifest.resources.map { it.name }.toSet()
val hasSubtitles = "subtitles" in resourceNames
val hasStream = "stream" in resourceNames
val addonType = when {
    hasSubtitles && !hasStream -> AddonType.SUBTITLE
    else -> AddonType.CUSTOM
}
```

- **Pure subtitle addon** (Wizdom, Ktuvit) → `SUBTITLE` → picked up by the subtitle fetcher, ignored by the stream fetcher.
- **Pure stream addon** → `CUSTOM` with `stream` resource → picked up by the stream fetcher only (unchanged behavior).
- **Hybrid addon** (declares both `stream` and `subtitles`) → `CUSTOM` → picked up by the stream fetcher AND by the subtitle fetcher's new branch (see below).

### 2. Broaden the subtitle fetcher to include CUSTOM addons that declare subtitles

`fetchSubtitlesForSelectedStream` now also queries CUSTOM addons whose manifest has a `subtitles` resource:

```kotlin
val subtitleAddons = allAddons.filter { addon ->
    if (!addon.isInstalled || !addon.isEnabled) return@filter false
    if (addon.type == AddonType.SUBTITLE) return@filter true
    if (addon.type == AddonType.CUSTOM) {
        val declaresSubtitles = addon.manifest?.resources?.any { res ->
            res.name.equals("subtitles", ignoreCase = true)
        } == true
        return@filter declaresSubtitles
    }
    false
}
```

This covers two cases the type-classification fix alone doesn't:

- **Users who installed Wizdom/Ktuvit before this fix landed** — their DataStore still has the addon classified as CUSTOM. They benefit from change (2) immediately without needing to reinstall.
- **Hybrid addons** that legitimately provide both streams and subtitles — they should be queried for both resources.

## Why the stream side is already correct

`getStreamAddons` at line 625 already skips `AddonType.SUBTITLE`, and at line 632-641 requires CUSTOM addons to declare a `stream` resource in the manifest. So newly-classified SUBTITLE addons are correctly excluded from stream fetches and won't pollute the stream picker with "no streams available" entries.

## Test matrix

| Scenario | Classification | Stream fetch | Subtitle fetch |
|----------|---------------|--------------|----------------|
| OpenSubtitles (builtin) | SUBTITLE | skip ✓ | query ✓ |
| Wizdom/Ktuvit (fresh install) | SUBTITLE (new) | skip ✓ | query ✓ (new) |
| Wizdom/Ktuvit (installed before fix) | CUSTOM (unchanged) | skip (no `stream` resource) ✓ | query ✓ (new branch) |
| Torrentio / Cinemeta (stream addon) | CUSTOM | query ✓ | skip ✓ |
| Hybrid addon (stream + subtitles) | CUSTOM | query ✓ | query ✓ (new branch) |

## Risk

Low. Single file, 40-line change. The stream-side filter logic is untouched. The subtitle-side filter is a strict superset of the previous filter — no previously-queried addon will stop being queried. All new behavior is additive.

One very small edge case worth noting: the subtitle URL construction (`buildSubtitlesUrl`) has been working for OpenSubtitles for months and follows the standard Stremio protocol (`/subtitles/{type}/{id}.json`). Wizdom and Ktuvit follow the same protocol, so it should work out of the box, but if a specific provider turns out to need an unusual query format we can iterate in a follow-up PR.
