### PR TITLE
feat: add focus border color theme setting

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/MainActivity.kt
+++ b/app/src/main/kotlin/com/arflix/tv/MainActivity.kt
@@ -66,6 +66,7 @@ import com.arflix.tv.util.DeviceType
 import com.arflix.tv.util.DEVICE_MODE_OVERRIDE_KEY
 import com.arflix.tv.util.SKIP_PROFILE_SELECTION_KEY
 import com.arflix.tv.util.OLED_BLACK_BACKGROUND_KEY
+import com.arflix.tv.util.FOCUS_BORDER_COLOR_KEY
 import com.arflix.tv.util.LocalDeviceType
 import com.arflix.tv.util.LocalHasTouchScreen
 import com.arflix.tv.util.LocalAppLanguage
@@ -262,6 +263,9 @@ class MainActivity : ComponentActivity() {
             val oledBlackBackground by remember {
                 this@MainActivity.settingsDataStore.data.map { it[OLED_BLACK_BACKGROUND_KEY] ?: false }
             }.collectAsStateWithLifecycle(initialValue = false)
+            val focusBorderColorName by remember {
+                this@MainActivity.settingsDataStore.data.map { it[FOCUS_BORDER_COLOR_KEY] }
+            }.collectAsStateWithLifecycle(initialValue = null)
             val activeProfileId by remember {
                 profileRepository.get().activeProfileId
             }.collectAsStateWithLifecycle(initialValue = null)
@@ -315,7 +319,10 @@ class MainActivity : ComponentActivity() {
                     if (isRtl) androidx.compose.ui.unit.LayoutDirection.Rtl
                     else androidx.compose.ui.unit.LayoutDirection.Ltr
             ) {
-                ArflixTvTheme(oledBlackBackground = oledBlackBackground) {
+                ArflixTvTheme(
+                    oledBlackBackground = oledBlackBackground,
+                    focusBorderColorName = focusBorderColorName
+                ) {
                     val startupState by startupViewModel.state.collectAsStateWithLifecycle()
                     ArflixApp(
                         authRepository = authRepository.get(),

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -755,9 +755,10 @@ fun SettingsScreen(
                                                 20 -> viewModel.cycleClockFormat()
                                                 21 -> viewModel.setShowBudget(!uiState.showBudget)
                                                 22 -> viewModel.setSpoilerBlurEnabled(!uiState.spoilerBlurEnabled)
-                                                23 -> openDnsProviderPicker()
-                                                24 -> viewModel.setShowLoadingStats(!uiState.showLoadingStats)
-                                                25 -> viewModel.cycleVolumeBoost()
+                                                23 -> viewModel.cycleFocusBorderColor()
+                                                24 -> openDnsProviderPicker()
+                                                25 -> viewModel.setShowLoadingStats(!uiState.showLoadingStats)
+                                                26 -> viewModel.cycleVolumeBoost()
                                             }
                                         }
                                         "iptv" -> {
@@ -1087,6 +1088,8 @@ fun SettingsScreen(
                             onShowBudgetToggle = { viewModel.setShowBudget(it) },
                             spoilerBlurEnabled = uiState.spoilerBlurEnabled,
                             onSpoilerBlurToggle = { viewModel.setSpoilerBlurEnabled(it) },
+                            focusBorderColor = uiState.focusBorderColor,
+                            onFocusBorderColorClick = { viewModel.cycleFocusBorderColor() },
                             showLoadingStats = uiState.showLoadingStats,
                             onShowLoadingStatsToggle = { viewModel.setShowLoadingStats(it) },
                             onVolumeBoostClick = { viewModel.cycleVolumeBoost() },
@@ -3126,6 +3129,14 @@ private fun MobileSettingsSubPage(
                         showDivider = false,
                         onClick = { viewModel.setSpoilerBlurEnabled(!uiState.spoilerBlurEnabled) }
                     )
+                    MobileSettingsRow(
+                        icon = Icons.Default.Palette,
+                        title = stringResource(R.string.focus_border_color),
+                        value = uiState.focusBorderColor,
+                        isFocused = false,
+                        showDivider = false,
+                        onClick = { viewModel.cycleFocusBorderColor() }
+                    )
                 }
             }
             "Plugins & Extensions" -> {
@@ -3639,6 +3650,7 @@ private fun GeneralSettings(
     clockFormat: String = "24h",
     showBudget: Boolean = true,
     spoilerBlurEnabled: Boolean = false,
+    focusBorderColor: String = "White",
     volumeBoostDb: Int = 0,
     focusedIndex: Int,
     onSubtitleClick: () -> Unit,
@@ -3657,6 +3669,7 @@ private fun GeneralSettings(
     onClockFormatClick: () -> Unit = {},
     onShowBudgetToggle: (Boolean) -> Unit = {},
     onSpoilerBlurToggle: (Boolean) -> Unit = {},
+    onFocusBorderColorClick: () -> Unit = {},
     showLoadingStats: Boolean = true,
     onShowLoadingStatsToggle: (Boolean) -> Unit = {},
     onVolumeBoostClick: () -> Unit = {},
@@ -3927,6 +3940,16 @@ private fun GeneralSettings(
             onToggle = onSpoilerBlurToggle,
             modifier = Modifier.settingsFocusSlot(22)
         )
+        Spacer(modifier = Modifier.height(10.dp))
+        SettingsRow(
+            icon = Icons.Default.Palette,
+            title = stringResource(R.string.focus_border_color),
+            subtitle = stringResource(R.string.focus_border_color_desc),
+            value = focusBorderColor,
+            isFocused = focusedIndex == 23,
+            onClick = onFocusBorderColorClick,
+            modifier = Modifier.settingsFocusSlot(23)
+        )
 
         // ── Network ──
         Spacer(modifier = Modifier.height(24.dp))
@@ -3942,18 +3965,18 @@ private fun GeneralSettings(
             title = stringResource(R.string.dns_provider),
             subtitle = stringResource(R.string.dns_desc),
             value = dnsProvider,
-            isFocused = focusedIndex == 23,
+            isFocused = focusedIndex == 24,
             onClick = onDnsProviderClick,
-            modifier = Modifier.settingsFocusSlot(23)
+            modifier = Modifier.settingsFocusSlot(24)
         )
         Spacer(modifier = Modifier.height(10.dp))
         SettingsToggleRow(
             title = stringResource(R.string.show_loading_stats),
             subtitle = stringResource(R.string.show_loading_stats_desc),
             isEnabled = showLoadingStats,
-            isFocused = focusedIndex == 24,
+            isFocused = focusedIndex == 25,
             onToggle = onShowLoadingStatsToggle,
-            modifier = Modifier.settingsFocusSlot(24)
+            modifier = Modifier.settingsFocusSlot(25)
         )
 
         // ── Audio ──
@@ -3973,9 +3996,9 @@ private fun GeneralSettings(
                 0 -> "Off"
                 else -> "+${volumeBoostDb} dB"
             },
-            isFocused = focusedIndex == 25,
+            isFocused = focusedIndex == 26,
             onClick = onVolumeBoostClick,
-            modifier = Modifier.settingsFocusSlot(25)
+            modifier = Modifier.settingsFocusSlot(26)
         )
     }
 }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -172,6 +172,8 @@ data class SettingsUiState(
     val qualityFilters: List<QualityFilterConfig> = emptyList(),
     // Spoiler blur — blur unwatched episode card images and hide synopsis
     val spoilerBlurEnabled: Boolean = false,
+    // Focus border color — user-selectable theme colour for the D-pad focus ring
+    val focusBorderColor: String = "White",
     val qualityFilterPresetLabel: String = "OFF",
     // Toast
     val toastMessage: String? = null,
@@ -376,6 +378,7 @@ class SettingsViewModel @Inject constructor(
             val spoilerBlurEnabled = prefs[spoilerBlurKey()] ?: false
             val showBudget = prefs[showBudgetKey()] ?: true
             val clockFormat = prefs[clockFormatKey()] ?: "24h"
+            val focusBorderColor = prefs[com.arflix.tv.util.FOCUS_BORDER_COLOR_KEY] ?: "White"
             val volumeBoostDb = prefs[volumeBoostDbKey()]?.toIntOrNull()?.coerceIn(0, 15) ?: 0
             val showLoadingStats = prefs[showLoadingStatsKey()] ?: true
 
@@ -453,6 +456,7 @@ class SettingsViewModel @Inject constructor(
                 skipProfileSelection = skipProfileSelection,
                 oledBlackBackground = oledBlackBackground,
                 clockFormat = clockFormat,
+                focusBorderColor = focusBorderColor,
                 qualityFilters = qualityFilters,
                 qualityFilterPresetLabel = detectQualityFilterPreset(qualityFilters).label
             )
@@ -993,6 +997,22 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             context.settingsDataStore.edit { it[clockFormatKey()] = next }
             _uiState.value = _uiState.value.copy(clockFormat = next)
+            syncLocalStateToCloud(silent = true)
+        }
+    }
+
+    /**
+     * Cycle the focus border color through the rainbow palette.
+     * Order: White → Red → Orange → Yellow → Green → Blue → Indigo → Violet → White
+     */
+    fun cycleFocusBorderColor() {
+        val colors = listOf("White", "Red", "Orange", "Yellow", "Green", "Blue", "Indigo", "Violet")
+        val current = _uiState.value.focusBorderColor
+        val nextIndex = (colors.indexOf(current) + 1) % colors.size
+        val next = colors[nextIndex]
+        viewModelScope.launch {
+            context.settingsDataStore.edit { it[com.arflix.tv.util.FOCUS_BORDER_COLOR_KEY] = next }
+            _uiState.value = _uiState.value.copy(focusBorderColor = next)
             syncLocalStateToCloud(silent = true)
         }
     }

--- a/app/src/main/kotlin/com/arflix/tv/ui/skin/ArvioFocus.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/skin/ArvioFocus.kt
@@ -54,6 +54,8 @@ fun Modifier.arvioFocusable(
     onFocusChanged: (Boolean) -> Unit = {},
 ): Modifier = composed {
     val interactionSource = remember { MutableInteractionSource() }
+    // Allow the user's "Focus border colour" setting to override the default
+    val resolvedOutlineColor = LocalFocusBorderColorOverride.current ?: outlineColor
     val isPressed by interactionSource.collectIsPressedAsState()
 
     var isFocused by remember { mutableStateOf(false) }
@@ -147,8 +149,8 @@ fun Modifier.arvioFocusable(
         if (highlightAlpha > 0.01f) {
             val outline = shape.createOutline(size, layoutDirection, this)
             val borderWidth = outlineWidth.toPx()
-            val ringColor = outlineColor.copy(alpha = highlightAlpha)
-            val glowColor = outlineColor.copy(alpha = highlightAlpha * 0.4f)
+            val ringColor = resolvedOutlineColor.copy(alpha = highlightAlpha)
+            val glowColor = resolvedOutlineColor.copy(alpha = highlightAlpha * 0.4f)
 
             onDrawWithContent {
                 drawContent()

--- a/app/src/main/kotlin/com/arflix/tv/ui/skin/ArvioSkin.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/skin/ArvioSkin.kt
@@ -4,8 +4,31 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
 
 val LocalArvioSkinTokens = staticCompositionLocalOf { ArvioSkinTokens.defaults() }
+
+/**
+ * Optional override for the focus border colour, driven by the user's
+ * "Focus border colour" setting. When non-null every [arvioFocusable]
+ * composable uses this colour instead of [ArvioColorTokens.focusOutline].
+ */
+val LocalFocusBorderColorOverride = staticCompositionLocalOf<Color?> { null }
+
+/**
+ * Maps a user-facing colour name to its [Color] value.
+ * Used by the focus border colour setting and the colour picker.
+ */
+fun focusBorderColorFromName(name: String): Color = when (name) {
+    "Red" -> Color(0xFFFF4444)
+    "Orange" -> Color(0xFFFF8800)
+    "Yellow" -> Color(0xFFFFDD44)
+    "Green" -> Color(0xFF44CC44)
+    "Blue" -> Color(0xFF4488FF)
+    "Indigo" -> Color(0xFF6644CC)
+    "Violet" -> Color(0xFFBB44CC)
+    else -> Color(0xFFFFFFFF) // White (default)
+}
 
 @Composable
 fun ProvideArvioSkin(

--- a/app/src/main/kotlin/com/arflix/tv/ui/theme/Theme.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/theme/Theme.kt
@@ -7,7 +7,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.darkColorScheme
+import com.arflix.tv.ui.skin.LocalFocusBorderColorOverride
 import com.arflix.tv.ui.skin.ProvideArvioSkin
+import com.arflix.tv.ui.skin.focusBorderColorFromName
 
 /**
  * ARVIO Color scheme holder - Arctic Fuse 2 inspired
@@ -87,9 +89,11 @@ val LocalArflixColors = LocalArvioColors
 @Composable
 fun ArvioTvTheme(
     oledBlackBackground: Boolean = false,
+    focusBorderColorName: String? = null,
     content: @Composable () -> Unit
 ) {
     val backgroundDark = if (oledBlackBackground) Color.Black else BackgroundDark
+    val focusBorderColor = focusBorderColorName?.let { focusBorderColorFromName(it) }
     val colorScheme = darkColorScheme(
         primary = ArcticWhite,
         onPrimary = ArcticBlack,
@@ -118,7 +122,8 @@ fun ArvioTvTheme(
 
     CompositionLocalProvider(
         LocalArvioColors provides arvioColors,
-        LocalOledBlackBackground provides oledBlackBackground
+        LocalOledBlackBackground provides oledBlackBackground,
+        LocalFocusBorderColorOverride provides focusBorderColor
     ) {
         ProvideArvioSkin {
             MaterialTheme(
@@ -134,8 +139,13 @@ fun ArvioTvTheme(
 @Composable
 fun ArflixTvTheme(
     oledBlackBackground: Boolean = false,
+    focusBorderColorName: String? = null,
     content: @Composable () -> Unit
-) = ArvioTvTheme(oledBlackBackground = oledBlackBackground, content = content)
+) = ArvioTvTheme(
+    oledBlackBackground = oledBlackBackground,
+    focusBorderColorName = focusBorderColorName,
+    content = content
+)
 
 /**
  * Access custom ARVIO colors

--- a/app/src/main/kotlin/com/arflix/tv/util/DeviceType.kt
+++ b/app/src/main/kotlin/com/arflix/tv/util/DeviceType.kt
@@ -35,6 +35,9 @@ val SKIP_PROFILE_SELECTION_KEY = booleanPreferencesKey("skip_profile_selection")
 /** Key for forcing pure-black (OLED) app background */
 val OLED_BLACK_BACKGROUND_KEY = booleanPreferencesKey("oled_black_background")
 
+/** Key for the user-selected focus border colour (e.g. "White", "Red", "Blue") */
+val FOCUS_BORDER_COLOR_KEY = stringPreferencesKey("focus_border_color")
+
 /**
  * Fast-path cache for the device-mode override. Read before onCreate() during
  * cold start, where the DataStore IO would otherwise block the main thread for

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -176,8 +176,8 @@
     <string name="show_budget_desc">Display the movie budget on the home hero banner</string>
     <string name="spoiler_blur">Spoiler Blur</string>
     <string name="spoiler_blur_desc">Blur unwatched episode cards to avoid spoilers</string>
-    <string name="focus_border_color">Focus Border Colour</string>
-    <string name="focus_border_color_desc">Choose the D-pad focus ring colour</string>
+    <string name="focus_border_color">Focus Border Color</string>
+    <string name="focus_border_color_desc">Choose the D-pad focus ring color</string>
     <string name="show_loading_stats_desc">Display stream resolution progress</string>
     <string name="volume_boost_desc">Amplify quiet sources (via system LoudnessEnhancer)</string>
     <string name="dns_desc">Resolve API and stream requests</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -176,6 +176,8 @@
     <string name="show_budget_desc">Display the movie budget on the home hero banner</string>
     <string name="spoiler_blur">Spoiler Blur</string>
     <string name="spoiler_blur_desc">Blur unwatched episode cards to avoid spoilers</string>
+    <string name="focus_border_color">Focus Border Colour</string>
+    <string name="focus_border_color_desc">Choose the D-pad focus ring colour</string>
     <string name="show_loading_stats_desc">Display stream resolution progress</string>
     <string name="volume_boost_desc">Amplify quiet sources (via system LoudnessEnhancer)</string>
     <string name="dns_desc">Resolve API and stream requests</string>


### PR DESCRIPTION
## Description

Adds a user-configurable focus border color setting that cycles through a rainbow palette. When a focus border color is selected, all D-pad focus indicators across the app use the chosen color instead of the default white.

### Palette (cycle order)
`White → Red → Orange → Yellow → Green → Blue → Indigo → Violet → White`

Cycling past Violet correctly wraps back to White (fixed from previous clamping bug).

### Changes
- [`app/src/main/kotlin/com/arflix/tv/MainActivity.kt`](https://github.com/EierKopZA/ARVIO/blob/pr/focus-border-color/app/src/main/kotlin/com/arflix/tv/MainActivity.kt) - Apply focus border color from settings
- [`app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt`](https://github.com/EierKopZA/ARVIO/blob/pr/focus-border-color/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt) - Settings UI for focus border color picker
- [`app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt`](https://github.com/EierKopZA/ARVIO/blob/pr/focus-border-color/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt) - `cycleFocusBorderColor()` with proper modulo wrap
- [`app/src/main/kotlin/com/arflix/tv/ui/skin/ArvioFocus.kt`](https://github.com/EierKopZA/ARVIO/blob/pr/focus-border-color/app/src/main/kotlin/com/arflix/tv/ui/skin/ArvioFocus.kt) - Focus rendering with configurable color
- [`app/src/main/kotlin/com/arflix/tv/ui/skin/ArvioSkin.kt`](https://github.com/EierKopZA/ARVIO/blob/pr/focus-border-color/app/src/main/kotlin/com/arflix/tv/ui/skin/ArvioSkin.kt) - Skin color palette integration
- [`app/src/main/kotlin/com/arflix/tv/ui/theme/Theme.kt`](https://github.com/EierKopZA/ARVIO/blob/pr/focus-border-color/app/src/main/kotlin/com/arflix/tv/ui/theme/Theme.kt) - Theme color mapping
- [`app/src/main/kotlin/com/arflix/tv/util/DeviceType.kt`](https://github.com/EierKopZA/ARVIO/blob/pr/focus-border-color/app/src/main/kotlin/com/arflix/tv/util/DeviceType.kt) - Device-specific color handling
- [`app/src/main/res/values/strings.xml`](https://github.com/EierKopZA/ARVIO/blob/pr/focus-border-color/app/src/main/res/values/strings.xml) - String resource for setting label

### Bug Fixes Applied
- **Wrap cycling**: `cycleFocusBorderColor()` now uses `(index + 1) % colors.size` instead of `coerceIn(0, colors.lastIndex)` which got stuck on Violet
- **Scoped**: Removed unrelated `mr_payload_episode_switcher.json` and excluded bundled collection/season changes from this PR

### Testing
- [ ] Navigate to Settings → Appearance → Focus Border Color
- [ ] Cycle through all 8 colors using D-pad click
- [ ] Verify Violet (last) wraps back to White (first)
- [ ] Check focus borders across Home, Details, Player, and Search screens
- [ ] Verify setting persists across app restart

Closes #83