### PR TITLE
prevent crashes from some addons

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
@@ -1036,7 +1036,7 @@ class StreamRepository @Inject constructor(
     }
 
     private fun supportsResourceType(resourceTypes: List<String>, requestedType: String): Boolean {
-        if (resourceTypes.isEmpty()) return true
+        if (resourceTypes.isNullOrEmpty()) return true
         val normalized = resourceTypes.map { it.trim().lowercase(Locale.US) }
         val aliases = when (requestedType) {
             "series", "tv", "show" -> setOf("series", "tv", "show")


### PR DESCRIPTION
when a Stremio addon is installed, its manifest is fetched from the network, converted to AddonManifest (which contains a list of AddonResource objects), and persisted to disk. When the app restarts and loads those  
  saved addons, Gson deserializes the stored JSON back into AddonResource objects — and if the original manifest had no types field (some addons omit it), Gson sets types to null despite the Kotlin type saying List<String>.
                                                                                                                                                                                                                                    
  So it crashes specifically when:                                
  1. The user has at least one installed addon whose manifest has a missing/null types field
  2. They navigate to a movie or episode and the app calls getStreamAddons() to figure out which addons support that content type
  3. supportsResourceType(resource.types, ...) is called with that null list → NPE

  An addon with a fully valid manifest (always includes "types": [...]) would never trigger it. It only hits users who installed certain addons that return incomplete manifests.
