### PR TITLE
feat: TMDB collections in Details (rebased)

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/api/TmdbApi.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/api/TmdbApi.kt
@@ -253,7 +253,16 @@ data class TmdbMovieDetails(
     val budget: Long = 0,
     val genres: List<TmdbGenre> = emptyList(),
     val status: String? = null,
-    val adult: Boolean = false
+    val adult: Boolean = false,
+    @SerializedName("belongs_to_collection") val belongsToCollection: TmdbCollectionRef? = null
+)
+
+/** Reference to a TMDB collection (franchise) returned inside movie/TV details. */
+data class TmdbCollectionRef(
+    val id: Int = 0,
+    val name: String? = null,
+    @SerializedName("poster_path") val posterPath: String? = null,
+    @SerializedName("backdrop_path") val backdropPath: String? = null
 )
 
 data class TmdbTvDetails(

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/MediaRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/MediaRepository.kt
@@ -2394,7 +2394,33 @@ class MediaRepository @Inject constructor(
         detailsCache[cacheKey] = CacheEntry(item, System.currentTimeMillis())
         return item
     }
-    
+
+    /**
+     * Get the TMDB collection (franchise) reference for a movie.
+     * Calls /movie/{id} directly to access the `belongs_to_collection` field,
+     * which is discarded by getMovieDetails() → toMediaItem().
+     * The response is cached by OkHttp, making the redundant call negligible.
+     */
+    suspend fun getMovieCollectionRef(movieId: Int): com.arflix.tv.data.api.TmdbCollectionRef? {
+        return runCatching {
+            tmdbApi.getMovieDetails(movieId, apiKey, language = contentLanguage).belongsToCollection
+        }.getOrNull()
+    }
+
+    /**
+     * Fetch all movies in a TMDB collection (franchise).
+     * Calls TMDB /collection/{id} and maps the parts array to Movie MediaItems.
+     * Used by the Details page to show franchise rows (e.g. "Cars Collection").
+     */
+    suspend fun getTmdbCollectionItems(collectionId: Int): List<MediaItem> {
+        val response = runCatching {
+            tmdbApi.getTmdbCollection(collectionId, apiKey, language = contentLanguage)
+        }.getOrNull() ?: return emptyList()
+        return response.parts
+            .sortedBy { it.releaseDate.orEmpty() }
+            .map { it.toMediaItem(MediaType.MOVIE) }
+    }
+
     /**
      * Get season episodes with Trakt watched status
      */

--- a/app/src/main/kotlin/com/arflix/tv/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/arflix/tv/navigation/AppNavigation.kt
@@ -385,6 +385,9 @@ fun AppNavigation(
                 onNavigateToDetails = { type, id ->
                     navController.navigate(Screen.Details.createRoute(type, id))
                 },
+                onNavigateToCollection = { catalogId ->
+                    navController.navigate(Screen.CollectionDetails.createRoute(catalogId))
+                },
                 onNavigateToHome = {
                     navigateHome()
                 },

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
@@ -428,6 +428,7 @@ fun DetailsScreen(
                                 val hasCast = uiState.cast.isNotEmpty()
                                 val hasReviews = uiState.reviews.isNotEmpty()
                                 val hasSimilar = uiState.similar.isNotEmpty()
+                                val hasCollection = uiState.collectionItems.isNotEmpty()
                                 focusedSection = when (focusedSection) {
                                     FocusSection.BUTTONS -> {
                                         isSidebarFocused = true

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
@@ -2045,14 +2045,14 @@ private fun DetailsTvRows(
     var idx = 0
     val seasonsIdx = if (hasSeasons) idx.also { idx++ } else -1
     val episodesIdx = if (hasEpisodes) idx.also { idx++ } else -1
-    if (hasCast) idx++
+    if (hasCast) idx++  // spacer
     val castIdx = if (hasCast) idx.also { idx++ } else -1
-    if (hasReviews) idx++
+    if (hasReviews) idx++  // spacer
     val reviewsIdx = if (hasReviews) idx.also { idx++ } else -1
-    if (hasSimilar) idx++
-    val similarIdx = if (hasSimilar) idx.also { idx++ } else -1
-    if (hasCollection) idx++
+    if (hasCollection) idx++  // spacer
     val collectionIdx = if (hasCollection) idx.also { idx++ } else -1
+    if (hasSimilar) idx++  // spacer
+    val similarIdx = if (hasSimilar) idx.also { idx++ } else -1
 
     LaunchedEffect(item.mediaType, item.id, currentSeason, hasEpisodes, hasSeasons) {
         contentScrollState.scrollToItem(0, 0)
@@ -2177,22 +2177,6 @@ private fun DetailsTvRows(
             }
         }
 
-        if (similar.isNotEmpty()) {
-            item { Spacer(modifier = Modifier.height(80.dp)) }
-            item {
-                DetailsSimilarRail(
-                    similar = similar,
-                    similarLogoUrls = similarLogoUrls,
-                    similarIndex = similarIndex,
-                    focusSectionForUi = focusSectionForUi,
-                    usePosterCards = usePosterCards,
-                    contentStartPadding = contentStartPadding,
-                    contentOuterStartPadding = contentOuterStartPadding,
-                    onSimilarClick = onSimilarClick
-                )
-            }
-        }
-
         // Collection items row — shown when this movie belongs to a TMDB collection
         if (collectionItems.isNotEmpty()) {
             item { Spacer(modifier = Modifier.height(80.dp)) }
@@ -2206,6 +2190,22 @@ private fun DetailsTvRows(
                     contentStartPadding = contentStartPadding,
                     contentOuterStartPadding = contentOuterStartPadding,
                     onCollectionClick = onCollectionClick
+                )
+            }
+        }
+
+        if (similar.isNotEmpty()) {
+            item { Spacer(modifier = Modifier.height(80.dp)) }
+            item {
+                DetailsSimilarRail(
+                    similar = similar,
+                    similarLogoUrls = similarLogoUrls,
+                    similarIndex = similarIndex,
+                    focusSectionForUi = focusSectionForUi,
+                    usePosterCards = usePosterCards,
+                    contentStartPadding = contentStartPadding,
+                    contentOuterStartPadding = contentOuterStartPadding,
+                    onSimilarClick = onSimilarClick
                 )
             }
         }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
@@ -186,6 +186,7 @@ fun DetailsScreen(
     currentProfile: com.arflix.tv.data.model.Profile? = null,
     onNavigateToPlayer: (MediaType, Int, Int?, Int?, String?, String?, String?, String?, Long?) -> Unit,
     onNavigateToDetails: (MediaType, Int) -> Unit,
+    onNavigateToCollection: (String) -> Unit = {},
     onNavigateToHome: () -> Unit = {},
     onNavigateToSearch: () -> Unit = {},
     onNavigateToWatchlist: () -> Unit = {},
@@ -208,6 +209,7 @@ fun DetailsScreen(
     var castIndex by remember { mutableIntStateOf(0) }
     var reviewIndex by remember { mutableIntStateOf(0) }
     var similarIndex by remember { mutableIntStateOf(0) }
+    var collectionIndex by remember { mutableIntStateOf(0) }
     var suppressSelectUntilMs by remember { mutableLongStateOf(0L) }
     
     // Sidebar state
@@ -387,14 +389,16 @@ fun DetailsScreen(
                                     FocusSection.CAST -> castIndex == 0
                                     FocusSection.REVIEWS -> reviewIndex == 0
                                     FocusSection.SIMILAR -> similarIndex == 0
+                                    FocusSection.COLLECTION -> collectionIndex == 0
                                 }
                                 if (atLeftmost) {
                                     true
                                 } else {
                                     handleLeft(
-                                        focusedSection, buttonIndex, episodeIndex, seasonIndex, castIndex, reviewIndex, similarIndex,
+                                        focusedSection, buttonIndex, episodeIndex, seasonIndex, castIndex, reviewIndex, similarIndex, collectionIndex,
                                         { buttonIndex = it }, { episodeIndex = it }, { seasonIndex = it },
-                                        { castIndex = it }, { reviewIndex = it }, { similarIndex = it }
+                                        { castIndex = it }, { reviewIndex = it }, { similarIndex = it },
+                                        { collectionIndex = it }
                                     )
                                 }
                             }
@@ -407,9 +411,10 @@ fun DetailsScreen(
                                 true
                             } else {
                                 handleRight(
-                                    focusedSection, buttonIndex, episodeIndex, seasonIndex, castIndex, reviewIndex, similarIndex,
+                                    focusedSection, buttonIndex, episodeIndex, seasonIndex, castIndex, reviewIndex, similarIndex, collectionIndex,
                                     uiState, { buttonIndex = it }, { episodeIndex = it }, { seasonIndex = it },
-                                    { castIndex = it }, { reviewIndex = it }, { similarIndex = it }
+                                    { castIndex = it }, { reviewIndex = it }, { similarIndex = it },
+                                    { collectionIndex = it }
                                 )
                             }
                         }
@@ -417,11 +422,12 @@ fun DetailsScreen(
                             if (isSidebarFocused) {
                                 true
                             } else {
-                                // Navigation: BUTTONS -> SEASONS -> EPISODES -> CAST -> REVIEWS -> SIMILAR
+                                // Navigation: BUTTONS -> SEASONS -> EPISODES -> CAST -> REVIEWS -> SIMILAR -> COLLECTION
                                 val isTV = mediaType == MediaType.TV
                                 val hasEpisodes = uiState.episodes.isNotEmpty()
                                 val hasCast = uiState.cast.isNotEmpty()
                                 val hasReviews = uiState.reviews.isNotEmpty()
+                                val hasSimilar = uiState.similar.isNotEmpty()
                                 focusedSection = when (focusedSection) {
                                     FocusSection.BUTTONS -> {
                                         isSidebarFocused = true
@@ -442,6 +448,12 @@ fun DetailsScreen(
                                     }
                                     FocusSection.REVIEWS -> if (hasCast) FocusSection.CAST else FocusSection.BUTTONS
                                     FocusSection.SIMILAR -> if (hasReviews) FocusSection.REVIEWS else if (hasCast) FocusSection.CAST else FocusSection.BUTTONS
+                                    FocusSection.COLLECTION -> {
+                                        if (hasSimilar) FocusSection.SIMILAR
+                                        else if (hasReviews) FocusSection.REVIEWS
+                                        else if (hasCast) FocusSection.CAST
+                                        else FocusSection.BUTTONS
+                                    }
                                 }
                                 true
                             }
@@ -451,13 +463,14 @@ fun DetailsScreen(
                                 isSidebarFocused = false
                                 true
                             } else {
-                                // Navigation: BUTTONS -> SEASONS -> EPISODES -> CAST -> REVIEWS -> SIMILAR
+                                // Navigation: BUTTONS -> SEASONS -> EPISODES -> CAST -> REVIEWS -> SIMILAR -> COLLECTION
                                 val isTV = mediaType == MediaType.TV
                                 val hasEpisodes = uiState.episodes.isNotEmpty()
                                 val hasSeasons = uiState.totalSeasons > 1
                                 val hasCast = uiState.cast.isNotEmpty()
                                 val hasReviews = uiState.reviews.isNotEmpty()
                                 val hasSimilar = uiState.similar.isNotEmpty()
+                                val hasCollection = uiState.collectionItems.isNotEmpty()
                                 focusedSection = when (focusedSection) {
                                     FocusSection.BUTTONS -> {
                                         if (isTV && hasSeasons) FocusSection.SEASONS
@@ -465,6 +478,7 @@ fun DetailsScreen(
                                         else if (hasCast) FocusSection.CAST
                                         else if (hasReviews) FocusSection.REVIEWS
                                         else if (hasSimilar) FocusSection.SIMILAR
+                                        else if (hasCollection) FocusSection.COLLECTION
                                         else FocusSection.BUTTONS
                                     }
                                     FocusSection.SEASONS -> {
@@ -472,23 +486,31 @@ fun DetailsScreen(
                                         else if (hasCast) FocusSection.CAST
                                         else if (hasReviews) FocusSection.REVIEWS
                                         else if (hasSimilar) FocusSection.SIMILAR
+                                        else if (hasCollection) FocusSection.COLLECTION
                                         else FocusSection.SEASONS
                                     }
                                     FocusSection.EPISODES -> {
                                         if (hasCast) FocusSection.CAST
                                         else if (hasReviews) FocusSection.REVIEWS
                                         else if (hasSimilar) FocusSection.SIMILAR
+                                        else if (hasCollection) FocusSection.COLLECTION
                                         else FocusSection.EPISODES
                                     }
                                     FocusSection.CAST -> {
                                         if (hasReviews) FocusSection.REVIEWS
                                         else if (hasSimilar) FocusSection.SIMILAR
+                                        else if (hasCollection) FocusSection.COLLECTION
                                         else FocusSection.CAST
                                     }
                                     FocusSection.REVIEWS -> {
-                                        if (hasSimilar) FocusSection.SIMILAR else FocusSection.REVIEWS
+                                        if (hasSimilar) FocusSection.SIMILAR
+                                        else if (hasCollection) FocusSection.COLLECTION
+                                        else FocusSection.REVIEWS
                                     }
-                                    FocusSection.SIMILAR -> FocusSection.SIMILAR  // Stay on similar (bottom)
+                                    FocusSection.SIMILAR -> {
+                                        if (hasCollection) FocusSection.COLLECTION else FocusSection.SIMILAR
+                                    }
+                                    FocusSection.COLLECTION -> FocusSection.COLLECTION  // Stay on collection (bottom)
                                 }
                                 true
                             }
@@ -601,6 +623,12 @@ fun DetailsScreen(
                                         onNavigateToDetails(similar.mediaType, similar.id)
                                     }
                                 }
+                                FocusSection.COLLECTION -> {
+                                    val collectionItem = uiState.collectionItems.getOrNull(collectionIndex)
+                                    if (collectionItem != null) {
+                                        onNavigateToDetails(collectionItem.mediaType, collectionItem.id)
+                                    }
+                                }
                             }
                             true
                         }
@@ -660,6 +688,9 @@ fun DetailsScreen(
                     reviews = uiState.reviews,
                     similar = uiState.similar,
                     similarLogoUrls = uiState.similarLogoUrls,
+                    collectionItems = uiState.collectionItems,
+                    collectionName = uiState.collectionName,
+                    collectionIndex = collectionIndex,
                     focusedSection = focusedSection,
                     buttonIndex = buttonIndex,
                     episodeIndex = episodeIndex,
@@ -722,6 +753,12 @@ fun DetailsScreen(
                             }
                             3 -> viewModel.toggleWatched(episodeIndex)
                             4 -> viewModel.toggleWatchlist()
+                            5 -> { // View Collection — navigate to the CollectionDetailsScreen
+                                val collectionId = uiState.collectionId
+                                if (collectionId != null) {
+                                    onNavigateToCollection(collectionId.toString())
+                                }
+                            }
                         }
                     },
                     onSeasonClick = { idx ->
@@ -754,6 +791,12 @@ fun DetailsScreen(
                         val sim = uiState.similar.getOrNull(idx)
                         if (sim != null) {
                             onNavigateToDetails(sim.mediaType, sim.id)
+                        }
+                    },
+                    onCollectionClick = { idx ->
+                        val item = uiState.collectionItems.getOrNull(idx)
+                        if (item != null) {
+                            onNavigateToDetails(item.mediaType, item.id)
                         }
                     }
                 )
@@ -913,7 +956,7 @@ fun DetailsScreen(
 }
 
 private enum class FocusSection {
-    BUTTONS, EPISODES, SEASONS, CAST, REVIEWS, SIMILAR
+    BUTTONS, EPISODES, SEASONS, CAST, REVIEWS, SIMILAR, COLLECTION
 }
 
 private data class PendingAutoPlayRequest(
@@ -980,8 +1023,10 @@ private fun isPendingDebridStream(stream: com.arflix.tv.data.model.StreamSource)
 private fun handleLeft(
     section: FocusSection,
     buttonIdx: Int, episodeIdx: Int, seasonIdx: Int, castIdx: Int, reviewIdx: Int, similarIdx: Int,
+    collectionIdx: Int,
     setButton: (Int) -> Unit, setEpisode: (Int) -> Unit, setSeason: (Int) -> Unit,
-    setCast: (Int) -> Unit, setReview: (Int) -> Unit, setSimilar: (Int) -> Unit
+    setCast: (Int) -> Unit, setReview: (Int) -> Unit, setSimilar: (Int) -> Unit,
+    setCollection: (Int) -> Unit
 ): Boolean {
     when (section) {
         FocusSection.BUTTONS -> if (buttonIdx > 0) setButton(buttonIdx - 1)
@@ -990,6 +1035,7 @@ private fun handleLeft(
         FocusSection.CAST -> if (castIdx > 0) setCast(castIdx - 1)
         FocusSection.REVIEWS -> if (reviewIdx > 0) setReview(reviewIdx - 1)
         FocusSection.SIMILAR -> if (similarIdx > 0) setSimilar(similarIdx - 1)
+        FocusSection.COLLECTION -> if (collectionIdx > 0) setCollection(collectionIdx - 1)
     }
     return true
 }
@@ -997,17 +1043,23 @@ private fun handleLeft(
 private fun handleRight(
     section: FocusSection,
     buttonIdx: Int, episodeIdx: Int, seasonIdx: Int, castIdx: Int, reviewIdx: Int, similarIdx: Int,
+    collectionIdx: Int,
     uiState: DetailsUiState,
     setButton: (Int) -> Unit, setEpisode: (Int) -> Unit, setSeason: (Int) -> Unit,
-    setCast: (Int) -> Unit, setReview: (Int) -> Unit, setSimilar: (Int) -> Unit
+    setCast: (Int) -> Unit, setReview: (Int) -> Unit, setSimilar: (Int) -> Unit,
+    setCollection: (Int) -> Unit
 ): Boolean {
     when (section) {
-        FocusSection.BUTTONS -> if (buttonIdx < 4) setButton(buttonIdx + 1)
+        FocusSection.BUTTONS -> {
+            val maxButton = if (uiState.collectionId != null) 5 else 4
+            if (buttonIdx < maxButton) setButton(buttonIdx + 1)
+        }
         FocusSection.EPISODES -> if (episodeIdx < uiState.episodes.size - 1) setEpisode(episodeIdx + 1)
         FocusSection.SEASONS -> if (seasonIdx < uiState.totalSeasons - 1) setSeason(seasonIdx + 1)
         FocusSection.CAST -> if (castIdx < uiState.cast.size - 1) setCast(castIdx + 1)
         FocusSection.REVIEWS -> if (reviewIdx < uiState.reviews.size - 1) setReview(reviewIdx + 1)
         FocusSection.SIMILAR -> if (similarIdx < uiState.similar.size - 1) setSimilar(similarIdx + 1)
+        FocusSection.COLLECTION -> if (collectionIdx < uiState.collectionItems.size - 1) setCollection(collectionIdx + 1)
     }
     return true
 }
@@ -1024,6 +1076,9 @@ private fun DetailsContent(
     reviews: List<Review>,
     similar: List<MediaItem>,
     similarLogoUrls: Map<String, String>,
+    collectionItems: List<MediaItem> = emptyList(),
+    collectionName: String? = null,
+    collectionIndex: Int = 0,
     focusedSection: FocusSection,
     buttonIndex: Int,
     episodeIndex: Int,
@@ -1048,7 +1103,8 @@ private fun DetailsContent(
     onEpisodeClick: (Int) -> Unit = {},
     onCastClick: (Int) -> Unit = {},
     spoilerBlurEnabled: Boolean = false,
-    onSimilarClick: (Int) -> Unit = {}
+    onSimilarClick: (Int) -> Unit = {},
+    onCollectionClick: (Int) -> Unit = {}
 ) {
     val context = LocalContext.current
     val metadataLogoImageLoader = remember(context) {
@@ -1488,6 +1544,43 @@ private fun DetailsContent(
                     }
                 }
 
+                // Collection items section — shown when this movie belongs to a TMDB collection
+                if (collectionItems.isNotEmpty()) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp)
+                    ) {
+                        Spacer(modifier = Modifier.height(24.dp))
+                        val displayName = collectionName ?: stringResource(R.string.more_like_this)
+                        Text(
+                            text = "$displayName Collection",
+                            style = ArvioSkin.typography.sectionTitle.copy(fontSize = 15.sp, fontWeight = FontWeight.Bold),
+                            color = Color.White.copy(alpha = 0.9f)
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                    }
+                    LazyRow(
+                        modifier = Modifier.arvioDpadFocusGroup(),
+                        contentPadding = PaddingValues(start = 16.dp, end = 16.dp),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        standardItemsIndexed(
+                            collectionItems,
+                            key = { index, m -> "mob_col_${m.mediaType.name}_${m.id}_$index" },
+                            contentType = { _, _ -> "collection" }
+                        ) { index, mediaItem ->
+                            SimilarMediaCard(
+                                item = mediaItem,
+                                logoImageUrl = null,
+                                usePosterCards = usePosterCards,
+                                isFocused = false,
+                                onClick = { onCollectionClick(index) }
+                            )
+                        }
+                    }
+                }
+
                 // Reviews section
                 if (reviews.isNotEmpty()) {
                     Column(
@@ -1857,6 +1950,18 @@ private fun DetailsContent(
                         isActive = isInWatchlist
                     )
                 }
+
+                // "View Collection" button — only shown when this movie belongs to a TMDB collection
+                if (collectionItems.isNotEmpty()) {
+                    Box(modifier = Modifier.clickable { onButtonClick(5) }) {
+                        PremiumActionButton(
+                            icon = Icons.Default.Star,
+                            text = stringResource(R.string.view_collection),
+                            isFocused = focusSectionForUi == FocusSection.BUTTONS && buttonIndex == 5,
+                            isIconOnly = true
+                        )
+                    }
+                }
             }
         }
 
@@ -1903,6 +2008,9 @@ private fun DetailsTvRows(
     reviews: List<Review>,
     similar: List<MediaItem>,
     similarLogoUrls: Map<String, String>,
+    collectionItems: List<MediaItem> = emptyList(),
+    collectionName: String? = null,
+    collectionIndex: Int = 0,
     focusedSection: FocusSection,
     focusSectionForUi: FocusSection?,
     episodeIndex: Int,
@@ -1920,7 +2028,8 @@ private fun DetailsTvRows(
     onSeasonClick: (Int) -> Unit,
     onEpisodeClick: (Int) -> Unit,
     onCastClick: (Int) -> Unit,
-    onSimilarClick: (Int) -> Unit
+    onSimilarClick: (Int) -> Unit,
+    onCollectionClick: (Int) -> Unit = {}
 ) {
     val contentScrollState = rememberTvLazyListState()
     val detailsStackOffsetPx = remember { Animatable(0f) }
@@ -1931,6 +2040,7 @@ private fun DetailsTvRows(
     val hasCast = cast.isNotEmpty()
     val hasReviews = reviews.isNotEmpty()
     val hasSimilar = similar.isNotEmpty()
+    val hasCollection = collectionItems.isNotEmpty()
 
     var idx = 0
     val seasonsIdx = if (hasSeasons) idx.also { idx++ } else -1
@@ -1941,6 +2051,8 @@ private fun DetailsTvRows(
     val reviewsIdx = if (hasReviews) idx.also { idx++ } else -1
     if (hasSimilar) idx++
     val similarIdx = if (hasSimilar) idx.also { idx++ } else -1
+    if (hasCollection) idx++
+    val collectionIdx = if (hasCollection) idx.also { idx++ } else -1
 
     LaunchedEffect(item.mediaType, item.id, currentSeason, hasEpisodes, hasSeasons) {
         contentScrollState.scrollToItem(0, 0)
@@ -1954,6 +2066,7 @@ private fun DetailsTvRows(
             FocusSection.CAST -> castIdx
             FocusSection.REVIEWS -> reviewsIdx
             FocusSection.SIMILAR -> similarIdx
+            FocusSection.COLLECTION -> collectionIdx
         }
         if (targetIndex < 0) return@LaunchedEffect
 
@@ -2076,6 +2189,23 @@ private fun DetailsTvRows(
                     contentStartPadding = contentStartPadding,
                     contentOuterStartPadding = contentOuterStartPadding,
                     onSimilarClick = onSimilarClick
+                )
+            }
+        }
+
+        // Collection items row — shown when this movie belongs to a TMDB collection
+        if (collectionItems.isNotEmpty()) {
+            item { Spacer(modifier = Modifier.height(80.dp)) }
+            item {
+                DetailsCollectionRail(
+                    collectionItems = collectionItems,
+                    collectionName = collectionName,
+                    collectionIndex = collectionIndex,
+                    focusSectionForUi = focusSectionForUi,
+                    usePosterCards = usePosterCards,
+                    contentStartPadding = contentStartPadding,
+                    contentOuterStartPadding = contentOuterStartPadding,
+                    onCollectionClick = onCollectionClick
                 )
             }
         }
@@ -2423,6 +2553,87 @@ private fun DetailsSimilarRail(
                     startPadding = contentStartPadding,
                     topPadding = 14.dp,
                     width = similarCardWidth,
+                    aspectRatio = if (usePosterCards) 2f / 3f else 16f / 9f
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DetailsCollectionRail(
+    collectionItems: List<MediaItem>,
+    collectionName: String?,
+    collectionIndex: Int,
+    focusSectionForUi: FocusSection?,
+    usePosterCards: Boolean,
+    contentStartPadding: Dp,
+    contentOuterStartPadding: Dp,
+    onCollectionClick: (Int) -> Unit
+) {
+    val collectionRowState = rememberTvLazyListState()
+    val collectionCardWidth = if (usePosterCards) 126.dp else 210.dp
+    val collectionFixedFocus = focusSectionForUi == FocusSection.COLLECTION &&
+        detailsRailUsesFixedFirstSlotFocus(
+            totalItems = collectionItems.size,
+            focusedItemIndex = collectionIndex
+        )
+    HomeStyleRowAutoScroll(
+        rowState = collectionRowState,
+        isCurrentRow = focusSectionForUi == FocusSection.COLLECTION,
+        focusedItemIndex = collectionIndex,
+        totalItems = collectionItems.size,
+        itemWidth = collectionCardWidth,
+        itemSpacing = 14.dp
+    )
+
+    Column {
+        val displayName = collectionName ?: stringResource(R.string.more_like_this)
+        Text(
+            text = "$displayName Collection",
+            style = ArvioSkin.typography.sectionTitle.copy(
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Bold
+            ),
+            color = Color.White.copy(alpha = 0.9f),
+            modifier = Modifier.padding(start = contentStartPadding, bottom = 10.dp)
+        )
+
+        Box(modifier = Modifier.fillMaxWidth()) {
+            TvLazyRow(
+                state = collectionRowState,
+                modifier = Modifier.arvioDpadFocusGroup(enableFocusRestorer = false),
+                contentPadding = PaddingValues(
+                    start = contentStartPadding,
+                    end = lockedDetailsRailEndPadding(
+                        itemWidth = collectionCardWidth,
+                        startPadding = contentStartPadding,
+                        outerStartPadding = contentOuterStartPadding,
+                        minimum = if (usePosterCards) 140.dp else 210.dp
+                    ),
+                    top = 14.dp,
+                    bottom = 14.dp,
+                ),
+                horizontalArrangement = Arrangement.spacedBy(14.dp)
+            ) {
+                itemsIndexed(
+                    collectionItems,
+                    key = { index, m -> "col_${m.mediaType.name}_${m.id}_$index" }
+                ) { index, mediaItem ->
+                    SimilarMediaCard(
+                        item = mediaItem,
+                        logoImageUrl = null,
+                        usePosterCards = usePosterCards,
+                        isFocused = focusSectionForUi == FocusSection.COLLECTION && index == collectionIndex && !collectionFixedFocus,
+                        onClick = { onCollectionClick(index) }
+                    )
+                }
+            }
+            if (collectionFixedFocus) {
+                FixedDetailsRailFocusOverlay(
+                    startPadding = contentStartPadding,
+                    topPadding = 14.dp,
+                    width = collectionCardWidth,
                     aspectRatio = if (usePosterCards) 2f / 3f else 16f / 9f
                 )
             }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
@@ -1555,7 +1555,7 @@ private fun DetailsContent(
                         Spacer(modifier = Modifier.height(24.dp))
                         val displayName = collectionName ?: stringResource(R.string.more_like_this)
                         Text(
-                            text = "$displayName Collection",
+                            text = displayName,
                             style = ArvioSkin.typography.sectionTitle.copy(fontSize = 15.sp, fontWeight = FontWeight.Bold),
                             color = Color.White.copy(alpha = 0.9f)
                         )

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
@@ -84,7 +84,12 @@ data class DetailsUiState(
     val playLabel: String? = null,
     val playPositionMs: Long? = null,
     val autoPlaySingleSource: Boolean = true,
-    val autoPlayMinQuality: String = "Any"
+    val autoPlayMinQuality: String = "Any",
+    // TMDB collection (franchise) info — populated for movies that belong to a collection
+    val collectionId: Int? = null,
+    val collectionName: String? = null,
+    val collectionItems: List<MediaItem> = emptyList(),
+    val collectionPosterPath: String? = null
 )
 
 data class StreamingServiceUi(
@@ -467,6 +472,34 @@ class DetailsViewModel @Inject constructor(
                     val reviews = runCatching { mediaRepository.getReviews(mediaType, mediaId) }.getOrNull()
                     if (!reviews.isNullOrEmpty()) {
                         updateState { state -> state.copy(reviews = reviews) }
+                    }
+                }
+
+                // TMDB collection (franchise) — only for movies
+                launch {
+                    if (mediaType != MediaType.MOVIE) return@launch
+                    val collectionRef = runCatching {
+                        mediaRepository.getMovieCollectionRef(mediaId)
+                    }.getOrNull()
+                    if (collectionRef != null) {
+                        updateState { state ->
+                            state.copy(
+                                collectionId = collectionRef.id,
+                                collectionName = collectionRef.name,
+                                collectionPosterPath = collectionRef.posterPath
+                            )
+                        }
+                        // Fetch collection items in background
+                        launch {
+                            val items = runCatching {
+                                mediaRepository.getTmdbCollectionItems(collectionRef.id)
+                            }.getOrNull() ?: emptyList()
+                            updateState { state ->
+                                if (state.collectionId == collectionRef.id) {
+                                    state.copy(collectionItems = items)
+                                } else state
+                            }
+                        }
                     }
                 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -207,4 +207,5 @@
     <string name="set_profile_pin">Set Profile PIN</string>
     <string name="done">Done</string>
     <string name="connect_to_cloud">Connect to ARVIO Cloud</string>
+    <string name="view_collection">View Collection</string>
 </resources>


### PR DESCRIPTION
## Summary
Recreated from GitLab MR #79 and rebased onto current `main`.

This PR adds TMDB movie collection support on the Details page and includes the collection routing/UX fixes needed for a clean merge.

## Included Changes
- Add TMDB collection data loading for movie details
- Show collection section on Details page
- Move collection items above "More Like This"
- Fix duplicate collection naming
- Fix `hasCollection` declaration scope
- Route **View Collection** to `CollectionDetails` using `collectionId`

## Why
The original GitLab MR was never merged. This recreates the intended feature/fixes on top of current GitHub `main`.

## Validation
- `git diff --check` against `upstream/main...mr-79-clean`: clean
- Compile checks attempted in this dev container but blocked by missing Android build-tools dependency (`25.0.2`):
  - `:app:compilePlayDebugKotlin`
  - `:app:compileSideloadDebugKotlin`

Please run compile checks in CI or local Android SDK.