### PR TITLE
fix: sync playback resume position across devices in real-time (#91)

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/RealtimeSyncManager.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/RealtimeSyncManager.kt
@@ -3,6 +3,9 @@ package com.arflix.tv.data.repository
 import android.util.Log
 import com.arflix.tv.util.Constants
 import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import okhttp3.*
 import org.json.JSONArray
 import org.json.JSONObject
@@ -14,13 +17,25 @@ import javax.inject.Singleton
 
 /**
  * Manages a Supabase Realtime WebSocket connection to receive instant
- * notifications when `account_sync_state` changes on any device.
+ * notifications when `account_sync_state` or `watch_history` changes on any device.
  *
- * When a change is detected, it triggers [CloudSyncRepository.pullFromCloud]
- * so the local app state updates within 1-2 seconds of a remote push.
+ * Two channels are joined on the same socket:
  *
- * Also runs a periodic fallback sync every 5 minutes in case the WebSocket
- * disconnects or misses an event.
+ * 1. `realtime:account_sync` \u2014 listens for UPDATEs on `account_sync_state`. On
+ *    change, the manager triggers [CloudSyncRepository.pullFromCloud] to reapply the
+ *    full JSON snapshot (addons, profiles, catalogs, IPTV config, preferences).
+ *
+ * 2. `realtime:watch_history` \u2014 listens for INSERTs/UPDATEs on `watch_history` so
+ *    the Home screen's Continue Watching row can refresh on other devices within
+ *    seconds of a progress update, instead of waiting for the user to reopen Home.
+ *    Because watch_history is a high-write table during playback (~every 10s), the
+ *    manager debounces events into [watchHistoryEvents] and the subscriber (HomeViewModel)
+ *    is expected to collect the flow and call refreshContinueWatchingOnly(force = true).
+ *    We do NOT trigger a full pullFromCloud on these events \u2014 that's wasteful for
+ *    what is effectively a single-row position update. Fixes issue #91.
+ *
+ * A periodic fallback sync runs every 90 seconds (lowered from 5 minutes) in case the
+ * WebSocket disconnects or misses an event on an unstable connection.
  */
 @Singleton
 class RealtimeSyncManager @Inject constructor(
@@ -31,8 +46,15 @@ class RealtimeSyncManager @Inject constructor(
         private const val TAG = "RealtimeSync"
         private const val HEARTBEAT_INTERVAL_MS = 30_000L
         private const val RECONNECT_DELAY_MS = 5_000L
-        private const val PERIODIC_SYNC_INTERVAL_MS = 5 * 60 * 1000L // 5 minutes
-        private const val DEBOUNCE_MS = 2_000L // Debounce pulls to avoid rapid-fire
+        // Periodic fallback: was 5 minutes. Lowered to 90s so users on flaky connections
+        // still get fresh playback resume positions within a reasonable time even if
+        // the WebSocket silently misses an event (#91).
+        private const val PERIODIC_SYNC_INTERVAL_MS = 90_000L
+        private const val DEBOUNCE_MS = 2_000L // Debounce full snapshot pulls to avoid rapid-fire
+        // Watch-history events fire every ~10s during playback. Coalesce bursts so we
+        // don't hammer Home's Continue Watching refresh on every tick while a user is
+        // actively watching something on the other device.
+        private const val WATCH_HISTORY_DEBOUNCE_MS = 5_000L
     }
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -44,17 +66,38 @@ class RealtimeSyncManager @Inject constructor(
     private var periodicSyncJob: Job? = null
     private var reconnectJob: Job? = null
     private var pendingPullJob: Job? = null
+    private var pendingWatchHistoryEmitJob: Job? = null
 
     // Track our own pushes to avoid pulling back what we just pushed
     @Volatile
     private var lastPushTimestamp = 0L
 
+    // Track our own watch_history writes (they happen every ~10s during local
+    // playback) so device A doesn't pointlessly refresh its own Continue Watching
+    // row in response to its own updates.
+    @Volatile
+    private var lastLocalWatchHistoryWriteTimestamp = 0L
+
     // User JWT for authenticated Realtime subscriptions
     @Volatile
     private var currentAccessToken: String? = null
 
+    // Event stream for watch_history realtime notifications. HomeViewModel collects
+    // this and triggers refreshContinueWatchingOnly(force = true) on each emission.
+    private val _watchHistoryEvents = MutableSharedFlow<Unit>(extraBufferCapacity = 4)
+    val watchHistoryEvents: SharedFlow<Unit> = _watchHistoryEvents.asSharedFlow()
+
     fun markPush() {
         lastPushTimestamp = System.currentTimeMillis()
+    }
+
+    /**
+     * Called by WatchHistoryRepository.saveProgress so incoming watch_history realtime
+     * events from our own write can be ignored (device A shouldn't refresh its own CW
+     * row when it was device A that just wrote the update).
+     */
+    fun markLocalWatchHistoryWrite() {
+        lastLocalWatchHistoryWriteTimestamp = System.currentTimeMillis()
     }
 
     /**
@@ -79,6 +122,7 @@ class RealtimeSyncManager @Inject constructor(
         periodicSyncJob?.cancel()
         reconnectJob?.cancel()
         pendingPullJob?.cancel()
+        pendingWatchHistoryEmitJob?.cancel()
     }
 
     // ── WebSocket Connection ────────────────────────────────────────
@@ -155,9 +199,9 @@ class RealtimeSyncManager @Inject constructor(
     }
 
     private fun joinChannel(ws: WebSocket, userId: String) {
-        // Subscribe to postgres_changes on account_sync_state table filtered by user_id
-        // access_token is required for Supabase RLS to authenticate the subscription
-        val joinMsg = JSONObject().apply {
+        // Channel 1: account_sync_state UPDATEs (full snapshot pulls).
+        // access_token is required for Supabase RLS to authenticate the subscription.
+        val accountSyncJoin = JSONObject().apply {
             put("topic", "realtime:account_sync")
             put("event", "phx_join")
             put("payload", JSONObject().apply {
@@ -175,24 +219,67 @@ class RealtimeSyncManager @Inject constructor(
             })
             put("ref", msgRef.getAndIncrement().toString())
         }
-        ws.send(joinMsg.toString())
-        Log.i(TAG, "Joined channel for user $userId")
+        ws.send(accountSyncJoin.toString())
+
+        // Channel 2: watch_history INSERT + UPDATE events for cross-device Continue
+        // Watching refresh (#91). We subscribe to both INSERT (first watch of a new
+        // item) and UPDATE (position/progress changes) so either event refreshes the
+        // other device's Home row.
+        val watchHistoryJoin = JSONObject().apply {
+            put("topic", "realtime:watch_history")
+            put("event", "phx_join")
+            put("payload", JSONObject().apply {
+                put("config", JSONObject().apply {
+                    put("postgres_changes", JSONArray().apply {
+                        put(JSONObject().apply {
+                            put("event", "INSERT")
+                            put("schema", "public")
+                            put("table", "watch_history")
+                            put("filter", "user_id=eq.$userId")
+                        })
+                        put(JSONObject().apply {
+                            put("event", "UPDATE")
+                            put("schema", "public")
+                            put("table", "watch_history")
+                            put("filter", "user_id=eq.$userId")
+                        })
+                    })
+                })
+                currentAccessToken?.let { put("access_token", it) }
+            })
+            put("ref", msgRef.getAndIncrement().toString())
+        }
+        ws.send(watchHistoryJoin.toString())
+
+        Log.i(TAG, "Joined account_sync + watch_history channels for user $userId")
     }
 
     private fun handleMessage(text: String) {
         try {
             val msg = JSONObject(text)
             val event = msg.optString("event", "")
+            val topic = msg.optString("topic", "")
 
             when (event) {
                 "postgres_changes" -> {
-                    // A change was detected on account_sync_state
-                    Log.i(TAG, "Received sync change notification")
-                    debouncedPull()
+                    // Route based on which channel sent the event.
+                    when (topic) {
+                        "realtime:account_sync" -> {
+                            Log.i(TAG, "Received account_sync change")
+                            debouncedPull()
+                        }
+                        "realtime:watch_history" -> {
+                            Log.i(TAG, "Received watch_history change")
+                            debouncedWatchHistoryEmit()
+                        }
+                        else -> {
+                            Log.w(TAG, "postgres_changes on unknown topic: $topic")
+                        }
+                    }
                 }
                 "phx_reply" -> {
                     val status = msg.optJSONObject("payload")?.optString("status")
-                    Log.d(TAG, "Channel reply: $status")
+                    Log.d(TAG, "Channel reply ($topic): $status")
                 }
                 "phx_error" -> {
                     Log.w(TAG, "Channel error: $text")
@@ -201,7 +288,7 @@ class RealtimeSyncManager @Inject constructor(
                     // System messages like subscription confirmation
                     val payload = msg.optJSONObject("payload")
                     if (payload?.optString("status") == "ok") {
-                        Log.i(TAG, "Subscription confirmed")
+                        Log.i(TAG, "Subscription confirmed ($topic)")
                     }
                 }
             }
@@ -223,6 +310,23 @@ class RealtimeSyncManager @Inject constructor(
             Log.i(TAG, "Pulling cloud state after realtime notification")
             runCatching { cloudSyncRepository.pullFromCloud() }
                 .onFailure { Log.w(TAG, "Realtime pull failed: ${it.message}") }
+        }
+    }
+
+    private fun debouncedWatchHistoryEmit() {
+        // Skip if the event is almost certainly from our own recent write. This
+        // catches the common case where the user is actively watching on device A
+        // and A's periodic watch_history UPDATE fires back to A as a realtime event.
+        if (System.currentTimeMillis() - lastLocalWatchHistoryWriteTimestamp < 3_000L) {
+            Log.d(TAG, "Skipping watch_history emit - recent local write")
+            return
+        }
+
+        pendingWatchHistoryEmitJob?.cancel()
+        pendingWatchHistoryEmitJob = scope.launch {
+            delay(WATCH_HISTORY_DEBOUNCE_MS)
+            Log.i(TAG, "Emitting watch_history event for Home refresh")
+            _watchHistoryEvents.tryEmit(Unit)
         }
     }
 

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/WatchHistoryRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/WatchHistoryRepository.kt
@@ -46,7 +46,8 @@ data class WatchHistoryEntry(
 class WatchHistoryRepository @Inject constructor(
     private val authRepositoryProvider: Provider<AuthRepository>,
     private val supabaseApi: SupabaseApi,
-    private val profileManager: ProfileManager
+    private val profileManager: ProfileManager,
+    private val realtimeSyncManagerProvider: Provider<RealtimeSyncManager>
 ) {
     private fun profileHistorySource(base: String): String {
         // Use stable profile ID so rename/case changes do not split history.
@@ -128,18 +129,28 @@ class WatchHistoryRepository @Inject constructor(
 
         // Upsert - update if exists, insert if not.
         // Retry without stream_* fields if the Supabase schema hasn't been migrated yet.
+        var saved = false
         try {
             executeSupabaseCall("save watch progress") { auth ->
                 supabaseApi.upsertWatchHistory(auth = auth, item = entry.toRecord())
             }
+            saved = true
         } catch (e: HttpException) {
             runCatching {
                 val fallback = entry.copy(stream_key = null, stream_addon_id = null, stream_title = null)
                 executeSupabaseCall("save watch progress fallback") { auth ->
                     supabaseApi.upsertWatchHistory(auth = auth, item = fallback.toRecord())
                 }
+                saved = true
             }
         } catch (_: Exception) {
+        }
+
+        // Mark the local write timestamp on the realtime manager so the incoming
+        // watch_history realtime event (which fires back to our own device) doesn't
+        // trigger a redundant Home Continue Watching refresh. See issue #91 fix.
+        if (saved) {
+            runCatching { realtimeSyncManagerProvider.get().markLocalWatchHistoryWrite() }
         }
     }
 

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
@@ -96,6 +96,7 @@ class HomeViewModel @Inject constructor(
     private val watchlistRepository: WatchlistRepository,
     private val cloudSyncRepository: CloudSyncRepository,
     private val launcherContinueWatchingRepository: LauncherContinueWatchingRepository,
+    private val realtimeSyncManager: com.arflix.tv.data.repository.RealtimeSyncManager,
     @ApplicationContext private val context: Context
 ) : ViewModel() {
     private val imageLoader: ImageLoader by lazy(LazyThreadSafetyMode.NONE) {
@@ -650,6 +651,18 @@ class HomeViewModel @Inject constructor(
                 }
                 _uiState.value = _uiState.value.copy(trailerAutoPlay = trailerEnabled)
             } catch (_: Exception) {}
+        }
+
+        // Subscribe to realtime watch_history events so Continue Watching refreshes on
+        // this device within a few seconds of another device updating the shared
+        // Supabase watch_history table. Before this, mid-playback updates from device A
+        // were only visible on device B after a manual Home ON_RESUME or the 5-minute
+        // periodic sync — so switching devices mid-episode always showed the stale
+        // resume position. Fixes #91.
+        viewModelScope.launch {
+            realtimeSyncManager.watchHistoryEvents.collect {
+                refreshContinueWatchingOnly(force = true)
+            }
         }
         // Restore logo URL cache from disk for instant clearlogos on cold start
         restoreLogoCacheFromDisk()


### PR DESCRIPTION
## Summary

Closes #91.

Cross-device playback resume position now updates within ~5 seconds of a progress update on another device, instead of waiting for the receiving device to manually reopen Home or for the 5-minute periodic fallback sync.

## Reported behavior

> If I stop an episode for example at minute 20 and finish it later on device A, device B is still showing the episode to resume at minute 20 instead of starting the next episode.

## Root cause

`RealtimeSyncManager` only subscribed to **one** Supabase realtime channel: `account_sync_state`. But playback progress is written directly to a different table — `watch_history` — by `WatchHistoryRepository.saveProgress()` every ~10 seconds during playback. The `account_sync_state` snapshot is only pushed at pause/stop/end, which meant:

- ✓ User finished an episode on device A → pushed via account_sync_state on END → device B realtime pull works.
- ✓ User paused mid-episode on device A → pushed via account_sync_state on PAUSE → works.
- ✗ User actively watching on device A with no pause: `watch_history` was being updated on Supabase every 10 seconds, but device B had **no realtime signal** and only saw the new position after manually reopening Home or after the 5-minute periodic fallback fired.

The bug has been invisible for users who always pause or finish episodes cleanly, but has been breaking cross-device experience for anyone switching devices mid-episode.

## Fix

### 1. Second realtime channel for `watch_history`

Subscribe to a second channel on the same WebSocket listening for INSERT + UPDATE on `watch_history` filtered by `user_id=eq.$userId`:

```kotlin
// Channel 2: watch_history INSERT + UPDATE events for cross-device Continue
// Watching refresh. We subscribe to both INSERT (first watch of a new item)
// and UPDATE (position/progress changes) so either event refreshes the other
// device's Home row.
val watchHistoryJoin = JSONObject().apply {
    put("topic", "realtime:watch_history")
    ...
}
ws.send(watchHistoryJoin.toString())
```

### 2. Topic-based dispatch in `handleMessage`

`postgres_changes` events now route by topic:

- `realtime:account_sync` → `debouncedPull()` (full cloud snapshot restore — unchanged)
- `realtime:watch_history` → `debouncedWatchHistoryEmit()` (lightweight CW-only refresh — new)

Watch-history events do **not** trigger `cloudSyncRepository.pullFromCloud()`. That would be wasteful for a single-row position update — it would re-download the entire addons/profiles/catalogs/IPTV snapshot.

### 3. `watchHistoryEvents: SharedFlow<Unit>`

New event stream on `RealtimeSyncManager`. `HomeViewModel` collects it in `init` and calls the existing `refreshContinueWatchingOnly(force = true)`, which re-queries `watch_history` via `WatchHistoryRepository.getContinueWatching()` and updates the Continue Watching row inline — no home reload.

### 4. 5-second debounce to coalesce bursts

Watch history fires every ~10 s during active playback. Without coalescing, a user binge-watching on device A would trigger a Home refresh on every other device every 10 seconds. The new `WATCH_HISTORY_DEBOUNCE_MS = 5_000L` groups rapid-fire events into a single refresh.

### 5. Self-echo protection

`WatchHistoryRepository.saveProgress()` now calls `realtimeSyncManager.markLocalWatchHistoryWrite()` on every successful save. `debouncedWatchHistoryEmit()` checks that timestamp with a 3-second window and skips the emit when the event almost certainly came from our own write. Without this, device A would pointlessly refresh its own Continue Watching row every 10 seconds while watching.

```kotlin
private fun debouncedWatchHistoryEmit() {
    if (System.currentTimeMillis() - lastLocalWatchHistoryWriteTimestamp < 3_000L) {
        return  // skip — our own write
    }
    ...
}
```

### 6. Periodic fallback: 5 minutes → 90 seconds

`PERIODIC_SYNC_INTERVAL_MS` was 5 minutes. Lowered to 90 seconds so users on flaky connections (or devices that missed a realtime notification) still see fresh data within a reasonable window. The interval runs `pullFromCloud()` only if nothing else has fired in between — net cost is at most one small Supabase query per 90 s per active user.

## Dependency injection

`WatchHistoryRepository` now takes `Provider<RealtimeSyncManager>` (lazy). This matches the existing `Provider<AuthRepository>` pattern in the same class and avoids any construction-order edge cases. Verified no dependency cycle:

```
HomeViewModel → RealtimeSyncManager → CloudSyncRepository → (no WatchHistoryRepository)
WatchHistoryRepository → Provider<RealtimeSyncManager>  (lazy, breaks construction)
```

## Test plan

1. Sign in on two devices (both need ARVIO Cloud auth).
2. Start playing an episode on device A.
3. On device B, open Home and note the current resume position for that episode in Continue Watching.
4. Let device A play for 30+ seconds.
5. Within ~10 seconds of device A's next `watch_history` update, device B's Continue Watching row should refresh to show the new position without any manual action.
6. On device A, pause and watch the next 5-second watch_history update fire. Verify device A's own Continue Watching row does NOT flicker (self-echo skip).
7. Fully watch an episode to end on device A. Device B should move to the next episode within ~10 seconds.
8. Kill device B's app, bring it back — Continue Watching should still show the latest state (this path uses the account_sync_state channel, unchanged).

## Risk

Medium. Changes touch the realtime sync core. Mitigations:

- The new `realtime:watch_history` channel is additive — if it fails, the existing `realtime:account_sync` channel still works and the 90-second periodic fallback still catches everything.
- The self-echo guard uses a tight 3-second window so local writes don't suppress legitimate events from other devices that happen to arrive at the same time.
- The event flow uses `extraBufferCapacity = 4` on `MutableSharedFlow` so event delivery is non-suspending and can't back-pressure the network handler.
- No schema changes, no new Supabase tables, no migration. Uses the `watch_history` table that already exists and is already being written to on every device.
