### PR TITLE
fix: player crash when switching audio language (#89)

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -106,6 +106,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.media3.common.C
+import androidx.media3.common.TrackSelectionOverride
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MimeTypes
 import androidx.media3.common.Player
@@ -1483,24 +1484,10 @@ fun PlayerScreen(
                                 } else {
                                     // Audio selection
                                     audioTracks.getOrNull(subtitleMenuIndex)?.let { track ->
-                                        // Switch audio track via ExoPlayer
-                                        val params = exoPlayer.trackSelectionParameters.buildUpon()
-                                        params.setPreferredAudioLanguage(track.language)
-                                        val trackGroups = exoPlayer.currentTracks.groups
-                                        if (track.groupIndex < trackGroups.size &&
-                                            trackGroups[track.groupIndex].type == C.TRACK_TYPE_AUDIO
-                                        ) {
-                                            params.setOverrideForType(
-                                                androidx.media3.common.TrackSelectionOverride(
-                                                    trackGroups[track.groupIndex].mediaTrackGroup,
-                                                    track.trackIndex
-                                                )
-                                            )
+                                        // Defensive track-selection — see applyAudioTrackSelection.
+                                        applyAudioTrackSelection(exoPlayer, track, audioTracks)?.let {
+                                            selectedAudioIndex = it
                                         }
-                                        exoPlayer.trackSelectionParameters = params.build()
-                                        selectedAudioIndex = audioTracks.indexOfFirst {
-                                            it.groupIndex == track.groupIndex && it.trackIndex == track.trackIndex
-                                        }.takeIf { it >= 0 } ?: track.index
                                     }
                                 }
                                 showSubtitleMenu = false
@@ -2073,24 +2060,12 @@ fun PlayerScreen(
                     }
                 },
                 onSelectAudio = { track ->
-                    // Switch audio track via ExoPlayer
-                    val params = exoPlayer.trackSelectionParameters.buildUpon()
-                    params.setPreferredAudioLanguage(track.language)
-                    val trackGroups = exoPlayer.currentTracks.groups
-                    if (track.groupIndex < trackGroups.size &&
-                        trackGroups[track.groupIndex].type == C.TRACK_TYPE_AUDIO
-                    ) {
-                        params.setOverrideForType(
-                            androidx.media3.common.TrackSelectionOverride(
-                                trackGroups[track.groupIndex].mediaTrackGroup,
-                                track.trackIndex
-                            )
-                        )
+                    // Defensive track-selection — validates group + track bounds and
+                    // swallows IllegalArgumentException from stale indices after a
+                    // player re-prepare. Fixes crash reported in issue #89.
+                    applyAudioTrackSelection(exoPlayer, track, audioTracks)?.let {
+                        selectedAudioIndex = it
                     }
-                    exoPlayer.trackSelectionParameters = params.build()
-                    selectedAudioIndex = audioTracks.indexOfFirst {
-                        it.groupIndex == track.groupIndex && it.trackIndex == track.trackIndex
-                    }.takeIf { it >= 0 } ?: track.index
                     showSubtitleMenu = false
                     showControls = true
                     // Restore focus to subtitle button after closing menu
@@ -2478,6 +2453,73 @@ data class AudioTrackInfo(
     val sampleRate: Int,
     val codec: String?
 )
+
+/**
+ * Apply an audio-track selection to the player defensively.
+ *
+ * The stored [AudioTrackInfo] captures `groupIndex` / `trackIndex` at the moment the
+ * `onTracksChanged` listener fires. Between that moment and the user actually picking
+ * a track from the menu, the player may have re-prepared (e.g. adaptive stream switch,
+ * source reselection, MediaItem rebuild for a new external subtitle), and the current
+ * `exoPlayer.currentTracks.groups` layout may no longer match those indices. Calling
+ * `TrackSelectionOverride(group, trackIndex)` with a stale `trackIndex >= group.length`
+ * throws `IllegalArgumentException` inside Media3 and crashes the player.
+ *
+ * This helper wraps the selection in try/catch, validates every index before use, and
+ * clears any existing audio override before applying the new one so stale overrides
+ * from prior selections don't pin the player to a no-longer-present track. Fixes #89.
+ *
+ * @return the index in [audioTracks] that was actually applied, or `null` if the
+ *         selection could not be applied (caller should leave the previous index).
+ */
+private fun applyAudioTrackSelection(
+    exoPlayer: ExoPlayer,
+    track: AudioTrackInfo,
+    audioTracks: List<AudioTrackInfo>
+): Int? {
+    return try {
+        val params = exoPlayer.trackSelectionParameters.buildUpon()
+            .clearOverridesOfType(C.TRACK_TYPE_AUDIO)
+            .setPreferredAudioLanguage(track.language)
+
+        val trackGroups = exoPlayer.currentTracks.groups
+        val groupInRange = track.groupIndex in trackGroups.indices
+        if (groupInRange) {
+            val group = trackGroups[track.groupIndex]
+            val isAudioGroup = group.type == C.TRACK_TYPE_AUDIO
+            val trackInRange = track.trackIndex in 0 until group.length
+            if (isAudioGroup && trackInRange) {
+                params.setOverrideForType(
+                    TrackSelectionOverride(
+                        group.mediaTrackGroup,
+                        track.trackIndex
+                    )
+                )
+            }
+            // If the group is stale we still fall through and apply the
+            // preferredAudioLanguage hint above — Media3 will pick the closest
+            // matching track on its own rather than crashing.
+        }
+
+        exoPlayer.trackSelectionParameters = params.build()
+
+        audioTracks.indexOfFirst {
+            it.groupIndex == track.groupIndex && it.trackIndex == track.trackIndex
+        }.takeIf { it >= 0 } ?: track.index
+    } catch (e: IllegalArgumentException) {
+        // Stale track/group index after a player re-prepare. Leave the current
+        // selection alone instead of crashing; user can retry the menu.
+        android.util.Log.w("PlayerScreen", "applyAudioTrackSelection rejected stale index: ${e.message}")
+        null
+    } catch (e: IllegalStateException) {
+        // Player released or in an invalid state.
+        android.util.Log.w("PlayerScreen", "applyAudioTrackSelection on invalid player: ${e.message}")
+        null
+    } catch (e: Exception) {
+        android.util.Log.e("PlayerScreen", "applyAudioTrackSelection unexpected error", e)
+        null
+    }
+}
 
 /**
  * Language code to full name mapping


### PR DESCRIPTION
## Summary

Closes #89.

Fixes the player crash users reported when switching audio language from the track menu during playback. Also removes a second, related bug where switching audio from the D-pad handler path ran duplicated unsafe code.

## Root cause

Two audio-track selection code paths in `PlayerScreen.kt` (the D-pad menu handler at ~line 1485 and the `onSelectAudio` callback at ~line 2075) built a `TrackSelectionOverride(group, trackIndex)` after only validating:

1. `track.groupIndex < trackGroups.size` ✓
2. `group.type == TRACK_TYPE_AUDIO` ✓
3. `track.trackIndex < group.length` ✗ **missing**

There was also no `try/catch` around `exoPlayer.trackSelectionParameters = params.build()`.

`AudioTrackInfo` captures `groupIndex` / `trackIndex` at the moment `onTracksChanged` fires. Between that moment and the user actually picking a track from the menu (several seconds later, especially if they first opened the subtitles menu, browsed, then switched to audio), the player may have re-prepared due to:

- adaptive stream switch
- user switching source from the source picker
- MediaItem rebuild when a new external subtitle is selected
- automatic recovery from a transient network error

After any of those events the track groups layout can change, leaving the cached `trackIndex` out of bounds for the new group. Media3's `TrackSelectionOverride` constructor throws `IllegalArgumentException` and the crash propagates up to the Composable, tearing down the player.

## Fix

Extracted the audio-track selection logic into a single private helper `applyAudioTrackSelection(exoPlayer, track, audioTracks): Int?` with proper defense:

```kotlin
private fun applyAudioTrackSelection(
    exoPlayer: ExoPlayer,
    track: AudioTrackInfo,
    audioTracks: List<AudioTrackInfo>
): Int? {
    return try {
        val params = exoPlayer.trackSelectionParameters.buildUpon()
            .clearOverridesOfType(C.TRACK_TYPE_AUDIO)
            .setPreferredAudioLanguage(track.language)

        val trackGroups = exoPlayer.currentTracks.groups
        val groupInRange = track.groupIndex in trackGroups.indices
        if (groupInRange) {
            val group = trackGroups[track.groupIndex]
            val isAudioGroup = group.type == C.TRACK_TYPE_AUDIO
            val trackInRange = track.trackIndex in 0 until group.length
            if (isAudioGroup && trackInRange) {
                params.setOverrideForType(
                    TrackSelectionOverride(group.mediaTrackGroup, track.trackIndex)
                )
            }
            // If stale, still apply setPreferredAudioLanguage so Media3 picks the
            // closest matching track on its own rather than crashing or leaving
            // the user on the wrong language.
        }

        exoPlayer.trackSelectionParameters = params.build()
        audioTracks.indexOfFirst { ... }.takeIf { it >= 0 } ?: track.index
    } catch (e: IllegalArgumentException) { ... null }
      catch (e: IllegalStateException) { ... null }
      catch (e: Exception) { ... null }
}
```

Key defensive additions:

1. **Full try/catch** around the whole block — the outer `params.build()` assignment could also throw on some devices when the player is in an invalid state.
2. **`clearOverridesOfType(C.TRACK_TYPE_AUDIO)` first** — stale overrides from prior selections no longer pin the player to a track index that may not exist in the new group layout.
3. **`trackIndex in 0 until group.length` bounds check** — this is the specific validation that was missing and caused the crash.
4. **Graceful fallback** — if the group/track validation fails, the `setPreferredAudioLanguage` hint still applies, so Media3 picks the closest matching track on its own rather than leaving the user on the wrong language.
5. **Returns `Int?`** — caller uses `?.let { selectedAudioIndex = it }` so when the selection fails we keep the previous index rather than jumping to an incorrect one.

Both audio-selection call sites now shrink from ~20 lines to 3.

## Not touched in this PR

The subtitle-selection paths at lines 934 and 983 already validate `groupIndex in groups.indices` and have been stable — they're left alone to keep the diff focused on the reported crash. They could be migrated to a similar helper in a follow-up if desired.

## Risk

Low. The helper is strictly more defensive than the inlined code it replaces. In the normal case (fresh tracks, user picks immediately), behavior is identical. In the edge case (stale indices after re-prepare), the old code crashed and the new code either silently picks the correct track via language hint, or keeps the previous selection. Either is strictly better than a crash.
