### PR TITLE
fix: keep app update install progress visible

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -1267,6 +1267,8 @@ fun SettingsScreen(
                             isAppUpdateAvailable = uiState.isAppUpdateAvailable,
                             availableAppUpdate = uiState.availableAppUpdate,
                             downloadedApkPath = uiState.downloadedApkPath,
+                            isInstallingUpdate = uiState.isInstallingAppUpdate,
+                            appUpdateInstallMessage = uiState.appUpdateInstallMessage,
                             focusedIndex = if (activeZone == Zone.CONTENT) contentFocusIndex else -1,
                             onConnectCloud = {
                                 if (isTouchDevice) {
@@ -1706,6 +1708,8 @@ fun SettingsScreen(
                 progress = uiState.appUpdateDownloadProgress,
                 errorMessage = uiState.appUpdateError,
                 downloadedApkPath = uiState.downloadedApkPath,
+                isInstalling = uiState.isInstallingAppUpdate,
+                installMessage = uiState.appUpdateInstallMessage,
                 isSelfUpdateSupported = uiState.isSelfUpdateSupported,
                 onDismiss = { viewModel.dismissAppUpdateDialog() },
                 onIgnore = { viewModel.ignoreAppUpdate() },
@@ -3570,13 +3574,15 @@ private fun AppUpdateModal(
     progress: Float?,
     errorMessage: String?,
     downloadedApkPath: String?,
+    isInstalling: Boolean,
+    installMessage: String?,
     isSelfUpdateSupported: Boolean,
     onDismiss: () -> Unit,
     onIgnore: () -> Unit,
     onDownload: () -> Unit,
     onInstall: () -> Unit
 ) {
-    val primaryEnabled = downloadedApkPath != null || isAppUpdateAvailable
+    val primaryEnabled = !isInstalling && (downloadedApkPath != null || isAppUpdateAvailable)
     var focusedIndex by remember(primaryEnabled) { mutableIntStateOf(if (primaryEnabled) 2 else 0) }
     val focusRequester = remember { FocusRequester() }
 
@@ -3634,6 +3640,7 @@ private fun AppUpdateModal(
 
             val subtitle = when {
                 !isSelfUpdateSupported -> "This install is managed by the Play Store."
+                isInstalling -> "Installing update…"
                 downloadedApkPath != null && update != null -> "${update.title} is ready to install."
                 isAppUpdateAvailable && update != null -> "Update available: ${update.title} (${update.tag})"
                 update != null -> "You already have the latest version installed."
@@ -3663,6 +3670,21 @@ private fun AppUpdateModal(
             }
 
             when {
+                isInstalling -> {
+                    Text("Installing update...", style = ArflixTypography.body, color = TextPrimary)
+                    Spacer(modifier = Modifier.height(8.dp))
+                    androidx.compose.material3.LinearProgressIndicator(
+                        modifier = Modifier.fillMaxWidth(),
+                        color = SuccessGreen,
+                        trackColor = Color.White.copy(alpha = 0.08f)
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = installMessage ?: "The system installer may show a confirmation screen.",
+                        style = ArflixTypography.caption,
+                        color = TextSecondary
+                    )
+                }
                 isDownloading -> {
                     Text("Downloading update...", style = ArflixTypography.body, color = TextPrimary)
                     Spacer(modifier = Modifier.height(8.dp))
@@ -3699,6 +3721,7 @@ private fun AppUpdateModal(
                 UpdateActionButton("Ignore", focusedIndex == 1, onIgnore)
                 UpdateActionButton(
                     when {
+                        isInstalling -> "Installing"
                         downloadedApkPath != null -> "Install"
                         isAppUpdateAvailable -> "Download"
                         else -> "Latest"
@@ -3706,7 +3729,7 @@ private fun AppUpdateModal(
                     focusedIndex == 2,
                     if (downloadedApkPath != null) onInstall else onDownload,
                     highlighted = true,
-                    enabled = isSelfUpdateSupported && !isChecking && primaryEnabled
+                    enabled = isSelfUpdateSupported && !isChecking && !isInstalling && primaryEnabled
                 )
             }
         }
@@ -6579,6 +6602,8 @@ private fun AccountsSettings(
     isAppUpdateAvailable: Boolean,
     availableAppUpdate: com.arflix.tv.updater.AppUpdate?,
     downloadedApkPath: String?,
+    isInstallingUpdate: Boolean,
+    appUpdateInstallMessage: String?,
     focusedIndex: Int,
     onConnectCloud: () -> Unit,
     onDisconnectCloud: () -> Unit,
@@ -6655,6 +6680,7 @@ private fun AccountsSettings(
             title = stringResource(R.string.app_update),
             description = when {
                 !isSelfUpdateSupported -> "This install is managed by the Play Store"
+                isInstallingUpdate -> appUpdateInstallMessage ?: "Installing update in progress"
                 downloadedApkPath != null -> "Latest update downloaded and ready to install"
                 isCheckingForUpdate -> "Checking GitHub Releases for a newer APK"
                 isAppUpdateAvailable -> "Update available: ${availableAppUpdate?.title ?: availableAppUpdate?.tag ?: "latest release"}"
@@ -6663,6 +6689,7 @@ private fun AccountsSettings(
             },
             actionLabel = when {
                 !isSelfUpdateSupported -> "PLAY"
+                isInstallingUpdate -> "INSTALLING"
                 downloadedApkPath != null -> "INSTALL"
                 isCheckingForUpdate -> "CHECKING"
                 isAppUpdateAvailable -> "UPDATE"
@@ -6670,7 +6697,9 @@ private fun AccountsSettings(
             },
             isFocused = focusedIndex == 3,
             onClick = {
-                if (downloadedApkPath != null) onInstallUpdate() else onCheckUpdates()
+                if (!isInstallingUpdate) {
+                    if (downloadedApkPath != null) onInstallUpdate() else onCheckUpdates()
+                }
             },
             modifier = Modifier.settingsFocusSlot(3)
         )

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -50,6 +50,7 @@ import com.arflix.tv.ui.components.CARD_LAYOUT_MODE_LANDSCAPE
 import com.arflix.tv.ui.components.normalizeCardLayoutMode
 import com.arflix.tv.updater.ApkDownloader
 import com.arflix.tv.updater.ApkInstaller
+import com.arflix.tv.updater.AppUpdateInstallPhase
 import com.arflix.tv.updater.AppUpdate
 import com.arflix.tv.updater.AppUpdateRepository
 import com.arflix.tv.updater.UpdatePreferences
@@ -154,6 +155,8 @@ data class SettingsUiState(
     val isDownloadingAppUpdate: Boolean = false,
     val appUpdateDownloadProgress: Float? = null,
     val downloadedApkPath: String? = null,
+    val isInstallingAppUpdate: Boolean = false,
+    val appUpdateInstallMessage: String? = null,
     val showAppUpdateDialog: Boolean = false,
     val showUnknownSourcesDialog: Boolean = false,
     val appUpdateError: String? = null,
@@ -346,6 +349,7 @@ class SettingsViewModel @Inject constructor(
 
     init {
         loadSettings()
+        observeAppUpdateInstallState()
         observeProfileChanges()
         observeAddons()
         observeTorrServer()
@@ -374,6 +378,26 @@ class SettingsViewModel @Inject constructor(
                 if (ignoredNormalized == installedNormalized || !com.arflix.tv.updater.VersionUtils.isRemoteNewer(ignoredTag, installedVersion)) {
                     updatePreferences.setIgnoredTag(null)
                 }
+            }
+        }
+    }
+
+    private fun observeAppUpdateInstallState() {
+        viewModelScope.launch {
+            updatePreferences.installStatus.collect { status ->
+                val installing = status.phase == AppUpdateInstallPhase.INSTALLING ||
+                    status.phase == AppUpdateInstallPhase.PENDING_USER_ACTION
+                val current = _uiState.value
+                _uiState.value = current.copy(
+                    isInstallingAppUpdate = installing,
+                    appUpdateInstallMessage = status.message,
+                    downloadedApkPath = if (status.phase == AppUpdateInstallPhase.SUCCESS) null else current.downloadedApkPath,
+                    isAppUpdateAvailable = if (status.phase == AppUpdateInstallPhase.SUCCESS) false else current.isAppUpdateAvailable,
+                    showAppUpdateDialog = if (status.phase == AppUpdateInstallPhase.SUCCESS) false else current.showAppUpdateDialog,
+                    appUpdateError = if (status.phase == AppUpdateInstallPhase.FAILED && !status.message.isNullOrBlank()) {
+                        status.message
+                    } else current.appUpdateError
+                )
             }
         }
     }
@@ -2602,6 +2626,8 @@ class SettingsViewModel @Inject constructor(
             _uiState.value = _uiState.value.copy(
                 isDownloadingAppUpdate = true,
                 appUpdateDownloadProgress = 0f,
+                isInstallingAppUpdate = false,
+                appUpdateInstallMessage = null,
                 appUpdateError = null,
                 showAppUpdateDialog = true
             )
@@ -2646,34 +2672,63 @@ class SettingsViewModel @Inject constructor(
         val apkPath = _uiState.value.downloadedApkPath ?: return
         val apkFile = File(apkPath)
         if (!apkFile.exists()) {
-            _uiState.value = _uiState.value.copy(appUpdateError = "Downloaded file is missing", showAppUpdateDialog = true)
+            _uiState.value = _uiState.value.copy(
+                isInstallingAppUpdate = false,
+                appUpdateInstallMessage = null,
+                appUpdateError = "Downloaded file is missing",
+                showAppUpdateDialog = true
+            )
             return
         }
 
         if (!ApkInstaller.canRequestPackageInstalls(context)) {
-            _uiState.value = _uiState.value.copy(showUnknownSourcesDialog = true, showAppUpdateDialog = false)
+            _uiState.value = _uiState.value.copy(
+                isInstallingAppUpdate = false,
+                appUpdateInstallMessage = null,
+                showUnknownSourcesDialog = true,
+                showAppUpdateDialog = false
+            )
             return
         }
 
         // Check for signature conflict before installing
         val conflictMsg = ApkInstaller.checkSignatureConflict(context, apkFile)
         if (conflictMsg != null) {
-            _uiState.value = _uiState.value.copy(appUpdateError = conflictMsg, showAppUpdateDialog = true)
+            _uiState.value = _uiState.value.copy(
+                isInstallingAppUpdate = false,
+                appUpdateInstallMessage = null,
+                appUpdateError = conflictMsg,
+                showAppUpdateDialog = true
+            )
             return
         }
 
-        ApkInstaller.launchInstall(context, apkFile)
-        // Mark this release as "installed" so we don't re-show the update after the
-        // system installer returns the user to the old still-running process.
         viewModelScope.launch {
-            _uiState.value.availableAppUpdate?.tag?.let { tag ->
-                updatePreferences.setIgnoredTag(tag)
+            updatePreferences.setInstallStatus(
+                AppUpdateInstallPhase.INSTALLING,
+                "Starting installation…"
+            )
+        }
+        val launchStarted = ApkInstaller.launchInstall(context, apkFile)
+        if (!launchStarted) {
+            viewModelScope.launch {
+                updatePreferences.setInstallStatus(
+                    AppUpdateInstallPhase.FAILED,
+                    "Could not launch the system installer."
+                )
             }
+            _uiState.value = _uiState.value.copy(
+                isInstallingAppUpdate = false,
+                appUpdateInstallMessage = null,
+                appUpdateError = "Could not launch the system installer.",
+                showAppUpdateDialog = true
+            )
+            return
         }
         _uiState.value = _uiState.value.copy(
-            downloadedApkPath = null,
-            showAppUpdateDialog = false,
-            isAppUpdateAvailable = false,
+            showAppUpdateDialog = true,
+            isInstallingAppUpdate = true,
+            appUpdateInstallMessage = "Waiting for installer confirmation…",
             toastMessage = "Installing update...",
             toastType = ToastType.INFO
         )

--- a/app/src/main/kotlin/com/arflix/tv/updater/ApkInstallReceiver.kt
+++ b/app/src/main/kotlin/com/arflix/tv/updater/ApkInstallReceiver.kt
@@ -7,6 +7,10 @@ import android.content.pm.PackageInstaller
 import android.os.Build
 import android.util.Log
 import android.widget.Toast
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.arflix.tv.util.settingsDataStore
+import kotlinx.coroutines.runBlocking
 
 /**
  * Handles PackageInstaller session callbacks for the in-app APK updater.
@@ -27,6 +31,11 @@ class ApkInstallReceiver : BroadcastReceiver() {
 
         when (status) {
             PackageInstaller.STATUS_PENDING_USER_ACTION -> {
+                persistInstallStatus(
+                    context,
+                    AppUpdateInstallPhase.PENDING_USER_ACTION,
+                    "Confirm installation in the system prompt."
+                )
                 // The system needs user confirmation — launch the confirm Activity.
                 val confirmIntent: Intent? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     intent.getParcelableExtra(Intent.EXTRA_INTENT, Intent::class.java)
@@ -58,6 +67,11 @@ class ApkInstallReceiver : BroadcastReceiver() {
 
             PackageInstaller.STATUS_SUCCESS -> {
                 Log.i(TAG, "Update installed successfully.")
+                persistInstallStatus(
+                    context,
+                    AppUpdateInstallPhase.SUCCESS,
+                    "Update installed successfully."
+                )
                 // No toast needed — the new APK is installing/replacing the running process.
             }
 
@@ -78,6 +92,11 @@ class ApkInstallReceiver : BroadcastReceiver() {
                     PackageInstaller.STATUS_FAILURE_STORAGE -> "Not enough storage to install update."
                     else -> message ?: "Update install failed."
                 }
+                persistInstallStatus(
+                    context,
+                    AppUpdateInstallPhase.FAILED,
+                    userMessage
+                )
                 showToast(context, userMessage)
             }
 
@@ -97,6 +116,8 @@ class ApkInstallReceiver : BroadcastReceiver() {
 
     companion object {
         private const val TAG = "ApkInstallReceiver"
+        private val installPhaseKey = stringPreferencesKey("app_update_install_phase")
+        private val installMessageKey = stringPreferencesKey("app_update_install_message")
 
         /**
          * The broadcast action used for PackageInstaller session callbacks. Derived from the
@@ -105,6 +126,23 @@ class ApkInstallReceiver : BroadcastReceiver() {
          */
         fun actionFor(context: Context): String {
             return "${context.packageName}.INSTALL_COMPLETE"
+        }
+    }
+
+    private fun persistInstallStatus(
+        context: Context,
+        phase: AppUpdateInstallPhase,
+        message: String?
+    ) {
+        runBlocking {
+            context.settingsDataStore.edit { prefs ->
+                prefs[installPhaseKey] = phase.name
+                if (message.isNullOrBlank()) {
+                    prefs.remove(installMessageKey)
+                } else {
+                    prefs[installMessageKey] = message
+                }
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/arflix/tv/updater/ApkInstaller.kt
+++ b/app/src/main/kotlin/com/arflix/tv/updater/ApkInstaller.kt
@@ -99,7 +99,7 @@ object ApkInstaller {
             .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
     }
 
-    fun launchInstall(context: Context, apkFile: File) {
+    fun launchInstall(context: Context, apkFile: File): Boolean {
         // Try session-based installer first (smoother UX on Android 5+)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             try {
@@ -137,7 +137,7 @@ object ApkInstaller {
 
                 session.commit(pendingIntent.intentSender)
                 session.close()
-                return
+                return true
             } catch (e: Exception) {
                 System.err.println("[ApkInstaller] Session install failed, falling back to ACTION_VIEW: ${e.message}")
             }
@@ -152,8 +152,10 @@ object ApkInstaller {
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
 
             context.startActivity(intent)
+            return true
         } catch (e: Exception) {
             System.err.println("[ApkInstaller] Fallback ACTION_VIEW install failed: ${e.message}")
+            return false
         }
     }
 }

--- a/app/src/main/kotlin/com/arflix/tv/updater/UpdatePreferences.kt
+++ b/app/src/main/kotlin/com/arflix/tv/updater/UpdatePreferences.kt
@@ -11,15 +11,39 @@ import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
 
+enum class AppUpdateInstallPhase {
+    IDLE,
+    INSTALLING,
+    PENDING_USER_ACTION,
+    SUCCESS,
+    FAILED
+}
+
+data class AppUpdateInstallStatus(
+    val phase: AppUpdateInstallPhase,
+    val message: String?
+)
+
 @Singleton
 class UpdatePreferences @Inject constructor(
     @ApplicationContext private val context: Context
 ) {
     private val ignoredTagKey = stringPreferencesKey("app_update_ignored_release_tag")
     private val lastCheckAtKey = longPreferencesKey("app_update_last_check_at_ms")
+    private val installPhaseKey = stringPreferencesKey("app_update_install_phase")
+    private val installMessageKey = stringPreferencesKey("app_update_install_message")
 
     val ignoredTag: Flow<String?> = context.settingsDataStore.data.map { prefs -> prefs[ignoredTagKey] }
     val lastCheckAtMs: Flow<Long> = context.settingsDataStore.data.map { prefs -> prefs[lastCheckAtKey] ?: 0L }
+    val installStatus: Flow<AppUpdateInstallStatus> = context.settingsDataStore.data.map { prefs ->
+        val phase = prefs[installPhaseKey]
+            ?.let { raw -> runCatching { AppUpdateInstallPhase.valueOf(raw) }.getOrNull() }
+            ?: AppUpdateInstallPhase.IDLE
+        AppUpdateInstallStatus(
+            phase = phase,
+            message = prefs[installMessageKey]
+        )
+    }
 
     suspend fun setIgnoredTag(tag: String?) {
         context.settingsDataStore.edit { prefs ->
@@ -31,5 +55,20 @@ class UpdatePreferences @Inject constructor(
         context.settingsDataStore.edit { prefs ->
             prefs[lastCheckAtKey] = value
         }
+    }
+
+    suspend fun setInstallStatus(phase: AppUpdateInstallPhase, message: String? = null) {
+        context.settingsDataStore.edit { prefs ->
+            prefs[installPhaseKey] = phase.name
+            if (message.isNullOrBlank()) {
+                prefs.remove(installMessageKey)
+            } else {
+                prefs[installMessageKey] = message
+            }
+        }
+    }
+
+    suspend fun clearInstallStatus() {
+        setInstallStatus(AppUpdateInstallPhase.IDLE, null)
     }
 }


### PR DESCRIPTION
Keep the app update modal visible after Install, persist installer status (installing/pending/success/failed), and surface that status in Settings so installation progress does not disappear. In this environment, gradlew test fails early with 25.0.2 before task execution.