### PR TITLE
feat: add 'Your Watch History' home row with 'Because You Watched' recommendations grid

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/arflix/tv/navigation/AppNavigation.kt
@@ -25,6 +25,7 @@ import com.arflix.tv.ui.screens.home.HomeScreen
 import com.arflix.tv.ui.screens.login.LoginScreen
 import com.arflix.tv.ui.screens.player.PlayerScreen
 import com.arflix.tv.ui.screens.collections.CollectionDetailsScreen
+import com.arflix.tv.ui.screens.recommendations.RecommendationsScreen
 import com.arflix.tv.ui.screens.search.SearchScreen
 import com.arflix.tv.ui.screens.settings.SettingsScreen
 import com.arflix.tv.ui.screens.tv.live.LiveTvScreen
@@ -95,6 +96,13 @@ sealed class Screen(val route: String) {
             preferredBingeGroup?.let { params.add("preferredBingeGroup=${java.net.URLEncoder.encode(it, "UTF-8")}") }
             startPositionMs?.let { params.add("startPositionMs=$it") }
             return if (params.isNotEmpty()) "$base?${params.joinToString("&")}" else base
+        }
+    }
+
+    object Recommendations : Screen("recommendations/{mediaType}/{mediaId}/{mediaTitle}") {
+        fun createRoute(mediaType: MediaType, mediaId: Int, mediaTitle: String): String {
+            val encodedTitle = java.net.URLEncoder.encode(mediaTitle, "UTF-8")
+            return "recommendations/${mediaType.name.lowercase()}/$mediaId/$encodedTitle"
         }
     }
 }
@@ -172,6 +180,9 @@ fun AppNavigation(
                 },
                 onNavigateToCollection = { catalogId ->
                     navController.navigate(Screen.CollectionDetails.createRoute(catalogId))
+                },
+                onNavigateToRecommendations = { mediaType, mediaId, mediaTitle ->
+                    navController.navigate(Screen.Recommendations.createRoute(mediaType, mediaId, mediaTitle))
                 },
                 onNavigateToSearch = {
                     navigateTopLevel(Screen.Search.route)
@@ -493,6 +504,36 @@ fun AppNavigation(
                         popUpTo(Screen.Player.route) { inclusive = true }
                     }
                 }
+            )
+        }
+
+        // Recommendations screen
+        composable(
+            route = Screen.Recommendations.route,
+            arguments = listOf(
+                navArgument("mediaType") { type = NavType.StringType },
+                navArgument("mediaId") { type = NavType.IntType },
+                navArgument("mediaTitle") { type = NavType.StringType }
+            )
+        ) { backStackEntry ->
+            val mediaTypeStr = backStackEntry.arguments?.getString("mediaType") ?: "movie"
+            val mediaId = backStackEntry.arguments?.getInt("mediaId") ?: 0
+            val mediaTitleEncoded = backStackEntry.arguments?.getString("mediaTitle").orEmpty()
+            val mediaTitle = java.net.URLDecoder.decode(mediaTitleEncoded, "UTF-8")
+            if (mediaId <= 0) {
+                navigateHome()
+                return@composable
+            }
+            val mediaType = if (mediaTypeStr == "tv") MediaType.TV else MediaType.MOVIE
+
+            RecommendationsScreen(
+                mediaType = mediaType,
+                mediaId = mediaId,
+                mediaTitle = mediaTitle,
+                onNavigateToDetails = { type, id ->
+                    navController.navigate(Screen.Details.createRoute(type, id))
+                },
+                onBack = { navController.popBackStack() }
             )
         }
     }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
@@ -537,6 +537,7 @@ fun HomeScreen(
     currentProfile: com.arflix.tv.data.model.Profile? = null,
     onNavigateToDetails: (MediaType, Int, Int?, Int?) -> Unit = { _, _, _, _ -> },
     onNavigateToCollection: (String) -> Unit = {},
+    onNavigateToRecommendations: (MediaType, Int, String) -> Unit = { _, _, _ -> },
     onNavigateToSearch: () -> Unit = {},
     onNavigateToWatchlist: () -> Unit = {},
     onNavigateToTv: (channelId: String?, streamUrl: String?) -> Unit = { _, _ -> },
@@ -1103,6 +1104,7 @@ fun HomeScreen(
             onItemFocusedPrefetch = {},
             onNavigateToDetails = onNavigateToDetails,
             onNavigateToCollection = onNavigateToCollection,
+            onNavigateToRecommendations = onNavigateToRecommendations,
             onNavigateToSearch = onNavigateToSearch,
             onNavigateToWatchlist = onNavigateToWatchlist,
             onNavigateToTv = onNavigateToTv,
@@ -2203,6 +2205,7 @@ private fun HomeInputLayer(
     onItemFocusedPrefetch: (MediaItem) -> Unit = {},
     onNavigateToDetails: (MediaType, Int, Int?, Int?) -> Unit,
     onNavigateToCollection: (String) -> Unit,
+    onNavigateToRecommendations: (MediaType, Int, String) -> Unit = { _, _, _ -> },
     onNavigateToSearch: () -> Unit,
     onNavigateToWatchlist: () -> Unit,
     onNavigateToTv: (channelId: String?, streamUrl: String?) -> Unit,
@@ -2478,21 +2481,27 @@ private fun HomeInputLayer(
                                         val isContinue = currentCategory?.id == "continue_watching"
                                         onOpenContextMenu(item, isContinue)
                                     } else {
-                                        // Short press: navigate. Must check collection:
-                                        // BEFORE falling through to Details — D-pad SELECT
-                                        // on a service tile (Netflix, HBO, ...) was hitting
-                                        // DetailsScreen with the synthetic hash id and
-                                        // spamming TMDB 404s instead of opening the catalog.
-                                        val iptvId = item.status?.removePrefix("iptv:")
-                                            ?.takeIf { item.status?.startsWith("iptv:") == true && it.isNotBlank() }
-                                        val collectionId = item.status?.removePrefix("collection:")
-                                            ?.takeIf { item.status?.startsWith("collection:") == true && it.isNotBlank() }
-                                        if (iptvId != null) {
-                                            onNavigateToTv(iptvId, getIptvStreamUrl(item.id))
-                                        } else if (collectionId != null) {
-                                            onNavigateToCollection(collectionId)
+                                        // Short press: navigate.
+                                        val currentCategory = categories.getOrNull(focusState.currentRowIndex)
+                                        if (currentCategory?.id == "watch_history") {
+                                            // "Your Watch History" items navigate to the recommendations screen
+                                            onNavigateToRecommendations(item.mediaType, item.id, item.title)
                                         } else {
-                                            onNavigateToDetails(item.mediaType, item.id, item.nextEpisode?.seasonNumber, item.nextEpisode?.episodeNumber)
+                                            // Must check collection BEFORE falling through to Details
+                                            // — D-pad SELECT on a service tile (Netflix, HBO, ...) was hitting
+                                            // DetailsScreen with the synthetic hash id and
+                                            // spamming TMDB 404s instead of opening the catalog.
+                                            val iptvId = item.status?.removePrefix("iptv:")
+                                                ?.takeIf { item.status?.startsWith("iptv:") == true && it.isNotBlank() }
+                                            val collectionId = item.status?.removePrefix("collection:")
+                                                ?.takeIf { item.status?.startsWith("collection:") == true && it.isNotBlank() }
+                                            if (iptvId != null) {
+                                                onNavigateToTv(iptvId, getIptvStreamUrl(item.id))
+                                            } else if (collectionId != null) {
+                                                onNavigateToCollection(collectionId)
+                                            } else {
+                                                onNavigateToDetails(item.mediaType, item.id, item.nextEpisode?.seasonNumber, item.nextEpisode?.episodeNumber)
+                                            }
                                         }
                                     }
                                 }
@@ -2551,6 +2560,12 @@ private fun HomeInputLayer(
             onNavigateToDetails = onNavigateToDetails,
             onItemClick = { item ->
                 if (!isActionableHomeItem(item)) {
+                    return@HomeRowsLayer
+                }
+                // Check if the clicked item is in the "Your Watch History" row
+                val category = categories.getOrNull(focusState.currentRowIndex)
+                if (category?.id == "watch_history") {
+                    onNavigateToRecommendations(item.mediaType, item.id, item.title)
                     return@HomeRowsLayer
                 }
                 val iptvId = item.status?.removePrefix("iptv:")?.takeIf { item.status?.startsWith("iptv:") == true && it.isNotBlank() }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
@@ -1621,6 +1621,35 @@ class HomeViewModel @Inject constructor(
             }
             _uiState.value = _uiState.value.copy(categories = current)
         }
+        // Keep the watch history row in sync whenever CW items change
+        publishWatchHistoryFromCachedItems()
+    }
+
+    /**
+     * Publishes a "Your Watch History" row built from the cached Continue Watching items.
+     * Injected at position 1 (immediately after Continue Watching).
+     * Each item in this row navigates to the RecommendationsScreen on click.
+     */
+    private suspend fun publishWatchHistoryFromCachedItems() {
+        val items = lastContinueWatchingItems
+        if (items.isEmpty()) return
+        val watchHistoryCategory = Category(
+            id = "watch_history",
+            title = "Your Watch History",
+            items = items
+        )
+        withContext(Dispatchers.Main) {
+            val current = _uiState.value.categories.toMutableList()
+            val whIdx = current.indexOfFirst { it.id == "watch_history" }
+            if (whIdx >= 0) {
+                current[whIdx] = watchHistoryCategory
+            } else {
+                // Insert at position 1 (right after Continue Watching which is at index 0)
+                val insertionIndex = if (current.isNotEmpty() && current.firstOrNull()?.id == "continue_watching") 1 else 0
+                current.add(insertionIndex.coerceAtMost(current.size), watchHistoryCategory)
+            }
+            _uiState.value = _uiState.value.copy(categories = current)
+        }
     }
 
     private fun loadHomeData() {
@@ -2000,6 +2029,28 @@ class HomeViewModel @Inject constructor(
                         items = merged.map { it.toMediaItem() }
                     )
                     categories.add(0, cwCat)
+                }
+                // Inject "Your Watch History" row from the same CW items
+                val watchHistoryItems = existingCW?.items
+                    ?: if (cachedContinueWatching.isNotEmpty()) {
+                        mergeContinueWatchingResumeData(cachedContinueWatching).map { it.toMediaItem() }
+                    } else {
+                        lastContinueWatchingItems
+                    }
+                if (watchHistoryItems.isNotEmpty()) {
+                    val watchHistoryCat = Category(
+                        id = "watch_history",
+                        title = "Your Watch History",
+                        items = watchHistoryItems
+                    )
+                    val whIdx = categories.indexOfFirst { it.id == "watch_history" }
+                    if (whIdx >= 0) {
+                        categories[whIdx] = watchHistoryCat
+                    } else {
+                        // Insert at position 1 (right after Continue Watching which is at index 0)
+                        val insertAt = if (categories.isNotEmpty() && categories.first().id == "continue_watching") 1 else 0
+                        categories.add(insertAt.coerceAtMost(categories.size), watchHistoryCat)
+                    }
                 }
                 // Launch the independent CW fetch
                 launchContinueWatchingFetch()

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
@@ -1635,7 +1635,7 @@ class HomeViewModel @Inject constructor(
         if (items.isEmpty()) return
         val watchHistoryCategory = Category(
             id = "watch_history",
-            title = "Your Watch History",
+            title = context.getString(com.arflix.tv.R.string.your_watch_history),
             items = items
         )
         withContext(Dispatchers.Main) {
@@ -2040,7 +2040,7 @@ class HomeViewModel @Inject constructor(
                 if (watchHistoryItems.isNotEmpty()) {
                     val watchHistoryCat = Category(
                         id = "watch_history",
-                        title = "Your Watch History",
+                        title = context.getString(com.arflix.tv.R.string.your_watch_history),
                         items = watchHistoryItems
                     )
                     val whIdx = categories.indexOfFirst { it.id == "watch_history" }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/recommendations/RecommendationsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/recommendations/RecommendationsScreen.kt
@@ -1,0 +1,273 @@
+package com.arflix.tv.ui.screens.recommendations
+
+import android.content.res.Configuration
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.tv.foundation.lazy.grid.TvGridCells
+import androidx.tv.foundation.lazy.grid.TvLazyVerticalGrid
+import androidx.tv.foundation.lazy.grid.itemsIndexed
+import androidx.tv.material3.Text
+import com.arflix.tv.data.model.MediaItem
+import com.arflix.tv.data.model.MediaType
+import com.arflix.tv.data.repository.MediaRepository
+import com.arflix.tv.ui.components.MediaCard
+import com.arflix.tv.ui.focus.arvioDpadFocusGroup
+import com.arflix.tv.ui.theme.ArflixTypography
+import com.arflix.tv.ui.theme.appBackgroundDark
+import com.arflix.tv.ui.theme.TextPrimary
+import com.arflix.tv.ui.theme.TextSecondary
+import com.arflix.tv.util.LocalDeviceType
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class RecommendationsUiState(
+    val items: List<MediaItem> = emptyList(),
+    val isLoading: Boolean = true,
+    val error: String? = null
+)
+
+@HiltViewModel
+class RecommendationsViewModel @Inject constructor(
+    private val mediaRepository: MediaRepository
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(RecommendationsUiState())
+    val uiState: StateFlow<RecommendationsUiState> = _uiState.asStateFlow()
+
+    fun load(mediaType: MediaType, mediaId: Int) {
+        if (!_uiState.value.isLoading && _uiState.value.items.isNotEmpty()) return
+        viewModelScope.launch {
+            _uiState.value = RecommendationsUiState(isLoading = true)
+            val result = runCatching {
+                mediaRepository.getSimilar(mediaType, mediaId)
+            }.getOrDefault(emptyList())
+
+            _uiState.value = if (result.isEmpty()) {
+                RecommendationsUiState(
+                    items = emptyList(),
+                    isLoading = false,
+                    error = "No recommendations found for this title."
+                )
+            } else {
+                RecommendationsUiState(
+                    items = result,
+                    isLoading = false
+                )
+            }
+        }
+    }
+
+    fun retry(mediaType: MediaType, mediaId: Int) {
+        _uiState.value = RecommendationsUiState(isLoading = true)
+        load(mediaType, mediaId)
+    }
+}
+
+@Composable
+fun RecommendationsScreen(
+    mediaType: MediaType,
+    mediaId: Int,
+    mediaTitle: String,
+    viewModel: RecommendationsViewModel = hiltViewModel(),
+    onNavigateToDetails: (MediaType, Int) -> Unit,
+    onBack: () -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    LaunchedEffect(mediaType, mediaId) { viewModel.load(mediaType, mediaId) }
+    BackHandler(onBack = onBack)
+
+    val isMobile = LocalDeviceType.current.isTouchDevice()
+    val configuration = LocalConfiguration.current
+    val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+
+    // Responsive grid columns — same formula as CollectionDetailsScreen poster mode
+    val gridColumns = if (isMobile) {
+        if (isLandscape) 4 else 3
+    } else {
+        when {
+            configuration.screenWidthDp >= 2200 -> 8
+            configuration.screenWidthDp >= 1600 -> 7
+            else -> 5
+        }
+    }
+
+    val cardWidth = if (isMobile) 138.dp else when {
+        configuration.screenWidthDp >= 2200 -> 196.dp
+        configuration.screenWidthDp >= 1600 -> 184.dp
+        else -> 172.dp
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(appBackgroundDark())
+            .onPreviewKeyEvent { event ->
+                if (event.type == KeyEventType.KeyDown &&
+                    (event.key == Key.Back || event.key == Key.Escape)
+                ) {
+                    onBack()
+                    true
+                } else {
+                    false
+                }
+            }
+    ) {
+        // Accent gradient backdrop
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    androidx.compose.ui.graphics.Brush.radialGradient(
+                        colors = listOf(
+                            Color(0xFF2F9C95).copy(alpha = 0.25f),
+                            Color.Transparent
+                        )
+                    )
+                )
+        )
+
+        if (uiState.isLoading) {
+            // Skeleton grid
+            TvLazyVerticalGrid(
+                columns = TvGridCells.Fixed(gridColumns),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .arvioDpadFocusGroup()
+                    .padding(top = 72.dp),
+                contentPadding = PaddingValues(
+                    start = 42.dp,
+                    end = 42.dp,
+                    top = 20.dp,
+                    bottom = 48.dp
+                ),
+                verticalArrangement = Arrangement.spacedBy(18.dp),
+                horizontalArrangement = Arrangement.spacedBy(18.dp)
+            ) {
+                itemsIndexed((1..gridColumns * 3).toList()) { _, _ ->
+                    Box(
+                        modifier = Modifier
+                            .height(cardWidth * 1.5f)
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(Color.White.copy(alpha = 0.05f))
+                    )
+                }
+            }
+
+            // Title overlay
+            Text(
+                text = "More Like $mediaTitle",
+                style = ArflixTypography.sectionTitle.copy(
+                    fontSize = 22.sp,
+                    fontWeight = FontWeight.Bold
+                ),
+                color = TextPrimary,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 42.dp, top = 18.dp, end = 42.dp)
+            )
+        } else if (uiState.error != null) {
+            // Error state
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                androidx.compose.foundation.layout.Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Text(
+                        text = uiState.error ?: "Something went wrong",
+                        style = ArflixTypography.body,
+                        color = TextSecondary
+                    )
+                    androidx.tv.material3.Button(
+                        onClick = { viewModel.retry(mediaType, mediaId) }
+                    ) {
+                        Text(androidx.compose.ui.res.stringResource(com.arflix.tv.R.string.retry))
+                    }
+                }
+            }
+        } else {
+            // Recommendations grid
+            TvLazyVerticalGrid(
+                columns = TvGridCells.Fixed(gridColumns),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .arvioDpadFocusGroup()
+                    .padding(top = 56.dp),
+                contentPadding = PaddingValues(
+                    start = 42.dp,
+                    end = 42.dp,
+                    top = 4.dp,
+                    bottom = 48.dp
+                ),
+                verticalArrangement = Arrangement.spacedBy(18.dp),
+                horizontalArrangement = Arrangement.spacedBy(18.dp)
+            ) {
+                item(
+                    span = { androidx.tv.foundation.lazy.grid.TvGridItemSpan(maxLineSpan) },
+                    contentType = "header"
+                ) {
+                    Text(
+                        text = "More Like $mediaTitle",
+                        style = ArflixTypography.sectionTitle.copy(
+                            fontSize = 22.sp,
+                            fontWeight = FontWeight.Bold
+                        ),
+                        color = TextPrimary,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 8.dp)
+                    )
+                }
+
+                itemsIndexed(
+                    items = uiState.items,
+                    key = { _, item -> "${item.mediaType}-${item.id}" },
+                    contentType = { _, _ -> "recommendation_card" }
+                ) { _, item ->
+                    MediaCard(
+                        item = item,
+                        width = cardWidth,
+                        isLandscape = false,
+                        showTitle = true,
+                        titleMaxLines = 2,
+                        onClick = { onNavigateToDetails(item.mediaType, item.id) }
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/recommendations/RecommendationsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/recommendations/RecommendationsScreen.kt
@@ -101,7 +101,7 @@ class RecommendationsViewModel @Inject constructor(
                 onFailure = { throwable ->
                     RecommendationsUiState(
                         isLoading = false,
-                        error = throwable.message ?: stringResource(R.string.recommendations_network_error)
+                        error = throwable.message ?: "Unable to load recommendations"
                     )
                 }
             )

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/recommendations/RecommendationsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/recommendations/RecommendationsScreen.kt
@@ -5,12 +5,12 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -18,6 +18,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
@@ -25,6 +26,7 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -33,9 +35,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.foundation.lazy.grid.TvGridCells
+import androidx.tv.foundation.lazy.grid.TvGridItemSpan
 import androidx.tv.foundation.lazy.grid.TvLazyVerticalGrid
 import androidx.tv.foundation.lazy.grid.itemsIndexed
+import androidx.tv.material3.Button
 import androidx.tv.material3.Text
+import com.arflix.tv.R
 import com.arflix.tv.data.model.MediaItem
 import com.arflix.tv.data.model.MediaType
 import com.arflix.tv.data.repository.MediaRepository
@@ -53,9 +58,14 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+/**
+ * UI state for the Recommendations screen.
+ * @param isEmptyResult true when the API returned successfully but had zero results
+ */
 data class RecommendationsUiState(
     val items: List<MediaItem> = emptyList(),
     val isLoading: Boolean = true,
+    val isEmptyResult: Boolean = false,
     val error: String? = null
 )
 
@@ -72,20 +82,29 @@ class RecommendationsViewModel @Inject constructor(
             _uiState.value = RecommendationsUiState(isLoading = true)
             val result = runCatching {
                 mediaRepository.getSimilar(mediaType, mediaId)
-            }.getOrDefault(emptyList())
-
-            _uiState.value = if (result.isEmpty()) {
-                RecommendationsUiState(
-                    items = emptyList(),
-                    isLoading = false,
-                    error = "No recommendations found for this title."
-                )
-            } else {
-                RecommendationsUiState(
-                    items = result,
-                    isLoading = false
-                )
             }
+
+            _uiState.value = result.fold(
+                onSuccess = { items ->
+                    if (items.isEmpty()) {
+                        RecommendationsUiState(
+                            isLoading = false,
+                            isEmptyResult = true
+                        )
+                    } else {
+                        RecommendationsUiState(
+                            items = items,
+                            isLoading = false
+                        )
+                    }
+                },
+                onFailure = { throwable ->
+                    RecommendationsUiState(
+                        isLoading = false,
+                        error = throwable.message ?: stringResource(R.string.recommendations_network_error)
+                    )
+                }
+            )
         }
     }
 
@@ -133,10 +152,9 @@ fun RecommendationsScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(appBackgroundDark())
+            // Key.Escape for keyboard support — BackHandler handles system/remote back
             .onPreviewKeyEvent { event ->
-                if (event.type == KeyEventType.KeyDown &&
-                    (event.key == Key.Back || event.key == Key.Escape)
-                ) {
+                if (event.type == KeyEventType.KeyDown && event.key == Key.Escape) {
                     onBack()
                     true
                 } else {
@@ -149,7 +167,7 @@ fun RecommendationsScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .background(
-                    androidx.compose.ui.graphics.Brush.radialGradient(
+                    Brush.radialGradient(
                         colors = listOf(
                             Color(0xFF2F9C95).copy(alpha = 0.25f),
                             Color.Transparent
@@ -185,9 +203,9 @@ fun RecommendationsScreen(
                 }
             }
 
-            // Title overlay
+            // Title overlay during loading
             Text(
-                text = "More Like $mediaTitle",
+                text = stringResource(R.string.more_like, mediaTitle),
                 style = ArflixTypography.sectionTitle.copy(
                     fontSize = 22.sp,
                     fontWeight = FontWeight.Bold
@@ -198,26 +216,38 @@ fun RecommendationsScreen(
                     .padding(start = 42.dp, top = 18.dp, end = 42.dp)
             )
         } else if (uiState.error != null) {
-            // Error state
+            // Network / API error state — show retry button
             Box(
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center
             ) {
-                androidx.compose.foundation.layout.Column(
+                Column(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     Text(
-                        text = uiState.error ?: "Something went wrong",
+                        text = uiState.error ?: stringResource(R.string.recommendations_network_error),
                         style = ArflixTypography.body,
                         color = TextSecondary
                     )
-                    androidx.tv.material3.Button(
+                    Button(
                         onClick = { viewModel.retry(mediaType, mediaId) }
                     ) {
-                        Text(androidx.compose.ui.res.stringResource(com.arflix.tv.R.string.retry))
+                        Text(stringResource(R.string.retry))
                     }
                 }
+            }
+        } else if (uiState.isEmptyResult) {
+            // Graceful empty state — API returned successfully but no recommendations exist
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = stringResource(R.string.no_recommendations_found),
+                    style = ArflixTypography.body,
+                    color = TextSecondary
+                )
             }
         } else {
             // Recommendations grid
@@ -237,11 +267,11 @@ fun RecommendationsScreen(
                 horizontalArrangement = Arrangement.spacedBy(18.dp)
             ) {
                 item(
-                    span = { androidx.tv.foundation.lazy.grid.TvGridItemSpan(maxLineSpan) },
+                    span = { TvGridItemSpan(maxLineSpan) },
                     contentType = "header"
                 ) {
                     Text(
-                        text = "More Like $mediaTitle",
+                        text = stringResource(R.string.more_like, mediaTitle),
                         style = ArflixTypography.sectionTitle.copy(
                             fontSize = 22.sp,
                             fontWeight = FontWeight.Bold

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -237,4 +237,10 @@
     <string name="ai_key_saved_title">API key saved</string>
     <string name="ai_key_saved_subtitle">AI translation is ready to use</string>
     <string name="ai_qr_scan_hint">Scan with your phone — choose Groq or Gemini</string>
+
+    <!-- Recommendations -->
+    <string name="your_watch_history">Your Watch History</string>
+    <string name="no_recommendations_found">No recommendations found for this title</string>
+    <string name="recommendations_network_error">Unable to load recommendations. Check your connection and try again</string>
+    <string name="more_like">More Like %s</string>
 </resources>


### PR DESCRIPTION
## Feature: "Your Watch History" + "Because You Watched" Recommendations

### Summary
Adds a **"Your Watch History"** row to the home screen (positioned after Continue Watching) showing all items from the user's watch history. Clicking any item opens a **recommendations grid** powered by TMDB's `getRecommendations()` API — the same engine used by the existing "More Like This" in the Details screen.

### Changes

| File | Change |
|------|--------|
| `ui/screens/recommendations/RecommendationsScreen.kt` | **New** — ViewModel + TvLazyVerticalGrid backed by `MediaRepository.getSimilar()` |
| `navigation/AppNavigation.kt` | Added `Screen.Recommendations` route + NavHost composable |
| `ui/screens/home/HomeViewModel.kt` | Injects "Your Watch History" row from cached Continue Watching items |
| `ui/screens/home/HomeScreen.kt` | Wired D-pad + click routing for watch_history category items |

### User Flow
