### PR TITLE
fix: make search filter focus border visible

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/search/SearchScreen.kt
@@ -776,12 +776,12 @@ private fun GlowChip(
     val active = focused || isSelected
     val chipShape = RoundedCornerShape(7.dp)
     val backgroundColor = when {
-        focused -> Color.White
+        focused -> Color.White.copy(alpha = 0.12f)  // Dark enough for white border to be visible
         isSelected -> Color.White.copy(alpha = 0.92f)
         else -> Color.White.copy(alpha = 0.075f)
     }
     val borderColor = when {
-        focused -> Color.White
+        focused -> Color.White                       // Same white as media card focusOutline
         isSelected -> Color.White.copy(alpha = 0.92f)
         else -> Color.White.copy(alpha = 0.24f)
     }
@@ -811,7 +811,11 @@ private fun GlowChip(
                 fontSize = 12.sp,
                 fontWeight = if (active) FontWeight.SemiBold else FontWeight.Medium
             ),
-            color = if (active) Color.Black else Color.White.copy(alpha = 0.84f),
+            color = when {
+                focused -> Color.White                // White text on dark bg
+                isSelected -> Color.Black             // Black text on bright bg
+                else -> Color.White.copy(alpha = 0.84f)
+            },
             maxLines = 1
         )
     }


### PR DESCRIPTION
## Body

### Issue
When navigating the search filter buttons ("All", "Movies", "TV Shows") on Android TV via D-pad, the focused chip shows no visible border. The white focus outline blends into the solid white background fill, making it impossible to tell which filter is currently focused.

### Root Cause
In the `GlowChip` composable at `SearchScreen.kt:778-787`, both `backgroundColor` and `borderColor` are set to `Color.White` when the chip is focused. Since the chip fills solid white behind the 2.5dp white border, there is zero contrast — the border is invisible.

```kotlin
// Before (focused state):
backgroundColor = Color.White    // solid white fill
borderColor = Color.White        // white border — invisible against fill
```

### Fix
Changed the focused `backgroundColor` from solid `Color.White` to `Color.White.copy(alpha = 0.12f)` — a dark semi-transparent value that provides enough contrast for the white border to be clearly visible. This matches the pattern used by media cards, which render `ArvioSkin.colors.focusOutline` (white) against a dark surface background.

Also split the text color logic to account for the new dark focused background:
- **Focused:** white text on dark background + visible white border
- **Selected-only:** black text on bright (0.92f) background (unchanged)
- **Default:** dim white text on very dim background (unchanged)

```kotlin
// After (focused state):
backgroundColor = Color.White.copy(alpha = 0.12f)  // dark enough for contrast
borderColor = Color.White                           // white border — now visible
```

### Visual States

| State | Background | Border | Text |
|-------|-----------|--------|------|
| Focused | Dark (0.12f alpha) | White, 2.5dp | White |
| Selected | Bright (0.92f alpha) | Near-white, 1dp | Black |
| Default | Dim (0.075f alpha) | Subtle white, 1dp | Dim white |

### Testing
- `compileSideloadDebugKotlin` — passes
- Verified D-pad focus transitions between filter chips remain unaffected (no focus trap changes)
- Selected state (e.g., "All" tab) visual appearance unchanged
