### PR TITLE
fix: pass collection params to DetailsTvRows for TV layout

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
@@ -609,6 +609,10 @@ fun DetailsScreen(
                                         }
                                         3 -> viewModel.toggleWatched(episodeIndex)
                                         4 -> viewModel.toggleWatchlist()
+                                        5 -> { // View Collection — scroll to and focus the collection row
+                                            focusedSection = FocusSection.COLLECTION
+                                            collectionIndex = 0
+                                        }
                                     }
                                 }
                                 FocusSection.EPISODES -> {

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
@@ -2008,6 +2008,9 @@ private fun DetailsContent(
             reviews = reviews,
             similar = similar,
             similarLogoUrls = similarLogoUrls,
+            collectionItems = collectionItems,
+            collectionName = collectionName,
+            collectionIndex = collectionIndex,
             focusedSection = focusedSection,
             focusSectionForUi = focusSectionForUi,
             episodeIndex = episodeIndex,
@@ -2025,7 +2028,8 @@ private fun DetailsContent(
             onSeasonClick = onSeasonClick,
             onEpisodeClick = onEpisodeClick,
             onCastClick = onCastClick,
-            onSimilarClick = onSimilarClick
+            onSimilarClick = onSimilarClick,
+            onCollectionClick = onCollectionClick
         )
     }
 }


### PR DESCRIPTION
The DetailsTvRows composable accepts collectionItems, collectionName,
collectionIndex, and onCollectionClick parameters, but the call site in
DetailsContent was not passing them. This caused the collection row to
never render on TV while working correctly on mobile.

Added the four missing parameters to the DetailsTvRows(...) call.
