### PR TITLE
fix: initialize watched cache before fetchSeasonProgress to prevent race condition

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
@@ -317,7 +317,16 @@ class DetailsViewModel @Inject constructor(
                     async { mediaRepository.getSeasonEpisodes(mediaId, seasonToLoad) }
                 } else null
 
-                // For TV shows, fetch season progress (watched/total per season)
+                // For TV shows, fetch season progress (watched/total per season).
+                // IMPORTANT: Initialize watched cache FIRST so fetchSeasonProgress()
+                // can read from the in-memory cache rather than falling back to a
+                // backend query that may return stale or empty data. The async below
+                // starts immediately, but initializeWatchedCache() runs synchronously
+                // before it, ensuring the cache is populated before fetchSeasonProgress
+                // checks getWatchedEpisodesFromCache().
+                if (mediaType == MediaType.TV) {
+                    runCatching { traktRepository.initializeWatchedCache() }
+                }
                 val seasonProgressDeferred = if (mediaType == MediaType.TV) {
                     async { fetchSeasonProgress(mediaId) }
                 } else null
@@ -1587,12 +1596,15 @@ class DetailsViewModel @Inject constructor(
                     traktRepository.markSeasonWatched(currentMediaId, season, episodeNumbers)
                 }
 
-                // 2. Remove from watch history concurrently (all episodes at once)
+                // 2. Remove from watch history FIRST (synchronous), before Supabase writes.
+                //    This avoids a race condition where removeFromHistory deletes the
+                //    just-written watched records, causing watched status to be lost on re-entry.
                 runCatching {
                     watchHistoryRepository.removeFromHistory(currentMediaId, season, null)
                 }
 
-                // 3. Concurrent Supabase writes for each episode (faster than sequential)
+                // 3. Concurrent Supabase writes for each episode (faster than sequential).
+                //    These run AFTER removeFromHistory to ensure the watched records are the final state.
                 episodeNumbers.map { epNum ->
                     async {
                         runCatching {


### PR DESCRIPTION
> ## Description
> 
> Fixes a race condition where marking a season as watched would temporarily remove the blur/spoiler filter, but the watched status would revert after browsing or re-entering the app.
> 
> ## Root Cause
> 
> In `loadDetails()`, `fetchSeasonProgress()` was launched as an `async` that starts executing immediately. However, `initializeWatchedCache()` was called much later in the sequential flow. Since `fetchSeasonProgress()` first checks the in-memory `watchedEpisodesCache` (which is empty because `initializeWatchedCache()` hasn't run yet), it falls back to `getWatchedEpisodesForShow()` which queries the backend. If the backend query returns stale or empty data, the season progress is empty, causing the blur/spoiler filter to return on re-entry.
> 
> ## Fix
> 
> Moved `initializeWatchedCache()` to run **before** `fetchSeasonProgress()` starts, ensuring the in-memory cache is populated before the progress calculation begins. The original conditional call at line 400 is now a no-op for TV shows (guarded by `cacheInitialized` in `initializeWatchedCache()`).
> 
> ## Changes
> 
> - `DetailsViewModel.kt`: Added `initializeWatchedCache()` call before the `async` block that starts `fetchSeasonProgress()` in `loadDetails()`
> 
> ## Testing
> 
> 1. Open a TV show details page
> 2. Mark a season as watched — blur/spoiler filter should be removed
> 3. Navigate away and back to the show — watched status should persist
> 4. Exit the app and re-enter — watched status should persist