### PR TITLE
fix: persist skip profile selection state

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -951,6 +951,7 @@ class SettingsViewModel @Inject constructor(
                 prefs[com.arflix.tv.util.SKIP_PROFILE_SELECTION_KEY] = skip
             }
             _uiState.value = _uiState.value.copy(skipProfileSelection = skip)
+            syncLocalStateToCloud(silent = true)
         }
     }
 


### PR DESCRIPTION
Summary: trigger cloud sync when Skip Profile Selection is toggled so cloud restore does not overwrite the new value on next startup. Testing: ./gradlew test fails in this environment with message 25.0.2 before and after this change.