### PR TITLE
Optimize Regex compilation for performance improvements

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/AnimeScoreRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/AnimeScoreRepository.kt
@@ -33,7 +33,7 @@ class AnimeScoreRepository @Inject constructor(
 ) {
     // Map<imdbId, malId?> \u2014 nulls cached to avoid re-hitting ARM for negative results.
     private val malIdCache: MutableMap<String, Int?> =
-        Collections.synchronizedMap(object : LinkedHashMap<String, Int?>() {
+        Collections.synchronizedMap(object : LinkedHashMap<String, Int?>(16, 0.75f, true) {
             override fun removeEldestEntry(eldest: Map.Entry<String, Int?>?): Boolean {
                 return size > 256
             }
@@ -41,7 +41,7 @@ class AnimeScoreRepository @Inject constructor(
 
     // Map<malId, score?> \u2014 same semantics as above.
     private val scoreCache: MutableMap<Int, Double?> =
-        Collections.synchronizedMap(object : LinkedHashMap<Int, Double?>() {
+        Collections.synchronizedMap(object : LinkedHashMap<Int, Double?>(16, 0.75f, true) {
             override fun removeEldestEntry(eldest: Map.Entry<Int, Double?>?): Boolean {
                 return size > 256
             }
@@ -64,7 +64,8 @@ class AnimeScoreRepository @Inject constructor(
 
     private suspend fun resolveMalId(imdbId: String): Int? {
         // Cache hit (including negative cache)
-        if (malIdCache.containsKey(imdbId)) return malIdCache[imdbId]
+        val cached = malIdCache[imdbId]
+        if (cached != null || malIdCache.containsKey(imdbId)) return cached
 
         val resolved = withTimeoutOrNull(2_000L) {
             runCatching { armApi.resolve(imdbId).firstOrNull()?.myanimelist }.getOrNull()
@@ -74,7 +75,8 @@ class AnimeScoreRepository @Inject constructor(
     }
 
     private suspend fun resolveScore(malId: Int): Double? {
-        if (scoreCache.containsKey(malId)) return scoreCache[malId]
+        val cached = scoreCache[malId]
+        if (cached != null || scoreCache.containsKey(malId)) return cached
 
         val score = withTimeoutOrNull(2_000L) {
             runCatching { jikanApi.getAnime(malId).data?.score }.getOrNull()

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/AnimeScoreRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/AnimeScoreRepository.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import java.util.Collections
 import javax.inject.Inject
 import javax.inject.Singleton
+import java.util.LinkedHashMap
 
 /**
  * Resolves MyAnimeList community scores for anime titles.
@@ -32,11 +33,19 @@ class AnimeScoreRepository @Inject constructor(
 ) {
     // Map<imdbId, malId?> \u2014 nulls cached to avoid re-hitting ARM for negative results.
     private val malIdCache: MutableMap<String, Int?> =
-        Collections.synchronizedMap(LinkedHashMap())
+        Collections.synchronizedMap(object : LinkedHashMap<String, Int?>() {
+            override fun removeEldestEntry(eldest: Map.Entry<String, Int?>?): Boolean {
+                return size > 256
+            }
+        })
 
     // Map<malId, score?> \u2014 same semantics as above.
     private val scoreCache: MutableMap<Int, Double?> =
-        Collections.synchronizedMap(LinkedHashMap())
+        Collections.synchronizedMap(object : LinkedHashMap<Int, Double?>() {
+            override fun removeEldestEntry(eldest: Map.Entry<Int, Double?>?): Boolean {
+                return size > 256
+            }
+        })
 
     /**
      * Look up the MAL community score for an anime by its IMDB id.
@@ -61,7 +70,6 @@ class AnimeScoreRepository @Inject constructor(
             runCatching { armApi.resolve(imdbId).firstOrNull()?.myanimelist }.getOrNull()
         }
         malIdCache[imdbId] = resolved
-        trimCache(malIdCache)
         return resolved
     }
 
@@ -72,22 +80,6 @@ class AnimeScoreRepository @Inject constructor(
             runCatching { jikanApi.getAnime(malId).data?.score }.getOrNull()
         }
         scoreCache[malId] = score
-        trimCache(scoreCache)
         return score
-    }
-
-    /** Crude LRU bound to keep per-process memory reasonable during long sessions. */
-    private fun <K, V> trimCache(cache: MutableMap<K, V>) {
-        val maxEntries = 256
-        if (cache.size <= maxEntries) return
-        synchronized(cache) {
-            val iterator = cache.entries.iterator()
-            var toRemove = cache.size - maxEntries
-            while (iterator.hasNext() && toRemove > 0) {
-                iterator.next()
-                iterator.remove()
-                toRemove--
-            }
-        }
     }
 }

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/CatalogDiscoveryRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/CatalogDiscoveryRepository.kt
@@ -187,7 +187,7 @@ class CatalogDiscoveryRepository @Inject constructor(
             append(result.description.orEmpty().lowercase())
         }
         val tokens = query.lowercase()
-            .split(Regex("[^a-z0-9]+"))
+            .split(NON_ALPHA_NUM_REGEX)
             .filter { it.length >= 3 }
             .distinct()
         if (tokens.isEmpty()) return 0
@@ -196,5 +196,8 @@ class CatalogDiscoveryRepository @Inject constructor(
             val bodyScore = if (searchable.contains(token)) 1 else 0
             titleScore + bodyScore
         }
+    }
+    private companion object {
+        private val NON_ALPHA_NUM_REGEX = Regex("[^a-z0-9]+")
     }
 }

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/CatalogRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/CatalogRepository.kt
@@ -50,6 +50,19 @@ class CatalogRepository @Inject constructor(
 ) {
     private companion object {
         private const val ADDON_SOURCE_REF_PREFIX = "addon_catalog|"
+
+        private val TITLE_FROM_META_REGEX = Regex(
+            """<meta\s+property=["']og:title["']\s+content=["']([^"']+)["']""",
+            RegexOption.IGNORE_CASE
+        )
+        private val TITLE_FROM_TAG_REGEX = Regex(
+            """<title>([^<]+)</title>""",
+            RegexOption.IGNORE_CASE
+        )
+        private val TRAKT_URL_REGEX = Regex(
+            """https?://(?:www\.)?trakt\.tv/users/[^"'\s<]+/lists/[^"'\s<]+""",
+            RegexOption.IGNORE_CASE
+        )
     }
 
     private val bundledPreinstalledCatalogsById by lazy(LazyThreadSafetyMode.NONE) {
@@ -814,15 +827,9 @@ class CatalogRepository @Inject constructor(
             }
         }
 
-        val titleFromMeta = Regex(
-            """<meta\s+property=["']og:title["']\s+content=["']([^"']+)["']""",
-            RegexOption.IGNORE_CASE
-        ).find(html)?.groupValues?.getOrNull(1)
+        val titleFromMeta = TITLE_FROM_META_REGEX.find(html)?.groupValues?.getOrNull(1)
 
-        val titleFromTag = Regex(
-            """<title>([^<]+)</title>""",
-            RegexOption.IGNORE_CASE
-        ).find(html)?.groupValues?.getOrNull(1)
+        val titleFromTag = TITLE_FROM_TAG_REGEX.find(html)?.groupValues?.getOrNull(1)
             ?.replace(" - MDBList", "", ignoreCase = true)
 
         val titleFromSlug = extractMdblistSlugTitle(url)
@@ -846,10 +853,7 @@ class CatalogRepository @Inject constructor(
     }
 
     private fun extractTraktUrl(html: String): String? {
-        return Regex(
-            """https?://(?:www\.)?trakt\.tv/users/[^"'\s<]+/lists/[^"'\s<]+""",
-            RegexOption.IGNORE_CASE
-        ).find(html)?.value
+        return TRAKT_URL_REGEX.find(html)?.value
     }
 
     private suspend fun fetchUrl(url: String): String? {

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/DataStoreSessionManager.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/DataStoreSessionManager.kt
@@ -36,13 +36,9 @@ class DataStoreSessionManager(
                 dataStore.edit { prefs ->
                     prefs[sessionKey] = payload
                 }
-                // Verify the save was successful
-                val verified = dataStore.data.first()[sessionKey]
-                if (verified == null) {
-                    AppLogger.w(TAG, "Saved session verified as null.")
-                }
             } catch (e: Exception) {
                 AppLogger.e(TAG, "Failed to save session", e)
+                throw e
             }
         }
     }
@@ -75,6 +71,7 @@ class DataStoreSessionManager(
                 dataStore.edit { prefs -> prefs.remove(sessionKey) }
             } catch (e: Exception) {
                 AppLogger.e(TAG, "Failed to delete session", e)
+                throw e
             }
         }
     }

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/DataStoreSessionManager.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/DataStoreSessionManager.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import io.github.jan.supabase.gotrue.SessionManager
 import io.github.jan.supabase.gotrue.user.UserSession
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -53,11 +54,13 @@ class DataStoreSessionManager(
                 val session = json.decodeFromString(UserSession.serializer(), raw)
                 session
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 AppLogger.e(TAG, "Failed to load session", e)
                 // Clear corrupted data
                 try {
                     dataStore.edit { prefs -> prefs.remove(sessionKey) }
                 } catch (clearError: Exception) {
+                    if (clearError is CancellationException) throw clearError
                     AppLogger.e(TAG, "Failed to clear corrupted session data", clearError)
                 }
                 null

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/DataStoreSessionManager.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/DataStoreSessionManager.kt
@@ -7,13 +7,11 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import io.github.jan.supabase.gotrue.SessionManager
 import io.github.jan.supabase.gotrue.user.UserSession
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import com.arflix.tv.util.AppLogger
-import com.arflix.tv.util.sanitizeEmail
 
 /**
  * DataStore-backed SessionManager for Supabase Auth.
@@ -40,10 +38,11 @@ class DataStoreSessionManager(
                 }
                 // Verify the save was successful
                 val verified = dataStore.data.first()[sessionKey]
-                if (verified != null) {
-                } else {
+                if (verified == null) {
+                    AppLogger.w(TAG, "Saved session verified as null.")
                 }
             } catch (e: Exception) {
+                AppLogger.e(TAG, "Failed to save session", e)
             }
         }
     }
@@ -58,10 +57,12 @@ class DataStoreSessionManager(
                 val session = json.decodeFromString(UserSession.serializer(), raw)
                 session
             } catch (e: Exception) {
+                AppLogger.e(TAG, "Failed to load session", e)
                 // Clear corrupted data
                 try {
                     dataStore.edit { prefs -> prefs.remove(sessionKey) }
                 } catch (clearError: Exception) {
+                    AppLogger.e(TAG, "Failed to clear corrupted session data", clearError)
                 }
                 null
             }
@@ -73,6 +74,7 @@ class DataStoreSessionManager(
             try {
                 dataStore.edit { prefs -> prefs.remove(sessionKey) }
             } catch (e: Exception) {
+                AppLogger.e(TAG, "Failed to delete session", e)
             }
         }
     }

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/HttpLocalScraperRuntime.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/HttpLocalScraperRuntime.kt
@@ -265,24 +265,19 @@ class HttpLocalScraperRuntime @Inject constructor(
             "https://vsrc.su/embed/$imdbId"
         }
         val embedHtml = getText(embedUrl)
-        val iframeSrc = Regex("""<iframe[^>]+src=["']([^"']+)["']""", RegexOption.IGNORE_CASE)
-            .find(embedHtml)
+        val iframeSrc = IFRAME_SRC_REGEX.find(embedHtml)
             ?.groupValues
             ?.getOrNull(1)
             ?: return@runCatching emptyList<HttpResolvedStream>()
         val iframeUrl = if (iframeSrc.startsWith("//")) "https:$iframeSrc" else iframeSrc
         val iframeHtml = getText(iframeUrl, mapOf("Referer" to "https://vsrc.su/"))
-        val prorcpSrc = Regex("""src:\s*['"]([^'"]+)['"]""", RegexOption.IGNORE_CASE)
-            .find(iframeHtml)
+        val prorcpSrc = PRORCP_SRC_REGEX.find(iframeHtml)
             ?.groupValues
             ?.getOrNull(1)
             ?: return@runCatching emptyList<HttpResolvedStream>()
         val cloudUrl = URL(URL("https://cloudnestra.com/"), prorcpSrc).toString()
         val cloudHtml = getText(cloudUrl, mapOf("Referer" to "https://cloudnestra.com/"))
-        val divMatch = Regex(
-            """<div id="([^"]+)"[^>]*style=["']display\s*:\s*none;?["'][^>]*>([a-zA-Z0-9:/.,{}\-_=+ ]+)</div>""",
-            RegexOption.IGNORE_CASE
-        ).find(cloudHtml) ?: return@runCatching emptyList<HttpResolvedStream>()
+        val divMatch = DIV_MATCH_REGEX.find(cloudHtml) ?: return@runCatching emptyList<HttpResolvedStream>()
         val decrypted = postJson(
             url = "https://enc-dec.app/api/dec-cloudnestra",
             body = """{"text":${gson.toJson(divMatch.groupValues[2])},"div_id":${gson.toJson(divMatch.groupValues[1])}}"""
@@ -326,7 +321,7 @@ class HttpLocalScraperRuntime @Inject constructor(
     }
 
     private suspend fun resolveTmdbId(imdbId: String, mediaType: String): Int? {
-        val clean = imdbId.trim().takeIf { it.matches(Regex("tt\\d{5,}")) } ?: return null
+        val clean = imdbId.trim().takeIf { it.matches(IMDB_ID_REGEX) } ?: return null
         val key = "$mediaType:$clean"
         synchronized(tmdbIdCache) {
             if (tmdbIdCache.containsKey(key)) return tmdbIdCache[key]
@@ -436,7 +431,7 @@ class HttpLocalScraperRuntime @Inject constructor(
     }
 
     private fun sanitizeProviderLabel(value: String): String {
-        return value.replace(Regex("nu" + "vio", RegexOption.IGNORE_CASE), "HTTP").trim()
+        return value.replace(NUVIO_REGEX, "HTTP").trim()
     }
 
     private fun String.urlEncode(): String = java.net.URLEncoder.encode(this, "UTF-8")
@@ -482,6 +477,14 @@ class HttpLocalScraperRuntime @Inject constructor(
     )
 
     companion object {
+        private val IFRAME_SRC_REGEX = Regex("""<iframe[^>]+src=["']([^"']+)["']""", RegexOption.IGNORE_CASE)
+        private val PRORCP_SRC_REGEX = Regex("""src:\s*['"]([^'"]+)['"]""", RegexOption.IGNORE_CASE)
+        private val DIV_MATCH_REGEX = Regex(
+            """<div id="([^"]+)"[^>]*style=["']display\s*:\s*none;?["'][^>]*>([a-zA-Z0-9:/.,{}\-_=+ ]+)</div>""",
+            RegexOption.IGNORE_CASE
+        )
+        private val IMDB_ID_REGEX = Regex("tt\\d{5,}")
+        private val NUVIO_REGEX = Regex("nu" + "vio", RegexOption.IGNORE_CASE)
         private const val HTTP_LOCAL_MANIFEST_PREFIX = "http.local."
         private const val LEGACY_LOCAL_MANIFEST_PREFIX = "nu" + "vio.local."
         private const val USER_AGENT =


### PR DESCRIPTION
This pull request focuses on improving code maintainability and efficiency by centralizing regular expressions, optimizing cache logic, and enhancing error handling across several repository classes. The most significant changes include replacing inline regular expressions with private constants, implementing proper LRU cache eviction, and improving logging and exception handling for session management.

**Regex Centralization and Code Maintainability:**
* Moved all inline `Regex` patterns in `CatalogRepository`, `HttpLocalScraperRuntime`, and `CatalogDiscoveryRepository` to private companion object constants, replacing repeated inline regex construction with shared, named constants for better maintainability and performance. [[1]](diffhunk://#diff-0d5b75d11fe0ec944395d31cfd9057f1f6c09353d301e516c510f9ecf1cdcd1cR53-R65) [[2]](diffhunk://#diff-0d5b75d11fe0ec944395d31cfd9057f1f6c09353d301e516c510f9ecf1cdcd1cL817-R832) [[3]](diffhunk://#diff-0d5b75d11fe0ec944395d31cfd9057f1f6c09353d301e516c510f9ecf1cdcd1cL849-R856) [[4]](diffhunk://#diff-fa4bf3dc174ba3ce89aa259ede57b341fbd00ff9eb6faf069f9d0b6ae44b76a1L532-R544) [[5]](diffhunk://#diff-fa4bf3dc174ba3ce89aa259ede57b341fbd00ff9eb6faf069f9d0b6ae44b76a1L736-R731) [[6]](diffhunk://#diff-fa4bf3dc174ba3ce89aa259ede57b341fbd00ff9eb6faf069f9d0b6ae44b76a1L900-R895) [[7]](diffhunk://#diff-fa4bf3dc174ba3ce89aa259ede57b341fbd00ff9eb6faf069f9d0b6ae44b76a1R957-R964) [[8]](diffhunk://#diff-289ab74fd2d56f52adf834a03fc57189044346573b1b7ba2a3a3ae8b65179f57L190-R190) [[9]](diffhunk://#diff-289ab74fd2d56f52adf834a03fc57189044346573b1b7ba2a3a3ae8b65179f57R200-R202)

**Cache Optimization:**
* Refactored the LRU cache logic in `AnimeScoreRepository` by using a custom `LinkedHashMap` with an overridden `removeEldestEntry` method, removing the need for a manual `trimCache` function and ensuring the cache size is automatically limited to 256 entries. [[1]](diffhunk://#diff-d82ba6e82f3d0d39ac0e612489a4c8bd9b8bb99536d23c1918ebba54e4b9430fR11) [[2]](diffhunk://#diff-d82ba6e82f3d0d39ac0e612489a4c8bd9b8bb99536d23c1918ebba54e4b9430fL35-R48) [[3]](diffhunk://#diff-d82ba6e82f3d0d39ac0e612489a4c8bd9b8bb99536d23c1918ebba54e4b9430fL58-L92)

**Error Handling and Logging Improvements:**
* Enhanced error handling in `DataStoreSessionManager` by adding logging for failed session save, load, and delete operations, and ensuring `CancellationException` is correctly propagated. Corrupted session data is now logged and cleared more robustly. [[1]](diffhunk://#diff-83121fe0becaf0bae034db512b19140e335b247fec3d68d8841763c285efa167R9-L16) [[2]](diffhunk://#diff-83121fe0becaf0bae034db512b19140e335b247fec3d68d8841763c285efa167L41-R42) [[3]](diffhunk://#diff-83121fe0becaf0bae034db512b19140e335b247fec3d68d8841763c285efa167R57-R64) [[4]](diffhunk://#diff-83121fe0becaf0bae034db512b19140e335b247fec3d68d8841763c285efa167R76-R77)

These changes collectively improve the codebase's clarity, maintainability, and reliability.This pull request refactors several Kotlin repository classes to improve code maintainability and performance by extracting commonly used regular expressions into private constants. This reduces repeated regex compilation and centralizes regex definitions, making the code easier to read and update.

Regex extraction and reuse:

* In `CatalogRepository`, regex patterns for extracting titles from HTML (`TITLE_FROM_META_REGEX`, `TITLE_FROM_TAG_REGEX`) and Trakt URLs (`TRAKT_URL_REGEX`) are now defined as private constants and reused throughout the class. [[1]](diffhunk://#diff-0d5b75d11fe0ec944395d31cfd9057f1f6c09353d301e516c510f9ecf1cdcd1cR53-R65) [[2]](diffhunk://#diff-0d5b75d11fe0ec944395d31cfd9057f1f6c09353d301e516c510f9ecf1cdcd1cL817-R832) [[3]](diffhunk://#diff-0d5b75d11fe0ec944395d31cfd9057f1f6c09353d301e516c510f9ecf1cdcd1cL849-R856)
* In `HttpLocalScraperRuntime`, regex patterns for extracting iframe sources, script sources, hidden divs, IMDb IDs, and the "nuvio" provider label are now defined as private constants (`IFRAME_SRC_REGEX`, `PRORCP_SRC_REGEX`, `DIV_MATCH_REGEX`, `IMDB_ID_REGEX`, `NUVIO_REGEX`) and used in place of inline regex definitions. [[1]](diffhunk://#diff-fa4bf3dc174ba3ce89aa259ede57b341fbd00ff9eb6faf069f9d0b6ae44b76a1L532-R544) [[2]](diffhunk://#diff-fa4bf3dc174ba3ce89aa259ede57b341fbd00ff9eb6faf069f9d0b6ae44b76a1L736-R731) [[3]](diffhunk://#diff-fa4bf3dc174ba3ce89aa259ede57b341fbd00ff9eb6faf069f9d0b6ae44b76a1L900-R895) [[4]](diffhunk://#diff-fa4bf3dc174ba3ce89aa259ede57b341fbd00ff9eb6faf069f9d0b6ae44b76a1R957-R964)

Minor consistency improvements:

* In `CatalogDiscoveryRepository`, the regex for splitting non-alphanumeric characters is now defined as a private constant (`NON_ALPHA_NUM_REGEX`). [[1]](diffhunk://#diff-289ab74fd2d56f52adf834a03fc57189044346573b1b7ba2a3a3ae8b65179f57L190-R190) [[2]](diffhunk://#diff-289ab74fd2d56f52adf834a03fc57189044346573b1b7ba2a3a3ae8b65179f57R200-R202)

These changes make the codebase more efficient and maintainable by avoiding repeated regex compilation and providing a single point of change for regex patterns.