### PR TITLE
fix: prevent poster continue-watching label overlap

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/components/MediaCard.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/MediaCard.kt
@@ -389,7 +389,11 @@ fun MediaCard(
                     if (item.mediaType == MediaType.TV && item.totalEpisodes != null && item.totalEpisodes > 0) {
                         val epsRemaining = item.totalEpisodes - (item.watchedEpisodes ?: 0)
                         if (epsRemaining > 0) {
-                            val epsLabel = if (epsRemaining == 1) "1 ep left" else "$epsRemaining eps left"
+                            val epsLabel = if (isLandscape) {
+                                if (epsRemaining == 1) "1 ep left" else "$epsRemaining eps left"
+                            } else {
+                                epsRemaining.toString()
+                            }
 
                             Box(
                                 modifier = Modifier

--- a/app/src/main/kotlin/com/arflix/tv/ui/components/PersonModal.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/PersonModal.kt
@@ -74,6 +74,23 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 
 /**
+ * Formats a TMDB birthday string ("yyyy-MM-dd") to the app-standard "d MMM yyyy" format.
+ * Matches [com.arflix.tv.data.repository.MediaRepository.formatDate] and
+ * [com.arflix.tv.ui.screens.details.DetailsScreen.formatEpisodeAirDateLabel].
+ */
+private fun formatBirthday(dateStr: String?): String {
+    if (dateStr.isNullOrEmpty()) return ""
+    return try {
+        val inputFormat = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+        val outputFormat = SimpleDateFormat("d MMM yyyy", Locale.US)
+        val date = inputFormat.parse(dateStr)
+        date?.let { outputFormat.format(it) } ?: dateStr
+    } catch (e: Exception) {
+        dateStr
+    }
+}
+
+/**
  * Premium full-screen modal for displaying person/cast details
  * Clean, minimal design with horizontal cards like homepage
  */
@@ -613,23 +630,6 @@ private fun HorizontalKnownForCard(
                 }
             }
             
-            /**
-             * Formats a TMDB birthday string ("yyyy-MM-dd") to the app-standard "d MMM yyyy" format.
-             * Matches [com.arflix.tv.data.repository.MediaRepository.formatDate] and
-             * [com.arflix.tv.ui.screens.details.DetailsScreen.formatEpisodeAirDateLabel].
-             */
-            private fun formatBirthday(dateStr: String?): String {
-                if (dateStr.isNullOrEmpty()) return ""
-                return try {
-                    val inputFormat = SimpleDateFormat("yyyy-MM-dd", Locale.US)
-                    val outputFormat = SimpleDateFormat("d MMM yyyy", Locale.US)
-                    val date = inputFormat.parse(dateStr)
-                    date?.let { outputFormat.format(it) } ?: dateStr
-                } catch (e: Exception) {
-                    dateStr
-                }
-            }
-
             // Focus glow effect
             if (isFocused) {
                 Box(


### PR DESCRIPTION
Summary: In poster mode, the Continue Watching top-left episode badge now shows only the numeric episodes-left value (for example, 5).

Landscape: Landscape mode is unchanged and still uses text labels like 1 ep left and N eps left.

Why: This prevents overlap with the top-right time-remaining badge on poster cards while keeping landscape readability intact.