### PR TITLE
fix: pass spoilerBlurEnabled to DetailsContent so episode blur actually works

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
@@ -676,6 +676,7 @@ fun DetailsScreen(
                     contentHasFocus = !isSidebarFocused,
                     usePosterCards = usePosterCards,
                     isMobile = isMobile,
+                    spoilerBlurEnabled = spoilerBlurEnabled,
                     onBack = onBack,
                     onButtonClick = { idx ->
                         when (idx) {


### PR DESCRIPTION
## Description

Fixes spoiler blur not applying to episode descriptions on the details page. The `spoilerBlurEnabled` parameter was not being passed through to `DetailsContent`, causing the blur effect to be silently ignored for episodes even when the setting was enabled.

### Changes
- [`app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt`](https://github.com/EierKopZA/ARVIO/blob/pr/fix-spoiler-blur-details-page/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt) - Pass `spoilerBlurEnabled` to `DetailsContent` composable

### Testing
- [ ] Enable spoiler blur in settings
- [ ] Navigate to a TV show details page
- [ ] Verify episode descriptions are blurred
- [ ] D-pad focus navigation remains correct

Closes #80