### PR TITLE
feat: add continue watching card enhancements

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/model/Models.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/model/Models.kt
@@ -50,7 +50,9 @@ data class MediaItem(
     // Explicit source order when a remote list already gives the correct order.
     val sourceOrder: Int = Int.MAX_VALUE,
     // Placeholder card - shows skeleton loading animation
-    val isPlaceholder: Boolean = false
+    val isPlaceholder: Boolean = false,
+    // Continue Watching: formatted time remaining (e.g., "23min left", "1hr 15min left")
+    val timeRemainingLabel: String? = null,
 ) : Serializable
 
 enum class MediaType {

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/TraktRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/TraktRepository.kt
@@ -3577,7 +3577,7 @@ data class ContinueWatchingItem(
             badge = null,
             budget = budget,
             nextEpisode = nextEp,
-            totalEpisodes = totalEpisodes.takeIf { it > 0 },
+            totalEpisodes = null,
             watchedEpisodes = estimatedWatchedEpisodes,
             timeRemainingLabel = timeRemainingLabel
         )

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/TraktRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/TraktRepository.kt
@@ -1995,7 +1995,8 @@ class TraktRepository @Inject constructor(
                     year = details?.firstAirDate?.take(4) ?: item.year,
                     imdbRating = details?.voteAverage?.let { String.format("%.1f", it) } ?: "",
                     duration = details?.episodeRunTime?.firstOrNull()?.let { "${it}m" } ?: "",
-                    episodeTitle = item.episodeTitle ?: episodeInfo?.name
+                    episodeTitle = item.episodeTitle ?: episodeInfo?.name,
+                    totalEpisodes = details?.numberOfEpisodes ?: 0
                 )
             } else {
                 val details = try {
@@ -3511,7 +3512,8 @@ data class ContinueWatchingItem(
     val imdbRating: String = "",
     val duration: String = "",
     val budget: Long? = null,
-    val updatedAtMs: Long = 0L
+    val updatedAtMs: Long = 0L,
+    val totalEpisodes: Int = 0
 ) {
     fun toMediaItem(): MediaItem {
         val resumeSeconds = when {
@@ -3544,6 +3546,21 @@ data class ContinueWatchingItem(
             )
         } else null
 
+        // Compute remaining time: duration - resume position
+        val timeRemainingSeconds = when {
+            durationSeconds > 0L && resumePositionSeconds > 0L ->
+                (durationSeconds - resumePositionSeconds).coerceAtLeast(0L)
+            durationSeconds > 0L && progress in 1..94 ->
+                (durationSeconds * (100L - progress) / 100L).coerceAtLeast(0L)
+            else -> 0L
+        }
+        val timeRemainingLabel = formatTimeRemainingCompact(timeRemainingSeconds)
+
+        // Estimate watched episodes: episodes before the current one in the series
+        val estimatedWatchedEpisodes = if (mediaType == MediaType.TV && episode != null) {
+            (episode - 1).coerceAtLeast(0)
+        } else null
+
         return MediaItem(
             id = id,
             title = title,
@@ -3559,7 +3576,10 @@ data class ContinueWatchingItem(
             backdrop = backdropPath,
             badge = null,
             budget = budget,
-            nextEpisode = nextEp
+            nextEpisode = nextEp,
+            totalEpisodes = totalEpisodes.takeIf { it > 0 },
+            watchedEpisodes = estimatedWatchedEpisodes,
+            timeRemainingLabel = timeRemainingLabel
         )
     }
 }
@@ -3575,6 +3595,22 @@ private fun formatResumeClock(totalSeconds: Long): String {
         "%d:%02d".format(minutes, seconds)
     }
 }
+/**
+ * Format seconds to a compact human-readable time remaining string.
+ * e.g., "45min left", "1hr 15min left", "2hr left"
+ */
+private fun formatTimeRemainingCompact(totalSeconds: Long): String? {
+    val safe = totalSeconds.coerceAtLeast(0L)
+    if (safe < 60) return null // Less than a minute
+    val hours = safe / 3600
+    val minutes = (safe % 3600) / 60
+    return when {
+        hours > 0 && minutes > 0 -> "${hours}hr ${minutes}min left"
+        hours > 0 -> "${hours}hr left"
+        else -> "${minutes}min left"
+    }
+}
+
 private data class ContinueWatchingCandidate(
     val item: ContinueWatchingItem,
     val lastActivityAt: String

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/TraktRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/TraktRepository.kt
@@ -1987,6 +1987,12 @@ class TraktRepository @Inject constructor(
                 // Use SHOW's backdrop and overview (like Trakt does), not episode's
                 val backdropUrl = details?.backdropPath?.let { "${Constants.BACKDROP_BASE_LARGE}$it" }
                 val posterUrl = details?.posterPath?.let { "${Constants.IMAGE_BASE}$it" }
+                val totalEpisodeCount = details?.numberOfEpisodes ?: 0
+                val watchedEpisodeCount = estimateWatchedEpisodesBeforeCurrent(
+                    seasons = details?.seasons.orEmpty(),
+                    currentSeason = item.season,
+                    currentEpisode = item.episode
+                )?.coerceAtMost(totalEpisodeCount)
 
                 item.copy(
                     overview = details?.overview ?: "",  // Show overview, not episode
@@ -1996,7 +2002,8 @@ class TraktRepository @Inject constructor(
                     imdbRating = details?.voteAverage?.let { String.format("%.1f", it) } ?: "",
                     duration = details?.episodeRunTime?.firstOrNull()?.let { "${it}m" } ?: "",
                     episodeTitle = item.episodeTitle ?: episodeInfo?.name,
-                    totalEpisodes = details?.numberOfEpisodes ?: 0
+                    totalEpisodes = totalEpisodeCount,
+                    watchedEpisodes = watchedEpisodeCount ?: item.watchedEpisodes
                 )
             } else {
                 val details = try {
@@ -3513,7 +3520,8 @@ data class ContinueWatchingItem(
     val duration: String = "",
     val budget: Long? = null,
     val updatedAtMs: Long = 0L,
-    val totalEpisodes: Int = 0
+    val totalEpisodes: Int = 0,
+    val watchedEpisodes: Int = 0
 ) {
     fun toMediaItem(): MediaItem {
         val resumeSeconds = when {
@@ -3556,10 +3564,10 @@ data class ContinueWatchingItem(
         }
         val timeRemainingLabel = formatTimeRemainingCompact(timeRemainingSeconds)
 
-        // Estimate watched episodes: episodes before the current one in the series
-        val estimatedWatchedEpisodes = if (mediaType == MediaType.TV && episode != null) {
-            (episode - 1).coerceAtLeast(0)
-        } else null
+        val totalEpisodeCount = totalEpisodes.takeIf { mediaType == MediaType.TV && it > 0 }
+        val watchedEpisodeCount = watchedEpisodes
+            .takeIf { totalEpisodeCount != null && it > 0 }
+            ?.coerceAtMost(totalEpisodeCount ?: 0)
 
         return MediaItem(
             id = id,
@@ -3577,11 +3585,24 @@ data class ContinueWatchingItem(
             badge = null,
             budget = budget,
             nextEpisode = nextEp,
-            totalEpisodes = null,
-            watchedEpisodes = estimatedWatchedEpisodes,
+            totalEpisodes = totalEpisodeCount,
+            watchedEpisodes = watchedEpisodeCount,
             timeRemainingLabel = timeRemainingLabel
         )
     }
+}
+
+private fun estimateWatchedEpisodesBeforeCurrent(
+    seasons: List<com.arflix.tv.data.api.TmdbTvSeason>,
+    currentSeason: Int?,
+    currentEpisode: Int?
+): Int? {
+    if (currentSeason == null || currentEpisode == null) return null
+    val previousSeasonCount = seasons
+        .asSequence()
+        .filter { it.seasonNumber > 0 && it.seasonNumber < currentSeason }
+        .sumOf { it.episodeCount.coerceAtLeast(0) }
+    return previousSeasonCount + (currentEpisode - 1).coerceAtLeast(0)
 }
 
 private fun formatResumeClock(totalSeconds: Long): String {

--- a/app/src/main/kotlin/com/arflix/tv/ui/components/MediaCard.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/MediaCard.kt
@@ -356,6 +356,55 @@ fun MediaCard(
                         )
                     }
                 }
+
+                // ── Continue Watching badges ──
+                if (showProgress) {
+                    // Top-right: time remaining or "New Episode" badge
+                    val topRightLabel = item.timeRemainingLabel
+                        ?: if (item.mediaType == MediaType.TV && item.progress == 0 && !item.isWatched) "New Episode" else null
+                    if (topRightLabel != null) {
+                        Box(
+                            modifier = Modifier
+                                .align(Alignment.TopEnd)
+                                .padding(ArvioSkin.spacing.x2)
+                                .background(
+                                    color = ArvioSkin.colors.surfaceRaised.copy(alpha = 0.85f),
+                                    shape = rememberArvioCardShape(ArvioSkin.radius.sm),
+                                )
+                                .padding(horizontal = ArvioSkin.spacing.x2, vertical = ArvioSkin.spacing.x1),
+                        ) {
+                            Text(
+                                text = topRightLabel,
+                                style = ArvioSkin.typography.badge,
+                                color = ArvioSkin.colors.textPrimary,
+                            )
+                        }
+                    }
+
+                    // Top-left: episodes remaining for TV shows
+                    if (item.mediaType == MediaType.TV && item.totalEpisodes != null && item.totalEpisodes > 0) {
+                        val epsRemaining = item.totalEpisodes - (item.watchedEpisodes ?: 0)
+                        if (epsRemaining > 0) {
+                            val epsLabel = if (epsRemaining == 1) "1 ep left" else "$epsRemaining eps left"
+                            Box(
+                                modifier = Modifier
+                                    .align(Alignment.TopStart)
+                                    .padding(ArvioSkin.spacing.x2)
+                                    .background(
+                                        color = ArvioSkin.colors.surfaceRaised.copy(alpha = 0.85f),
+                                        shape = rememberArvioCardShape(ArvioSkin.radius.sm),
+                                    )
+                                    .padding(horizontal = ArvioSkin.spacing.x2, vertical = ArvioSkin.spacing.x1),
+                            ) {
+                                Text(
+                                    text = epsLabel,
+                                    style = ArvioSkin.typography.badge,
+                                    color = ArvioSkin.colors.textPrimary,
+                                )
+                            }
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Changes made across 3 files:
1. [Models.kt](vscode-webview://0qb7dhfpkuiun8reev1g526mqkd0kif8ft1crq9qs0g93lorue7c/ArvioGitlab/app/src/main/kotlin/com/arflix/tv/data/model/Models.kt:54) — Added timeRemainingLabel: String? = null field to MediaItem for carrying formatted time-remaining strings (e.g., "23min left").

2. [TraktRepository.kt](vscode-webview://0qb7dhfpkuiun8reev1g526mqkd0kif8ft1crq9qs0g93lorue7c/ArvioGitlab/app/src/main/kotlin/com/arflix/tv/data/repository/TraktRepository.kt) — Three changes:

Added totalEpisodes: Int = 0 to [ContinueWatchingItem](vscode-webview://0qb7dhfpkuiun8reev1g526mqkd0kif8ft1crq9qs0g93lorue7c/ArvioGitlab/app/src/main/kotlin/com/arflix/tv/data/repository/TraktRepository.kt:3516) data class
Populated totalEpisodes from TMDB numberOfEpisodes during enrichment in [enrichLocalContinueWatchingItem](vscode-webview://0qb7dhfpkuiun8reev1g526mqkd0kif8ft1crq9qs0g93lorue7c/ArvioGitlab/app/src/main/kotlin/com/arflix/tv/data/repository/TraktRepository.kt:1997)
Updated [toMediaItem()](vscode-webview://0qb7dhfpkuiun8reev1g526mqkd0kif8ft1crq9qs0g93lorue7c/ArvioGitlab/app/src/main/kotlin/com/arflix/tv/data/repository/TraktRepository.kt:3553-3576) to compute:
timeRemainingSeconds from durationSeconds - resumePositionSeconds
timeRemainingLabel via formatTimeRemainingCompact() ("Xmin left", "Xhr Ymin left")
Passes totalEpisodes and estimated watchedEpisodes to MediaItem
Added [formatTimeRemainingCompact()](vscode-webview://0qb7dhfpkuiun8reev1g526mqkd0kif8ft1crq9qs0g93lorue7c/ArvioGitlab/app/src/main/kotlin/com/arflix/tv/data/repository/TraktRepository.kt:3581) helper function
3. [MediaCard.kt](vscode-webview://0qb7dhfpkuiun8reev1g526mqkd0kif8ft1crq9qs0g93lorue7c/ArvioGitlab/app/src/main/kotlin/com/arflix/tv/ui/components/MediaCard.kt:360) — Added Continue Watching badges that render when showProgress == true:

Top-left: Episodes remaining badge — shows "3 eps left" (or "1 ep left") for TV shows with totalEpisodes > 0
Top-right: Time remaining badge — shows timeRemainingLabel for in-progress items, or "New Episode" for unwatched TV episodes (progress == 0)
Progress bar behavior unchanged — already hidden at progress == 0 (the existing condition item.progress in 1..94 excludes 0)
How it works:
The showProgress = isContinueWatching flag (already passed from HomeScreen.kt) gates both the progress bar AND the new badges
All data flows through the existing MediaItem fields — no new parameters on MediaCard
Works for both landscape (16:9) and poster (2:3) card layouts since the badges use Alignment.TopEnd/TopStart positioning
D-pad navigation unaffected — badges are purely visual overlays inside the existing focusable card surface