### PR TITLE
refactor: Improve data repository lifecycle safety

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/AddonRuntimeAggregator.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/AddonRuntimeAggregator.kt
@@ -11,25 +11,19 @@ class AddonRuntimeAggregator(
         stremioAddons: List<Addon>,
         request: MovieRuntimeRequest
     ): List<StreamSource> {
-        val streams = mutableListOf<StreamSource>()
-        if (stremioAddons.isNotEmpty()) {
-            streams += addonRuntimes[RuntimeKind.STREMIO]
-                ?.resolveMovieStreams(stremioAddons, request)
-                .orEmpty()
-        }
-        return streams
+        if (stremioAddons.isEmpty()) return emptyList()
+        return addonRuntimes[RuntimeKind.STREMIO]
+            ?.resolveMovieStreams(stremioAddons, request)
+            .orEmpty()
     }
 
     suspend fun resolveEpisodeStreams(
         stremioAddons: List<Addon>,
         request: EpisodeRuntimeRequest
     ): List<StreamSource> {
-        val streams = mutableListOf<StreamSource>()
-        if (stremioAddons.isNotEmpty()) {
-            streams += addonRuntimes[RuntimeKind.STREMIO]
-                ?.resolveEpisodeStreams(stremioAddons, request)
-                .orEmpty()
-        }
-        return streams
+        if (stremioAddons.isEmpty()) return emptyList()
+        return addonRuntimes[RuntimeKind.STREMIO]
+            ?.resolveEpisodeStreams(stremioAddons, request)
+            .orEmpty()
     }
 }

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncCoordinator.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncCoordinator.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -18,40 +19,48 @@ class CloudSyncCoordinator @Inject constructor(
     private val authRepository: AuthRepository
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val lifecycleLock = Any()
     private var collectorJob: Job? = null
     private var flushJob: Job? = null
 
-    private val started = java.util.concurrent.atomic.AtomicBoolean(false)
+    private val started = AtomicBoolean(false)
 
     fun start() {
-        if (!started.compareAndSet(false, true)) return
-        collectorJob = scope.launch {
-            invalidationBus.events.collectLatest { invalidation ->
-                if (authRepository.getCurrentUserId().isNullOrBlank()) return@collectLatest
-                cloudSyncRepository.markLocalStateDirty()
-                scheduleFlush(invalidation)
+        synchronized(lifecycleLock) {
+            if (!started.compareAndSet(false, true)) return
+            collectorJob = scope.launch {
+                invalidationBus.events.collectLatest { invalidation ->
+                    if (authRepository.getCurrentUserId().isNullOrBlank()) return@collectLatest
+                    cloudSyncRepository.markLocalStateDirty()
+                    scheduleFlush(invalidation)
+                }
             }
         }
     }
 
     fun stop() {
-        started.set(false)
-        collectorJob?.cancel()
-        flushJob?.cancel()
-        collectorJob = null
-        flushJob = null
+        synchronized(lifecycleLock) {
+            started.set(false)
+            collectorJob?.cancel()
+            flushJob?.cancel()
+            collectorJob = null
+            flushJob = null
+        }
     }
 
     private fun scheduleFlush(invalidation: CloudSyncInvalidation) {
-        flushJob?.cancel()
-        flushJob = scope.launch {
-            delay(debounceMsFor(invalidation.scope))
-            if (authRepository.getCurrentUserId().isNullOrBlank()) return@launch
-            runCatching { cloudSyncRepository.pushToCloud() }
-                .onFailure { error ->
-                    Log.w("CloudSyncCoordinator", "Cloud push failed after ${invalidation.scope}: ${error.message}")
-                    cloudSyncRepository.markLocalStateDirty()
-                }
+        synchronized(lifecycleLock) {
+            if (!started.get()) return
+            flushJob?.cancel()
+            flushJob = scope.launch {
+                delay(debounceMsFor(invalidation.scope))
+                if (authRepository.getCurrentUserId().isNullOrBlank()) return@launch
+                runCatching { cloudSyncRepository.pushToCloud() }
+                    .onFailure { error ->
+                        Log.w("CloudSyncCoordinator", "Cloud push failed after ${invalidation.scope}: ${error.message}")
+                        cloudSyncRepository.markLocalStateDirty()
+                    }
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncCoordinator.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncCoordinator.kt
@@ -21,12 +21,10 @@ class CloudSyncCoordinator @Inject constructor(
     private var collectorJob: Job? = null
     private var flushJob: Job? = null
 
-    @Volatile
-    private var started = false
+    private val started = java.util.concurrent.atomic.AtomicBoolean(false)
 
     fun start() {
-        if (started) return
-        started = true
+        if (!started.compareAndSet(false, true)) return
         collectorJob = scope.launch {
             invalidationBus.events.collectLatest { invalidation ->
                 if (authRepository.getCurrentUserId().isNullOrBlank()) return@collectLatest
@@ -37,7 +35,7 @@ class CloudSyncCoordinator @Inject constructor(
     }
 
     fun stop() {
-        started = false
+        started.set(false)
         collectorJob?.cancel()
         flushJob?.cancel()
         collectorJob = null

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/PlaybackTelemetryRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/PlaybackTelemetryRepository.kt
@@ -13,15 +13,17 @@ import javax.inject.Singleton
 class PlaybackTelemetryRepository @Inject constructor(
     @ApplicationContext private val context: Context
 ) {
-    private val startupSamplesKey = longPreferencesKey("telemetry_startup_samples_v1")
-    private val startupAvgMsKey = longPreferencesKey("telemetry_startup_avg_ms_v1")
-    private val startupRetriesKey = longPreferencesKey("telemetry_startup_retries_v1")
-    private val failoverAttemptsKey = longPreferencesKey("telemetry_failover_attempts_v1")
-    private val failoverSuccessesKey = longPreferencesKey("telemetry_failover_successes_v1")
-    private val longRebuffersKey = longPreferencesKey("telemetry_long_rebuffers_v1")
-    private val playbackFailuresKey = longPreferencesKey("telemetry_playback_failures_v1")
-    private val lastStartupMsKey = longPreferencesKey("telemetry_last_startup_ms_v1")
-    private val lastSessionRetriesKey = intPreferencesKey("telemetry_last_session_retries_v1")
+    private companion object {
+        val startupSamplesKey = longPreferencesKey("telemetry_startup_samples_v1")
+        val startupAvgMsKey = longPreferencesKey("telemetry_startup_avg_ms_v1")
+        val startupRetriesKey = longPreferencesKey("telemetry_startup_retries_v1")
+        val failoverAttemptsKey = longPreferencesKey("telemetry_failover_attempts_v1")
+        val failoverSuccessesKey = longPreferencesKey("telemetry_failover_successes_v1")
+        val longRebuffersKey = longPreferencesKey("telemetry_long_rebuffers_v1")
+        val playbackFailuresKey = longPreferencesKey("telemetry_playback_failures_v1")
+        val lastStartupMsKey = longPreferencesKey("telemetry_last_startup_ms_v1")
+        val lastSessionRetriesKey = intPreferencesKey("telemetry_last_session_retries_v1")
+    }
 
     suspend fun recordStartup(startupMs: Long, retries: Int, failoversBeforeStart: Int) {
         val safeStartup = startupMs.coerceAtLeast(0L)


### PR DESCRIPTION
## Original PR #11 Context

Source PR: https://github.com/Himanth-reddy/ARVIO/pull/11

CodeRabbit walkthrough from PR #11:

> Three independent repository class refactorings improve stream resolution logic clarity, add atomic lifecycle state management to prevent concurrent starts, and reorganize telemetry DataStore keys into a companion object.

## Original Changes

| Layer / File(s) | Summary |
| --- | --- |
| Stream resolution optimization<br>`app/src/main/kotlin/com/arflix/tv/data/repository/AddonRuntimeAggregator.kt` | `resolveMovieStreams` and `resolveEpisodeStreams` now use early returns on empty input and direct STREMIO runtime resolution with `.orEmpty()`, removing intermediate mutable lists and conditional blocks. |
| Lifecycle thread-safety<br>`app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncCoordinator.kt` | `started` state changed from volatile boolean to `AtomicBoolean`, with `start()` using atomic `compareAndSet(false, true)` for idempotent behavior and `stop()` resetting via `set(false)`. |
| Telemetry key organization<br>`app/src/main/kotlin/com/arflix/tv/data/repository/PlaybackTelemetryRepository.kt` | DataStore preference keys (`startupSamplesKey`, `startupAvgMsKey`, and telemetry counters) moved from instance-level properties into a `private companion object`. |

## Review Feedback Addressed

CodeRabbit flagged a remaining lifecycle race in `CloudSyncCoordinator.kt`: `AtomicBoolean.compareAndSet` serialized concurrent `start()` calls, but did not protect `collectorJob` and `flushJob` from a concurrent `stop()` call. That could allow `start()` to assign a live job after `stop()` had nulled the job fields, leaving coroutine work running while `started == false`.

CodeRabbit also suggested replacing the fully-qualified `java.util.concurrent.atomic.AtomicBoolean` usage with an import.

## Additional Commit Added

Commit: `c7d0944 fix: synchronize cloud sync coordinator lifecycle`

This commit:

- Adds a shared `lifecycleLock` in `CloudSyncCoordinator`.
- Synchronizes `start()` and `stop()` so `started`, `collectorJob`, and `flushJob` are updated together.
- Synchronizes `scheduleFlush()` and skips scheduling if the coordinator has already stopped.
- Cancels/replaces `flushJob` under the same lifecycle lock.
- Imports `AtomicBoolean` directly and uses `AtomicBoolean(false)`.

## Validation

- `./gradlew assembleSideloadDebug --no-daemon`
