### PR TITLE
feat: add in-player episode switcher with season tabs and episode list

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
@@ -68,6 +69,7 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.VolumeDown
 import androidx.compose.material.icons.filled.VolumeMute
 import androidx.compose.material.icons.filled.VolumeUp
+import androidx.compose.material.icons.filled.List
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.Dp
@@ -131,6 +133,7 @@ import coil.compose.AsyncImage
 import com.arflix.tv.ArflixApplication
 import com.arflix.tv.network.OkHttpProvider
 import com.arflix.tv.data.model.MediaType
+import com.arflix.tv.data.model.Episode
 import com.arflix.tv.data.model.StreamSource
 import com.arflix.tv.data.model.Subtitle
 import com.arflix.tv.ui.components.LoadingIndicator
@@ -270,6 +273,7 @@ fun PlayerScreen(
     val playButtonFocusRequester = remember { FocusRequester() }
     val trackbarFocusRequester = remember { FocusRequester() }
     val subtitleButtonFocusRequester = remember { FocusRequester() }
+    val episodeButtonFocusRequester = remember { FocusRequester() }
     val sourceButtonFocusRequester = remember { FocusRequester() }
     val rewindButtonFocusRequester = remember { FocusRequester() }
     val forwardButtonFocusRequester = remember { FocusRequester() }
@@ -282,6 +286,7 @@ fun PlayerScreen(
     var focusedButton by remember { mutableIntStateOf(0) }
     var showSubtitleMenu by remember { mutableStateOf(false) }
     var showSourceMenu by remember { mutableStateOf(false) }
+    var showEpisodeMenu by remember { mutableStateOf(false) }
     // Post-episode "Up Next" prompt (issue #86). Shown on STATE_ENDED for TV shows:
     // a 10-second countdown lets the user Cancel or immediately Continue. On timeout we
     // advance to the next episode. Gated on the existing autoPlayNext profile setting —
@@ -1138,7 +1143,7 @@ fun PlayerScreen(
 
     // Auto-hide controls and return focus to container
     LaunchedEffect(showControls, isPlaying) {
-        if (showControls && isPlaying && !showSubtitleMenu && !showSourceMenu) {
+        if (showControls && isPlaying && !showSubtitleMenu && !showSourceMenu && !showEpisodeMenu) {
             delay(5000)
             showControls = false
             // Return focus to container so it can receive key events
@@ -1154,7 +1159,7 @@ fun PlayerScreen(
     // AnimatedVisibility(visible = hasPlaybackStarted && showControls),
     // so the play button isn't in composition until playback begins.
     LaunchedEffect(showControls, hasPlaybackStarted) {
-        if (showControls && hasPlaybackStarted && !showSubtitleMenu && !showSourceMenu && uiState.error == null) {
+        if (showControls && hasPlaybackStarted && !showSubtitleMenu && !showSourceMenu && !showEpisodeMenu && uiState.error == null) {
             delay(300)
             try {
                 playButtonFocusRequester.requestFocus()
@@ -1393,6 +1398,7 @@ fun PlayerScreen(
                 !showNextEpisodePrompt &&
                 !showSourceMenu &&
                 !showSubtitleMenu &&
+                !showEpisodeMenu &&
                 uiState.error == null
             ) {
                 if (seasonNumber != null && episodeNumber != null && uiState.autoPlayNext) {
@@ -1489,12 +1495,13 @@ fun PlayerScreen(
         if (uiState.error != null) {
             showSourceMenu = false
             showSubtitleMenu = false
+            showEpisodeMenu = false
         }
     }
 
     // Request focus on the container when not showing controls
-    LaunchedEffect(showControls, showSubtitleMenu, showSourceMenu, showNextEpisodePrompt, uiState.error) {
-        if (!showControls && !showSubtitleMenu && !showSourceMenu && !showNextEpisodePrompt && uiState.error == null) {
+    LaunchedEffect(showControls, showSubtitleMenu, showSourceMenu, showEpisodeMenu, showNextEpisodePrompt, uiState.error) {
+        if (!showControls && !showSubtitleMenu && !showSourceMenu && !showEpisodeMenu && !showNextEpisodePrompt && uiState.error == null) {
             delay(100)
             try {
                 containerFocusRequester.requestFocus()
@@ -1505,6 +1512,15 @@ fun PlayerScreen(
             try {
                 containerFocusRequester.requestFocus()
             } catch (_: Exception) {}
+        }
+    }
+
+    BackHandler(enabled = showEpisodeMenu) {
+        showEpisodeMenu = false
+        showControls = true
+        coroutineScope.launch {
+            delay(150)
+            try { episodeButtonFocusRequester.requestFocus() } catch (_: Exception) {}
         }
     }
 
@@ -1527,7 +1543,7 @@ fun PlayerScreen(
     }
 
     BackHandler(
-        enabled = !showSubtitleMenu && !showSourceMenu && !showNextEpisodePrompt && uiState.error == null
+        enabled = !showSubtitleMenu && !showSourceMenu && !showEpisodeMenu && !showNextEpisodePrompt && uiState.error == null
     ) {
         if (showControls) {
             showControls = false
@@ -1568,12 +1584,12 @@ fun PlayerScreen(
                     Modifier.pointerInput(Unit) {
                         detectTapGestures(
                             onTap = {
-                                if (uiState.error == null && !showSubtitleMenu && !showSourceMenu) {
+                                if (uiState.error == null && !showSubtitleMenu && !showSourceMenu && !showEpisodeMenu) {
                                     showControls = !showControls
                                 }
                             },
                             onDoubleTap = { offset ->
-                                if (uiState.error == null && !showSubtitleMenu && !showSourceMenu) {
+                                if (uiState.error == null && !showSubtitleMenu && !showSourceMenu && !showEpisodeMenu) {
                                     val halfWidth = size.width / 2
                                     if (offset.x < halfWidth) {
                                         // Double-tap left side: rewind 10 seconds
@@ -1662,7 +1678,7 @@ fun PlayerScreen(
                     }
 
                     if ((event.key == Key.Back || event.key == Key.Escape) &&
-                        !showSubtitleMenu && !showSourceMenu && !showNextEpisodePrompt && uiState.error == null
+                        !showSubtitleMenu && !showSourceMenu && !showEpisodeMenu && !showNextEpisodePrompt && uiState.error == null
                     ) {
                         if (showControls) {
                             showControls = false
@@ -2047,7 +2063,7 @@ fun PlayerScreen(
 
         // Netflix-style Controls Overlay
         AnimatedVisibility(
-            visible = hasPlaybackStarted && showControls && !showSubtitleMenu && !showSourceMenu,
+            visible = hasPlaybackStarted && showControls && !showSubtitleMenu && !showSourceMenu && !showEpisodeMenu,
             enter = fadeIn(androidx.compose.animation.core.tween(150)),
             exit = fadeOut(androidx.compose.animation.core.tween(200))
         ) {
@@ -2260,17 +2276,46 @@ fun PlayerScreen(
                                 }
                             },
                             onLeftKey = { if (mediaType == MediaType.TV) nextEpisodeButtonFocusRequester.requestFocus() else aspectButtonFocusRequester.requestFocus() },
-                            onRightKey = { sourceButtonFocusRequester.requestFocus() },
+                            onRightKey = { if (mediaType == MediaType.TV) episodeButtonFocusRequester.requestFocus() else sourceButtonFocusRequester.requestFocus() },
                             onDownKey = { trackbarFocusRequester.requestFocus() })
 
                         Spacer(modifier = Modifier.width(gap))
+
+                        // Episodes — only shown for TV content. Opens the in-player
+                        // episode picker so users can switch episodes without leaving
+                        // the player.
+                        if (mediaType == MediaType.TV) {
+                            PlayerIconButton(
+                                icon = Icons.Default.List,
+                                contentDescription = stringResource(R.string.episodes),
+                                focusRequester = episodeButtonFocusRequester,
+                                size = smallBtn,
+                                iconSize = smallIcon,
+                                onFocusChanged = {},
+                                onClick = {
+                                    showEpisodeMenu = true
+                                    // Kick off season/episode data load if not already loaded
+                                    if (uiState.seasons.isNotEmpty() && uiState.episodes.isEmpty()) {
+                                        viewModel.loadEpisodesForSeason(
+                                            mediaId,
+                                            uiState.selectedSeasonForPicker
+                                        )
+                                    }
+                                },
+                                onLeftKey = { subtitleButtonFocusRequester.requestFocus() },
+                                onRightKey = { sourceButtonFocusRequester.requestFocus() },
+                                onDownKey = { trackbarFocusRequester.requestFocus() }
+                            )
+
+                            Spacer(modifier = Modifier.width(gap))
+                        }
 
                         // Sources
                         PlayerIconButton(icon = Icons.Default.Folder, contentDescription = stringResource(R.string.sources),
                             focusRequester = sourceButtonFocusRequester, size = smallBtn, iconSize = smallIcon,
                             onFocusChanged = {},
                             onClick = { showSourceMenu = true; showControls = true },
-                            onLeftKey = { subtitleButtonFocusRequester.requestFocus() },
+                            onLeftKey = { if (mediaType == MediaType.TV) episodeButtonFocusRequester.requestFocus() else subtitleButtonFocusRequester.requestFocus() },
                             onRightKey = { if (isTouchDevice) playButtonFocusRequester.requestFocus() else rewindButtonFocusRequester.requestFocus() },
                             onDownKey = { trackbarFocusRequester.requestFocus() })
 
@@ -2525,6 +2570,43 @@ fun PlayerScreen(
                 }
             }
         )
+
+        // Episode picker — modal overlay for the in-player episode switcher.
+        // Appears when the user focuses an episode button in the control row.
+        AnimatedVisibility(
+            visible = showEpisodeMenu,
+            enter = fadeIn(androidx.compose.animation.core.tween(150)),
+            exit = fadeOut(androidx.compose.animation.core.tween(200))
+        ) {
+            EpisodePicker(
+                uiState = uiState,
+                currentSeason = seasonNumber,
+                currentEpisode = episodeNumber,
+                onSeasonSelected = { season ->
+                    viewModel.loadEpisodesForSeason(mediaId, season)
+                },
+                onEpisodeSelected = { epSeason, epEpisode ->
+                    showEpisodeMenu = false
+                    showControls = true
+                    val selected = uiState.selectedStream
+                    onPlayNext(
+                        epSeason,
+                        epEpisode,
+                        selected?.addonId?.takeIf { it.isNotBlank() },
+                        selected?.source?.takeIf { it.isNotBlank() },
+                        selected?.behaviorHints?.bingeGroup?.takeIf { it.isNotBlank() }
+                    )
+                },
+                onClose = {
+                    showEpisodeMenu = false
+                    showControls = true
+                    coroutineScope.launch {
+                        delay(150)
+                        try { episodeButtonFocusRequester.requestFocus() } catch (_: Exception) {}
+                    }
+                }
+            )
+        }
 
         // Post-episode "Up Next" prompt (issue #86). Shown when a TV episode ends and
         // autoPlayNext is enabled. 10-second countdown auto-advances, or the user can
@@ -3209,6 +3291,316 @@ private fun handleSubtitleMenuKey(
             true
         }
         else -> false
+    }
+}
+
+/**
+ * Modal overlay for the in-player episode switcher. Shown when the user clicks
+ * the "Episodes" button in the OSD control row. Displays season tabs at the
+ * top and a scrollable list of episodes below. Selecting an episode navigates
+ * via [onEpisodeSelected] which calls [onPlayNext] (route replacement).
+ *
+ * D-pad flow: Season tabs (horizontal) ↔ Episode list (vertical).
+ * Enter selects the focused item.
+ */
+@Composable
+private fun EpisodePicker(
+    uiState: PlayerUiState,
+    currentSeason: Int?,
+    currentEpisode: Int?,
+    onSeasonSelected: (Int) -> Unit,
+    onEpisodeSelected: (Int, Int) -> Unit,
+    onClose: () -> Unit
+) {
+    val context = LocalContext.current
+    val isTouchDevice = LocalDeviceType.current.isTouchDevice()
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.85f))
+            .then(
+                if (!isTouchDevice) {
+                    Modifier.onKeyEvent { event ->
+                        if (event.type == KeyEventType.KeyDown &&
+                            (event.key == Key.Back || event.key == Key.Escape)
+                        ) {
+                            onClose()
+                            true
+                        } else false
+                    }
+                } else Modifier
+            )
+    ) {
+        Column(
+            modifier = Modifier
+                .align(Alignment.Center)
+                .fillMaxWidth(0.88f)
+                .fillMaxHeight(0.78f)
+                .background(Color(0xFF1A1A2E), RoundedCornerShape(14.dp))
+                .padding(horizontal = 20.dp, vertical = 18.dp),
+            horizontalAlignment = Alignment.Start
+        ) {
+            // Header row with title and close button
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = stringResource(R.string.episodes),
+                    style = ArflixTypography.sectionTitle.copy(
+                        fontSize = if (isTouchDevice) 20.sp else 22.sp,
+                        fontWeight = FontWeight.Bold
+                    ),
+                    color = TextPrimary
+                )
+                if (isTouchDevice) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = "Close",
+                        tint = TextSecondary,
+                        modifier = Modifier
+                            .size(28.dp)
+                            .clickable { onClose() }
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(14.dp))
+
+            // Season tabs — horizontal focusable row (TV) / scrollable row (touch)
+            if (uiState.seasons.isNotEmpty()) {
+                LazyRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    itemsIndexed(uiState.seasons) { _, season ->
+                        val isSelected = season.seasonNumber == uiState.selectedSeasonForPicker
+                        val seasonName = season.name ?: "Season ${season.seasonNumber}"
+                        val focuses = remember { mutableStateOf(false) }
+                        Box(
+                            modifier = Modifier
+                                .background(
+                                    if (isSelected) Pink else Color.White.copy(alpha = 0.1f),
+                                    RoundedCornerShape(8.dp)
+                                )
+                                .onFocusChanged { focuses.value = it.isFocused }
+                                .focusable()
+                                .then(
+                                    if (!isTouchDevice) {
+                                        Modifier.onKeyEvent { event ->
+                                            if (event.type == KeyEventType.KeyDown &&
+                                                (event.key == Key.Enter || event.key == Key.DirectionCenter)
+                                            ) {
+                                                if (!isSelected) onSeasonSelected(season.seasonNumber)
+                                                true
+                                            } else false
+                                        }
+                                    } else Modifier
+                                )
+                                .clickable(
+                                    interactionSource = remember { MutableInteractionSource() },
+                                    indication = null
+                                ) {
+                                    if (!isSelected) onSeasonSelected(season.seasonNumber)
+                                }
+                                .padding(horizontal = 14.dp, vertical = 8.dp)
+                        ) {
+                            Text(
+                                text = seasonName,
+                                style = ArflixTypography.body.copy(
+                                    fontSize = if (isTouchDevice) 13.sp else 14.sp,
+                                    fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal
+                                ),
+                                color = if (focuses.value) Color.White
+                                    else if (isSelected) Color.White else TextSecondary,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(14.dp))
+
+                // Divider
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(1.dp)
+                        .background(Color.White.copy(alpha = 0.08f))
+                )
+
+                Spacer(modifier = Modifier.height(10.dp))
+            }
+
+            // Episode list
+            if (uiState.isLoadingEpisodes) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    LoadingIndicator()
+                }
+            } else if (uiState.episodes.isEmpty()) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = if (uiState.seasons.isEmpty()) "No season data available" else "No episodes found",
+                        color = TextSecondary,
+                        style = ArflixTypography.body.copy(fontSize = 15.sp)
+                    )
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    itemsIndexed(uiState.episodes) { _, episode ->
+                        val isCurrent = episode.seasonNumber == currentSeason &&
+                            episode.episodeNumber == currentEpisode
+                        EpisodePickerItem(
+                            episode = episode,
+                            isCurrentEpisode = isCurrent,
+                            isTouchDevice = isTouchDevice,
+                            onClick = {
+                                if (!isCurrent) {
+                                    onEpisodeSelected(episode.seasonNumber, episode.episodeNumber)
+                                }
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EpisodePickerItem(
+    episode: Episode,
+    isCurrentEpisode: Boolean,
+    isTouchDevice: Boolean,
+    onClick: () -> Unit
+) {
+    var focused by remember { mutableStateOf(false) }
+    val bgColor = when {
+        focused -> Color.White.copy(alpha = 0.15f)
+        isCurrentEpisode -> Pink.copy(alpha = 0.2f)
+        else -> Color.White.copy(alpha = 0.04f)
+    }
+    val borderColor = when {
+        focused -> Pink.copy(alpha = 0.6f)
+        isCurrentEpisode -> Pink.copy(alpha = 0.4f)
+        else -> Color.Transparent
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(bgColor, RoundedCornerShape(10.dp))
+            .border(
+                width = if (focused || isCurrentEpisode) 1.5.dp else 0.dp,
+                color = borderColor,
+                shape = RoundedCornerShape(10.dp)
+            )
+            .onFocusChanged { focused = it.isFocused }
+            .focusable()
+            .then(
+                if (!isTouchDevice) {
+                    Modifier.onKeyEvent { event ->
+                        if (event.type == KeyEventType.KeyDown &&
+                            (event.key == Key.Enter || event.key == Key.DirectionCenter)
+                        ) {
+                            onClick()
+                            true
+                        } else false
+                    }
+                } else Modifier
+            )
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = onClick
+            )
+            .padding(horizontal = 14.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // Episode number
+        Box(
+            modifier = Modifier
+                .size(if (isTouchDevice) 32.dp else 36.dp)
+                .background(
+                    if (isCurrentEpisode) Pink.copy(alpha = 0.3f)
+                        else Color.White.copy(alpha = 0.08f),
+                    CircleShape
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = episode.episodeNumber.toString(),
+                style = ArflixTypography.body.copy(
+                    fontSize = if (isTouchDevice) 12.sp else 13.sp,
+                    fontWeight = FontWeight.Bold
+                ),
+                color = if (isCurrentEpisode) Color.White else TextSecondary
+            )
+        }
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        // Episode info
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = episode.name.ifBlank { "Episode ${episode.episodeNumber}" },
+                style = ArflixTypography.body.copy(
+                    fontSize = if (isTouchDevice) 14.sp else 15.sp,
+                    fontWeight = if (isCurrentEpisode) FontWeight.Bold else FontWeight.Normal
+                ),
+                color = if (focused || isCurrentEpisode) Color.White else TextPrimary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            if (episode.overview.isNotBlank()) {
+                Text(
+                    text = episode.overview,
+                    style = ArflixTypography.caption.copy(
+                        fontSize = if (isTouchDevice) 11.sp else 12.sp
+                    ),
+                    color = TextSecondary.copy(alpha = 0.7f),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(top = 2.dp)
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.width(8.dp))
+
+        // Watched badge or "Now Playing" badge
+        if (isCurrentEpisode) {
+            Text(
+                text = "NOW",
+                style = ArflixTypography.caption.copy(
+                    fontSize = if (isTouchDevice) 10.sp else 11.sp,
+                    fontWeight = FontWeight.Bold
+                ),
+                color = Pink,
+                modifier = Modifier
+                    .background(Pink.copy(alpha = 0.15f), RoundedCornerShape(4.dp))
+                    .padding(horizontal = 8.dp, vertical = 3.dp)
+            )
+        } else if (episode.isWatched) {
+            Icon(
+                imageVector = Icons.Default.Check,
+                contentDescription = "Watched",
+                tint = Color.White.copy(alpha = 0.4f),
+                modifier = Modifier.size(if (isTouchDevice) 18.dp else 20.dp)
+            )
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -3449,7 +3449,13 @@ private fun EpisodePicker(
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
-                        text = if (uiState.seasons.isEmpty()) "No season data available" else "No episodes found",
+                        text = stringResource(
+                            if (uiState.seasons.isEmpty()) {
+                                R.string.no_season_data_available
+                            } else {
+                                R.string.no_episodes_found
+                            }
+                        ),
                         color = TextSecondary,
                         style = ArflixTypography.body.copy(fontSize = 15.sp)
                     )

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
@@ -9,6 +9,8 @@ import androidx.lifecycle.viewModelScope
 import androidx.media3.common.Player
 import com.arflix.tv.BuildConfig
 import com.arflix.tv.data.api.TmdbApi
+import com.arflix.tv.data.api.TmdbTvSeason
+import com.arflix.tv.data.model.Episode
 import com.arflix.tv.data.model.MediaType
 import com.arflix.tv.data.model.StreamSource
 import com.arflix.tv.data.model.Subtitle
@@ -84,7 +86,13 @@ data class PlayerUiState(
     val streamProgress: Float? = null,
     // Human-readable phase label for the loading UI (e.g. "Searching 3/8
     // sources"). Null when progress isn't meaningful.
-    val streamLoadPhase: String? = null
+    val streamLoadPhase: String? = null,
+    // TV episode picker state — populated lazily when user opens the episode
+    // menu within the player, so we don't fetch seasons/episodes on every load.
+    val seasons: List<TmdbTvSeason> = emptyList(),
+    val episodes: List<Episode> = emptyList(),
+    val isLoadingEpisodes: Boolean = false,
+    val selectedSeasonForPicker: Int = 1
 )
 
 @HiltViewModel
@@ -624,6 +632,23 @@ class PlayerViewModel @Inject constructor(
     }
 
     /**
+     * Load episodes for a given season, used by the in-player episode picker.
+     * Results are stored in [PlayerUiState.episodes] so the picker can display them.
+     */
+    fun loadEpisodesForSeason(mediaId: Int, seasonNumber: Int) {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoadingEpisodes = true, selectedSeasonForPicker = seasonNumber)
+            try {
+                val episodes = mediaRepository.getSeasonEpisodes(mediaId, seasonNumber)
+                _uiState.value = _uiState.value.copy(episodes = episodes, isLoadingEpisodes = false)
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to load episodes for season $seasonNumber", e)
+                _uiState.value = _uiState.value.copy(isLoadingEpisodes = false)
+            }
+        }
+    }
+
+    /**
      * Fetch media metadata in background (non-blocking)
      */
     private suspend fun fetchMediaMetadata(mediaType: MediaType, mediaId: Int) {
@@ -648,6 +673,14 @@ class PlayerViewModel @Inject constructor(
                 backdropUrl = tvDetails.backdropPath?.let { "${Constants.BACKDROP_BASE_LARGE}$it" }
                 posterUrl = tvDetails.posterPath?.let { "${Constants.IMAGE_BASE}$it" }
                 currentOriginalLanguage = tvDetails.originalLanguage ?: currentOriginalLanguage
+
+                // Store seasons for the in-player episode picker.
+                // Filter out season 0 (specials) and empty seasons.
+                val filteredSeasons = tvDetails.seasons.filter { it.seasonNumber > 0 && it.episodeCount > 0 }
+                _uiState.value = _uiState.value.copy(
+                    seasons = filteredSeasons,
+                    selectedSeasonForPicker = currentSeason ?: filteredSeasons.firstOrNull()?.seasonNumber ?: 1
+                )
 
                 // Keep episode title aligned with saved progress rows for TV playback sessions.
                 val season = currentSeason

--- a/upstream_DetailsScreen.kt
+++ b/upstream_DetailsScreen.kt
@@ -1,0 +1,3767 @@
+package com.arflix.tv.ui.screens.details
+
+import android.content.Intent
+import android.net.Uri
+import android.os.SystemClock
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.MutatePriority
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed as standardItemsIndexed
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.draw.blur
+import com.arflix.tv.util.settingsDataStore
+import kotlinx.coroutines.flow.first
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.filled.BookmarkBorder
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.List
+import androidx.compose.material.icons.filled.Movie
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.lerp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.tv.foundation.lazy.list.TvLazyColumn
+import androidx.tv.foundation.lazy.list.TvLazyListState
+import androidx.tv.foundation.lazy.list.TvLazyRow
+import androidx.tv.foundation.lazy.list.itemsIndexed
+import androidx.tv.foundation.lazy.list.rememberTvLazyListState
+import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.Text
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import coil.ImageLoader
+import coil.compose.AsyncImage
+import coil.compose.SubcomposeAsyncImage
+import coil.decode.SvgDecoder
+import coil.request.ImageRequest
+import coil.size.Precision
+import com.arflix.tv.R
+import com.arflix.tv.data.model.CastMember
+import com.arflix.tv.data.model.Episode
+import com.arflix.tv.data.model.MediaItem
+import com.arflix.tv.data.model.MediaType
+import com.arflix.tv.data.model.Review
+import com.arflix.tv.network.OkHttpProvider
+import com.arflix.tv.ui.components.EpisodeContextMenu
+import com.arflix.tv.ui.components.SeasonContextMenu
+import com.arflix.tv.ui.components.LoadingIndicator
+import com.arflix.tv.ui.components.AppTopBar
+import com.arflix.tv.ui.components.AppTopBarContentTopInset
+import com.arflix.tv.ui.components.CardLayoutMode
+import com.arflix.tv.ui.components.MediaCard
+import com.arflix.tv.ui.components.PersonModal
+import com.arflix.tv.ui.components.PosterCard
+import com.arflix.tv.ui.components.rememberCatalogueRowLayoutMode
+import com.arflix.tv.ui.components.SidebarItem
+import com.arflix.tv.ui.components.SkeletonDetailsPage
+import com.arflix.tv.ui.components.StreamSelector
+import com.arflix.tv.ui.components.TrailerPlayer
+import androidx.activity.compose.BackHandler
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.ui.zIndex
+import androidx.compose.ui.input.key.onKeyEvent
+import com.arflix.tv.ui.components.Toast
+import com.arflix.tv.ui.components.topBarFocusedItem
+import com.arflix.tv.ui.components.topBarMaxIndex
+import com.arflix.tv.ui.focus.arvioManualBringIntoViewBoundary
+import com.arflix.tv.ui.focus.arvioDpadFocusGroup
+import com.arflix.tv.ui.focus.isArvioDpadNavigationKey
+import com.arflix.tv.ui.focus.rememberArvioDpadRepeatGate
+import com.arflix.tv.ui.skin.ArvioFocusableSurface
+import com.arflix.tv.ui.skin.ArvioSkin
+import com.arflix.tv.ui.skin.rememberArvioCardShape
+import com.arflix.tv.ui.theme.AnimationConstants
+import com.arflix.tv.ui.theme.ArflixTypography
+import com.arflix.tv.ui.theme.BackgroundCard
+import com.arflix.tv.ui.theme.appBackgroundDark
+import com.arflix.tv.ui.theme.Pink
+import com.arflix.tv.ui.theme.Purple
+import com.arflix.tv.ui.theme.TextPrimary
+import com.arflix.tv.ui.theme.TextSecondary
+import com.arflix.tv.util.LocalDeviceType
+import com.arflix.tv.util.isInCinema
+import com.arflix.tv.util.parseRatingValue
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import kotlin.math.abs
+import androidx.compose.ui.res.stringResource
+
+/**
+ * Details screen for movies and TV shows
+ */
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+fun DetailsScreen(
+    mediaType: MediaType,
+    mediaId: Int,
+    initialSeason: Int? = null,
+    initialEpisode: Int? = null,
+    viewModel: DetailsViewModel = hiltViewModel(),
+    currentProfile: com.arflix.tv.data.model.Profile? = null,
+    onNavigateToPlayer: (MediaType, Int, Int?, Int?, String?, String?, String?, String?, Long?) -> Unit,
+    onNavigateToDetails: (MediaType, Int) -> Unit,
+    onNavigateToHome: () -> Unit = {},
+    onNavigateToSearch: () -> Unit = {},
+    onNavigateToWatchlist: () -> Unit = {},
+    onNavigateToTv: () -> Unit = {},
+    onNavigateToSettings: () -> Unit = {},
+    onSwitchProfile: () -> Unit = {},
+    onBack: () -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val usePosterCards = rememberCatalogueRowLayoutMode("details:similar") == CardLayoutMode.POSTER
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val isMobile = LocalDeviceType.current.isTouchDevice()
+
+    // Start on buttons for both TV and movies (buttons are now shown for both)
+    var focusedSection by remember { mutableStateOf(FocusSection.BUTTONS) }
+    var buttonIndex by remember { mutableIntStateOf(0) }
+    var episodeIndex by rememberSaveable { mutableIntStateOf(0) }
+    var seasonIndex by rememberSaveable { mutableIntStateOf(0) }
+    var castIndex by remember { mutableIntStateOf(0) }
+    var reviewIndex by remember { mutableIntStateOf(0) }
+    var similarIndex by remember { mutableIntStateOf(0) }
+    var suppressSelectUntilMs by remember { mutableLongStateOf(0L) }
+    
+    // Sidebar state
+    var isSidebarFocused by remember { mutableStateOf(false) }
+    val hasProfile = currentProfile != null
+    val maxSidebarIndex = topBarMaxIndex(hasProfile)
+    var sidebarFocusIndex by remember { mutableIntStateOf(if (hasProfile) 2 else 1) }
+    
+    // Stream Selector state
+    var showStreamSelector by remember { mutableStateOf(false) }
+    var showTrailerPlayer by remember { mutableStateOf(false) }
+    var pendingAutoPlayRequest by remember { mutableStateOf<PendingAutoPlayRequest?>(null) }
+    
+    // Episode Context Menu state
+    var showEpisodeContextMenu by remember { mutableStateOf(false) }
+    var contextMenuEpisode by remember { mutableStateOf<Episode?>(null) }
+    var showSeasonContextMenu by remember { mutableStateOf(false) }
+    var contextMenuSeason by remember { mutableIntStateOf(1) }
+    var seasonSelectDownAtMs by remember { mutableLongStateOf(0L) }
+    var ignoreFirstResumeRefresh by remember(mediaType, mediaId, initialSeason, initialEpisode) { mutableStateOf(true) }
+
+    // Spoiler blur setting
+    var spoilerBlurEnabled by remember { mutableStateOf(false) }
+    LaunchedEffect(context, currentProfile) {
+        runCatching {
+            val prefs = context.settingsDataStore.data.first()
+            val profileId = currentProfile?.id
+            if (profileId != null) {
+                spoilerBlurEnabled = prefs[booleanPreferencesKey("profile_${profileId}_spoiler_blur")] ?: false
+            }
+        }
+    }
+
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(mediaType, mediaId, initialSeason, initialEpisode) {
+        focusedSection = FocusSection.BUTTONS
+        buttonIndex = 0
+        episodeIndex = 0
+        seasonIndex = 0
+        castIndex = 0
+        reviewIndex = 0
+        similarIndex = 0
+        isSidebarFocused = false
+        viewModel.loadDetails(mediaType, mediaId, initialSeason, initialEpisode)
+    }
+
+    LaunchedEffect(uiState.episodes.size, uiState.totalSeasons, uiState.cast.size, uiState.reviews.size, uiState.similar.size) {
+        if (episodeIndex >= uiState.episodes.size) {
+            episodeIndex = (uiState.episodes.size - 1).coerceAtLeast(0)
+        }
+        if (seasonIndex >= uiState.totalSeasons) {
+            seasonIndex = (uiState.totalSeasons - 1).coerceAtLeast(0)
+        }
+        if (castIndex >= uiState.cast.size) {
+            castIndex = (uiState.cast.size - 1).coerceAtLeast(0)
+        }
+        if (reviewIndex >= uiState.reviews.size) {
+            reviewIndex = (uiState.reviews.size - 1).coerceAtLeast(0)
+        }
+        if (similarIndex >= uiState.similar.size) {
+            similarIndex = (uiState.similar.size - 1).coerceAtLeast(0)
+        }
+    }
+
+    // Keep watched badges and continue target fresh when returning from player.
+    DisposableEffect(lifecycleOwner, mediaType, mediaId) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                if (ignoreFirstResumeRefresh) {
+                    ignoreFirstResumeRefresh = false
+                } else {
+                    viewModel.refreshAfterPlayerReturn()
+                }
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+        suppressSelectUntilMs = SystemClock.elapsedRealtime() + 150L
+    }
+
+    LaunchedEffect(pendingAutoPlayRequest, uiState.isLoadingStreams, uiState.streams) {
+        val request = pendingAutoPlayRequest ?: return@LaunchedEffect
+        if (uiState.isLoadingStreams) return@LaunchedEffect
+
+        val validStreams = uiState.streams.filter(::isAutoPlayableStream)
+        val minThreshold = minQualityThreshold(uiState.autoPlayMinQuality)
+        val singleStream = validStreams.singleOrNull()
+
+        when {
+            singleStream != null && qualityScoreForAutoPlay(singleStream.quality) >= minThreshold -> {
+                onNavigateToPlayer(
+                    mediaType,
+                    mediaId,
+                    request.season,
+                    request.episode,
+                    uiState.imdbId,
+                    singleStream.url?.takeIf { it.isNotBlank() },
+                    singleStream.addonId.takeIf { it.isNotBlank() },
+                    singleStream.source.takeIf { it.isNotBlank() },
+                    request.startPositionMs
+                )
+            }
+            validStreams.size > 1 || uiState.streams.isNotEmpty() -> {
+                showStreamSelector = true
+            }
+            else -> {
+                // When no streams found, show the StreamSelector with its
+                // friendly "no addons" / "no sources" empty state instead of
+                // navigating to the player which would show a scary error.
+                showStreamSelector = true
+            }
+        }
+        pendingAutoPlayRequest = null
+    }
+
+    // Sync episodeIndex with initialEpisodeIndex from ViewModel
+    LaunchedEffect(uiState.initialEpisodeIndex, uiState.episodes) {
+        if (uiState.initialEpisodeIndex > 0 && uiState.episodes.isNotEmpty()) {
+            episodeIndex = uiState.initialEpisodeIndex
+        }
+    }
+
+    // Sync seasonIndex with initialSeasonIndex from ViewModel
+    LaunchedEffect(uiState.initialSeasonIndex) {
+        if (uiState.initialSeasonIndex > 0) {
+            seasonIndex = uiState.initialSeasonIndex
+        }
+    }
+
+    // D-pad key handler — only used on TV (skipped on mobile/touch devices)
+    val dpadRepeatGate = rememberArvioDpadRepeatGate(minRepeatIntervalMs = 78L)
+    val keyModifier = if (isMobile) Modifier else Modifier.onPreviewKeyEvent { event ->
+                if (event.type == KeyEventType.KeyUp && isArvioDpadNavigationKey(event.key)) {
+                    dpadRepeatGate.reset()
+                }
+                if (
+                    event.type == KeyEventType.KeyDown &&
+                    isArvioDpadNavigationKey(event.key) &&
+                    dpadRepeatGate.shouldSkip(
+                        keyCode = event.nativeKeyEvent.keyCode,
+                        repeatCount = event.nativeKeyEvent.repeatCount,
+                        nowMs = SystemClock.elapsedRealtime()
+                    )
+                ) {
+                    return@onPreviewKeyEvent true
+                }
+                if (event.type == KeyEventType.KeyDown) {
+                    // Check if any modal is showing
+                    if (showStreamSelector || showEpisodeContextMenu || showSeasonContextMenu || uiState.showPersonModal) {
+                        return@onPreviewKeyEvent false // Let the modal handle it
+                    }
+                    
+                    when (event.key) {
+                        Key.Back, Key.Escape -> {
+                            if (showTrailerPlayer) { showTrailerPlayer = false; true }
+                            else { onBack(); true }
+                        }
+                        Key.DirectionLeft -> {
+                            if (isSidebarFocused) {
+                                if (sidebarFocusIndex > 0) {
+                                    sidebarFocusIndex = (sidebarFocusIndex - 1).coerceIn(0, maxSidebarIndex)
+                                }
+                                true
+                            } else {
+                                // Check if at leftmost item in any section - go to sidebar
+                                val atLeftmost = when (focusedSection) {
+                                    FocusSection.BUTTONS -> buttonIndex == 0
+                                    FocusSection.EPISODES -> episodeIndex == 0
+                                    FocusSection.SEASONS -> seasonIndex == 0
+                                    FocusSection.CAST -> castIndex == 0
+                                    FocusSection.REVIEWS -> reviewIndex == 0
+                                    FocusSection.SIMILAR -> similarIndex == 0
+                                }
+                                if (atLeftmost) {
+                                    true
+                                } else {
+                                    handleLeft(
+                                        focusedSection, buttonIndex, episodeIndex, seasonIndex, castIndex, reviewIndex, similarIndex,
+                                        { buttonIndex = it }, { episodeIndex = it }, { seasonIndex = it },
+                                        { castIndex = it }, { reviewIndex = it }, { similarIndex = it }
+                                    )
+                                }
+                            }
+                        }
+                        Key.DirectionRight -> {
+                            if (isSidebarFocused) {
+                                if (sidebarFocusIndex < maxSidebarIndex) {
+                                    sidebarFocusIndex = (sidebarFocusIndex + 1).coerceIn(0, maxSidebarIndex)
+                                }
+                                true
+                            } else {
+                                handleRight(
+                                    focusedSection, buttonIndex, episodeIndex, seasonIndex, castIndex, reviewIndex, similarIndex,
+                                    uiState, { buttonIndex = it }, { episodeIndex = it }, { seasonIndex = it },
+                                    { castIndex = it }, { reviewIndex = it }, { similarIndex = it }
+                                )
+                            }
+                        }
+                        Key.DirectionUp -> {
+                            if (isSidebarFocused) {
+                                true
+                            } else {
+                                // Navigation: BUTTONS -> SEASONS -> EPISODES -> CAST -> REVIEWS -> SIMILAR
+                                val isTV = mediaType == MediaType.TV
+                                val hasEpisodes = uiState.episodes.isNotEmpty()
+                                val hasCast = uiState.cast.isNotEmpty()
+                                val hasReviews = uiState.reviews.isNotEmpty()
+                                focusedSection = when (focusedSection) {
+                                    FocusSection.BUTTONS -> {
+                                        isSidebarFocused = true
+                                        FocusSection.BUTTONS
+                                    }
+                                    FocusSection.SEASONS -> FocusSection.BUTTONS
+                                    FocusSection.EPISODES -> {
+                                        if (uiState.totalSeasons > 1) FocusSection.SEASONS else FocusSection.BUTTONS
+                                    }
+                                    FocusSection.CAST -> {
+                                        if (isTV) {
+                                            when {
+                                                hasEpisodes -> FocusSection.EPISODES
+                                                uiState.totalSeasons > 1 -> FocusSection.SEASONS
+                                                else -> FocusSection.BUTTONS
+                                            }
+                                        } else FocusSection.BUTTONS
+                                    }
+                                    FocusSection.REVIEWS -> if (hasCast) FocusSection.CAST else FocusSection.BUTTONS
+                                    FocusSection.SIMILAR -> if (hasReviews) FocusSection.REVIEWS else if (hasCast) FocusSection.CAST else FocusSection.BUTTONS
+                                }
+                                true
+                            }
+                        }
+                        Key.DirectionDown -> {
+                            if (isSidebarFocused) {
+                                isSidebarFocused = false
+                                true
+                            } else {
+                                // Navigation: BUTTONS -> SEASONS -> EPISODES -> CAST -> REVIEWS -> SIMILAR
+                                val isTV = mediaType == MediaType.TV
+                                val hasEpisodes = uiState.episodes.isNotEmpty()
+                                val hasSeasons = uiState.totalSeasons > 1
+                                val hasCast = uiState.cast.isNotEmpty()
+                                val hasReviews = uiState.reviews.isNotEmpty()
+                                val hasSimilar = uiState.similar.isNotEmpty()
+                                focusedSection = when (focusedSection) {
+                                    FocusSection.BUTTONS -> {
+                                        if (isTV && hasSeasons) FocusSection.SEASONS
+                                        else if (isTV && hasEpisodes) FocusSection.EPISODES
+                                        else if (hasCast) FocusSection.CAST
+                                        else if (hasReviews) FocusSection.REVIEWS
+                                        else if (hasSimilar) FocusSection.SIMILAR
+                                        else FocusSection.BUTTONS
+                                    }
+                                    FocusSection.SEASONS -> {
+                                        if (hasEpisodes) FocusSection.EPISODES
+                                        else if (hasCast) FocusSection.CAST
+                                        else if (hasReviews) FocusSection.REVIEWS
+                                        else if (hasSimilar) FocusSection.SIMILAR
+                                        else FocusSection.SEASONS
+                                    }
+                                    FocusSection.EPISODES -> {
+                                        if (hasCast) FocusSection.CAST
+                                        else if (hasReviews) FocusSection.REVIEWS
+                                        else if (hasSimilar) FocusSection.SIMILAR
+                                        else FocusSection.EPISODES
+                                    }
+                                    FocusSection.CAST -> {
+                                        if (hasReviews) FocusSection.REVIEWS
+                                        else if (hasSimilar) FocusSection.SIMILAR
+                                        else FocusSection.CAST
+                                    }
+                                    FocusSection.REVIEWS -> {
+                                        if (hasSimilar) FocusSection.SIMILAR else FocusSection.REVIEWS
+                                    }
+                                    FocusSection.SIMILAR -> FocusSection.SIMILAR  // Stay on similar (bottom)
+                                }
+                                true
+                            }
+                        }
+                        Key.Enter, Key.DirectionCenter -> {
+                            if (!isSidebarFocused && focusedSection == FocusSection.SEASONS) {
+                                if (seasonSelectDownAtMs == 0L) {
+                                    seasonSelectDownAtMs = SystemClock.elapsedRealtime()
+                                }
+                                return@onPreviewKeyEvent true
+                            }
+                            if (isSidebarFocused) {
+                                if (hasProfile && sidebarFocusIndex == 0) {
+                                    onSwitchProfile()
+                                } else {
+                                    when (topBarFocusedItem(sidebarFocusIndex, hasProfile)) {
+                                        SidebarItem.SEARCH -> onNavigateToSearch()
+                                        SidebarItem.HOME -> onNavigateToHome()
+                                        SidebarItem.WATCHLIST -> onNavigateToWatchlist()
+                                        SidebarItem.TV -> onNavigateToTv()
+                                        SidebarItem.SETTINGS -> onNavigateToSettings()
+                                        null -> Unit
+                                    }
+                                }
+                                return@onPreviewKeyEvent true
+                            }
+                            when (focusedSection) {
+                                FocusSection.BUTTONS -> {
+                                    when (buttonIndex) {
+                                        0 -> { // Play - Auto-play highest quality source
+                                            val season = if (mediaType == MediaType.TV) {
+                                                uiState.playSeason
+                                                    ?: uiState.episodes.getOrNull(episodeIndex)?.seasonNumber
+                                                    ?: 1
+                                            } else null
+                                            val episode = if (mediaType == MediaType.TV) {
+                                                uiState.playEpisode
+                                                    ?: uiState.episodes.getOrNull(episodeIndex)?.episodeNumber
+                                                    ?: 1
+                                            } else null
+                                            val startPositionMs = if (
+                                                mediaType == MediaType.TV &&
+                                                season == uiState.playSeason &&
+                                                episode == uiState.playEpisode
+                                            ) {
+                                                uiState.playPositionMs
+                                            } else if (mediaType == MediaType.MOVIE) {
+                                                uiState.playPositionMs
+                                            } else null
+
+                                            if (!uiState.autoPlaySingleSource) {
+                                                // Autoplay OFF → open the source picker; never auto-play.
+                                                showStreamSelector = true
+                                                viewModel.loadStreams(uiState.imdbId, season, episode)
+                                            } else {
+                                                // Autoplay ON → go straight to the player; PlayerScreen auto-picks.
+                                                onNavigateToPlayer(
+                                                    mediaType,
+                                                    mediaId,
+                                                    season,
+                                                    episode,
+                                                    uiState.imdbId,
+                                                    null,
+                                                    null,
+                                                    null,
+                                                    startPositionMs
+                                                )
+                                            }
+                                        }
+                                        1 -> { // Sources - Show StreamSelector for manual selection
+                                            showStreamSelector = true
+                                            // Pass the currently focused episode for TV shows
+                                            val ep = uiState.episodes.getOrNull(episodeIndex)
+                                            viewModel.loadStreams(uiState.imdbId, ep?.seasonNumber, ep?.episodeNumber)
+                                        }
+                                        2 -> { // Trailer
+                                            uiState.trailerKey?.let {
+                                                showTrailerPlayer = true
+                                            }
+                                        }
+                                        3 -> viewModel.toggleWatched(episodeIndex)
+                                        4 -> viewModel.toggleWatchlist()
+                                    }
+                                }
+                                FocusSection.EPISODES -> {
+                                    val ep = uiState.episodes.getOrNull(episodeIndex)
+                                    if (ep != null) {
+                                        onNavigateToPlayer(
+                                            mediaType, mediaId,
+                                            ep.seasonNumber, ep.episodeNumber, uiState.imdbId, null, null, null, null
+                                        )
+                                    }
+                                }
+                                FocusSection.SEASONS -> {
+                                    episodeIndex = 0
+                                    viewModel.loadSeason(seasonIndex + 1)
+                                }
+                                FocusSection.CAST -> {
+                                    val member = uiState.cast.getOrNull(castIndex)
+                                    if (member != null) {
+                                        viewModel.loadPerson(member.id)
+                                    }
+                                }
+                                FocusSection.REVIEWS -> {
+                                    // Reviews don't have an action on Enter, just focus
+                                }
+                                FocusSection.SIMILAR -> {
+                                    val similar = uiState.similar.getOrNull(similarIndex)
+                                    if (similar != null) {
+                                        onNavigateToDetails(similar.mediaType, similar.id)
+                                    }
+                                }
+                            }
+                            true
+                        }
+                        // Long press or menu key for context menu
+                        Key.Menu -> {
+                            if (focusedSection == FocusSection.EPISODES) {
+                                contextMenuEpisode = uiState.episodes.getOrNull(episodeIndex)
+                                showEpisodeContextMenu = true
+                            }
+                            true
+                        }
+                        else -> false
+                    }
+                } else if (event.type == KeyEventType.KeyUp && (event.key == Key.Enter || event.key == Key.DirectionCenter)) {
+                    if (!isSidebarFocused && focusedSection == FocusSection.SEASONS && seasonSelectDownAtMs > 0L) {
+                        val heldMs = SystemClock.elapsedRealtime() - seasonSelectDownAtMs
+                        seasonSelectDownAtMs = 0L
+                        if (heldMs >= 900L) {
+                            contextMenuSeason = seasonIndex + 1
+                            showSeasonContextMenu = true
+                        } else {
+                            episodeIndex = 0
+                            viewModel.loadSeason(seasonIndex + 1)
+                        }
+                        true
+                    } else {
+                        seasonSelectDownAtMs = 0L
+                        false
+                    }
+                } else false
+            }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(appBackgroundDark())
+            .focusRequester(focusRequester)
+            .focusable()
+            .then(keyModifier)
+    ) {
+        // Main content - full screen with sidebar overlay (same as HomeScreen)
+        if (uiState.isLoading || uiState.item == null) {
+            // Use skeleton loader for better UX
+            SkeletonDetailsPage(
+                isTV = mediaType == MediaType.TV,
+                modifier = Modifier.fillMaxSize()
+            )
+        } else {
+            uiState.item?.let { item ->
+                DetailsContent(
+                    item = item,
+                    logoUrl = uiState.logoUrl,
+                    episodes = uiState.episodes,
+                    totalSeasons = uiState.totalSeasons,
+                    currentSeason = uiState.currentSeason,
+                    cast = uiState.cast,
+                    reviews = uiState.reviews,
+                    similar = uiState.similar,
+                    similarLogoUrls = uiState.similarLogoUrls,
+                    focusedSection = focusedSection,
+                    buttonIndex = buttonIndex,
+                    episodeIndex = episodeIndex,
+                    seasonIndex = seasonIndex,
+                    castIndex = castIndex,
+                    reviewIndex = reviewIndex,
+                    similarIndex = similarIndex,
+                    isInWatchlist = uiState.isInWatchlist,
+                    genres = uiState.genres,
+                    budget = uiState.budget,
+                    seasonProgress = uiState.seasonProgress,
+                    playLabel = uiState.playLabel,
+                    hasTrailer = uiState.trailerKey != null,
+                    contentHasFocus = !isSidebarFocused,
+                    usePosterCards = usePosterCards,
+                    isMobile = isMobile,
+                    onBack = onBack,
+                    onButtonClick = { idx ->
+                        when (idx) {
+                            0 -> { // Play
+                                val season = if (mediaType == MediaType.TV) {
+                                    uiState.playSeason
+                                        ?: uiState.episodes.getOrNull(episodeIndex)?.seasonNumber
+                                        ?: 1
+                                } else null
+                                val episode = if (mediaType == MediaType.TV) {
+                                    uiState.playEpisode
+                                        ?: uiState.episodes.getOrNull(episodeIndex)?.episodeNumber
+                                        ?: 1
+                                } else null
+                                val startPositionMs = if (
+                                    mediaType == MediaType.TV &&
+                                    season == uiState.playSeason &&
+                                    episode == uiState.playEpisode
+                                ) {
+                                    uiState.playPositionMs
+                                } else if (mediaType == MediaType.MOVIE) {
+                                    uiState.playPositionMs
+                                } else null
+
+                                if (!uiState.autoPlaySingleSource) {
+                                    // Autoplay OFF → open the source picker; never auto-play.
+                                    showStreamSelector = true
+                                    viewModel.loadStreams(uiState.imdbId, season, episode)
+                                } else {
+                                    // Autoplay ON → go straight to the player; PlayerScreen auto-picks.
+                                    onNavigateToPlayer(
+                                        mediaType, mediaId, season, episode,
+                                        uiState.imdbId, null, null, null, startPositionMs
+                                    )
+                                }
+                            }
+                            1 -> { // Sources
+                                showStreamSelector = true
+                                val ep = uiState.episodes.getOrNull(episodeIndex)
+                                viewModel.loadStreams(uiState.imdbId, ep?.seasonNumber, ep?.episodeNumber)
+                            }
+                            2 -> { // Trailer
+                                uiState.trailerKey?.let { showTrailerPlayer = true }
+                            }
+                            3 -> viewModel.toggleWatched(episodeIndex)
+                            4 -> viewModel.toggleWatchlist()
+                        }
+                    },
+                    onSeasonClick = { idx ->
+                        seasonIndex = idx
+                        episodeIndex = 0
+                        viewModel.loadSeason(idx + 1)
+                    },
+                    onEpisodeClick = { idx ->
+                        val ep = uiState.episodes.getOrNull(idx)
+                        if (ep != null) {
+                            episodeIndex = idx
+                            if (isMobile) {
+                                showStreamSelector = true
+                                viewModel.loadStreams(uiState.imdbId, ep.seasonNumber, ep.episodeNumber)
+                            } else {
+                                onNavigateToPlayer(
+                                    mediaType, mediaId,
+                                    ep.seasonNumber, ep.episodeNumber, uiState.imdbId, null, null, null, null
+                                )
+                            }
+                        }
+                    },
+                    onCastClick = { idx ->
+                        val member = uiState.cast.getOrNull(idx)
+                        if (member != null) {
+                            viewModel.loadPerson(member.id)
+                        }
+                    },
+                    onSimilarClick = { idx ->
+                        val sim = uiState.similar.getOrNull(idx)
+                        if (sim != null) {
+                            onNavigateToDetails(sim.mediaType, sim.id)
+                        }
+                    }
+                )
+            }
+        }
+
+        if (!LocalDeviceType.current.isTouchDevice()) {
+            AppTopBar(
+                selectedItem = SidebarItem.HOME,
+                isFocused = isSidebarFocused,
+                focusedIndex = sidebarFocusIndex,
+                profile = currentProfile
+            )
+        }
+        
+        // Person Modal
+        PersonModal(
+            isVisible = uiState.showPersonModal,
+            person = uiState.selectedPerson,
+            isLoading = uiState.isLoadingPerson,
+            onClose = { viewModel.closePersonModal() },
+            onMediaClick = { type, id ->
+                viewModel.closePersonModal()
+                onNavigateToDetails(type, id)
+            }
+        )
+        
+        // In-app Trailer Player (fullscreen overlay)
+        if (showTrailerPlayer && uiState.trailerKey != null) {
+            BackHandler { showTrailerPlayer = false }
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black)
+                    .zIndex(50f)
+                    .clickable { showTrailerPlayer = false }
+            ) {
+                TrailerPlayer(
+                    youtubeKey = uiState.trailerKey!!,
+                    modifier = Modifier.fillMaxSize(),
+                    delayMs = 0L,
+                    volume = 1f
+                )
+                // Close button for touch devices
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(top = 48.dp, end = 16.dp)
+                        .size(40.dp)
+                        .clip(CircleShape)
+                        .background(Color.Black.copy(alpha = 0.6f))
+                        .clickable { showTrailerPlayer = false },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = stringResource(R.string.close),
+                        tint = Color.White,
+                        modifier = Modifier.size(24.dp)
+                    )
+                }
+            }
+        }
+
+        // Stream Selector Modal
+        StreamSelector(
+            isVisible = showStreamSelector,
+            streams = uiState.streams,
+            selectedStream = null,
+            isLoading = uiState.isLoadingStreams,
+            hasStreamingAddons = uiState.hasStreamingAddons,
+            onFocusedStream = { stream ->
+                viewModel.prewarmStreamsAround(stream, uiState.streams)
+            },
+            onSelect = { stream ->
+                if (isPendingDebridStream(stream)) {
+                    viewModel.showToast(
+                        "This debrid torrent is still being downloaded. Try another source or wait a bit.",
+                        ToastType.ERROR
+                    )
+                    return@StreamSelector
+                }
+                showStreamSelector = false
+                val ep = uiState.episodes.getOrNull(episodeIndex)
+                onNavigateToPlayer(
+                    mediaType, mediaId,
+                    ep?.seasonNumber, ep?.episodeNumber,
+                    uiState.imdbId,
+                    stream.url?.takeIf { it.isNotBlank() },
+                    stream.addonId.takeIf { it.isNotBlank() },
+                    stream.source.takeIf { it.isNotBlank() },
+                    null
+                )
+            },
+            onClose = { showStreamSelector = false }
+        )
+        
+        // Episode Context Menu
+        contextMenuEpisode?.let { episode ->
+            EpisodeContextMenu(
+                isVisible = showEpisodeContextMenu,
+                episodeName = episode.name,
+                seasonEpisode = "S${episode.seasonNumber}:E${episode.episodeNumber}",
+                isWatched = episode.isWatched,
+                onPlay = {
+                    showEpisodeContextMenu = false
+                    onNavigateToPlayer(
+                        mediaType, mediaId,
+                        episode.seasonNumber, episode.episodeNumber, uiState.imdbId, null, null, null, null
+                    )
+                },
+                onSelectSource = {
+                    showEpisodeContextMenu = false
+                    showStreamSelector = true
+                    viewModel.loadStreams(uiState.imdbId, episode.seasonNumber, episode.episodeNumber)
+                },
+                onToggleWatched = {
+                    viewModel.markEpisodeWatched(
+                        episode.seasonNumber,
+                        episode.episodeNumber,
+                        !episode.isWatched
+                    )
+                },
+                onDismiss = {
+                    showEpisodeContextMenu = false
+                    contextMenuEpisode = null
+                }
+            )
+        }
+
+        SeasonContextMenu(
+            isVisible = showSeasonContextMenu,
+            seasonNumber = contextMenuSeason,
+            onMarkSeasonWatched = {
+                viewModel.markSeasonWatched(contextMenuSeason)
+            },
+            onDismiss = {
+                showSeasonContextMenu = false
+            }
+        )
+
+        // Toast notifications
+        uiState.toastMessage?.let { message ->
+            Toast(
+                message = message,
+                type = when (uiState.toastType) {
+                    com.arflix.tv.ui.screens.details.ToastType.SUCCESS -> com.arflix.tv.ui.components.ToastType.SUCCESS
+                    com.arflix.tv.ui.screens.details.ToastType.ERROR -> com.arflix.tv.ui.components.ToastType.ERROR
+                    com.arflix.tv.ui.screens.details.ToastType.INFO -> com.arflix.tv.ui.components.ToastType.INFO
+                },
+                isVisible = true,
+                durationMs = if (uiState.toastType == com.arflix.tv.ui.screens.details.ToastType.ERROR) 8000 else 4000,
+                onDismiss = { viewModel.dismissToast() }
+            )
+        }
+    }
+}
+
+private enum class FocusSection {
+    BUTTONS, EPISODES, SEASONS, CAST, REVIEWS, SIMILAR
+}
+
+private data class PendingAutoPlayRequest(
+    val season: Int?,
+    val episode: Int?,
+    val startPositionMs: Long?
+)
+
+private fun qualityScoreForAutoPlay(quality: String): Int {
+    return when {
+        quality.contains("4K", ignoreCase = true) || quality.contains("2160p", ignoreCase = true) -> 4
+        quality.contains("1080p", ignoreCase = true) -> 3
+        quality.contains("720p", ignoreCase = true) -> 2
+        quality.contains("480p", ignoreCase = true) -> 1
+        else -> 0
+    }
+}
+
+/** Score quality from ALL stream text (source + quality + addonName) for more accurate detection */
+private fun qualityScoreForStream(stream: com.arflix.tv.data.model.StreamSource): Int {
+    val combined = listOfNotNull(stream.quality, stream.source, stream.addonName).joinToString(" ")
+    return when {
+        combined.contains("2160p", ignoreCase = true) || Regex("\\b4[kK]\\b").containsMatchIn(combined) -> 4
+        combined.contains("1080p", ignoreCase = true) -> 3
+        combined.contains("720p", ignoreCase = true) -> 2
+        combined.contains("480p", ignoreCase = true) -> 1
+        else -> 0 // Truly unknown
+    }
+}
+
+private fun minQualityThreshold(value: String): Int {
+    return when (value.trim().lowercase()) {
+        "720p", "hd" -> 2
+        "1080p", "fullhd", "fhd" -> 3
+        "4k", "2160p", "uhd" -> 4
+        else -> 0
+    }
+}
+
+private fun isAutoPlayableStream(stream: com.arflix.tv.data.model.StreamSource): Boolean {
+    val url = stream.url?.trim().orEmpty()
+    if (!url.startsWith("http", ignoreCase = true)) return false
+    return !isPendingDebridStream(stream)
+}
+
+private fun isPendingDebridStream(stream: com.arflix.tv.data.model.StreamSource): Boolean {
+    val text = listOfNotNull(stream.source, stream.addonName, stream.quality, stream.url)
+        .joinToString(" ")
+        .lowercase()
+    return listOf(
+        "torrent being downloaded",
+        "being downloaded",
+        "still downloading",
+        "queued",
+        "not cached",
+        "uncached",
+        "cache pending",
+        "caching",
+        "processing torrent",
+        "download in progress"
+    ).any { text.contains(it) }
+}
+
+private fun handleLeft(
+    section: FocusSection,
+    buttonIdx: Int, episodeIdx: Int, seasonIdx: Int, castIdx: Int, reviewIdx: Int, similarIdx: Int,
+    setButton: (Int) -> Unit, setEpisode: (Int) -> Unit, setSeason: (Int) -> Unit,
+    setCast: (Int) -> Unit, setReview: (Int) -> Unit, setSimilar: (Int) -> Unit
+): Boolean {
+    when (section) {
+        FocusSection.BUTTONS -> if (buttonIdx > 0) setButton(buttonIdx - 1)
+        FocusSection.EPISODES -> if (episodeIdx > 0) setEpisode(episodeIdx - 1)
+        FocusSection.SEASONS -> if (seasonIdx > 0) setSeason(seasonIdx - 1)
+        FocusSection.CAST -> if (castIdx > 0) setCast(castIdx - 1)
+        FocusSection.REVIEWS -> if (reviewIdx > 0) setReview(reviewIdx - 1)
+        FocusSection.SIMILAR -> if (similarIdx > 0) setSimilar(similarIdx - 1)
+    }
+    return true
+}
+
+private fun handleRight(
+    section: FocusSection,
+    buttonIdx: Int, episodeIdx: Int, seasonIdx: Int, castIdx: Int, reviewIdx: Int, similarIdx: Int,
+    uiState: DetailsUiState,
+    setButton: (Int) -> Unit, setEpisode: (Int) -> Unit, setSeason: (Int) -> Unit,
+    setCast: (Int) -> Unit, setReview: (Int) -> Unit, setSimilar: (Int) -> Unit
+): Boolean {
+    when (section) {
+        FocusSection.BUTTONS -> if (buttonIdx < 4) setButton(buttonIdx + 1)
+        FocusSection.EPISODES -> if (episodeIdx < uiState.episodes.size - 1) setEpisode(episodeIdx + 1)
+        FocusSection.SEASONS -> if (seasonIdx < uiState.totalSeasons - 1) setSeason(seasonIdx + 1)
+        FocusSection.CAST -> if (castIdx < uiState.cast.size - 1) setCast(castIdx + 1)
+        FocusSection.REVIEWS -> if (reviewIdx < uiState.reviews.size - 1) setReview(reviewIdx + 1)
+        FocusSection.SIMILAR -> if (similarIdx < uiState.similar.size - 1) setSimilar(similarIdx + 1)
+    }
+    return true
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun DetailsContent(
+    item: MediaItem,
+    logoUrl: String?,
+    episodes: List<Episode>,
+    totalSeasons: Int,
+    currentSeason: Int,
+    cast: List<CastMember>,
+    reviews: List<Review>,
+    similar: List<MediaItem>,
+    similarLogoUrls: Map<String, String>,
+    focusedSection: FocusSection,
+    buttonIndex: Int,
+    episodeIndex: Int,
+    seasonIndex: Int,
+    castIndex: Int,
+    reviewIndex: Int,
+    similarIndex: Int,
+    isInWatchlist: Boolean,
+    genres: List<String> = emptyList(),
+    budget: String? = null,
+    seasonProgress: Map<Int, Pair<Int, Int>> = emptyMap(),
+    playLabel: String? = null,
+    hasTrailer: Boolean = false,
+    contentHasFocus: Boolean = true,
+    usePosterCards: Boolean = false,
+    isMobile: Boolean = false,
+    // Persistent back callback used by the phone-layout back button overlay
+    // (issue #43). No-op by default so tablet/TV callers don't need to pass it.
+    onBack: () -> Unit = {},
+    onButtonClick: (Int) -> Unit = {},
+    onSeasonClick: (Int) -> Unit = {},
+    onEpisodeClick: (Int) -> Unit = {},
+    onCastClick: (Int) -> Unit = {},
+    spoilerBlurEnabled: Boolean = false,
+    onSimilarClick: (Int) -> Unit = {}
+) {
+    val context = LocalContext.current
+    val metadataLogoImageLoader = remember(context) {
+        ImageLoader.Builder(context)
+            .okHttpClient(OkHttpProvider.coilClient)
+            .components { add(SvgDecoder.Factory()) }
+            .crossfade(false)
+            .build()
+    }
+    val focusSectionForUi = if (contentHasFocus) focusedSection else null
+    // === PREMIUM LAYERED TEXT SHADOWS ===
+    val textShadow = Shadow(
+        color = Color.Black.copy(alpha = 0.9f),
+        offset = Offset(0f, 2f),
+        blurRadius = 8f  // Soft spread shadow for better readability
+    )
+
+    // ===================== MOBILE LAYOUT =====================
+    if (isMobile) {
+        val configuration = LocalConfiguration.current
+        val screenHeightDp = configuration.screenHeightDp.dp
+        val backdropHeight = (screenHeightDp * 0.53f).coerceAtLeast(400.dp)
+        val mobileScrollState = rememberScrollState()
+        val density = LocalDensity.current
+        var stickyThreshold by remember { mutableStateOf(-1f) }
+        val topBarAlpha by remember {
+            derivedStateOf {
+                if (stickyThreshold >= 0f && mobileScrollState.value > stickyThreshold) {
+                    val overscroll = mobileScrollState.value - stickyThreshold
+                    val maxOverscroll = 150f
+                    (overscroll / maxOverscroll).coerceIn(0f, 1f)
+                } else {
+                    0f
+                }
+            }
+        }
+
+        val genreText = genres.take(2).joinToString(" / ").ifBlank {
+            if (item.mediaType == MediaType.TV) "TV Series" else "Movie"
+        }
+        val displayDate = item.year.takeIf { it.isNotBlank() }
+            ?: item.releaseDate?.trim()?.takeIf { it.isNotEmpty() }?.let { date ->
+                Regex("\\d{4}").find(date)?.value ?: date
+            }
+            ?: ""
+        val hasDuration = item.duration.isNotEmpty() && item.duration != "0m"
+        val rating = item.imdbRating.ifEmpty { item.tmdbRating }
+        val ratingValue = parseRatingValue(rating)
+        val buttonWatched = if (item.mediaType == MediaType.TV) {
+            episodes.getOrNull(episodeIndex)?.isWatched ?: item.isWatched
+        } else {
+            item.isWatched
+        }
+
+        Box(modifier = Modifier.fillMaxSize().background(Color.Black)) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(mobileScrollState)
+            ) {
+                // --- Backdrop with gradient ---
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(backdropHeight)
+                        .zIndex(10f)
+                ) {
+                    AsyncImage(
+                        model = item.backdrop ?: item.image,
+                        contentDescription = null,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                    // Strong bottom gradient
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(
+                                brush = Brush.verticalGradient(
+                                    colorStops = arrayOf(
+                                        0.0f to Color.Transparent,
+                                        0.55f to Color.Transparent,
+                                        0.8f to Color.Black.copy(alpha = 0.84f),
+                                        1.0f to Color.Black
+                                    )
+                                )
+                            )
+                    )
+                    
+                    if (topBarAlpha > 0f) {
+                        Box(
+                            modifier = Modifier
+                                .align(Alignment.TopCenter)
+                                .fillMaxWidth()
+                                .graphicsLayer { 
+                                    alpha = topBarAlpha
+                                    translationY = mobileScrollState.value.toFloat()
+                                }
+                                .background(Color.Black.copy(alpha = 0.85f))
+                        ) {
+                            Spacer(modifier = Modifier.statusBarsPadding().height(64.dp))
+                        }
+                    }
+
+                    // Title and metadata over backdrop bottom
+                    Column(
+                        modifier = Modifier
+                            .align(Alignment.BottomCenter)
+                            .fillMaxWidth()
+                            .padding(start = 24.dp, end = 24.dp, bottom = 18.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        val statusBarsTop = WindowInsets.statusBars.getTop(density)
+                        Box(
+                            modifier = Modifier
+                                .zIndex(11f)
+                                .height(86.dp)
+                                .onGloballyPositioned { coords ->
+                                    val currentInitialY = coords.positionInWindow().y + mobileScrollState.value
+                                    val pinnedY = statusBarsTop - with(density) { 12.dp.toPx() }
+                                    val calculatedThreshold = currentInitialY - pinnedY
+                                    
+                                    // Update if uninitialized, or if the layout shifts significantly (e.g. metadata loaded)
+                                    // The > 10f check prevents infinite recomposition loops and ignores 1-2px scroll jitter.
+                                    if (stickyThreshold < 0f || kotlin.math.abs(calculatedThreshold - stickyThreshold) > 10f) {
+                                        stickyThreshold = calculatedThreshold
+                                    }
+                                }
+                                .graphicsLayer {
+                                    if (stickyThreshold >= 0f && mobileScrollState.value > stickyThreshold) {
+                                        val overscroll = mobileScrollState.value - stickyThreshold
+                                        translationY = overscroll
+                                        
+                                        // Smooth scale down to feel like a header
+                                        val maxOverscroll = 200f
+                                        val progress = (overscroll / maxOverscroll).coerceIn(0f, 1f)
+                                        val scale = 1f - (0.28f * progress) 
+                                        scaleX = scale
+                                        scaleY = scale
+                                    }
+                                }
+                        ) {
+                            if (logoUrl != null) {
+                                AsyncImage(
+                                    model = logoUrl,
+                                    contentDescription = item.title,
+                                    contentScale = ContentScale.Fit,
+                                    alignment = Alignment.Center,
+                                    modifier = Modifier
+                                        .fillMaxWidth(0.78f)
+                                        .height(86.dp)
+                                )
+                            }
+                        }
+
+                        Spacer(modifier = Modifier.height(12.dp))
+
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .horizontalScroll(rememberScrollState())
+                        ) {
+                            if (ratingValue > 0f) {
+                                DetailsImdbSvgRatingBadge(
+                                    rating = rating,
+                                    imageLoader = metadataLogoImageLoader,
+                                    ratingFontSize = 13,
+                                    logoWidth = 34.dp,
+                                    logoHeight = 14.dp,
+                                    textShadow = textShadow
+                                )
+                            }
+                            if (displayDate.isNotEmpty()) {
+                                MobileMetadataSeparator()
+                                Text(
+                                    text = displayDate,
+                                    style = ArflixTypography.caption.copy(
+                                        fontSize = 13.sp,
+                                        fontWeight = FontWeight.SemiBold,
+                                        shadow = textShadow
+                                    ),
+                                    color = Color.White.copy(alpha = 0.78f),
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                            }
+                            if (hasDuration) {
+                                MobileMetadataSeparator()
+                                Text(
+                                    text = item.duration,
+                                    style = ArflixTypography.caption.copy(
+                                        fontSize = 13.sp,
+                                        fontWeight = FontWeight.SemiBold,
+                                        shadow = textShadow
+                                    ),
+                                    color = Color.White.copy(alpha = 0.78f),
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                            }
+                        }
+
+                        if (genreText.isNotEmpty()) {
+                            Spacer(modifier = Modifier.height(6.dp))
+                            Text(
+                                text = genreText,
+                                style = ArflixTypography.caption.copy(
+                                    fontSize = 13.sp,
+                                    fontWeight = FontWeight.SemiBold,
+                                    shadow = textShadow
+                                ),
+                                color = Color.White.copy(alpha = 0.74f),
+                                textAlign = TextAlign.Center,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.fillMaxWidth(0.9f)
+                            )
+                        }
+                    }
+
+                }
+
+                // --- Content on black background ---
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(Color.Black)
+                        .padding(horizontal = 16.dp)
+                ) {
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    // Primary mobile actions
+                    val playButtonLabel = if (!playLabel.isNullOrBlank()) playLabel else "Play"
+                    MobileActionButton(
+                        icon = Icons.Default.PlayArrow,
+                        text = playButtonLabel,
+                        isPrimary = true,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(58.dp),
+                        onClick = { onButtonClick(0) }
+                    )
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        MobileIconActionButton(
+                            icon = Icons.Default.List,
+                            contentDescription = stringResource(R.string.sources),
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(54.dp),
+                            onClick = { onButtonClick(1) }
+                        )
+                        MobileIconActionButton(
+                            icon = Icons.Default.Movie,
+                            contentDescription = stringResource(R.string.trailer),
+                            enabled = hasTrailer,
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(54.dp),
+                            onClick = { onButtonClick(2) }
+                        )
+                        MobileIconActionButton(
+                            icon = if (buttonWatched) Icons.Default.Check else Icons.Default.Visibility,
+                            contentDescription = if (buttonWatched) "Watched" else "Mark watched",
+                            isActive = buttonWatched,
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(54.dp),
+                            onClick = { onButtonClick(3) }
+                        )
+                        MobileIconActionButton(
+                            icon = if (isInWatchlist) Icons.Default.Bookmark else Icons.Default.BookmarkBorder,
+                            contentDescription = if (isInWatchlist) "In watchlist" else "Add to watchlist",
+                            isActive = isInWatchlist,
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(54.dp),
+                            onClick = { onButtonClick(4) }
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(18.dp))
+
+                    // Description
+                    Text(
+                        text = item.overview,
+                        style = ArflixTypography.body.copy(
+                            fontSize = 12.sp,
+                            lineHeight = 18.sp,
+                            fontWeight = FontWeight.Normal
+                        ),
+                        color = Color.White.copy(alpha = 0.88f),
+                        maxLines = 4,
+                        overflow = TextOverflow.Ellipsis
+                    )
+
+                    // --- TV Show: Season selector & Episodes ---
+                    if (item.mediaType == MediaType.TV && episodes.isNotEmpty()) {
+                        if (totalSeasons > 1) {
+                            Spacer(modifier = Modifier.height(20.dp))
+                            Text(
+                                text = stringResource(R.string.seasons),
+                                style = ArvioSkin.typography.sectionTitle.copy(fontSize = 15.sp, fontWeight = FontWeight.Bold),
+                                color = Color.White.copy(alpha = 0.9f)
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .horizontalScroll(rememberScrollState()),
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                (1..totalSeasons).forEachIndexed { index, season ->
+                                    val progress = seasonProgress[season]
+                                    val currentSeasonProgress = if (season == currentSeason && episodes.isNotEmpty()) {
+                                        Pair(episodes.count { it.isWatched }, episodes.size)
+                                    } else null
+                                    SeasonButton(
+                                        season = season,
+                                        isSelected = season == currentSeason,
+                                        isFocused = false,
+                                        watchedCount = currentSeasonProgress?.first ?: progress?.first ?: 0,
+                                        totalCount = currentSeasonProgress?.second ?: progress?.second ?: 0,
+                                        onClick = { onSeasonClick(index) }
+                                    )
+                                }
+                            }
+                        }
+
+                        Spacer(modifier = Modifier.height(20.dp))
+                        Text(
+                            text = stringResource(R.string.episodes),
+                            style = ArvioSkin.typography.sectionTitle.copy(fontSize = 15.sp, fontWeight = FontWeight.Bold),
+                            color = Color.White.copy(alpha = 0.9f)
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                    }
+                }
+
+                // Episodes LazyRow (outside the inner Column to allow independent horizontal scroll)
+                if (item.mediaType == MediaType.TV && episodes.isNotEmpty()) {
+                    LazyRow(
+                        modifier = Modifier.arvioDpadFocusGroup(),
+                        contentPadding = PaddingValues(start = 16.dp, end = 16.dp),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        standardItemsIndexed(
+                            episodes,
+                            key = { index, ep -> "mob_ep_${ep.seasonNumber}_${ep.episodeNumber}_$index" },
+                            contentType = { _, _ -> "episode" }
+                        ) { index, episode ->
+                            EpisodeCard(
+                                episode = episode,
+                                isFocused = false,
+                                spoilerBlurEnabled = spoilerBlurEnabled,
+                                onClick = { onEpisodeClick(index) }
+                            )
+                        }
+                    }
+                }
+
+                // Cast section
+                if (cast.isNotEmpty()) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp)
+                    ) {
+                        Spacer(modifier = Modifier.height(24.dp))
+                        Text(
+                            text = stringResource(R.string.cast),
+                            style = ArvioSkin.typography.sectionTitle.copy(fontSize = 15.sp, fontWeight = FontWeight.Bold),
+                            color = Color.White.copy(alpha = 0.9f)
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                    }
+                    LazyRow(
+                        modifier = Modifier.arvioDpadFocusGroup(),
+                        contentPadding = PaddingValues(start = 16.dp, end = 16.dp),
+                        horizontalArrangement = Arrangement.spacedBy(14.dp)
+                    ) {
+                        standardItemsIndexed(
+                            cast,
+                            key = { index, c -> "mob_cast_${c.id}_$index" },
+                            contentType = { _, _ -> "cast" }
+                        ) { index, castMember ->
+                            CircularCastCard(
+                                castMember = castMember,
+                                isFocused = false,
+                                onClick = { onCastClick(index) }
+                            )
+                        }
+                    }
+                }
+
+                // Similar / More Like This section
+                if (similar.isNotEmpty()) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp)
+                    ) {
+                        Spacer(modifier = Modifier.height(24.dp))
+                        Text(
+                            text = stringResource(R.string.more_like_this),
+                            style = ArvioSkin.typography.sectionTitle.copy(fontSize = 15.sp, fontWeight = FontWeight.Bold),
+                            color = Color.White.copy(alpha = 0.9f)
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                    }
+                    LazyRow(
+                        modifier = Modifier.arvioDpadFocusGroup(),
+                        contentPadding = PaddingValues(start = 16.dp, end = 16.dp),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        standardItemsIndexed(
+                            similar,
+                            key = { index, m -> "mob_sim_${m.mediaType.name}_${m.id}_$index" },
+                            contentType = { _, _ -> "similar" }
+                        ) { index, mediaItem ->
+                            SimilarMediaCard(
+                                item = mediaItem,
+                                logoImageUrl = similarLogoUrls["${mediaItem.mediaType}_${mediaItem.id}"],
+                                usePosterCards = usePosterCards,
+                                isFocused = false,
+                                onClick = { onSimilarClick(index) }
+                            )
+                        }
+                    }
+                }
+
+                // Reviews section
+                if (reviews.isNotEmpty()) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp)
+                    ) {
+                        Spacer(modifier = Modifier.height(24.dp))
+                        Text(
+                            text = stringResource(R.string.reviews),
+                            style = ArvioSkin.typography.sectionTitle.copy(fontSize = 15.sp, fontWeight = FontWeight.Bold),
+                            color = Color.White.copy(alpha = 0.9f)
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                    }
+                    LazyRow(
+                        modifier = Modifier.arvioDpadFocusGroup(),
+                        contentPadding = PaddingValues(start = 16.dp, end = 16.dp),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        standardItemsIndexed(
+                            reviews,
+                            key = { index, r -> "mob_review_${r.author}_$index" },
+                            contentType = { _, _ -> "review" }
+                        ) { index, review ->
+                            ReviewCard(
+                                review = review,
+                                isFocused = false
+                            )
+                        }
+                    }
+                }
+
+                // Bottom spacing
+                Spacer(modifier = Modifier.height(32.dp))
+            }
+
+            // Persistent back button for phone users (hidden on tablet/TV).
+            // Sits on top of the scrolling Column so it's always reachable even
+            // when the system nav bar auto-hides. Issue #43.
+            com.arflix.tv.ui.components.MobileBackButton(
+                onBack = onBack,
+                modifier = Modifier.align(Alignment.TopStart).statusBarsPadding()
+            )
+        }
+        return
+    }
+    // ===================== END MOBILE LAYOUT =====================
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        // Full-screen hero background
+        AsyncImage(
+            model = item.backdrop ?: item.image,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.fillMaxSize()
+        )
+
+        // === PREMIUM MULTI-LAYER SCRIM SYSTEM ===
+
+        // Layer 1: Strong left gradient for hero text area (Netflix-style)
+        // Uses colorStops with percentages to work on any resolution
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    brush = Brush.horizontalGradient(
+                        colorStops = arrayOf(
+                            0.0f to Color.Black.copy(alpha = 0.85f),
+                            0.15f to Color.Black.copy(alpha = 0.75f),
+                            0.25f to Color.Black.copy(alpha = 0.55f),
+                            0.35f to Color.Black.copy(alpha = 0.35f),
+                            0.45f to Color.Black.copy(alpha = 0.15f),
+                            0.55f to Color.Transparent,
+                            1.0f to Color.Transparent
+                        )
+                    )
+                )
+        )
+
+        // Layer 2: Top vignette for clock/status area
+        // Uses colorStops with percentages to work on any resolution
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    brush = Brush.verticalGradient(
+                        colorStops = arrayOf(
+                            0.0f to Color.Black.copy(alpha = 0.5f),
+                            0.05f to Color.Black.copy(alpha = 0.25f),
+                            0.12f to Color.Transparent,
+                            1.0f to Color.Transparent
+                        )
+                    )
+                )
+        )
+
+        // Layer 3: Bottom floor-fade (starts low, darker at bottom)
+        // Uses colorStops with percentages to work on any resolution
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    brush = Brush.verticalGradient(
+                        colorStops = arrayOf(
+                            0.0f to Color.Transparent,
+                            0.85f to Color.Transparent,
+                            0.92f to Color.Black.copy(alpha = 0.5f),
+                            1.0f to Color.Black.copy(alpha = 0.85f)
+                        )
+                    )
+                )
+        )
+
+        // Layer 4 removed for performance - radial gradients are expensive on TV
+
+        // Hero metadata positioned above the content rows
+        val heroStartPadding = 36.dp
+        val heroEndPadding = 400.dp
+        val configuration = LocalConfiguration.current
+        val contentRowHeight = (configuration.screenHeightDp * 0.34f).dp.coerceIn(240.dp, 320.dp)
+        val contentRowBottomPadding = 12.dp
+        val contentRowTopPadding = contentRowHeight + contentRowBottomPadding
+        val buttonsBottomPadding = contentRowTopPadding - 10.dp
+        val heroBottomPadding = buttonsBottomPadding + if (configuration.screenHeightDp < 720) 46.dp else 58.dp
+
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(
+                    bottom = heroBottomPadding,
+                    start = heroStartPadding,
+                    end = heroEndPadding
+                )
+        ) {
+            Column(verticalArrangement = Arrangement.Bottom) {
+                val showInCinema = remember(item.releaseDate, item.mediaType) {
+                    isInCinema(item)
+                }
+                val inCinemaColor = Color(0xFF8AD5FF)
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Box(
+                        modifier = Modifier.height(72.dp),
+                        contentAlignment = Alignment.CenterStart
+                    ) {
+                        if (logoUrl != null) {
+                            AsyncImage(
+                                model = logoUrl,
+                                contentDescription = item.title,
+                                contentScale = ContentScale.Fit,
+                                alignment = Alignment.CenterStart,
+                                modifier = Modifier
+                                    .height(72.dp)
+                                    .width(320.dp)
+                            )
+                        }
+                    }
+
+                    if (showInCinema) {
+                        Box(
+                            modifier = Modifier
+                                .background(inCinemaColor, RoundedCornerShape(6.dp))
+                                .padding(horizontal = 10.dp, vertical = 4.dp)
+                        ) {
+                            Text(
+                                text = stringResource(R.string.in_cinema),
+                                style = ArflixTypography.caption.copy(
+                                    fontSize = 10.sp,
+                                    fontWeight = FontWeight.Bold
+                                ),
+                                color = Color.Black
+                            )
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(4.dp))
+
+                val genreText = genres.take(2).joinToString(" / ").ifEmpty {
+                    if (item.mediaType == MediaType.TV) "TV Series" else "Movie"
+                }
+                val isCompactHeight = configuration.screenHeightDp < 720
+                val displayDate = item.releaseDate?.takeIf { it.isNotEmpty() } ?: item.year
+                val hasDuration = item.duration.isNotEmpty() && item.duration != "0m"
+                val rating = item.imdbRating.ifEmpty { item.tmdbRating }
+                val ratingValue = parseRatingValue(rating)
+                val primaryNetworkLogo = item.primaryNetworkLogo?.takeIf { it.isNotBlank() }
+                val budgetText = budget?.trim()?.takeIf { it.isNotEmpty() && item.mediaType == MediaType.MOVIE }
+                val overviewMaxHeight = if (isCompactHeight) 68.dp else 72.dp
+
+                val separatorStyle = ArflixTypography.caption.copy(
+                    fontSize = 13.sp,
+                    shadow = textShadow
+                )
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(3.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = genreText,
+                        style = ArflixTypography.caption.copy(
+                            fontSize = 13.sp,
+                            fontWeight = FontWeight.Bold,
+                            shadow = textShadow
+                        ),
+                        color = Color.White
+                    )
+
+                    if (displayDate.isNotEmpty()) {
+                        Text(text = "|", style = separatorStyle, color = Color.White.copy(alpha = 0.7f))
+                        Text(
+                            text = displayDate,
+                            style = ArflixTypography.caption.copy(
+                                fontSize = 13.sp,
+                                fontWeight = FontWeight.Bold,
+                                shadow = textShadow
+                            ),
+                            color = Color.White
+                        )
+                    }
+
+                    if (hasDuration) {
+                        Text(text = "|", style = separatorStyle, color = Color.White.copy(alpha = 0.7f))
+                        Text(
+                            text = item.duration,
+                            style = ArflixTypography.caption.copy(
+                                fontSize = 13.sp,
+                                fontWeight = FontWeight.Bold,
+                                shadow = textShadow
+                            ),
+                            color = Color.White
+                        )
+                    }
+
+                    if (primaryNetworkLogo != null) {
+                        Text(text = "|", style = separatorStyle, color = Color.White.copy(alpha = 0.7f))
+                        AsyncImage(
+                            model = primaryNetworkLogo,
+                            imageLoader = metadataLogoImageLoader,
+                            contentDescription = "Primary streaming provider",
+                            contentScale = ContentScale.Fit,
+                            modifier = Modifier
+                                .height(16.dp)
+                                .width(52.dp)
+                        )
+                    }
+
+                    if (ratingValue > 0f) {
+                        Text(text = "|", style = separatorStyle, color = Color.White.copy(alpha = 0.7f))
+                        DetailsImdbSvgRatingBadge(
+                            rating = rating,
+                            imageLoader = metadataLogoImageLoader,
+                            ratingFontSize = 13,
+                            logoWidth = 34.dp,
+                            logoHeight = 14.dp,
+                            textShadow = textShadow
+                        )
+                    }
+
+                    if (!budgetText.isNullOrBlank()) {
+                        Text(text = "|", style = separatorStyle, color = Color.White.copy(alpha = 0.7f))
+                        Text(
+                            text = "${stringResource(R.string.budget)} $budgetText",
+                            style = ArflixTypography.caption.copy(
+                                fontSize = 13.sp,
+                                fontWeight = FontWeight.Bold,
+                                shadow = textShadow
+                            ),
+                            color = Color.White
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(6.dp))
+
+                val displayOverview = item.overview
+
+                Box(
+                    modifier = Modifier
+                        .width(360.dp)
+                        .height(overviewMaxHeight)
+                ) {
+                    Text(
+                        text = displayOverview,
+                        style = ArflixTypography.body.copy(
+                            fontSize = 12.sp,
+                            fontWeight = FontWeight.Normal,
+                            lineHeight = 16.sp,
+                            shadow = textShadow
+                        ),
+                        color = Color.White.copy(alpha = 0.9f),
+                        maxLines = 4,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(
+                    bottom = buttonsBottomPadding,
+                    start = heroStartPadding,
+                    end = heroEndPadding
+                )
+        ) {
+            val buttonWatched = if (item.mediaType == MediaType.TV) {
+                episodes.getOrNull(episodeIndex)?.isWatched ?: item.isWatched
+            } else {
+                item.isWatched
+            }
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                val playButtonLabel = if (!playLabel.isNullOrBlank()) {
+                    playLabel
+                } else {
+                    "Play"
+                }
+                Box(modifier = Modifier.clickable { onButtonClick(0) }) {
+                    PremiumActionButton(
+                        icon = Icons.Default.PlayArrow,
+                        text = playButtonLabel,
+                        isPrimary = true,
+                        isFocused = focusSectionForUi == FocusSection.BUTTONS && buttonIndex == 0
+                    )
+                }
+                Box(modifier = Modifier.clickable { onButtonClick(1) }) {
+                    PremiumActionButton(
+                        icon = Icons.Default.List,
+                        text = stringResource(R.string.sources),
+                        isFocused = focusSectionForUi == FocusSection.BUTTONS && buttonIndex == 1,
+                        isIconOnly = true
+                    )
+                }
+                Box(modifier = Modifier.clickable { onButtonClick(2) }) {
+                    PremiumActionButton(
+                        icon = Icons.Default.Movie,
+                        text = stringResource(R.string.trailer),
+                        isFocused = focusSectionForUi == FocusSection.BUTTONS && buttonIndex == 2,
+                        isIconOnly = true
+                    )
+                }
+                Box(modifier = Modifier.clickable { onButtonClick(3) }) {
+                    PremiumActionButton(
+                        icon = if (buttonWatched) Icons.Default.Check else Icons.Default.Visibility,
+                        text = if (buttonWatched) "Watched" else "Mark Watched",
+                        isFocused = focusSectionForUi == FocusSection.BUTTONS && buttonIndex == 3,
+                        isActive = buttonWatched,
+                        isIconOnly = true
+                    )
+                }
+                Box(modifier = Modifier.clickable { onButtonClick(4) }) {
+                    PremiumActionButton(
+                        icon = if (isInWatchlist) Icons.Default.Bookmark else Icons.Default.BookmarkBorder,
+                        text = stringResource(R.string.watchlist),
+                        isFocused = focusSectionForUi == FocusSection.BUTTONS && buttonIndex == 4,
+                        isIconOnly = true,
+                        isActive = isInWatchlist
+                    )
+                }
+            }
+        }
+
+        DetailsTvRows(
+            modifier = Modifier.align(Alignment.BottomStart),
+            item = item,
+            episodes = episodes,
+            totalSeasons = totalSeasons,
+            currentSeason = currentSeason,
+            cast = cast,
+            reviews = reviews,
+            similar = similar,
+            similarLogoUrls = similarLogoUrls,
+            focusedSection = focusedSection,
+            focusSectionForUi = focusSectionForUi,
+            episodeIndex = episodeIndex,
+            seasonIndex = seasonIndex,
+            castIndex = castIndex,
+            reviewIndex = reviewIndex,
+            similarIndex = similarIndex,
+            seasonProgress = seasonProgress,
+            usePosterCards = usePosterCards,
+            spoilerBlurEnabled = spoilerBlurEnabled,
+            contentRowHeight = contentRowHeight,
+            contentRowBottomPadding = contentRowBottomPadding,
+            configuration = configuration,
+            contentHasFocus = contentHasFocus,
+            onSeasonClick = onSeasonClick,
+            onEpisodeClick = onEpisodeClick,
+            onCastClick = onCastClick,
+            onSimilarClick = onSimilarClick
+        )
+    }
+}
+
+@Composable
+private fun DetailsTvRows(
+    modifier: Modifier,
+    item: MediaItem,
+    episodes: List<Episode>,
+    totalSeasons: Int,
+    currentSeason: Int,
+    cast: List<CastMember>,
+    reviews: List<Review>,
+    similar: List<MediaItem>,
+    similarLogoUrls: Map<String, String>,
+    focusedSection: FocusSection,
+    focusSectionForUi: FocusSection?,
+    episodeIndex: Int,
+    seasonIndex: Int,
+    castIndex: Int,
+    reviewIndex: Int,
+    similarIndex: Int,
+    seasonProgress: Map<Int, Pair<Int, Int>>,
+    usePosterCards: Boolean,
+    spoilerBlurEnabled: Boolean,
+    contentRowHeight: Dp,
+    contentRowBottomPadding: Dp,
+    configuration: android.content.res.Configuration,
+    contentHasFocus: Boolean,
+    onSeasonClick: (Int) -> Unit,
+    onEpisodeClick: (Int) -> Unit,
+    onCastClick: (Int) -> Unit,
+    onSimilarClick: (Int) -> Unit
+) {
+    val contentScrollState = rememberTvLazyListState()
+    val detailsStackOffsetPx = remember { Animatable(0f) }
+    val density = LocalDensity.current
+    val isTV = item.mediaType == MediaType.TV
+    val hasEpisodes = isTV && episodes.isNotEmpty()
+    val hasSeasons = isTV && totalSeasons > 1
+    val hasCast = cast.isNotEmpty()
+    val hasReviews = reviews.isNotEmpty()
+    val hasSimilar = similar.isNotEmpty()
+
+    var idx = 0
+    val seasonsIdx = if (hasSeasons) idx.also { idx++ } else -1
+    val episodesIdx = if (hasEpisodes) idx.also { idx++ } else -1
+    if (hasCast) idx++
+    val castIdx = if (hasCast) idx.also { idx++ } else -1
+    if (hasReviews) idx++
+    val reviewsIdx = if (hasReviews) idx.also { idx++ } else -1
+    if (hasSimilar) idx++
+    val similarIdx = if (hasSimilar) idx.also { idx++ } else -1
+
+    LaunchedEffect(item.mediaType, item.id, currentSeason, hasEpisodes, hasSeasons) {
+        contentScrollState.scrollToItem(0, 0)
+    }
+
+    LaunchedEffect(focusedSection, contentHasFocus) {
+        if (!contentHasFocus) return@LaunchedEffect
+
+        val targetIndex = when (focusedSection) {
+            FocusSection.BUTTONS, FocusSection.EPISODES, FocusSection.SEASONS -> 0
+            FocusSection.CAST -> castIdx
+            FocusSection.REVIEWS -> reviewsIdx
+            FocusSection.SIMILAR -> similarIdx
+        }
+        if (targetIndex < 0) return@LaunchedEffect
+
+        val firstVisible = contentScrollState.firstVisibleItemIndex
+        val topClusterMaxIndex = maxOf(episodesIdx, seasonsIdx, 0)
+        if (
+            focusSectionForUi == FocusSection.BUTTONS ||
+            focusSectionForUi == FocusSection.EPISODES ||
+            focusSectionForUi == FocusSection.SEASONS
+        ) {
+            if (firstVisible > topClusterMaxIndex || contentScrollState.firstVisibleItemScrollOffset != 0) {
+                val travelPx = with(density) { 96.dp.toPx() }
+                detailsStackOffsetPx.stop()
+                detailsStackOffsetPx.snapTo(-travelPx)
+                contentScrollState.scrollToItem(0, 0)
+                detailsStackOffsetPx.animateTo(
+                    targetValue = 0f,
+                    animationSpec = tween(durationMillis = 150, easing = FastOutSlowInEasing)
+                )
+            }
+            return@LaunchedEffect
+        }
+
+        if (firstVisible != targetIndex) {
+            val direction = if (targetIndex > firstVisible) 1f else -1f
+            val travelPx = with(density) { 96.dp.toPx() }
+            detailsStackOffsetPx.stop()
+            detailsStackOffsetPx.snapTo(direction * travelPx)
+            contentScrollState.scrollToItem(targetIndex)
+            detailsStackOffsetPx.animateTo(
+                targetValue = 0f,
+                animationSpec = tween(durationMillis = 150, easing = FastOutSlowInEasing)
+            )
+        }
+    }
+
+    val contentStartPadding = 12.dp
+    val contentOuterStartPadding = 24.dp
+
+    TvLazyColumn(
+        state = contentScrollState,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(contentRowHeight)
+            .padding(start = 24.dp, bottom = contentRowBottomPadding)
+            .graphicsLayer { translationY = detailsStackOffsetPx.value }
+            .arvioManualBringIntoViewBoundary()
+            .arvioDpadFocusGroup(enableFocusRestorer = false)
+            .clipToBounds(),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+        contentPadding = PaddingValues(top = 6.dp)
+    ) {
+        if (item.mediaType == MediaType.TV && episodes.isNotEmpty()) {
+            if (totalSeasons > 1) {
+                item {
+                    DetailsSeasonRail(
+                        totalSeasons = totalSeasons,
+                        currentSeason = currentSeason,
+                        episodes = episodes,
+                        seasonProgress = seasonProgress,
+                        focusSectionForUi = focusSectionForUi,
+                        seasonIndex = seasonIndex,
+                        contentStartPadding = contentStartPadding,
+                        contentOuterStartPadding = contentOuterStartPadding,
+                        onSeasonClick = onSeasonClick
+                    )
+                }
+            }
+
+            item {
+                DetailsEpisodeRail(
+                    episodes = episodes,
+                    episodeIndex = episodeIndex,
+                    focusSectionForUi = focusSectionForUi,
+                    configuration = configuration,
+                    contentStartPadding = contentStartPadding,
+                    contentOuterStartPadding = contentOuterStartPadding,
+                    spoilerBlurEnabled = spoilerBlurEnabled,
+                    onEpisodeClick = onEpisodeClick
+                )
+            }
+        }
+
+        if (cast.isNotEmpty()) {
+            item { Spacer(modifier = Modifier.height(4.dp)) }
+            item {
+                DetailsCastRail(
+                    cast = cast,
+                    castIndex = castIndex,
+                    focusSectionForUi = focusSectionForUi,
+                    contentStartPadding = contentStartPadding,
+                    contentOuterStartPadding = contentOuterStartPadding,
+                    onCastClick = onCastClick
+                )
+            }
+        }
+
+        if (reviews.isNotEmpty()) {
+            item { Spacer(modifier = Modifier.height(64.dp)) }
+            item {
+                DetailsReviewRail(
+                    reviews = reviews,
+                    reviewIndex = reviewIndex,
+                    focusSectionForUi = focusSectionForUi,
+                    contentStartPadding = contentStartPadding,
+                    contentOuterStartPadding = contentOuterStartPadding
+                )
+            }
+        }
+
+        if (similar.isNotEmpty()) {
+            item { Spacer(modifier = Modifier.height(80.dp)) }
+            item {
+                DetailsSimilarRail(
+                    similar = similar,
+                    similarLogoUrls = similarLogoUrls,
+                    similarIndex = similarIndex,
+                    focusSectionForUi = focusSectionForUi,
+                    usePosterCards = usePosterCards,
+                    contentStartPadding = contentStartPadding,
+                    contentOuterStartPadding = contentOuterStartPadding,
+                    onSimilarClick = onSimilarClick
+                )
+            }
+        }
+
+        item { Spacer(modifier = Modifier.height(20.dp)) }
+    }
+}
+
+@Composable
+private fun DetailsSeasonRail(
+    totalSeasons: Int,
+    currentSeason: Int,
+    episodes: List<Episode>,
+    seasonProgress: Map<Int, Pair<Int, Int>>,
+    focusSectionForUi: FocusSection?,
+    seasonIndex: Int,
+    contentStartPadding: Dp,
+    contentOuterStartPadding: Dp,
+    onSeasonClick: (Int) -> Unit
+) {
+    val seasonRowState = rememberTvLazyListState()
+    val seasonItems = remember(totalSeasons) { (1..totalSeasons).toList() }
+    HomeStyleRowAutoScroll(
+        rowState = seasonRowState,
+        isCurrentRow = focusSectionForUi == FocusSection.SEASONS,
+        focusedItemIndex = seasonIndex,
+        totalItems = totalSeasons,
+        itemWidth = 128.dp,
+        itemSpacing = 8.dp
+    )
+
+    val seasonFocusIndex by remember(focusSectionForUi, seasonIndex) {
+        derivedStateOf {
+            if (focusSectionForUi == FocusSection.SEASONS) seasonIndex else -1
+        }
+    }
+
+    TvLazyRow(
+        state = seasonRowState,
+        modifier = Modifier.arvioDpadFocusGroup(enableFocusRestorer = false),
+        contentPadding = PaddingValues(
+            start = contentStartPadding,
+            end = lockedDetailsRailEndPadding(
+                itemWidth = 128.dp,
+                startPadding = contentStartPadding,
+                outerStartPadding = contentOuterStartPadding,
+                minimum = 150.dp
+            ),
+            top = 6.dp,
+            bottom = 6.dp,
+        ),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        itemsIndexed(seasonItems, key = { _, s -> s }) { index, season ->
+            val progress = seasonProgress[season]
+            val currentSeasonProgress = if (season == currentSeason && episodes.isNotEmpty()) {
+                Pair(episodes.count { it.isWatched }, episodes.size)
+            } else {
+                null
+            }
+            val onClickForSeason = remember(index, onSeasonClick) {
+                { onSeasonClick(index) }
+            }
+            SeasonButton(
+                season = season,
+                isSelected = season == currentSeason,
+                isFocused = focusSectionForUi == FocusSection.SEASONS && index == seasonFocusIndex,
+                watchedCount = currentSeasonProgress?.first ?: progress?.first ?: 0,
+                totalCount = currentSeasonProgress?.second ?: progress?.second ?: 0,
+                onClick = onClickForSeason
+            )
+        }
+    }
+}
+
+@Composable
+private fun DetailsEpisodeRail(
+    episodes: List<Episode>,
+    episodeIndex: Int,
+    focusSectionForUi: FocusSection?,
+    configuration: android.content.res.Configuration,
+    contentStartPadding: Dp,
+    contentOuterStartPadding: Dp,
+    spoilerBlurEnabled: Boolean,
+    onEpisodeClick: (Int) -> Unit
+) {
+    val episodeCardWidth = if (configuration.screenWidthDp < 1400) 292.dp else 300.dp
+    val episodeRowState = rememberTvLazyListState()
+    val episodeFixedFocus = focusSectionForUi == FocusSection.EPISODES &&
+        detailsRailUsesFixedFirstSlotFocus(
+            totalItems = episodes.size,
+            focusedItemIndex = episodeIndex
+        )
+    HomeStyleRowAutoScroll(
+        rowState = episodeRowState,
+        isCurrentRow = focusSectionForUi == FocusSection.EPISODES,
+        focusedItemIndex = episodeIndex,
+        totalItems = episodes.size,
+        itemWidth = episodeCardWidth,
+        itemSpacing = 16.dp
+    )
+
+    val currentFocusedSection by rememberUpdatedState(focusSectionForUi)
+    val currentEpisodeIndex by rememberUpdatedState(episodeIndex)
+
+    Box(modifier = Modifier.fillMaxWidth()) {
+        TvLazyRow(
+            state = episodeRowState,
+            modifier = Modifier.arvioDpadFocusGroup(enableFocusRestorer = false),
+            contentPadding = PaddingValues(
+                start = contentStartPadding,
+                end = lockedDetailsRailEndPadding(
+                    itemWidth = episodeCardWidth,
+                    startPadding = contentStartPadding,
+                    outerStartPadding = contentOuterStartPadding,
+                    minimum = 520.dp
+                ),
+                top = 6.dp,
+                bottom = 6.dp,
+            ),
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            itemsIndexed(
+                episodes,
+                key = { index, ep -> "${ep.seasonNumber}_${ep.episodeNumber}_$index" }
+            ) { index, episode ->
+                val isFocused = currentFocusedSection == FocusSection.EPISODES && index == currentEpisodeIndex
+                val onClickForEpisode = remember(index, onEpisodeClick) {
+                    { onEpisodeClick(index) }
+                }
+                EpisodeCard(
+                    episode = episode,
+                    cardWidth = episodeCardWidth,
+                    isFocused = isFocused && !episodeFixedFocus,
+                    spoilerBlurEnabled = spoilerBlurEnabled,
+                    onClick = onClickForEpisode
+                )
+            }
+        }
+        if (episodeFixedFocus) {
+            FixedDetailsRailFocusOverlay(
+                startPadding = contentStartPadding,
+                topPadding = 6.dp,
+                width = episodeCardWidth,
+                aspectRatio = 16f / 9f
+            )
+        }
+    }
+}
+
+@Composable
+private fun DetailsCastRail(
+    cast: List<CastMember>,
+    castIndex: Int,
+    focusSectionForUi: FocusSection?,
+    contentStartPadding: Dp,
+    contentOuterStartPadding: Dp,
+    onCastClick: (Int) -> Unit
+) {
+    val castRowState = rememberTvLazyListState()
+    HomeStyleRowAutoScroll(
+        rowState = castRowState,
+        isCurrentRow = focusSectionForUi == FocusSection.CAST,
+        focusedItemIndex = castIndex,
+        totalItems = cast.size,
+        itemWidth = 90.dp,
+        itemSpacing = 16.dp
+    )
+
+    Column {
+        Text(
+            text = stringResource(R.string.cast),
+            style = ArvioSkin.typography.sectionTitle.copy(
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Bold
+            ),
+            color = Color.White.copy(alpha = 0.9f),
+            modifier = Modifier.padding(start = contentStartPadding, bottom = 10.dp)
+        )
+
+        TvLazyRow(
+            state = castRowState,
+            modifier = Modifier.arvioDpadFocusGroup(enableFocusRestorer = false),
+            contentPadding = PaddingValues(
+                start = contentStartPadding,
+                end = lockedDetailsRailEndPadding(
+                    itemWidth = 90.dp,
+                    startPadding = contentStartPadding,
+                    outerStartPadding = contentOuterStartPadding,
+                    minimum = 120.dp
+                ),
+                top = 10.dp,
+                bottom = 10.dp,
+            ),
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            itemsIndexed(
+                cast,
+                key = { index, c -> "${c.id}_${c.character}_$index" }
+            ) { index, castMember ->
+                val onClickForCast = remember(index, onCastClick) {
+                    { onCastClick(index) }
+                }
+                CircularCastCard(
+                    castMember = castMember,
+                    isFocused = focusSectionForUi == FocusSection.CAST && index == castIndex,
+                    onClick = onClickForCast
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DetailsReviewRail(
+    reviews: List<Review>,
+    reviewIndex: Int,
+    focusSectionForUi: FocusSection?,
+    contentStartPadding: Dp,
+    contentOuterStartPadding: Dp
+) {
+    val reviewRowState = rememberTvLazyListState()
+    HomeStyleRowAutoScroll(
+        rowState = reviewRowState,
+        isCurrentRow = focusSectionForUi == FocusSection.REVIEWS,
+        focusedItemIndex = reviewIndex,
+        totalItems = reviews.size,
+        itemWidth = 320.dp,
+        itemSpacing = 16.dp
+    )
+
+    Column {
+        Text(
+            text = stringResource(R.string.reviews),
+            style = ArvioSkin.typography.sectionTitle.copy(
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Bold
+            ),
+            color = Color.White.copy(alpha = 0.9f),
+            modifier = Modifier.padding(start = contentStartPadding, bottom = 10.dp)
+        )
+
+        TvLazyRow(
+            state = reviewRowState,
+            modifier = Modifier.arvioDpadFocusGroup(enableFocusRestorer = false),
+            contentPadding = PaddingValues(
+                start = contentStartPadding,
+                end = lockedDetailsRailEndPadding(
+                    itemWidth = 320.dp,
+                    startPadding = contentStartPadding,
+                    outerStartPadding = contentOuterStartPadding,
+                    minimum = 350.dp
+                ),
+                top = 14.dp,
+                bottom = 14.dp,
+            ),
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            itemsIndexed(
+                reviews,
+                key = { index, r -> "${r.id}_$index" }
+            ) { index, review ->
+                ReviewCard(
+                    review = review,
+                    isFocused = focusSectionForUi == FocusSection.REVIEWS && index == reviewIndex
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DetailsSimilarRail(
+    similar: List<MediaItem>,
+    similarLogoUrls: Map<String, String>,
+    similarIndex: Int,
+    focusSectionForUi: FocusSection?,
+    usePosterCards: Boolean,
+    contentStartPadding: Dp,
+    contentOuterStartPadding: Dp,
+    onSimilarClick: (Int) -> Unit
+) {
+    val similarRowState = rememberTvLazyListState()
+    val similarCardWidth = if (usePosterCards) 126.dp else 210.dp
+    val similarFixedFocus = focusSectionForUi == FocusSection.SIMILAR &&
+        detailsRailUsesFixedFirstSlotFocus(
+            totalItems = similar.size,
+            focusedItemIndex = similarIndex
+        )
+    HomeStyleRowAutoScroll(
+        rowState = similarRowState,
+        isCurrentRow = focusSectionForUi == FocusSection.SIMILAR,
+        focusedItemIndex = similarIndex,
+        totalItems = similar.size,
+        itemWidth = similarCardWidth,
+        itemSpacing = 14.dp
+    )
+
+    Column {
+        Text(
+            text = stringResource(R.string.more_like_this),
+            style = ArvioSkin.typography.sectionTitle.copy(
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Bold
+            ),
+            color = Color.White.copy(alpha = 0.9f),
+            modifier = Modifier.padding(start = contentStartPadding, bottom = 10.dp)
+        )
+
+        Box(modifier = Modifier.fillMaxWidth()) {
+            TvLazyRow(
+                state = similarRowState,
+                modifier = Modifier.arvioDpadFocusGroup(enableFocusRestorer = false),
+                contentPadding = PaddingValues(
+                    start = contentStartPadding,
+                    end = lockedDetailsRailEndPadding(
+                        itemWidth = similarCardWidth,
+                        startPadding = contentStartPadding,
+                        outerStartPadding = contentOuterStartPadding,
+                        minimum = if (usePosterCards) 140.dp else 210.dp
+                    ),
+                    top = 14.dp,
+                    bottom = 14.dp,
+                ),
+                horizontalArrangement = Arrangement.spacedBy(14.dp)
+            ) {
+                itemsIndexed(
+                    similar,
+                    key = { index, m -> "${m.mediaType.name}_${m.id}_$index" }
+                ) { index, mediaItem ->
+                    val onClickForSimilar = remember(index, onSimilarClick) {
+                        { onSimilarClick(index) }
+                    }
+                    SimilarMediaCard(
+                        item = mediaItem,
+                        logoImageUrl = similarLogoUrls["${mediaItem.mediaType}_${mediaItem.id}"],
+                        usePosterCards = usePosterCards,
+                        isFocused = focusSectionForUi == FocusSection.SIMILAR && index == similarIndex && !similarFixedFocus,
+                        onClick = onClickForSimilar
+                    )
+                }
+            }
+            if (similarFixedFocus) {
+                FixedDetailsRailFocusOverlay(
+                    startPadding = contentStartPadding,
+                    topPadding = 14.dp,
+                    width = similarCardWidth,
+                    aspectRatio = if (usePosterCards) 2f / 3f else 16f / 9f
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun detailsRailIsScrollable(
+    totalItems: Int,
+    itemWidth: Dp,
+    itemSpacing: Dp
+): Boolean {
+    val configuration = LocalConfiguration.current
+    val density = LocalDensity.current
+    val visibleCapacity = remember(configuration, density, itemWidth, itemSpacing) {
+        val availablePx = with(density) {
+            (configuration.screenWidthDp.dp - 56.dp - 12.dp).coerceAtLeast(1.dp).roundToPx()
+        }
+        val itemSpanPx = with(density) { (itemWidth + itemSpacing).roundToPx() }.coerceAtLeast(1)
+        ((availablePx + itemSpanPx - 1) / itemSpanPx).coerceAtLeast(1)
+    }
+    return totalItems > visibleCapacity
+}
+
+private fun detailsRailUsesFixedFirstSlotFocus(
+    totalItems: Int,
+    focusedItemIndex: Int
+): Boolean {
+    if (focusedItemIndex < 0 || totalItems <= 0) return false
+    return totalItems > 1 && focusedItemIndex <= totalItems - 1
+}
+
+@Composable
+private fun lockedDetailsRailEndPadding(
+    itemWidth: Dp,
+    startPadding: Dp,
+    outerStartPadding: Dp,
+    minimum: Dp
+): Dp {
+    val configuration = LocalConfiguration.current
+    return (configuration.screenWidthDp.dp - outerStartPadding - startPadding - itemWidth)
+        .coerceAtLeast(minimum)
+}
+
+private suspend fun TvLazyListState.animateDetailsScrollDelta(
+    deltaPx: Float,
+    durationMillis: Int
+) {
+    if (abs(deltaPx) <= 1f) return
+    scroll(scrollPriority = MutatePriority.PreventUserInput) {
+        var previousValue = 0f
+        animate(
+            initialValue = 0f,
+            targetValue = deltaPx,
+            animationSpec = tween(durationMillis = durationMillis, easing = FastOutSlowInEasing)
+        ) { value, _ ->
+            val step = value - previousValue
+            if (abs(step) > 0.01f) {
+                scrollBy(step)
+            }
+            previousValue = value
+        }
+    }
+}
+
+@Composable
+private fun FixedDetailsRailFocusOverlay(
+    startPadding: Dp,
+    topPadding: Dp,
+    width: Dp,
+    aspectRatio: Float
+) {
+    ArvioFocusableSurface(
+        modifier = Modifier
+            .padding(start = startPadding, top = topPadding)
+            .width(width)
+            .aspectRatio(aspectRatio)
+            .zIndex(4f),
+        shape = rememberArvioCardShape(ArvioSkin.radius.md),
+        backgroundColor = Color.Transparent,
+        outlineColor = ArvioSkin.colors.focusOutline,
+        outlineWidth = 2.5.dp,
+        focusedScale = 1f,
+        pressedScale = 0.97f,
+        animateFocus = false,
+        enableSystemFocus = false,
+        isFocusedOverride = true
+    ) {
+        // Fixed focus lane: rows scroll under this ring.
+    }
+}
+
+@Composable
+private fun HomeStyleRowAutoScroll(
+    rowState: TvLazyListState,
+    isCurrentRow: Boolean,
+    focusedItemIndex: Int,
+    totalItems: Int,
+    itemWidth: androidx.compose.ui.unit.Dp,
+    itemSpacing: androidx.compose.ui.unit.Dp
+) {
+    val density = LocalDensity.current
+    val maxFirstIndex = remember(totalItems) {
+        (totalItems - 1).coerceAtLeast(0)
+    }
+    val scrollTargetIndex by remember(rowState, focusedItemIndex, isCurrentRow, totalItems, maxFirstIndex) {
+        derivedStateOf {
+            if (!isCurrentRow || focusedItemIndex < 0) return@derivedStateOf -1
+            if (totalItems == 0) return@derivedStateOf -1
+            focusedItemIndex.coerceAtMost(maxFirstIndex)
+        }
+    }
+    val itemSpanPx = remember(density, itemWidth, itemSpacing) {
+        with(density) { (itemWidth + itemSpacing).toPx().coerceAtLeast(1f) }
+    }
+
+    var lastScrollIndex by remember { mutableIntStateOf(-1) }
+    var lastScrollOffset by remember { mutableIntStateOf(-1) }
+    LaunchedEffect(isCurrentRow) {
+        if (!isCurrentRow) {
+            lastScrollIndex = -1
+            lastScrollOffset = -1
+        }
+    }
+    LaunchedEffect(scrollTargetIndex, isCurrentRow, focusedItemIndex) {
+        if (!isCurrentRow || scrollTargetIndex < 0) return@LaunchedEffect
+
+        val extraOffset = 0
+
+        if (focusedItemIndex == 0 && scrollTargetIndex == 0) {
+            rowState.scrollToItem(index = 0, scrollOffset = 0)
+            lastScrollIndex = 0
+            lastScrollOffset = 0
+            return@LaunchedEffect
+        }
+
+        if (lastScrollIndex == scrollTargetIndex && lastScrollOffset == extraOffset) return@LaunchedEffect
+        if (lastScrollIndex == -1) {
+            rowState.scrollToItem(index = scrollTargetIndex, scrollOffset = extraOffset)
+            lastScrollIndex = scrollTargetIndex
+            lastScrollOffset = extraOffset
+            return@LaunchedEffect
+        }
+        val currentFirst = rowState.firstVisibleItemIndex
+        val currentOffset = rowState.firstVisibleItemScrollOffset
+        val currentLast = rowState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: currentFirst
+        val targetOutsideViewport = focusedItemIndex < currentFirst || focusedItemIndex > currentLast
+        val delta = scrollTargetIndex - currentFirst
+        if (abs(delta) > 6) {
+            rowState.scrollToItem(index = scrollTargetIndex, scrollOffset = extraOffset)
+        } else if (delta != 0 || targetOutsideViewport || lastScrollOffset != extraOffset) {
+            val deltaPx = (delta * itemSpanPx) + (extraOffset - currentOffset)
+            rowState.animateDetailsScrollDelta(
+                deltaPx = deltaPx,
+                durationMillis = if (abs(delta) >= 3) 180 else 150
+            )
+            if (
+                rowState.firstVisibleItemIndex != scrollTargetIndex ||
+                abs(rowState.firstVisibleItemScrollOffset - extraOffset) > 8
+            ) {
+                rowState.scrollToItem(index = scrollTargetIndex, scrollOffset = extraOffset)
+            }
+        }
+        lastScrollIndex = scrollTargetIndex
+        lastScrollOffset = extraOffset
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun DetailsImdbSvgRatingBadge(
+    rating: String,
+    imageLoader: ImageLoader,
+    ratingFontSize: Int,
+    logoWidth: Dp,
+    logoHeight: Dp,
+    textShadow: Shadow
+) {
+    val imdbLogoUri = remember { "android.resource://com.arvio.tv/${R.raw.logo_imdb_rectangle}" }
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(3.dp)
+    ) {
+        AsyncImage(
+            model = imdbLogoUri,
+            imageLoader = imageLoader,
+            contentDescription = "IMDb",
+            contentScale = ContentScale.Fit,
+            modifier = Modifier
+                .width(logoWidth)
+                .height(logoHeight)
+        )
+        Text(
+            text = rating,
+            style = ArflixTypography.caption.copy(
+                fontSize = ratingFontSize.sp,
+                fontWeight = FontWeight.Bold,
+                shadow = textShadow
+            ),
+            color = Color.White,
+            maxLines = 1
+        )
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun MobileScoreBadge(
+    label: String,
+    value: String,
+    backgroundColor: Color,
+    contentColor: Color
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        modifier = Modifier
+            .background(backgroundColor, RoundedCornerShape(3.dp))
+            .padding(horizontal = 6.dp, vertical = 2.dp)
+    ) {
+        Text(
+            text = label,
+            style = ArflixTypography.caption.copy(fontSize = 8.sp, fontWeight = FontWeight.Black),
+            color = contentColor,
+            maxLines = 1
+        )
+        Text(
+            text = value,
+            style = ArflixTypography.caption.copy(fontSize = 11.sp, fontWeight = FontWeight.Bold),
+            color = contentColor,
+            maxLines = 1
+        )
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun MobileMetadataSeparator() {
+    Text(
+        text = "•",
+        style = ArflixTypography.caption.copy(fontSize = 15.sp, fontWeight = FontWeight.SemiBold),
+        color = Color.White.copy(alpha = 0.42f),
+        maxLines = 1
+    )
+}
+
+/**
+ * Mobile action button — labeled, tappable, Netflix-style
+ */
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun MobileActionButton(
+    icon: ImageVector,
+    text: String,
+    isPrimary: Boolean = false,
+    isActive: Boolean = false,
+    isOutlined: Boolean = false,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    val shape = RoundedCornerShape(percent = 50)
+    val bgColor = when {
+        isPrimary -> Color.White
+        isOutlined -> Color.Transparent
+        isActive -> Color.White.copy(alpha = 0.15f)
+        else -> Color.White.copy(alpha = 0.08f)
+    }
+    val contentColor = if (isPrimary) Color.Black else Color.White.copy(alpha = 0.92f)
+    val borderColor = if (isOutlined) Color.White.copy(alpha = if (isActive) 0.55f else 0.22f) else Color.Transparent
+
+    Row(
+        modifier = modifier
+            .clip(shape)
+            .background(bgColor, shape)
+            .border(1.dp, borderColor, shape)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 18.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = contentColor,
+            modifier = Modifier.size(if (isPrimary) 24.dp else 22.dp)
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = text,
+            style = ArvioSkin.typography.button.copy(
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Bold
+            ),
+            color = contentColor,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.weight(1f, fill = false)
+        )
+    }
+}
+
+@Composable
+private fun MobileIconActionButton(
+    icon: ImageVector,
+    contentDescription: String,
+    isActive: Boolean = false,
+    enabled: Boolean = true,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    val shape = RoundedCornerShape(20.dp)
+    val backgroundColor = when {
+        !enabled -> Color.White.copy(alpha = 0.04f)
+        isActive -> Color.White.copy(alpha = 0.18f)
+        else -> Color.White.copy(alpha = 0.08f)
+    }
+    val contentColor = if (enabled) {
+        Color.White.copy(alpha = if (isActive) 0.96f else 0.88f)
+    } else {
+        Color.White.copy(alpha = 0.3f)
+    }
+    val borderColor = if (isActive) {
+        Color.White.copy(alpha = 0.28f)
+    } else {
+        Color.White.copy(alpha = 0.12f)
+    }
+
+    Box(
+        modifier = modifier
+            .clip(shape)
+            .background(backgroundColor, shape)
+            .border(1.dp, borderColor, shape)
+            .clickable(enabled = enabled, onClick = onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = contentDescription,
+            tint = contentColor,
+            modifier = Modifier.size(24.dp)
+        )
+    }
+}
+
+/**
+ * Premium ActionButton with smooth animations and glass morphism effect
+ */
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun PremiumActionButton(
+    icon: ImageVector,
+    text: String,
+    isFocused: Boolean,
+    isPrimary: Boolean = false,
+    isIconOnly: Boolean = false,
+    isActive: Boolean = false
+) {
+    val shape = RoundedCornerShape(12.dp)
+    val density = LocalDensity.current
+    val textMeasurer = rememberTextMeasurer()
+    val textStyle = ArvioSkin.typography.button.copy(
+        fontSize = 12.sp,
+        fontWeight = FontWeight.SemiBold,
+        letterSpacing = 0.3.sp
+    )
+    val iconSize = if (isIconOnly) 20.dp else 16.dp
+    val expandedPadding = 12.dp
+    val collapsedPadding = 0.dp
+    val labelSpacing = 8.dp
+    val labelExtraWidth = 12.dp
+    val showLabel = isFocused && text.isNotBlank()
+
+    val labelWidthPx = remember(text, density) {
+        if (text.isBlank()) 0 else {
+            textMeasurer.measure(AnnotatedString(text), style = textStyle).size.width
+        }
+    }
+    val labelWidthDp = with(density) { labelWidthPx.toDp() }
+    val targetPadding = if (showLabel || !isIconOnly) expandedPadding else collapsedPadding
+    val horizontalPadding by animateDpAsState(
+        targetValue = targetPadding,
+        animationSpec = tween(140),
+        label = "button_padding"
+    )
+    val baseWidth = iconSize + targetPadding * 2
+    val expandedWidth = baseWidth + labelSpacing + labelWidthDp + labelExtraWidth
+    val targetWidth = if (showLabel) expandedWidth else baseWidth
+    val animatedWidth by animateDpAsState(
+        targetValue = targetWidth,
+        animationSpec = tween(
+            durationMillis = AnimationConstants.DURATION_FAST,
+            easing = AnimationConstants.EaseOut
+        ),
+        label = "button_width"
+    )
+    val labelAlpha by animateFloatAsState(
+        targetValue = if (showLabel) 1f else 0f,
+        animationSpec = tween(
+            durationMillis = AnimationConstants.DURATION_FAST,
+            easing = AnimationConstants.EaseOut
+        ),
+        label = "button_label_alpha"
+    )
+
+    // Animated scale for focus
+    val scale by animateFloatAsState(
+        targetValue = if (isFocused) 1.05f else 1f,
+        animationSpec = androidx.compose.animation.core.spring(dampingRatio = 0.8f, stiffness = 400f),
+        label = "button_scale"
+    )
+
+    // Animated background color - buttons only glow when focused
+    val backgroundColor by animateColorAsState(
+        targetValue = when {
+            isFocused && isPrimary -> Color.White
+            isFocused -> Color.White.copy(alpha = 0.95f)
+            else -> Color.Transparent
+        },
+        animationSpec = tween(150),
+        label = "button_bg"
+    )
+
+    // Animated text/icon color - black when focused (on white bg), white otherwise
+    val contentColor by animateColorAsState(
+        targetValue = if (isFocused) Color.Black else Color.White.copy(alpha = 0.9f),
+        animationSpec = tween(150),
+        label = "button_content"
+    )
+
+    // Animated border - all non-focused buttons get a subtle border
+    val borderAlpha by animateFloatAsState(
+        targetValue = 0f,
+        animationSpec = tween(150),
+        label = "border_alpha"
+    )
+
+    val contentAlignment = if (!showLabel) Alignment.Center else Alignment.CenterStart
+
+    Box(
+        modifier = Modifier
+            .graphicsLayer {
+                scaleX = scale
+                scaleY = scale
+            }
+            .width(animatedWidth)
+            .background(
+                if (isFocused) backgroundColor else Color.Transparent,
+                shape
+            )
+            .then(
+                if (borderAlpha > 0f) {
+                    Modifier.border(
+                        width = 1.dp,
+                        color = Color.White.copy(alpha = borderAlpha),
+                        shape = shape
+                    )
+                } else Modifier
+            )
+            .clipToBounds()
+            .padding(horizontal = horizontalPadding, vertical = 8.dp),
+        contentAlignment = contentAlignment
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(labelSpacing)
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = contentColor,
+                modifier = Modifier.size(iconSize)
+            )
+            if (text.isNotEmpty()) {
+                Text(
+                    text = text,
+                    style = textStyle,
+                    color = contentColor,
+                    maxLines = 1,
+                    softWrap = false,
+                    overflow = TextOverflow.Clip,
+                    modifier = Modifier.graphicsLayer {
+                        alpha = labelAlpha
+                        translationX = (1f - labelAlpha) * with(density) { 6.dp.toPx() }
+                    }
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun EpisodeCard(
+    episode: Episode,
+    cardWidth: androidx.compose.ui.unit.Dp = 300.dp,
+    isFocused: Boolean,
+    spoilerBlurEnabled: Boolean = false,
+    onClick: () -> Unit = {}
+) {
+    val aspectRatio = 16f / 9f
+    val context = LocalContext.current
+    val density = LocalDensity.current
+
+    val shape = rememberArvioCardShape(ArvioSkin.radius.md)
+    val scale by animateFloatAsState(
+        targetValue = if (isFocused) 1.03f else 1f,
+        animationSpec = androidx.compose.animation.core.spring(dampingRatio = 0.8f, stiffness = 400f),
+        label = "episode_scale"
+    )
+    val borderWidth = if (isFocused || scale != 1f) 3.dp else 0.dp
+
+    val imageRequest = remember(episode.stillPath, cardWidth, context, density) {
+        val widthPx = with(density) { cardWidth.roundToPx() }
+        val heightPx = (widthPx / aspectRatio).toInt().coerceAtLeast(1)
+        ImageRequest.Builder(context)
+            .data(episode.stillPath)
+            .size(widthPx, heightPx)
+            .precision(Precision.INEXACT)
+            .allowHardware(true)
+            .crossfade(false)
+            .build()
+    }
+
+    val episodeCode = "S${episode.seasonNumber} • E${String.format("%02d", episode.episodeNumber)}"
+    val ratingLabel = if (episode.voteAverage > 0f) {
+        "${String.format("%.1f", episode.voteAverage)}"
+    } else {
+        null
+    }
+    val isSpoilerBlurred = spoilerBlurEnabled && !episode.isWatched
+    val previewText = if (isSpoilerBlurred) {
+        ""
+    } else {
+        episode.overview
+            .trim()
+            .ifEmpty { "No episode synopsis available." }
+    }
+    val episodeAirDateLabel = remember(episode.airDate) { formatEpisodeAirDateLabel(episode.airDate) }
+    val isEpisodeUnaired = remember(episode.airDate) { isFutureEpisodeAirDate(episode.airDate) }
+
+    val scaleModifier = if (scale != 1f) {
+        Modifier.graphicsLayer {
+            scaleX = scale
+            scaleY = scale
+            transformOrigin = androidx.compose.ui.graphics.TransformOrigin(0.5f, 1f)
+        }
+    } else {
+        Modifier
+    }
+
+    ArvioFocusableSurface(
+        modifier = Modifier
+            .width(cardWidth)
+            .aspectRatio(aspectRatio)
+            .then(scaleModifier),
+        shape = shape,
+        backgroundColor = ArvioSkin.colors.surface,
+        outlineColor = ArvioSkin.colors.focusOutline,
+        outlineWidth = borderWidth,
+        focusedScale = 1f,
+        pressedScale = 1f,
+        enableSystemFocus = false,
+        isFocusedOverride = isFocused,
+        onClick = onClick,
+    ) { _ ->
+        Box(modifier = Modifier.fillMaxSize()) {
+            AsyncImage(
+                model = imageRequest,
+                contentDescription = episode.name,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .then(
+                        if (isSpoilerBlurred) Modifier.blur(20.dp) else Modifier
+                    )
+            )
+
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(
+                        brush = Brush.verticalGradient(
+                            colors = listOf(
+                                Color.Black.copy(alpha = 0.18f),
+                                Color.Transparent,
+                                Color.Black.copy(alpha = 0.28f),
+                                Color.Black.copy(alpha = 0.86f)
+                            )
+                        )
+                    )
+            )
+
+            Row(
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(horizontal = 8.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier
+                        .background(Color.Black.copy(alpha = 0.55f), RoundedCornerShape(6.dp))
+                        .border(1.dp, Color.White.copy(alpha = 0.3f), RoundedCornerShape(6.dp))
+                        .padding(horizontal = 6.dp, vertical = 3.dp)
+                ) {
+                    Text(
+                        text = episodeCode,
+                        style = ArvioSkin.typography.caption.copy(
+                            fontSize = 9.sp,
+                            fontWeight = FontWeight.Bold,
+                            letterSpacing = 0.3.sp
+                        ),
+                        color = Color.White.copy(alpha = 0.95f),
+                        maxLines = 1
+                    )
+                }
+            }
+
+            if (episodeAirDateLabel != null) {
+                Row(
+                    modifier = Modifier
+                        .align(Alignment.TopCenter)
+                        .padding(top = 8.dp)
+                        .background(Color.Black.copy(alpha = 0.58f), RoundedCornerShape(6.dp))
+                        .border(
+                            width = 1.dp,
+                            color = if (isEpisodeUnaired) Color(0xFF8AD5FF) else Color.White.copy(alpha = 0.24f),
+                            shape = RoundedCornerShape(6.dp)
+                        )
+                        .padding(horizontal = 7.dp, vertical = 3.dp),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    if (isEpisodeUnaired) {
+                        Icon(
+                            imageVector = Icons.Default.Schedule,
+                            contentDescription = null,
+                            tint = Color(0xFF8AD5FF),
+                            modifier = Modifier.size(10.dp)
+                        )
+                    }
+                    Text(
+                        text = episodeAirDateLabel,
+                        style = ArvioSkin.typography.caption.copy(
+                            fontSize = 9.sp,
+                            fontWeight = FontWeight.SemiBold
+                        ),
+                        color = if (isEpisodeUnaired) Color(0xFFBDEBFF) else Color.White.copy(alpha = 0.92f),
+                        maxLines = 1
+                    )
+                }
+            }
+
+            ratingLabel?.let { rating ->
+                Row(
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(horizontal = 8.dp, vertical = 8.dp)
+                        .background(Color.Black.copy(alpha = 0.6f), RoundedCornerShape(6.dp))
+                        .border(1.dp, Color.White.copy(alpha = 0.25f), RoundedCornerShape(6.dp))
+                        .padding(horizontal = 6.dp, vertical = 3.dp),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Star,
+                        contentDescription = null,
+                        tint = Color(0xFFF5C518),
+                        modifier = Modifier.size(10.dp)
+                    )
+                    Text(
+                        text = rating,
+                        style = ArvioSkin.typography.caption.copy(fontSize = 9.sp, fontWeight = FontWeight.Bold),
+                        color = Color.White
+                    )
+                }
+            }
+
+            Column(
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(horizontal = 10.dp, vertical = 8.dp)
+            ) {
+                Text(
+                    text = episode.name,
+                    style = ArvioSkin.typography.cardTitle.copy(
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.Bold
+                    ),
+                    color = Color.White,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = previewText,
+                    style = ArvioSkin.typography.caption.copy(
+                        fontSize = 10.sp,
+                        lineHeight = 14.sp,
+                        fontWeight = FontWeight.Medium
+                    ),
+                    color = Color.White.copy(alpha = 0.92f),
+                    maxLines = 4,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+
+            if (episode.isWatched) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(bottom = 8.dp, end = 8.dp)
+                        .size(16.dp)
+                        .background(
+                            color = ArvioSkin.colors.watchedGreen.copy(alpha = 0.22f),
+                            shape = CircleShape
+                        )
+                        .border(
+                            width = 1.dp,
+                            color = ArvioSkin.colors.watchedGreen,
+                            shape = CircleShape
+                        ),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Check,
+                        contentDescription = null,
+                        tint = ArvioSkin.colors.watchedGreen,
+                        modifier = Modifier.size(9.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun formatEpisodeAirDateLabel(rawDate: String): String? {
+    val value = rawDate.trim()
+    if (value.isEmpty()) return null
+    return try {
+        val parser = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+        parser.isLenient = false
+        val date = parser.parse(value) ?: return value
+        SimpleDateFormat("d MMM yyyy", Locale.US).format(date)
+    } catch (_: Exception) {
+        value
+    }
+}
+
+private fun isFutureEpisodeAirDate(rawDate: String): Boolean {
+    val value = rawDate.trim()
+    if (value.isEmpty()) return false
+    return try {
+        val parser = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+        parser.isLenient = false
+        val date = parser.parse(value) ?: return false
+        date.after(Date())
+    } catch (_: Exception) {
+        false
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun SeasonButton(
+    season: Int,
+    isSelected: Boolean,
+    isFocused: Boolean,
+    watchedCount: Int = 0,
+    totalCount: Int = 0,
+    onClick: () -> Unit = {}
+) {
+    val shape = RoundedCornerShape(8.dp)
+    val backgroundColor = when {
+        isFocused -> Color.White
+        isSelected -> Color.White.copy(alpha = 0.2f)
+        else -> Color.White.copy(alpha = 0.08f)
+    }
+    val textColor = when {
+        isFocused -> Color.Black
+        isSelected -> Color.White
+        else -> Color.White.copy(alpha = 0.6f)
+    }
+
+    val isFullyWatched = totalCount > 0 && watchedCount >= totalCount
+
+    Row(
+        modifier = Modifier
+            .clickable { onClick() }
+            .background(backgroundColor, shape)
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(
+            text = "${stringResource(R.string.season_label)} $season",
+            style = ArvioSkin.typography.button.copy(
+                fontSize = 13.sp,
+                fontWeight = if (isFocused || isSelected) FontWeight.Bold else FontWeight.Medium
+            ),
+            color = textColor
+        )
+
+        if (isFullyWatched) {
+            Box(
+                modifier = Modifier
+                    .size(14.dp)
+                    .background(
+                        color = ArvioSkin.colors.watchedGreen.copy(alpha = 0.2f),
+                        shape = CircleShape
+                    )
+                    .border(
+                        width = 1.dp,
+                        color = ArvioSkin.colors.watchedGreen,
+                        shape = CircleShape
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = null,
+                    tint = ArvioSkin.colors.watchedGreen,
+                    modifier = Modifier.size(8.dp)
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun CastCard(
+    member: CastMember,
+    isFocused: Boolean
+) {
+    val shape = CircleShape
+    val scale by animateFloatAsState(
+        targetValue = if (isFocused) 1.08f else 1f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessMedium
+        ),
+        label = "cast_scale"
+    )
+    val borderWidth = if (isFocused || scale != 1f) 3.dp else 0.dp
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.width(120.dp)
+    ) {
+        val scaleModifier = if (scale != 1f) {
+            Modifier.graphicsLayer {
+                scaleX = scale
+                scaleY = scale
+            }
+        } else {
+            Modifier
+        }
+        ArvioFocusableSurface(
+            modifier = Modifier
+                .size(100.dp)
+                .then(scaleModifier),
+            shape = shape,
+            backgroundColor = ArvioSkin.colors.surfaceRaised.copy(alpha = 0.65f),
+            enableSystemFocus = false,
+            isFocusedOverride = isFocused,
+            outlineWidth = borderWidth,
+            focusedScale = 1f,
+            pressedScale = 1f,
+            onClick = null,
+            glowWidth = 8.dp,
+            glowAlpha = 0.18f,
+        ) { _ ->
+            if (member.profilePath != null) {
+                AsyncImage(
+                    model = member.profilePath,
+                    contentDescription = member.name,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            } else {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = member.name.firstOrNull()?.toString().orEmpty(),
+                        style = ArvioSkin.typography.sectionTitle,
+                        color = ArvioSkin.colors.textMuted
+                    )
+                }
+            }
+        }
+        
+        Spacer(modifier = Modifier.height(8.dp))
+        
+        Text(
+            text = member.name,
+            style = ArvioSkin.typography.cardTitle,
+            color = if (isFocused) ArvioSkin.colors.textPrimary else ArvioSkin.colors.textMuted,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+        
+        if (member.character.isNotEmpty()) {
+            Text(
+                text = member.character,
+                style = ArvioSkin.typography.caption,
+                color = ArvioSkin.colors.textMuted.copy(alpha = 0.85f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}
+
+/**
+ * Circular cast card with premium focus effect matching home screen style
+ */
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun CircularCastCard(
+    castMember: CastMember,
+    isFocused: Boolean,
+    onClick: () -> Unit
+) {
+    // Animated scale for focus
+    val scale by animateFloatAsState(
+        targetValue = if (isFocused) 1.08f else 1f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessMedium
+        ),
+        label = "cast_scale"
+    )
+
+    // Border stays consistent; scale handles the jump
+    val borderWidth = if (isFocused || scale != 1f) 3.dp else 0.dp
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .width(90.dp)
+            .clickable { onClick() }
+    ) {
+        val scaleModifier = if (scale != 1f) {
+            Modifier.graphicsLayer {
+                scaleX = scale
+                scaleY = scale
+            }
+        } else {
+            Modifier
+        }
+        Box(
+            modifier = Modifier
+                .size(72.dp)
+                .then(scaleModifier)
+                .then(
+                    if (isFocused) {
+                        Modifier.border(
+                            width = borderWidth,
+                            color = ArvioSkin.colors.focusOutline,
+                            shape = CircleShape
+                        )
+                    } else Modifier
+                )
+                .clip(CircleShape)
+                .background(ArvioSkin.colors.surfaceRaised.copy(alpha = 0.4f)),
+            contentAlignment = Alignment.Center
+        ) {
+            if (castMember.profilePath != null) {
+                AsyncImage(
+                    model = castMember.profilePath,
+                    contentDescription = castMember.name,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            } else {
+                // Placeholder with initials
+                Text(
+                    text = castMember.name.take(1).uppercase(),
+                    style = ArvioSkin.typography.sectionTitle.copy(
+                        fontSize = 24.sp,
+                        fontWeight = FontWeight.Bold
+                    ),
+                    color = Color.White.copy(alpha = 0.6f)
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Name
+        Text(
+            text = castMember.name,
+            style = ArvioSkin.typography.caption.copy(
+                fontSize = 11.sp,
+                fontWeight = if (isFocused) FontWeight.Bold else FontWeight.Medium
+            ),
+            color = if (isFocused) Color.White else Color.White.copy(alpha = 0.8f),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        // Character name
+        if (castMember.character.isNotEmpty()) {
+            Text(
+                text = castMember.character,
+                style = ArvioSkin.typography.caption.copy(fontSize = 10.sp),
+                color = Color.White.copy(alpha = 0.5f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}
+
+/**
+ * Beautiful transparent review card
+ */
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun ReviewCard(
+    review: Review,
+    isFocused: Boolean
+) {
+    val shape = RoundedCornerShape(16.dp)
+
+    // Animated scale for focus
+    val scale by animateFloatAsState(
+        targetValue = if (isFocused) 1.08f else 1f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessMedium
+        ),
+        label = "review_scale"
+    )
+
+    // Animated border
+    val borderAlpha by animateFloatAsState(
+        targetValue = if (isFocused) 1f else 0.2f,
+        animationSpec = tween(150),
+        label = "review_border"
+    )
+
+    val scaleModifier = if (scale != 1f) {
+        Modifier.graphicsLayer {
+            scaleX = scale
+            scaleY = scale
+        }
+    } else {
+        Modifier
+    }
+    Box(
+        modifier = Modifier
+            .width(320.dp)
+            .height(160.dp)
+            .then(scaleModifier)
+            .background(
+                color = Color.White.copy(alpha = if (isFocused) 0.12f else 0.06f),
+                shape = shape
+            )
+            .border(
+                width = if (isFocused) 2.dp else 1.dp,
+                color = if (isFocused) ArvioSkin.colors.focusOutline else Color.White.copy(alpha = borderAlpha),
+                shape = shape
+            )
+            .padding(16.dp)
+    ) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.SpaceBetween
+        ) {
+            // Author row
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                // Author avatar
+                Box(
+                    modifier = Modifier
+                        .size(36.dp)
+                        .clip(CircleShape)
+                        .background(ArvioSkin.colors.surfaceRaised.copy(alpha = 0.5f)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    if (review.authorAvatar != null) {
+                        AsyncImage(
+                            model = review.authorAvatar,
+                            contentDescription = review.author,
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier.fillMaxSize()
+                        )
+                    } else {
+                        Text(
+                            text = review.author.take(1).uppercase(),
+                            style = ArvioSkin.typography.button.copy(
+                                fontSize = 14.sp,
+                                fontWeight = FontWeight.Bold
+                            ),
+                            color = Color.White.copy(alpha = 0.7f)
+                        )
+                    }
+                }
+
+                Column {
+                    Text(
+                        text = review.author,
+                        style = ArvioSkin.typography.cardTitle.copy(
+                            fontSize = 13.sp,
+                            fontWeight = FontWeight.SemiBold
+                        ),
+                        color = Color.White,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+
+                    // Rating if available
+                    if (review.rating != null && review.rating > 0f) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Star,
+                                contentDescription = null,
+                                tint = Color(0xFFF5C518),
+                                modifier = Modifier.size(12.dp)
+                            )
+                            Text(
+                                text = String.format("%.1f", review.rating),
+                                style = ArvioSkin.typography.caption.copy(fontSize = 11.sp),
+                                color = Color.White.copy(alpha = 0.8f)
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Review content
+            Text(
+                text = review.content,
+                style = ArvioSkin.typography.body.copy(
+                    fontSize = 12.sp,
+                    lineHeight = 18.sp
+                ),
+                color = Color.White.copy(alpha = 0.85f),
+                maxLines = 4,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun MetaPill(text: String) {
+    Box(
+        modifier = Modifier
+            .background(Color.White.copy(alpha = 0.05f), RoundedCornerShape(6.dp))
+            .border(1.dp, Color.White.copy(alpha = 0.1f), RoundedCornerShape(6.dp))
+            .padding(horizontal = 12.dp, vertical = 6.dp)
+    ) {
+        Text(
+            text = text.uppercase(),
+            style = ArflixTypography.label,
+            color = TextSecondary
+        )
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun ImdbBadge(rating: String) {
+    Box(
+        modifier = Modifier
+            .background(Color(0xFFF5C518), RoundedCornerShape(6.dp))
+            .padding(horizontal = 10.dp, vertical = 6.dp)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            Text(
+                text = "IMDb",
+                style = ArflixTypography.label,
+                color = Color.Black
+            )
+            Text(
+                text = rating,
+                style = ArflixTypography.label,
+                color = Color.Black
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun OngoingBadge() {
+    // Cyan/teal color like webapp
+    val cyanColor = Color(0xFF22D3EE)
+
+    Row(
+        modifier = Modifier
+            .background(cyanColor.copy(alpha = 0.15f), RoundedCornerShape(6.dp))
+            .border(1.dp, cyanColor.copy(alpha = 0.3f), RoundedCornerShape(6.dp))
+            .padding(horizontal = 10.dp, vertical = 5.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Icon(
+            imageVector = Icons.Default.Schedule,
+            contentDescription = null,
+            tint = cyanColor,
+            modifier = Modifier.size(14.dp)
+        )
+        Text(
+            text = stringResource(R.string.ongoing).uppercase(),
+            style = ArflixTypography.label,
+            color = cyanColor
+        )
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun GenreBadge(genre: String) {
+    Box(
+        modifier = Modifier
+            .background(Pink.copy(alpha = 0.15f), RoundedCornerShape(6.dp))
+            .border(1.dp, Pink.copy(alpha = 0.3f), RoundedCornerShape(6.dp))
+            .padding(horizontal = 10.dp, vertical = 5.dp)
+    ) {
+        Text(
+            text = genre.uppercase(),
+            style = ArflixTypography.label,
+            color = Pink
+        )
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun LanguageBadge(language: String) {
+    // Purple color for language
+    val purpleColor = Purple
+
+    Box(
+        modifier = Modifier
+            .background(purpleColor.copy(alpha = 0.15f), RoundedCornerShape(6.dp))
+            .border(1.dp, purpleColor.copy(alpha = 0.3f), RoundedCornerShape(6.dp))
+            .padding(horizontal = 10.dp, vertical = 5.dp)
+    ) {
+        Text(
+            text = language.uppercase(),
+            style = ArflixTypography.label,
+            color = purpleColor
+        )
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun BudgetBadge(budget: String) {
+    // Green color for budget
+    val greenColor = Color(0xFF10B981) // Emerald green
+
+    Box(
+        modifier = Modifier
+            .background(greenColor.copy(alpha = 0.15f), RoundedCornerShape(6.dp))
+            .border(1.dp, greenColor.copy(alpha = 0.3f), RoundedCornerShape(6.dp))
+            .padding(horizontal = 10.dp, vertical = 5.dp)
+    ) {
+        Text(
+            text = "${stringResource(R.string.budget).uppercase()}: $budget",
+            style = ArflixTypography.label,
+            color = greenColor
+        )
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun StatusBadge(status: String) {
+    // Different colors based on status
+    val (bgColor, textColor) = when {
+        status.contains("Return", ignoreCase = true) -> Pair(Color(0xFF22D3EE), Color(0xFF22D3EE)) // Cyan for ongoing
+        status.contains("Ended", ignoreCase = true) -> Pair(Color(0xFF6B7280), Color(0xFF6B7280)) // Gray for ended
+        status.contains("Cancel", ignoreCase = true) -> Pair(Color(0xFFEF4444), Color(0xFFEF4444)) // Red for canceled
+        else -> Pair(Color(0xFF6B7280), Color(0xFF6B7280))
+    }
+
+    Box(
+        modifier = Modifier
+            .background(bgColor.copy(alpha = 0.15f), RoundedCornerShape(6.dp))
+            .border(1.dp, bgColor.copy(alpha = 0.3f), RoundedCornerShape(6.dp))
+            .padding(horizontal = 10.dp, vertical = 5.dp)
+    ) {
+        Text(
+            text = status.uppercase(),
+            style = ArflixTypography.label,
+            color = textColor
+        )
+    }
+}
+
+/**
+ * Similar media card for "More Like This" section - same style as home screen
+ */
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun SimilarMediaCard(
+    item: MediaItem,
+    logoImageUrl: String?,
+    usePosterCards: Boolean,
+    isFocused: Boolean,
+    onClick: () -> Unit = {}
+) {
+    val mediaTypeLabel = if (item.mediaType == MediaType.TV) "TV Series" else "Movie"
+    val yearSuffix = item.year.takeIf { it.isNotBlank() }?.let { " | $it" }.orEmpty()
+    MediaCard(
+        item = item.copy(subtitle = "$mediaTypeLabel$yearSuffix"),
+        width = if (usePosterCards) 126.dp else 210.dp,
+        isLandscape = !usePosterCards,
+        logoImageUrl = logoImageUrl,
+        showProgress = false,
+        titleMaxLines = if (usePosterCards) 2 else 1,
+        subtitleMaxLines = 1,
+        isFocusedOverride = isFocused,
+        enableSystemFocus = false,
+        onFocused = { },
+        onClick = onClick
+    )
+}


### PR DESCRIPTION
## Description

Adds an in-player episode switcher overlay that allows users to browse and switch between episodes without leaving the player screen. Includes season tab navigation for multi-season TV shows.

### Features
- Episode list overlay accessible from within the player
- Season tab switching with horizontal tab row
- Episode cards showing title, number, and overview
- D-pad friendly navigation with proper focus states
- Current episode highlighted in the list
- Overlay dismisses on back press or selecting an episode

### Files Changed
- [`app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt`](https://github.com/EierKopZA/ARVIO/blob/pr/in-player-episode-switcher/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt) - Episode switcher UI composables (+414 lines)
- [`app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt`](https://github.com/EierKopZA/ARVIO/blob/pr/in-player-episode-switcher/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt) - Episode loading and state management (+35 lines)

### D-Pad Navigation Flow


Player Controls → Episode Switcher Button (focused)
↓
Season Tabs (horizontal, left/right)
↓
Episode List (vertical, up/down)
↓
Select → loads episode + dismisses overlay
Back   → dismisses overlay, returns to player controls


### Testing
- [ ] Open player for a TV show with multiple seasons
- [ ] Navigate to episode switcher via D-pad
- [ ] Switch between seasons using tab row
- [ ] Select an episode and confirm it loads
- [ ] Verify back press dismisses overlay
- [ ] All D-pad focus movements are predictable

Closes #82
