### PR TITLE
feat: add IMAX badge and fix DV false-positive detection (#118)

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/components/StreamSelector.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/StreamSelector.kt
@@ -935,8 +935,8 @@ private fun GlassyStreamCard(
                 horizontalArrangement = Arrangement.spacedBy(6.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                // Quality badge
-                CompactQualityBadge(stream.quality)
+                // Quality badge (resolution + HDR/DV/IMAX detection from full stream metadata)
+                CompactQualityBadge(stream)
 
                 // Size
                 if (stream.size.isNotEmpty()) {
@@ -1007,14 +1007,34 @@ private fun FilterTab(
     }
 }
 
+// Pre-compiled badge detection regexes. All use word boundaries to avoid matching
+// "DV" inside "DVD" or "HDVD" (the long-standing bug that made the DV badge appear
+// on SD DVDrip sources). IMAX detection was missing entirely before issue #118.
+private val DV_REGEX = Regex("""\b(DV|DoVi|Dolby[\s._-]*Vision)\b""", RegexOption.IGNORE_CASE)
+private val HDR_REGEX = Regex("""\bHDR(10\+?|10)?\b""", RegexOption.IGNORE_CASE)
+private val IMAX_REGEX = Regex("""\bIMAX\b""", RegexOption.IGNORE_CASE)
+
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
-private fun CompactQualityBadge(quality: String) {
+private fun CompactQualityBadge(stream: StreamSource) {
+    // IMAX and DV tokens are almost always in the filename / source title, not the
+    // pre-extracted `quality` string. Combine all fields we have so detection works
+    // regardless of where the token lives. This fixes issue #118.
+    val searchBlob = buildString {
+        append(stream.quality)
+        append(' ')
+        append(stream.source)
+        append(' ')
+        append(stream.behaviorHints?.filename.orEmpty())
+    }
+
+    val quality = stream.quality
     val is4K = quality.contains("4K", ignoreCase = true) || quality.contains("2160p")
     val is1080 = quality.contains("1080p")
     val is720 = quality.contains("720p")
-    val isHDR = quality.contains("HDR", ignoreCase = true)
-    val isDV = quality.contains("DV", ignoreCase = true) || quality.contains("Dolby Vision", ignoreCase = true)
+    val isHDR = HDR_REGEX.containsMatchIn(searchBlob)
+    val isDV = DV_REGEX.containsMatchIn(searchBlob)
+    val isIMAX = IMAX_REGEX.containsMatchIn(searchBlob)
 
     val displayText = when {
         is4K -> "4K"
@@ -1076,6 +1096,26 @@ private fun CompactQualityBadge(quality: String) {
                         fontWeight = FontWeight.Black
                     ),
                     color = Color(0xFFEC4899)
+                )
+            }
+        }
+
+        if (isIMAX) {
+            // IMAX badge — distinctive cyan/blue to stand out from HDR (purple) and DV (pink).
+            // Requested in issue #118 as a premium format that deserves its own badge
+            // since users scan the source list for IMAX-tagged releases.
+            Box(
+                modifier = Modifier
+                    .background(Color(0xFF06B6D4).copy(alpha = 0.18f), RoundedCornerShape(4.dp))
+                    .padding(horizontal = 5.dp, vertical = 2.dp)
+            ) {
+                Text(
+                    text = "IMAX",
+                    style = ArflixTypography.caption.copy(
+                        fontSize = 9.sp,
+                        fontWeight = FontWeight.Black
+                    ),
+                    color = Color(0xFF06B6D4)
                 )
             }
         }


### PR DESCRIPTION
## Summary

Closes #118.

Adds an IMAX badge to stream source entries and fixes a long-standing false-positive where SD DVDrip sources were being incorrectly flagged as Dolby Vision.

## Root cause

Two bugs in `CompactQualityBadge` in `StreamSelector.kt:1010-1083`:

1. **DV false positives** — The DV badge used:
   ```kotlin
   val isDV = quality.contains("DV", ignoreCase = true) || quality.contains("Dolby Vision", ignoreCase = true)
   ```
   Substring matching on `"DV"` matched everything containing those two letters, including `"DVD"`, `"HDVD"`, `"DVDRip"`, `"MediaDVx"`, etc. Standard-definition DVD rips were visually indistinguishable from true Dolby Vision sources in the picker.

2. **No IMAX detection** — IMAX was not in the badge list at all, despite being one of the most visually distinctive premium formats users explicitly scan for.

3. **Narrow search scope** — Both HDR and DV detection only looked at the pre-extracted `stream.quality` string. IMAX and DV tokens almost always live in the filename / source title (`stream.source` or `stream.behaviorHints.filename`), not the quality ladder slot.

## Fix

### 1. Widen the search blob

`CompactQualityBadge` now takes the full `StreamSource` instead of just `quality`, and builds a single search blob:

```kotlin
val searchBlob = buildString {
    append(stream.quality)
    append(' ')
    append(stream.source)
    append(' ')
    append(stream.behaviorHints?.filename.orEmpty())
}
```

This way tokens are detected wherever they appear.

### 2. Word-boundary regex constants

Replaced `contains(...)` substring matching with pre-compiled `\b`-bounded regexes:

```kotlin
private val DV_REGEX = Regex("""\b(DV|DoVi|Dolby[\s._-]*Vision)\b""", RegexOption.IGNORE_CASE)
private val HDR_REGEX = Regex("""\bHDR(10\+?|10)?\b""", RegexOption.IGNORE_CASE)
private val IMAX_REGEX = Regex("""\bIMAX\b""", RegexOption.IGNORE_CASE)
```

- `\bDV\b` matches `DV` as a whole token but NOT `DVD`, `HDVD`, `DVDRip`.
- `DoVi` and `Dolby.Vision` / `Dolby_Vision` / `Dolby-Vision` / `Dolby Vision` still match.
- HDR regex also cleanly matches `HDR10` and `HDR10+` as the same badge.
- IMAX regex matches the standalone `IMAX` token.

Regexes are declared at file scope with `val`, so they're compiled once.

### 3. IMAX badge

Rendered in a distinctive cyan/blue (`0xFF06B6D4`) so it stands out from HDR (purple) and DV (pink). Only rendered when `isIMAX` is true, so non-IMAX sources get no extra space.

## Test cases handled

| Source title | Before | After |
|--------------|--------|-------|
| `Movie.2021.1080p.DVDRip.x264.mkv` | ❌ shows DV badge | ✓ no DV badge |
| `Movie.2021.2160p.IMAX.WEB-DL.DV.HDR.mkv` | only HDR shown | 4K + HDR + DV + IMAX |
| `Movie.2021.DoVi.Remux.mkv` | ❌ no DV badge (DoVi not in regex) | ✓ DV badge |
| `Movie.2021.Dolby.Vision.mkv` | ✓ (but for the wrong reason — substring match) | ✓ (word-boundary match) |
| `Movie.2021.HDR10+.mkv` | ✓ HDR badge | ✓ HDR badge |

## Risk

Minimal. Single-file, 45-line change. Pure UI — no stream selection logic touched, no network calls, no settings, no cross-device state. The only API change is the internal helper signature (`String` → `StreamSource`), and there's only one call site which is updated in the same PR.
