### PR TITLE
fix: season unwatch context menu + Trakt batch cleanup (rebased)

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/TraktRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/TraktRepository.kt
@@ -563,19 +563,22 @@ class TraktRepository @Inject constructor(
 
     /**
      * Mark episode as unwatched - updates local cache immediately (optimistic), then syncs to backend
+     * @param syncTrakt If true (default), also syncs to Trakt. Set false when batch Trakt removal is already done.
      */
-    suspend fun markEpisodeUnwatched(showTmdbId: Int, season: Int, episode: Int) {
+    suspend fun markEpisodeUnwatched(showTmdbId: Int, season: Int, episode: Int, syncTrakt: Boolean = true) {
         ensureProfileCacheScope()
         // OPTIMISTIC UPDATE: Update all caches immediately so the UI responds instantly
         updateWatchedCache(showTmdbId, season, episode, false)
         updateShowWatchedCache(showTmdbId, season, episode, false)
         persistLocalWatchedSnapshotForCurrentProfile()
 
-        // Then sync to backend in background
-        try {
-            syncService.markEpisodeUnwatched(showTmdbId, season, episode)
-        } catch (e: Exception) {
-            // Sync failed, but local cache is already updated
+        // Then sync to backend in background (skip if batch Trakt removal already handled it)
+        if (syncTrakt) {
+            try {
+                syncService.markEpisodeUnwatched(showTmdbId, season, episode)
+            } catch (e: Exception) {
+                // Sync failed, but local cache is already updated
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/arflix/tv/ui/components/ContextMenu.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/ContextMenu.kt
@@ -84,6 +84,7 @@ object ContextActions {
     val removeWatchlist = ContextAction("remove_watchlist", "Remove from Watchlist", Icons.Default.Bookmark, TextSecondary)
     val viewDetails = ContextAction("view_details", "View Details", Icons.Default.Info, TextPrimary)
     val markSeasonWatched = ContextAction("mark_season_watched", "Mark Season Watched", Icons.Default.Check, Color(0xFF22C55E))
+    val markSeasonUnwatched = ContextAction("mark_season_unwatched", "Mark Season Unwatched", Icons.Default.Clear, TextSecondary)
 }
 
 /**
@@ -450,16 +451,21 @@ fun SeasonContextMenu(
     isVisible: Boolean,
     seasonNumber: Int,
     onMarkSeasonWatched: () -> Unit,
+    onMarkSeasonUnwatched: () -> Unit,
     onDismiss: () -> Unit
 ) {
     ContextMenu(
         isVisible = isVisible,
         title = "Season $seasonNumber",
         subtitle = "Quick Actions",
-        actions = listOf(ContextActions.markSeasonWatched),
+        actions = listOf(
+            ContextActions.markSeasonWatched,
+            ContextActions.markSeasonUnwatched
+        ),
         onAction = { action ->
-            if (action.id == "mark_season_watched") {
-                onMarkSeasonWatched()
+            when (action.id) {
+                "mark_season_watched" -> onMarkSeasonWatched()
+                "mark_season_unwatched" -> onMarkSeasonUnwatched()
             }
             onDismiss()
         },

--- a/app/src/main/kotlin/com/arflix/tv/ui/components/ContextMenu.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/ContextMenu.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.BookmarkBorder
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.PlayArrow

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
@@ -890,6 +890,9 @@ fun DetailsScreen(
             onMarkSeasonWatched = {
                 viewModel.markSeasonWatched(contextMenuSeason)
             },
+            onMarkSeasonUnwatched = {
+                viewModel.markSeasonUnwatched(contextMenuSeason)
+            },
             onDismiss = {
                 showSeasonContextMenu = false
             }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
@@ -1633,9 +1633,9 @@ class DetailsViewModel @Inject constructor(
                 val episodeNumbers = seasonEpisodes.map { it.episodeNumber }
 
                 // 1. Single batch Trakt API call to remove from history
-                val batchTraktRemovalResult = runCatching {
+                val batchTraktRemoved = runCatching {
                     traktRepository.removeSeasonFromHistory(currentMediaId, season, episodeNumbers)
-                }
+                }.getOrDefault(false)
 
                 // 2. Concurrent local/Supabase unwatch writes for each episode.
                 // If the batch Trakt removal failed, fall back to per-episode Trakt sync.
@@ -1646,13 +1646,13 @@ class DetailsViewModel @Inject constructor(
                                 currentMediaId,
                                 season,
                                 epNum,
-                                syncTrakt = batchTraktRemovalResult.isFailure
+                                syncTrakt = !batchTraktRemoved
                             )
                         }
                     }
                 }.map { it.await() }
 
-                if (batchTraktRemovalResult.isFailure && episodeUnwatchResults.any { it.isFailure }) {
+                if (!batchTraktRemoved && episodeUnwatchResults.any { it.isFailure }) {
                     _uiState.value = _uiState.value.copy(
                         episodes = updatedEpisodes,
                         seasonProgress = optimisticProgress,

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
@@ -1633,18 +1633,34 @@ class DetailsViewModel @Inject constructor(
                 val episodeNumbers = seasonEpisodes.map { it.episodeNumber }
 
                 // 1. Single batch Trakt API call to remove from history
-                runCatching {
+                val batchTraktRemovalResult = runCatching {
                     traktRepository.removeSeasonFromHistory(currentMediaId, season, episodeNumbers)
                 }
 
-                // 2. Concurrent local/Supabase unwatch writes for each episode (Trakt already handled by batch removal above)
-                episodeNumbers.map { epNum ->
+                // 2. Concurrent local/Supabase unwatch writes for each episode.
+                // If the batch Trakt removal failed, fall back to per-episode Trakt sync.
+                val episodeUnwatchResults = episodeNumbers.map { epNum ->
                     async {
                         runCatching {
-                            traktRepository.markEpisodeUnwatched(currentMediaId, season, epNum, syncTrakt = false)
+                            traktRepository.markEpisodeUnwatched(
+                                currentMediaId,
+                                season,
+                                epNum,
+                                syncTrakt = batchTraktRemovalResult.isFailure
+                            )
                         }
                     }
-                }.forEach { it.await() }
+                }.map { it.await() }
+
+                if (batchTraktRemovalResult.isFailure && episodeUnwatchResults.any { it.isFailure }) {
+                    _uiState.value = _uiState.value.copy(
+                        episodes = updatedEpisodes,
+                        seasonProgress = optimisticProgress,
+                        toastMessage = "Failed to sync Season $season as unwatched with Trakt",
+                        toastType = ToastType.ERROR
+                    )
+                    return@launch
+                }
 
                 val refreshedProgress = runCatching { fetchSeasonProgress(currentMediaId) }.getOrNull()
 

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
@@ -1593,6 +1593,79 @@ class DetailsViewModel @Inject constructor(
         }
     }
 
+    fun markSeasonUnwatched(season: Int) {
+        if (currentMediaType != MediaType.TV) return
+        val currentItem = _uiState.value.item ?: return
+
+        viewModelScope.launch {
+            try {
+                val seasonEpisodes = if (_uiState.value.currentSeason == season && _uiState.value.episodes.isNotEmpty()) {
+                    _uiState.value.episodes
+                } else {
+                    mediaRepository.getSeasonEpisodes(currentMediaId, season)
+                }
+
+                if (seasonEpisodes.isEmpty()) {
+                    _uiState.value = _uiState.value.copy(
+                        toastMessage = "No episodes found for Season $season",
+                        toastType = ToastType.ERROR
+                    )
+                    return@launch
+                }
+
+                // OPTIMISTIC UPDATE: Update local state immediately
+                val updatedEpisodes = if (_uiState.value.currentSeason == season) {
+                    _uiState.value.episodes.map { ep ->
+                        if (ep.seasonNumber == season) ep.copy(isWatched = false) else ep
+                    }
+                } else {
+                    _uiState.value.episodes
+                }
+                val optimisticProgress = _uiState.value.seasonProgress.toMutableMap().apply {
+                    this[season] = Pair(0, seasonEpisodes.size)
+                }
+                _uiState.value = _uiState.value.copy(
+                    episodes = updatedEpisodes,
+                    seasonProgress = optimisticProgress
+                )
+
+                // BATCH: Single Trakt API call to remove all episodes, then concurrent Supabase writes
+                val episodeNumbers = seasonEpisodes.map { it.episodeNumber }
+
+                // 1. Single batch Trakt API call to remove from history
+                runCatching {
+                    traktRepository.removeSeasonFromHistory(currentMediaId, season, episodeNumbers)
+                }
+
+                // 2. Concurrent Supabase unwatch writes for each episode
+                episodeNumbers.map { epNum ->
+                    async {
+                        runCatching {
+                            traktRepository.markEpisodeUnwatched(currentMediaId, season, epNum)
+                        }
+                    }
+                }.forEach { it.await() }
+
+                val refreshedProgress = runCatching { fetchSeasonProgress(currentMediaId) }.getOrNull()
+
+                _uiState.value = _uiState.value.copy(
+                    item = currentItem.copy(isWatched = false),
+                    episodes = updatedEpisodes,
+                    seasonProgress = refreshedProgress?.progress ?: optimisticProgress,
+                    toastMessage = "Season $season marked as unwatched",
+                    toastType = ToastType.SUCCESS
+                )
+                runCatching { launcherContinueWatchingRepository.refreshForCurrentProfile() }
+                runCatching { cloudSyncRepository.pushToCloud() }
+            } catch (_: Exception) {
+                _uiState.value = _uiState.value.copy(
+                    toastMessage = "Failed to mark season as unwatched",
+                    toastType = ToastType.ERROR
+                )
+            }
+        }
+    }
+
     /**
      * Resolve real IMDB ID from TMDB using external_ids endpoint
      * This is required for addon stream resolution

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
@@ -1637,11 +1637,11 @@ class DetailsViewModel @Inject constructor(
                     traktRepository.removeSeasonFromHistory(currentMediaId, season, episodeNumbers)
                 }
 
-                // 2. Concurrent Supabase unwatch writes for each episode
+                // 2. Concurrent local/Supabase unwatch writes for each episode (Trakt already handled by batch removal above)
                 episodeNumbers.map { epNum ->
                     async {
                         runCatching {
-                            traktRepository.markEpisodeUnwatched(currentMediaId, season, epNum)
+                            traktRepository.markEpisodeUnwatched(currentMediaId, season, epNum, syncTrakt = false)
                         }
                     }
                 }.forEach { it.await() }


### PR DESCRIPTION
Recreated from GitLab MR #73 and rebased onto current main: 
https://gitlab.com/arvio1/ARVIO/-/merge_requests/73

Includes:

- Add "Mark Season as Unwatched" action in season context menu
- Fix compile issue by importing `Icons.Default.Clear` in ContextMenu.kt
- Fix Trakt duplicate-removal behavior in season-unwatch flow:
  - keep batch `removeSeasonFromHistory(...)`
  - per-episode cleanup uses `markEpisodeUnwatched(..., syncTrakt = false)`\n\nValidation:
  - `git diff --check` against `upstream/main...mr-73-clean`: clean
  - Tried:
    - `:app:compilePlayDebugKotlin`
      - `:app:compileSideloadDebugKotlin`
      - Both fail in this dev container due missing Android build-tools dependency (`25.0.2`). 
      Please confirm in CI/local SDK.