### PR TITLE
feat: add Sx • Ex badge to poster continue-watching cards

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/components/MediaCard.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/MediaCard.kt
@@ -390,6 +390,8 @@ fun MediaCard(
                         val epsRemaining = item.totalEpisodes - (item.watchedEpisodes ?: 0)
                         if (epsRemaining > 0) {
                             val epsLabel = if (epsRemaining == 1) "1 ep left" else "$epsRemaining eps left"
+
+
                             Box(
                                 modifier = Modifier
                                     .align(Alignment.TopStart)
@@ -406,6 +408,30 @@ fun MediaCard(
                                     color = ArvioSkin.colors.textPrimary,
                                 )
                             }
+                        }
+                    }
+
+                    // Poster-only: season/episode marker, right-aligned with top-right badge.
+                    val nextEpisode = item.nextEpisode
+                    if (!isLandscape && !item.isWatched && item.mediaType == MediaType.TV && nextEpisode != null) {
+                        Box(
+                            modifier = Modifier
+                                .align(Alignment.BottomEnd)
+                                .padding(
+                                    end = ArvioSkin.spacing.x2,
+                                    bottom = 14.dp
+                                )
+                                .background(
+                                    color = ArvioSkin.colors.surfaceRaised.copy(alpha = 0.70f),
+                                    shape = rememberArvioCardShape(ArvioSkin.radius.sm),
+                                )
+                                .padding(horizontal = ArvioSkin.spacing.x2, vertical = ArvioSkin.spacing.x1),
+                        ) {
+                            Text(
+                                text = "S${nextEpisode.seasonNumber} • E${nextEpisode.episodeNumber}",
+                                style = ArvioSkin.typography.badge,
+                                color = ArvioSkin.colors.textPrimary,
+                            )
                         }
                     }
                 }

--- a/app/src/main/kotlin/com/arflix/tv/ui/components/MediaCard.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/MediaCard.kt
@@ -391,7 +391,6 @@ fun MediaCard(
                         if (epsRemaining > 0) {
                             val epsLabel = if (epsRemaining == 1) "1 ep left" else "$epsRemaining eps left"
 
-
                             Box(
                                 modifier = Modifier
                                     .align(Alignment.TopStart)

--- a/app/src/main/kotlin/com/arflix/tv/ui/components/MediaCard.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/MediaCard.kt
@@ -411,9 +411,9 @@ fun MediaCard(
                         }
                     }
 
-                    // Poster-only: season/episode marker, right-aligned with top-right badge.
+                    // Season/episode marker, right-aligned with top-right badge.
                     val nextEpisode = item.nextEpisode
-                    if (!isLandscape && !item.isWatched && item.mediaType == MediaType.TV && nextEpisode != null) {
+                    if (!item.isWatched && item.mediaType == MediaType.TV && nextEpisode != null) {
                         Box(
                             modifier = Modifier
                                 .align(Alignment.BottomEnd)


### PR DESCRIPTION
## Summary
- add a season/episode badge for Continue Watching TV cards
- render the badge as Sx • Ex at the bottom-right, above the progress bar
- keep the badge right edge aligned with the top-right time badge padding

## Notes
- scoped to MediaCard continue-watching badge rendering only