### PR TITLE
fix: let Enter event reach native onClick to trigger IME on TV search

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/search/SearchScreen.kt
@@ -424,10 +424,7 @@ fun SearchScreen(
                             else when (topBarFocusedItem(sidebarFocusIndex, hasProfile)) { SidebarItem.SEARCH -> Unit; SidebarItem.HOME -> onNavigateToHome(); SidebarItem.WATCHLIST -> onNavigateToWatchlist(); SidebarItem.TV -> onNavigateToTv(); SidebarItem.SETTINGS -> onNavigateToSettings(); null -> Unit }
                             true
                         }
-                        FocusZone.SEARCH_INPUT -> {
-                            isSearchEditing = true
-                            true
-                        }
+                        FocusZone.SEARCH_INPUT -> false
                         FocusZone.FILTERS -> {
                             quickFilters.getOrNull(focusedFilterIndex)?.onSelect?.invoke()
                             true
@@ -650,7 +647,6 @@ private fun SearchInputBar(
                 when (event.key) {
                     Key.DirectionUp -> { onMoveUp(); true }
                     Key.DirectionDown -> { onMoveDown(); true }
-                    Key.Enter, Key.DirectionCenter -> { onStartEditing(); true }
                     else -> false
                 }
             }


### PR DESCRIPTION
**Description:**

The on-screen keyboard on Android TV wasn't reliably opening when pressing Enter on the search bar.

**Root cause:** The screen-level `dpadModifier.onPreviewKeyEvent` was swallowing the Enter/DirectionCenter event (returning `true`) for `FocusZone.SEARCH_INPUT`, preventing the native `clickable` modifier inside `ArvioFocusableSurface` from ever receiving it. Programmatic `focusRequester.requestFocus()` + `keyboardController?.show()` is unreliable for triggering the IME on Android TV — only a native click event consistently works.

**Fix:**
- `dpadModifier`: Return `false` for `FocusZone.SEARCH_INPUT` so the Enter event propagates
- `SearchInputBar.onPreviewKeyEvent`: Remove the `Key.Enter, Key.DirectionCenter` handler so it falls through to `ArvioFocusableSurface.onClick = onStartEditing`

Now the event chain is: Enter → dpadModifier (`false`) → SearchInputBar (`false`) → native `onClick = onStartEditing` → IME opens reliably.