### PR TITLE
Fix ProfileSelectionScreen to respect OLED black background setting

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/profile/ProfileSelectionScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/profile/ProfileSelectionScreen.kt
@@ -59,9 +59,7 @@ import androidx.tv.material3.Text
 import com.arflix.tv.data.model.Profile
 import com.arflix.tv.ui.components.ProfileAvatarVisual
 import com.arflix.tv.ui.components.Toast
-import com.arflix.tv.ui.theme.BackgroundGradientCenter
-import com.arflix.tv.ui.theme.BackgroundGradientEnd
-import com.arflix.tv.ui.theme.BackgroundGradientStart
+import com.arflix.tv.ui.theme.appBackgroundDark
 import com.arflix.tv.util.LocalDeviceType
 import androidx.compose.ui.res.stringResource
 import com.arflix.tv.R
@@ -145,15 +143,7 @@ fun ProfileSelectionScreen(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(
-                brush = Brush.linearGradient(
-                    colors = listOf(
-                        BackgroundGradientStart,
-                        BackgroundGradientCenter,
-                        BackgroundGradientEnd
-                    )
-                )
-            ),
+            .background(appBackgroundDark()),
         contentAlignment = Alignment.Center
     ) {
         Column(


### PR DESCRIPTION
Replaces the hardcoded BackgroundDark gradient background in 
ProfileSelectionScreen with appBackgroundDark(), which reads the 
LocalOledBlackBackground CompositionLocal.

When the user enables "OLED black background" in Settings, this screen
now renders pure black (Color.Black) like every other screen already does.
