### PR TITLE
Fix iOS keychain certificate import

### DIFF
--- a/iosApp/ci/prepare-signing.mjs
+++ b/iosApp/ci/prepare-signing.mjs
@@ -162,6 +162,13 @@ async function main() {
     certificatePemPath,
     "-out",
     p12Path,
+    "-legacy",
+    "-certpbe",
+    "PBE-SHA1-3DES",
+    "-keypbe",
+    "PBE-SHA1-3DES",
+    "-macalg",
+    "sha1",
     "-password",
     `pass:${p12Password}`,
   ]);


### PR DESCRIPTION
Exports the generated iOS distribution certificate using PKCS#12 settings compatible with macOS Security on the macOS 26 runner.