### PR TITLE
feat: Fire TV and Bluetooth media remote keys in the player (#68 part)

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -1390,6 +1390,75 @@ fun PlayerScreen(
             )
             .onKeyEvent { event ->
                 if (event.type == KeyEventType.KeyDown) {
+                    // Fire TV / Bluetooth media remote keys. These must be handled at the
+                    // top of the key handler so they work regardless of which overlay
+                    // (error, menus, post-episode prompt) is currently visible. Previously
+                    // only Key.MediaPlayPause was handled, and only when the subtitle menu
+                    // was open \u2014 useless for the common case of watching with a Fire TV
+                    // stick remote that has dedicated FF/RW/Play buttons. Issue #68 (part).
+                    when (event.key) {
+                        Key.MediaPlayPause -> {
+                            if (exoPlayer.isPlaying) exoPlayer.pause() else exoPlayer.play()
+                            showControls = true
+                            return@onKeyEvent true
+                        }
+                        Key.MediaPlay -> {
+                            exoPlayer.play()
+                            showControls = true
+                            return@onKeyEvent true
+                        }
+                        Key.MediaPause -> {
+                            exoPlayer.pause()
+                            showControls = true
+                            return@onKeyEvent true
+                        }
+                        Key.MediaStop -> {
+                            exoPlayer.pause()
+                            onBack()
+                            return@onKeyEvent true
+                        }
+                        Key.MediaRewind -> {
+                            queueControlsSeek(-10_000L)
+                            showControls = true
+                            return@onKeyEvent true
+                        }
+                        Key.MediaFastForward -> {
+                            queueControlsSeek(10_000L)
+                            showControls = true
+                            return@onKeyEvent true
+                        }
+                        Key.MediaNext -> {
+                            // Jump to next episode if this is a TV series and we have a
+                            // current episode. No-op for movies (there is no next).
+                            if (mediaType == MediaType.TV && seasonNumber != null && episodeNumber != null) {
+                                val selected = uiState.selectedStream
+                                onPlayNext(
+                                    seasonNumber,
+                                    episodeNumber + 1,
+                                    selected?.addonId?.takeIf { it.isNotBlank() },
+                                    selected?.source?.takeIf { it.isNotBlank() },
+                                    selected?.behaviorHints?.bingeGroup?.takeIf { it.isNotBlank() }
+                                )
+                                return@onKeyEvent true
+                            }
+                        }
+                        Key.MediaPrevious -> {
+                            // Jump to previous episode for TV series. Movies: no-op.
+                            if (mediaType == MediaType.TV && seasonNumber != null && episodeNumber != null && episodeNumber > 1) {
+                                val selected = uiState.selectedStream
+                                onPlayNext(
+                                    seasonNumber,
+                                    episodeNumber - 1,
+                                    selected?.addonId?.takeIf { it.isNotBlank() },
+                                    selected?.source?.takeIf { it.isNotBlank() },
+                                    selected?.behaviorHints?.bingeGroup?.takeIf { it.isNotBlank() }
+                                )
+                                return@onKeyEvent true
+                            }
+                        }
+                        else -> Unit // fall through to normal handling
+                    }
+
                     // Handle error modal
                     if (uiState.error != null) {
                         val maxButtons = if (uiState.isSetupError) 0 else 1 // setup=1 button, error=2 buttons


### PR DESCRIPTION
Closes the Fire TV remote part of #68. (Subtitle timing sync is in PR #108; in-player episode picker is scoped separately.)

## Problem

On Fire TV Stick and Bluetooth media remotes, the dedicated FF/RW/Play/Pause/Next/Prev buttons did nothing during playback. Only `Key.MediaPlayPause` / `MediaPlay` / `MediaPause` were handled in PlayerScreen.kt, and only inside the `if (showSubtitleMenu)` branch \u2014 so media keys were silently dropped unless the user had already opened the audio/subtitle menu, which is the opposite of the normal use case.

## Fix

Added a top-level media-key dispatch at the very start of the player `.onKeyEvent` handler, BEFORE the error / menu / overlay branches. Each key returns `true` immediately so it always wins regardless of which overlay is open.

| Key | Action |
|-----|--------|
| `MediaPlayPause` | Toggle play/pause |
| `MediaPlay` | Play |
| `MediaPause` | Pause |
| `MediaStop` | Pause + exit player |
| `MediaRewind` | -10s (uses existing `queueControlsSeek`) |
| `MediaFastForward` | +10s |
| `MediaNext` | Next episode (TV only, reuses existing `onPlayNext` lambda \u2014 same binge-group / source-preservation logic as the in-UI Next Episode button) |
| `MediaPrevious` | Previous episode (TV only, guarded by `episodeNumber > 1`) |

Single file, 69 lines added, 0 removed. The existing `MediaPlayPause` branch inside the subtitle menu is left as a harmless safety net \u2014 it becomes unreachable in practice but protects against future regressions to the top handler.

## Test plan

- Fire TV Stick: open the player, test all 8 media buttons on the stock Alexa remote.
- Android phone with a Bluetooth keyboard: test the multimedia row (F7/F8/F9/F10 on most keyboards map to these KeyEvents).
- TV D-pad: verify existing D-pad/Enter/Back navigation still works (the new handler only returns `true` for media keys, other keys fall through to the existing handlers).