### PR TITLE
fix: collections row not scrolling into view on TV details page

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
@@ -771,12 +771,9 @@ fun DetailsScreen(
                             }
                             3 -> viewModel.toggleWatched(episodeIndex)
                             4 -> viewModel.toggleWatchlist()
-                            5 -> { // View Collection — navigate to the CollectionDetailsScreen
-                                val collectionId = uiState.collectionId
-                                if (collectionId != null) {
-                                    val collectionName = uiState.collectionName.orEmpty()
-                                    onNavigateToCollection("tmdb_collection:$collectionId:$collectionName")
-                                }
+                            5 -> { // View Collection — scroll to and focus the collection row on this page
+                                focusedSection = FocusSection.COLLECTION
+                                collectionIndex = 0
                             }
                         }
                     },
@@ -2091,7 +2088,7 @@ private fun DetailsTvRows(
         contentScrollState.scrollToItem(0, 0)
     }
 
-    LaunchedEffect(focusedSection, contentHasFocus) {
+    LaunchedEffect(focusedSection, contentHasFocus, hasCollection, hasSimilar) {
         if (!contentHasFocus) return@LaunchedEffect
 
         val targetIndex = when (focusedSection) {


### PR DESCRIPTION
## Fix: Collections row not scrolling into view + View Collection button now anchors to row

### Problem 1: Collections row invisible on TV
When navigating down to the Collections row on the details page via D-pad, the collection items were not visible. The user could see that focus was moving (pressing Enter would open the hidden-but-focused card), but the `TvLazyColumn` never scrolled to bring the collection row into view.

**Root cause**: A race condition in `LaunchedEffect(focusedSection, contentHasFocus)`. Collection items load asynchronously. When the user navigates to COLLECTION section before the API responds, `collectionIdx = -1` causes early return — scroll never happens. When data eventually loads, the LaunchedEffect keys haven't changed so it never re-fires.

**Fix**: Added `hasCollection` and `hasSimilar` as keys: `LaunchedEffect(focusedSection, contentHasFocus, hasCollection, hasSimilar)`.

### Problem 2: View Collection button navigated away instead of focusing the row
Pressing the "View Collection" star button navigated to a separate `CollectionDetailsScreen`, which was confusing on TV — the user expected to land on the collection row on the current page.

**Fix**: Changed button index 5 to set `focusedSection = FocusSection.COLLECTION` and `collectionIndex = 0`. This triggers the LaunchedEffect scroll handler to animate the `TvLazyColumn` to the collection row and focus its first item — exactly the same as if the user pressed D-pad Down from the buttons.

### Changes
- **`DetailsScreen.kt`**: Changed `LaunchedEffect(focusedSection, contentHasFocus)` → `LaunchedEffect(focusedSection, contentHasFocus, hasCollection, hasSimilar)`
- **`DetailsScreen.kt`**: Changed "View Collection" button (index 5) from `onNavigateToCollection(...)` to `focusedSection = FocusSection.COLLECTION; collectionIndex = 0`