### PR TITLE
fix: format cast birthday in PersonModal to match app-standard d MMMyyyy

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/components/PersonModal.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/PersonModal.kt
@@ -70,6 +70,8 @@ import com.arflix.tv.ui.theme.ArflixTypography
 import com.arflix.tv.ui.theme.Pink
 import com.arflix.tv.ui.theme.TextPrimary
 import com.arflix.tv.ui.theme.TextSecondary
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 /**
  * Premium full-screen modal for displaying person/cast details
@@ -246,7 +248,7 @@ fun PersonModal(
                         // Birth info - subtle
                         if (person.birthday != null) {
                             Text(
-                                text = person.birthday,
+                                text = formatBirthday(person.birthday),
                                 style = ArflixTypography.body.copy(fontSize = 13.sp),
                                 color = TextSecondary.copy(alpha = 0.7f)
                             )
@@ -428,7 +430,7 @@ private fun MobilePersonContent(
             if (person.birthday != null) {
                 Spacer(modifier = Modifier.height(6.dp))
                 Text(
-                    text = person.birthday,
+                    text = formatBirthday(person.birthday),
                     style = ArflixTypography.body.copy(fontSize = 13.sp),
                     color = TextSecondary.copy(alpha = 0.7f)
                 )
@@ -608,6 +610,23 @@ private fun HorizontalKnownForCard(
                             color = Color.White.copy(alpha = 0.7f)
                         )
                     }
+                }
+            }
+            
+            /**
+             * Formats a TMDB birthday string ("yyyy-MM-dd") to the app-standard "d MMM yyyy" format.
+             * Matches [com.arflix.tv.data.repository.MediaRepository.formatDate] and
+             * [com.arflix.tv.ui.screens.details.DetailsScreen.formatEpisodeAirDateLabel].
+             */
+            private fun formatBirthday(dateStr: String?): String {
+                if (dateStr.isNullOrEmpty()) return ""
+                return try {
+                    val inputFormat = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+                    val outputFormat = SimpleDateFormat("d MMM yyyy", Locale.US)
+                    val date = inputFormat.parse(dateStr)
+                    date?.let { outputFormat.format(it) } ?: dateStr
+                } catch (e: Exception) {
+                    dateStr
                 }
             }
 


### PR DESCRIPTION
The cast birthday in the PersonModal was displayed in raw TMDB format
("yyyy-MM-dd", e.g. "1974-11-11"), which didn't match the rest of the
app's standardized date format.

This fix adds a `formatBirthday()` helper that converts it to
"d MMM yyyy" (e.g. "11 Nov 1974") — the same pattern used by
`MediaRepository.formatDate()` for release dates and
`DetailsScreen.formatEpisodeAirDateLabel()` for episode air dates.

### Changes
- Added `formatBirthday()` utility function in PersonModal.kt
- Applied formatting to both TV layout and mobile layout birthday
  displays
- Uses `SimpleDateFormat("d MMM yyyy", Locale.US)` for consistency
  with the rest of the app
