### PR TITLE
Add iOS cloud addon and Trakt parity foundation

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -19,6 +19,27 @@ jobs:
       - name: Install XcodeGen
         run: brew install xcodegen
 
+      - name: Write iOS runtime config
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
+        run: |
+          node - <<'NODE'
+          const fs = require('fs');
+          const path = 'iosApp/ARVIO/AppConfig.swift';
+          let source = fs.readFileSync(path, 'utf8');
+          const replacements = {
+            '__SUPABASE_URL__': process.env.SUPABASE_URL || '',
+            '__SUPABASE_ANON_KEY__': process.env.SUPABASE_ANON_KEY || '',
+            '__TRAKT_CLIENT_ID__': process.env.TRAKT_CLIENT_ID || '',
+          };
+          for (const [token, value] of Object.entries(replacements)) {
+            source = source.replaceAll(token, value.replace(/\\/g, '\\\\').replace(/"/g, '\\"'));
+          }
+          fs.writeFileSync(path, source);
+          NODE
+
       - name: Write App Store Connect key
         env:
           APP_STORE_CONNECT_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY }}

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -156,3 +156,11 @@ jobs:
           name: ARVIO-iOS-IPA
           path: ${{ runner.temp }}/export/*.ipa
           if-no-files-found: ignore
+
+      - name: Clean up temporary signing assets
+        if: always()
+        env:
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          ASC_KEY_PATH: ${{ runner.temp }}/private_keys/AuthKey_${{ secrets.APP_STORE_CONNECT_KEY_ID }}.p8
+        run: node iosApp/ci/cleanup-signing.mjs

--- a/iosApp/ARVIO/ARVIOApp.swift
+++ b/iosApp/ARVIO/ARVIOApp.swift
@@ -2,10 +2,16 @@ import SwiftUI
 
 @main
 struct ARVIOApp: App {
+    @StateObject private var appState = AppState()
+
     var body: some Scene {
         WindowGroup {
             RootView()
+                .environmentObject(appState)
                 .preferredColorScheme(.dark)
+                .task {
+                    await appState.bootstrap()
+                }
         }
     }
 }

--- a/iosApp/ARVIO/AddonService.swift
+++ b/iosApp/ARVIO/AddonService.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+struct InstalledAddon: Codable, Identifiable, Hashable {
+    let id: String
+    let name: String
+    let version: String
+    let manifestURL: String
+    let description: String?
+    let catalogs: [String]
+    let resources: [String]
+}
+
+private struct AddonManifest: Codable {
+    let id: String?
+    let name: String
+    let version: String?
+    let description: String?
+    let catalogs: [AddonCatalog]?
+    let resources: [AddonResourceValue]?
+}
+
+private struct AddonCatalog: Codable {
+    let type: String?
+    let id: String?
+    let name: String?
+}
+
+private enum AddonResourceValue: Codable {
+    case string(String)
+    case object(name: String?)
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let value = try? container.decode(String.self) {
+            self = .string(value)
+            return
+        }
+        let object = try container.decode(ResourceObject.self)
+        self = .object(name: object.name)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let value):
+            try container.encode(value)
+        case .object(let name):
+            try container.encode(ResourceObject(name: name))
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .string(let value):
+            return value
+        case .object(let name):
+            return name ?? "resource"
+        }
+    }
+
+    private struct ResourceObject: Codable {
+        let name: String?
+    }
+}
+
+@MainActor
+final class AddonService: ObservableObject {
+    @Published private(set) var addons: [InstalledAddon] = []
+    @Published var installURL = ""
+    @Published var errorMessage: String?
+
+    private let cloud: CloudSyncService
+    private let storageKey = "arvio.ios.installedAddons"
+
+    init(cloud: CloudSyncService) {
+        self.cloud = cloud
+        loadLocal()
+    }
+
+    func loadFromCloud() {
+        if !cloud.payload.addons.isEmpty {
+            addons = cloud.payload.addons
+            saveLocal()
+        }
+    }
+
+    func install() async {
+        let trimmed = installURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        do {
+            let addon = try await fetchAddon(from: trimmed)
+            if let index = addons.firstIndex(where: { $0.id == addon.id }) {
+                addons[index] = addon
+            } else {
+                addons.append(addon)
+            }
+            installURL = ""
+            errorMessage = nil
+            saveLocal()
+            await cloud.save(addons: addons)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func remove(_ addon: InstalledAddon) async {
+        addons.removeAll { $0.id == addon.id }
+        saveLocal()
+        await cloud.save(addons: addons)
+    }
+
+    private func fetchAddon(from rawURL: String) async throws -> InstalledAddon {
+        let manifestURL = normalizedManifestURL(rawURL)
+        guard let url = URL(string: manifestURL) else {
+            throw ArvioError.invalidURL(rawURL)
+        }
+        let (data, response) = try await URLSession.shared.data(from: url)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw ArvioError.requestFailed("Addon manifest failed to load")
+        }
+        let manifest = try JSONDecoder().decode(AddonManifest.self, from: data)
+        let catalogs = manifest.catalogs?.compactMap { catalog in
+            catalog.name ?? catalog.id ?? catalog.type
+        } ?? []
+        let resources = manifest.resources?.map(\.displayName) ?? []
+        return InstalledAddon(
+            id: manifest.id ?? manifestURL,
+            name: manifest.name,
+            version: manifest.version ?? "1.0.0",
+            manifestURL: manifestURL,
+            description: manifest.description,
+            catalogs: catalogs,
+            resources: resources
+        )
+    }
+
+    private func normalizedManifestURL(_ rawURL: String) -> String {
+        if rawURL.hasSuffix("/manifest.json") { return rawURL }
+        return rawURL.trimmingCharacters(in: CharacterSet(charactersIn: "/")) + "/manifest.json"
+    }
+
+    private func loadLocal() {
+        guard let data = UserDefaults.standard.data(forKey: storageKey),
+              let saved = try? JSONDecoder().decode([InstalledAddon].self, from: data) else {
+            return
+        }
+        addons = saved
+    }
+
+    private func saveLocal() {
+        guard let data = try? JSONEncoder().encode(addons) else { return }
+        UserDefaults.standard.set(data, forKey: storageKey)
+    }
+}

--- a/iosApp/ARVIO/AddonsView.swift
+++ b/iosApp/ARVIO/AddonsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct AddonsView: View {
     @EnvironmentObject private var appState: AppState
+    @State private var installURL = ""
 
     var body: some View {
         ScrollView {
@@ -16,7 +17,7 @@ struct AddonsView: View {
                 }
 
                 HStack(spacing: 12) {
-                    TextField("https://example.com/manifest.json", text: $appState.addons.installURL)
+                    TextField("https://example.com/manifest.json", text: $installURL)
                         .textInputAutocapitalization(.never)
                         .keyboardType(.URL)
                         .padding(16)
@@ -25,7 +26,11 @@ struct AddonsView: View {
                         .foregroundStyle(ArvioTheme.textPrimary)
 
                     Button("Install") {
-                        Task { await appState.addons.install() }
+                        appState.addons.installURL = installURL
+                        Task {
+                            await appState.addons.install()
+                            installURL = appState.addons.installURL
+                        }
                     }
                     .buttonStyle(.borderedProminent)
                     .tint(ArvioTheme.gold)

--- a/iosApp/ARVIO/AddonsView.swift
+++ b/iosApp/ARVIO/AddonsView.swift
@@ -1,0 +1,99 @@
+import SwiftUI
+
+struct AddonsView: View {
+    @EnvironmentObject private var appState: AppState
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 22) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Addons")
+                        .font(.system(size: 38, weight: .bold))
+                        .foregroundStyle(ArvioTheme.textPrimary)
+                    Text("Install Stremio-compatible addon manifests and sync them through your ARVIO cloud account.")
+                        .font(.system(size: 17))
+                        .foregroundStyle(ArvioTheme.textSecondary)
+                }
+
+                HStack(spacing: 12) {
+                    TextField("https://example.com/manifest.json", text: $appState.addons.installURL)
+                        .textInputAutocapitalization(.never)
+                        .keyboardType(.URL)
+                        .padding(16)
+                        .background(RoundedRectangle(cornerRadius: 8).fill(ArvioTheme.panel))
+                        .overlay(RoundedRectangle(cornerRadius: 8).stroke(ArvioTheme.border, lineWidth: 1))
+                        .foregroundStyle(ArvioTheme.textPrimary)
+
+                    Button("Install") {
+                        Task { await appState.addons.install() }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(ArvioTheme.gold)
+                }
+
+                if let error = appState.addons.errorMessage {
+                    Text(error)
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(Color.red.opacity(0.9))
+                }
+
+                if appState.addons.addons.isEmpty {
+                    EmptyStatePanel(
+                        title: "No addons installed",
+                        message: appState.auth.isAuthenticated ? "Install an addon URL to make it available across your ARVIO devices." : "Sign in first so addon changes sync to cloud."
+                    )
+                } else {
+                    LazyVStack(spacing: 12) {
+                        ForEach(appState.addons.addons) { addon in
+                            AddonRow(addon: addon) {
+                                Task { await appState.addons.remove(addon) }
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(28)
+        }
+    }
+}
+
+struct AddonRow: View {
+    let addon: InstalledAddon
+    let onRemove: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 16) {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 10) {
+                    Text(addon.name)
+                        .font(.system(size: 18, weight: .bold))
+                        .foregroundStyle(ArvioTheme.textPrimary)
+                    Text(addon.version)
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(ArvioTheme.gold)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(RoundedRectangle(cornerRadius: 6).fill(ArvioTheme.gold.opacity(0.14)))
+                }
+                if let description = addon.description, !description.isEmpty {
+                    Text(description)
+                        .font(.system(size: 14))
+                        .foregroundStyle(ArvioTheme.textSecondary)
+                        .lineLimit(2)
+                }
+                Text((addon.catalogs + addon.resources).prefix(6).joined(separator: " - "))
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(ArvioTheme.textTertiary)
+                    .lineLimit(1)
+            }
+
+            Spacer()
+
+            Button("Remove", role: .destructive, action: onRemove)
+                .buttonStyle(.bordered)
+        }
+        .padding(18)
+        .background(RoundedRectangle(cornerRadius: 8).fill(ArvioTheme.panel))
+        .overlay(RoundedRectangle(cornerRadius: 8).stroke(ArvioTheme.border, lineWidth: 1))
+    }
+}

--- a/iosApp/ARVIO/AppConfig.swift
+++ b/iosApp/ARVIO/AppConfig.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+enum AppConfig {
+    static let supabaseURL = "__SUPABASE_URL__"
+    static let supabaseAnonKey = "__SUPABASE_ANON_KEY__"
+    static let traktClientID = "__TRAKT_CLIENT_ID__"
+
+    static var isCloudConfigured: Bool {
+        supabaseURL.hasPrefix("https://") &&
+        supabaseURL.contains(".supabase.co") &&
+        supabaseAnonKey.count > 40
+    }
+
+    static var isTraktConfigured: Bool {
+        !traktClientID.isEmpty && !traktClientID.hasPrefix("__")
+    }
+}

--- a/iosApp/ARVIO/AppState.swift
+++ b/iosApp/ARVIO/AppState.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Combine
+
+@MainActor
+final class AppState: ObservableObject {
+    let auth: AuthService
+    let cloud: CloudSyncService
+    let addons: AddonService
+    let trakt: TraktService
+    private var cancellables: Set<AnyCancellable> = []
+
+    init() {
+        let auth = AuthService()
+        let cloud = CloudSyncService(auth: auth)
+        self.auth = auth
+        self.cloud = cloud
+        self.addons = AddonService(cloud: cloud)
+        self.trakt = TraktService()
+
+        [auth.objectWillChange, cloud.objectWillChange, addons.objectWillChange, trakt.objectWillChange]
+            .forEach { publisher in
+                publisher
+                    .sink { [weak self] _ in self?.objectWillChange.send() }
+                    .store(in: &cancellables)
+            }
+    }
+
+    func bootstrap() async {
+        await auth.restore()
+        await cloud.pull()
+        addons.loadFromCloud()
+        if trakt.isConnected {
+            await trakt.loadWatchlist()
+        }
+    }
+}

--- a/iosApp/ARVIO/AuthService.swift
+++ b/iosApp/ARVIO/AuthService.swift
@@ -1,0 +1,281 @@
+import Foundation
+import Security
+
+struct AuthSession: Codable, Equatable {
+    let accessToken: String
+    let refreshToken: String
+    let userId: String
+    let email: String
+    let expiresAt: Date
+}
+
+struct UserProfile: Codable, Equatable {
+    let id: String
+    let email: String?
+    let addons: String?
+    let defaultSubtitle: String?
+    let autoPlayNext: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case email
+        case addons
+        case defaultSubtitle = "default_subtitle"
+        case autoPlayNext = "auto_play_next"
+    }
+}
+
+private struct SupabaseAuthResponse: Decodable {
+    let accessToken: String
+    let refreshToken: String
+    let expiresIn: Int?
+    let user: SupabaseUser?
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case refreshToken = "refresh_token"
+        case expiresIn = "expires_in"
+        case user
+    }
+}
+
+private struct SupabaseUser: Decodable {
+    let id: String
+    let email: String?
+}
+
+private struct EmailPasswordBody: Encodable {
+    let email: String
+    let password: String
+}
+
+private struct RefreshBody: Encodable {
+    let refreshToken: String
+
+    enum CodingKeys: String, CodingKey {
+        case refreshToken = "refresh_token"
+    }
+}
+
+final class KeychainStore {
+    private let service = "com.arvio.ios.session"
+
+    func save<T: Encodable>(_ value: T, account: String) throws {
+        let data = try JSONEncoder().encode(value)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        SecItemDelete(query as CFDictionary)
+        var attributes = query
+        attributes[kSecValueData as String] = data
+        attributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        let status = SecItemAdd(attributes as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw ArvioError.requestFailed("Unable to save secure session")
+        }
+    }
+
+    func load<T: Decodable>(_ type: T.Type, account: String) -> T? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true
+        ]
+        var item: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
+              let data = item as? Data else {
+            return nil
+        }
+        return try? JSONDecoder().decode(type, from: data)
+    }
+
+    func delete(account: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}
+
+@MainActor
+final class AuthService: ObservableObject {
+    @Published private(set) var session: AuthSession?
+    @Published private(set) var profile: UserProfile?
+    @Published private(set) var isLoading = false
+    @Published var errorMessage: String?
+
+    private let client = JSONClient()
+    private let keychain = KeychainStore()
+    private let sessionAccount = "supabase-session"
+
+    init() {
+        session = keychain.load(AuthSession.self, account: sessionAccount)
+    }
+
+    var isAuthenticated: Bool {
+        session != nil
+    }
+
+    func restore() async {
+        guard let existing = session else { return }
+        do {
+            if existing.expiresAt.timeIntervalSinceNow < 120 {
+                try await refreshSession()
+            }
+            try await loadProfile()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func signIn(email: String, password: String) async {
+        await authenticate(path: "/auth/v1/token?grant_type=password", body: EmailPasswordBody(email: email, password: password))
+    }
+
+    func signUp(email: String, password: String) async {
+        await authenticate(path: "/auth/v1/signup", body: EmailPasswordBody(email: email, password: password))
+    }
+
+    func signOut() {
+        session = nil
+        profile = nil
+        errorMessage = nil
+        keychain.delete(account: sessionAccount)
+    }
+
+    func accessToken() async throws -> String {
+        guard let current = session else { throw ArvioError.notAuthenticated }
+        if current.expiresAt.timeIntervalSinceNow < 120 {
+            try await refreshSession()
+        }
+        guard let token = session?.accessToken else { throw ArvioError.notAuthenticated }
+        return token
+    }
+
+    func loadProfile() async throws {
+        guard let current = session else { throw ArvioError.notAuthenticated }
+        let rows: [UserProfile] = try await supabaseRequest(
+            "/rest/v1/profiles?id=eq.\(current.userId)&select=id,email,addons,default_subtitle,auto_play_next",
+            token: current.accessToken
+        )
+        profile = rows.first ?? UserProfile(id: current.userId, email: current.email, addons: nil, defaultSubtitle: nil, autoPlayNext: nil)
+    }
+
+    func supabaseRequest<T: Decodable, B: Encodable>(
+        _ path: String,
+        method: String = "GET",
+        token: String,
+        prefer: String? = nil,
+        body: B? = nil
+    ) async throws -> T {
+        guard AppConfig.isCloudConfigured else {
+            throw ArvioError.missingConfiguration("Supabase")
+        }
+        guard let url = URL(string: AppConfig.supabaseURL + path) else {
+            throw ArvioError.invalidURL(path)
+        }
+        var headers = [
+            "apikey": AppConfig.supabaseAnonKey,
+            "Authorization": "Bearer \(token)"
+        ]
+        if let prefer {
+            headers["Prefer"] = prefer
+        }
+        return try await client.request(url, method: method, headers: headers, body: body)
+    }
+
+    func supabaseRequest<T: Decodable>(
+        _ path: String,
+        method: String = "GET",
+        token: String,
+        prefer: String? = nil
+    ) async throws -> T {
+        let body: EmptyBody? = nil
+        return try await supabaseRequest(path, method: method, token: token, prefer: prefer, body: body)
+    }
+
+    private func authenticate(path: String, body: EmailPasswordBody) async {
+        guard AppConfig.isCloudConfigured else {
+            errorMessage = "Supabase is not configured for iOS"
+            return
+        }
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+
+        do {
+            guard let url = URL(string: AppConfig.supabaseURL + path) else {
+                throw ArvioError.invalidURL(path)
+            }
+            let response: SupabaseAuthResponse = try await client.request(
+                url,
+                method: "POST",
+                headers: ["apikey": AppConfig.supabaseAnonKey],
+                body: body
+            )
+            try persist(response: response, fallbackEmail: body.email)
+            try await loadProfile()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func refreshSession() async throws {
+        guard AppConfig.isCloudConfigured else {
+            throw ArvioError.missingConfiguration("Supabase")
+        }
+        guard let current = session else { throw ArvioError.notAuthenticated }
+        guard let url = URL(string: AppConfig.supabaseURL + "/auth/v1/token?grant_type=refresh_token") else {
+            throw ArvioError.invalidURL("refresh")
+        }
+        let response: SupabaseAuthResponse = try await client.request(
+            url,
+            method: "POST",
+            headers: ["apikey": AppConfig.supabaseAnonKey],
+            body: RefreshBody(refreshToken: current.refreshToken)
+        )
+        try persist(response: response, fallbackEmail: current.email)
+    }
+
+    private func persist(response: SupabaseAuthResponse, fallbackEmail: String) throws {
+        guard let userId = response.user?.id ?? decodeSubject(response.accessToken) else {
+            throw ArvioError.requestFailed("Auth response missing user")
+        }
+        let email = response.user?.email ?? decodeEmail(response.accessToken) ?? fallbackEmail
+        let expiresAt = Date().addingTimeInterval(TimeInterval(response.expiresIn ?? 3600))
+        let newSession = AuthSession(
+            accessToken: response.accessToken,
+            refreshToken: response.refreshToken,
+            userId: userId,
+            email: email,
+            expiresAt: expiresAt
+        )
+        try keychain.save(newSession, account: sessionAccount)
+        session = newSession
+    }
+
+    private func decodeSubject(_ jwt: String) -> String? {
+        decodePayload(jwt)?["sub"] as? String
+    }
+
+    private func decodeEmail(_ jwt: String) -> String? {
+        decodePayload(jwt)?["email"] as? String
+    }
+
+    private func decodePayload(_ jwt: String) -> [String: Any]? {
+        let parts = jwt.split(separator: ".")
+        guard parts.count >= 2 else { return nil }
+        var base64 = String(parts[1]).replacingOccurrences(of: "-", with: "+").replacingOccurrences(of: "_", with: "/")
+        while base64.count % 4 != 0 { base64.append("=") }
+        guard let data = Data(base64Encoded: base64),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return json
+    }
+}

--- a/iosApp/ARVIO/CloudSyncService.swift
+++ b/iosApp/ARVIO/CloudSyncService.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+struct CloudPayload: Codable {
+    var version: Int
+    var addons: [InstalledAddon]
+    var updatedAt: TimeInterval
+
+    static let empty = CloudPayload(version: 1, addons: [], updatedAt: Date().timeIntervalSince1970)
+}
+
+private struct AccountSyncRow: Codable {
+    let userId: String?
+    let payload: String?
+    let updatedAt: String?
+
+    enum CodingKeys: String, CodingKey {
+        case userId = "user_id"
+        case payload
+        case updatedAt = "updated_at"
+    }
+}
+
+private struct AccountSyncUpsert: Codable {
+    let userId: String
+    let payload: String
+    let updatedAt: String
+
+    enum CodingKeys: String, CodingKey {
+        case userId = "user_id"
+        case payload
+        case updatedAt = "updated_at"
+    }
+}
+
+@MainActor
+final class CloudSyncService: ObservableObject {
+    @Published private(set) var payload = CloudPayload.empty
+    @Published private(set) var isSyncing = false
+    @Published var lastError: String?
+
+    private let auth: AuthService
+    private let decoder = JSONDecoder()
+    private let encoder = JSONEncoder()
+
+    init(auth: AuthService) {
+        self.auth = auth
+    }
+
+    func pull() async {
+        guard let session = auth.session else { return }
+        isSyncing = true
+        defer { isSyncing = false }
+        do {
+            let token = try await auth.accessToken()
+            let rows: [AccountSyncRow] = try await auth.supabaseRequest(
+                "/rest/v1/account_sync_state?user_id=eq.\(session.userId)&select=user_id,payload,updated_at",
+                token: token
+            )
+            if let rawPayload = rows.first?.payload,
+               let data = rawPayload.data(using: .utf8),
+               let decoded = try? decoder.decode(CloudPayload.self, from: data) {
+                payload = decoded
+            }
+            lastError = nil
+        } catch {
+            lastError = error.localizedDescription
+        }
+    }
+
+    func save(addons: [InstalledAddon]) async {
+        guard let session = auth.session else { return }
+        isSyncing = true
+        defer { isSyncing = false }
+        do {
+            let token = try await auth.accessToken()
+            payload = CloudPayload(version: 1, addons: addons, updatedAt: Date().timeIntervalSince1970)
+            let data = try encoder.encode(payload)
+            let raw = String(data: data, encoding: .utf8) ?? "{}"
+            let body = AccountSyncUpsert(
+                userId: session.userId,
+                payload: raw,
+                updatedAt: ISO8601DateFormatter().string(from: Date())
+            )
+            let _: EmptyResponse = try await auth.supabaseRequest(
+                "/rest/v1/account_sync_state",
+                method: "POST",
+                token: token,
+                prefer: "resolution=merge-duplicates",
+                body: body
+            )
+            lastError = nil
+        } catch {
+            lastError = error.localizedDescription
+        }
+    }
+}

--- a/iosApp/ARVIO/Networking.swift
+++ b/iosApp/ARVIO/Networking.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+enum ArvioError: LocalizedError {
+    case missingConfiguration(String)
+    case invalidURL(String)
+    case requestFailed(String)
+    case decodingFailed
+    case notAuthenticated
+
+    var errorDescription: String? {
+        switch self {
+        case .missingConfiguration(let value):
+            return "\(value) is not configured"
+        case .invalidURL(let value):
+            return "Invalid URL: \(value)"
+        case .requestFailed(let value):
+            return value
+        case .decodingFailed:
+            return "Unable to read server response"
+        case .notAuthenticated:
+            return "Sign in required"
+        }
+    }
+}
+
+struct EmptyBody: Encodable {}
+
+final class JSONClient {
+    private let session: URLSession
+    private let decoder: JSONDecoder
+    private let encoder: JSONEncoder
+
+    init(session: URLSession = .shared) {
+        self.session = session
+        self.decoder = JSONDecoder()
+        self.encoder = JSONEncoder()
+    }
+
+    func request<T: Decodable, B: Encodable>(
+        _ url: URL,
+        method: String = "GET",
+        headers: [String: String] = [:],
+        body: B? = nil
+    ) async throws -> T {
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        headers.forEach { request.setValue($0.value, forHTTPHeaderField: $0.key) }
+
+        if let body {
+            request.httpBody = try encoder.encode(body)
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw ArvioError.requestFailed("No HTTP response")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            let message = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+            throw ArvioError.requestFailed(message?.isEmpty == false ? message! : "Request failed with \(http.statusCode)")
+        }
+        if T.self == EmptyResponse.self {
+            return EmptyResponse() as! T
+        }
+        do {
+            return try decoder.decode(T.self, from: data)
+        } catch {
+            throw ArvioError.decodingFailed
+        }
+    }
+
+    func request<T: Decodable>(
+        _ url: URL,
+        method: String = "GET",
+        headers: [String: String] = [:]
+    ) async throws -> T {
+        let body: EmptyBody? = nil
+        return try await request(url, method: method, headers: headers, body: body)
+    }
+}
+
+struct EmptyResponse: Decodable {}

--- a/iosApp/ARVIO/RootView.swift
+++ b/iosApp/ARVIO/RootView.swift
@@ -4,12 +4,15 @@ enum ArvioTab: String, CaseIterable {
     case home = "Home"
     case movies = "Movies"
     case series = "Series"
+    case liveTV = "Live TV"
     case watchlist = "Watchlist"
     case search = "Search"
+    case addons = "Addons"
     case settings = "Settings"
 }
 
 struct RootView: View {
+    @EnvironmentObject private var appState: AppState
     @State private var selectedTab: ArvioTab = .home
 
     var body: some View {
@@ -34,10 +37,14 @@ struct RootView: View {
                         CatalogView(title: "Movies", subtitle: "Curated cinema and recent releases.", items: featuredItems.filter { $0.kind == .movie })
                     case .series:
                         CatalogView(title: "Series", subtitle: "Continue seasons and discover premium TV.", items: featuredItems.filter { $0.kind == .series })
+                    case .liveTV:
+                        CatalogView(title: "Live TV", subtitle: "IPTV guide and channels are next in the iOS parity queue.", items: featuredItems)
                     case .watchlist:
                         WatchlistView()
                     case .search:
                         SearchView()
+                    case .addons:
+                        AddonsView()
                     case .settings:
                         SettingsView()
                     }

--- a/iosApp/ARVIO/SettingsView.swift
+++ b/iosApp/ARVIO/SettingsView.swift
@@ -1,20 +1,121 @@
 import SwiftUI
 
 struct SettingsView: View {
+    @EnvironmentObject private var appState: AppState
+    @State private var email = ""
+    @State private var password = ""
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 18) {
-            Text("Settings")
-                .font(.system(size: 38, weight: .bold))
-                .foregroundStyle(ArvioTheme.textPrimary)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                Text("Settings")
+                    .font(.system(size: 38, weight: .bold))
+                    .foregroundStyle(ArvioTheme.textPrimary)
 
-            SettingsRow(title: "Profile", value: "Default")
-            SettingsRow(title: "Cloud sync", value: "Ready")
-            SettingsRow(title: "Trakt", value: "Connect later")
-            SettingsRow(title: "Playback", value: "Native iOS player")
-
-            Spacer()
+                cloudPanel
+                traktPanel
+                SettingsRow(title: "Cloud sync", value: appState.cloud.isSyncing ? "Syncing" : (appState.auth.isAuthenticated ? "Connected" : "Disconnected"))
+                SettingsRow(title: "Addons", value: "\(appState.addons.addons.count) installed")
+                SettingsRow(title: "Playback", value: "AVPlayer parity work pending")
+            }
+            .padding(28)
         }
-        .padding(28)
+    }
+
+    private var cloudPanel: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Cloud login")
+                        .font(.system(size: 20, weight: .bold))
+                        .foregroundStyle(ArvioTheme.textPrimary)
+                    Text(appState.auth.session?.email ?? "Use the same ARVIO account as Android.")
+                        .font(.system(size: 14))
+                        .foregroundStyle(ArvioTheme.textSecondary)
+                }
+                Spacer()
+                if appState.auth.isAuthenticated {
+                    Button("Sign out") { appState.auth.signOut() }
+                        .buttonStyle(.bordered)
+                }
+            }
+
+            if !appState.auth.isAuthenticated {
+                TextField("Email", text: $email)
+                    .textInputAutocapitalization(.never)
+                    .keyboardType(.emailAddress)
+                    .settingsField()
+                SecureField("Password", text: $password)
+                    .settingsField()
+                HStack {
+                    Button("Sign in") {
+                        Task { await appState.auth.signIn(email: email, password: password) }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(ArvioTheme.gold)
+
+                    Button("Create account") {
+                        Task { await appState.auth.signUp(email: email, password: password) }
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
+
+            if let error = appState.auth.errorMessage {
+                Text(error)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(Color.red.opacity(0.9))
+            }
+        }
+        .settingsPanel()
+    }
+
+    private var traktPanel: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Trakt")
+                        .font(.system(size: 20, weight: .bold))
+                        .foregroundStyle(ArvioTheme.textPrimary)
+                    Text(appState.trakt.isConnected ? "Connected. Watchlist sync is active." : "Link Trakt to mirror Android watchlist/history.")
+                        .font(.system(size: 14))
+                        .foregroundStyle(ArvioTheme.textSecondary)
+                }
+                Spacer()
+                if appState.trakt.isConnected {
+                    Button("Disconnect") { appState.trakt.disconnect() }
+                        .buttonStyle(.bordered)
+                } else {
+                    Button("Link") {
+                        Task { await appState.trakt.beginDeviceLink() }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(ArvioTheme.gold)
+                }
+            }
+
+            if let code = appState.trakt.deviceCode {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(code.userCode)
+                        .font(.system(size: 34, weight: .bold, design: .monospaced))
+                        .foregroundStyle(ArvioTheme.gold)
+                    Text(code.verificationURL)
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(ArvioTheme.textSecondary)
+                    Button("I approved it") {
+                        Task { await appState.trakt.pollForToken() }
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
+
+            if let error = appState.trakt.errorMessage {
+                Text(error)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(Color.red.opacity(0.9))
+            }
+        }
+        .settingsPanel()
     }
 }
 
@@ -35,5 +136,20 @@ struct SettingsRow: View {
         .padding(18)
         .background(RoundedRectangle(cornerRadius: 8).fill(ArvioTheme.panel))
         .overlay(RoundedRectangle(cornerRadius: 8).stroke(ArvioTheme.border, lineWidth: 1))
+    }
+}
+
+private extension View {
+    func settingsPanel() -> some View {
+        padding(18)
+            .background(RoundedRectangle(cornerRadius: 8).fill(ArvioTheme.panel))
+            .overlay(RoundedRectangle(cornerRadius: 8).stroke(ArvioTheme.border, lineWidth: 1))
+    }
+
+    func settingsField() -> some View {
+        padding(14)
+            .background(RoundedRectangle(cornerRadius: 8).fill(Color.black.opacity(0.28)))
+            .overlay(RoundedRectangle(cornerRadius: 8).stroke(ArvioTheme.border, lineWidth: 1))
+            .foregroundStyle(ArvioTheme.textPrimary)
     }
 }

--- a/iosApp/ARVIO/TraktService.swift
+++ b/iosApp/ARVIO/TraktService.swift
@@ -1,0 +1,189 @@
+import Foundation
+
+struct TraktDeviceCode: Decodable, Equatable {
+    let deviceCode: String
+    let userCode: String
+    let verificationURL: String
+    let expiresIn: Int
+    let interval: Int
+
+    enum CodingKeys: String, CodingKey {
+        case deviceCode = "device_code"
+        case userCode = "user_code"
+        case verificationURL = "verification_url"
+        case expiresIn = "expires_in"
+        case interval
+    }
+}
+
+struct TraktToken: Codable, Equatable {
+    let accessToken: String
+    let refreshToken: String
+    let expiresAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case refreshToken = "refresh_token"
+        case expiresAt
+    }
+}
+
+struct TraktWatchlistItem: Identifiable, Decodable, Hashable {
+    let id = UUID()
+    let type: String
+    let title: String
+    let year: Int?
+
+    enum RootKeys: String, CodingKey {
+        case type
+        case movie
+        case show
+    }
+
+    enum MediaKeys: String, CodingKey {
+        case title
+        case year
+    }
+
+    init(from decoder: Decoder) throws {
+        let root = try decoder.container(keyedBy: RootKeys.self)
+        type = try root.decode(String.self, forKey: .type)
+        if let movie = try? root.nestedContainer(keyedBy: MediaKeys.self, forKey: .movie) {
+            title = (try? movie.decode(String.self, forKey: .title)) ?? "Untitled"
+            year = try? movie.decode(Int.self, forKey: .year)
+        } else if let show = try? root.nestedContainer(keyedBy: MediaKeys.self, forKey: .show) {
+            title = (try? show.decode(String.self, forKey: .title)) ?? "Untitled"
+            year = try? show.decode(Int.self, forKey: .year)
+        } else {
+            title = "Untitled"
+            year = nil
+        }
+    }
+}
+
+private struct DeviceCodeRequest: Encodable {
+    let clientId: String
+
+    enum CodingKeys: String, CodingKey {
+        case clientId = "client_id"
+    }
+}
+
+private struct DeviceTokenRequest: Encodable {
+    let code: String
+    let clientId: String
+
+    enum CodingKeys: String, CodingKey {
+        case code
+        case clientId = "client_id"
+    }
+}
+
+private struct DeviceTokenResponse: Decodable {
+    let accessToken: String
+    let refreshToken: String
+    let expiresIn: Int
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case refreshToken = "refresh_token"
+        case expiresIn = "expires_in"
+    }
+}
+
+@MainActor
+final class TraktService: ObservableObject {
+    @Published private(set) var token: TraktToken?
+    @Published private(set) var deviceCode: TraktDeviceCode?
+    @Published private(set) var watchlist: [TraktWatchlistItem] = []
+    @Published private(set) var isLoading = false
+    @Published var errorMessage: String?
+
+    private let client = JSONClient()
+    private let keychain = KeychainStore()
+    private let tokenAccount = "trakt-token"
+    private let baseURL = "https://api.trakt.tv"
+
+    init() {
+        token = keychain.load(TraktToken.self, account: tokenAccount)
+    }
+
+    var isConnected: Bool {
+        token != nil
+    }
+
+    func beginDeviceLink() async {
+        guard AppConfig.isTraktConfigured else {
+            errorMessage = "Trakt is not configured for iOS"
+            return
+        }
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            guard let url = URL(string: "\(baseURL)/oauth/device/code") else { return }
+            deviceCode = try await client.request(
+                url,
+                method: "POST",
+                headers: ["trakt-api-version": "2", "trakt-api-key": AppConfig.traktClientID],
+                body: DeviceCodeRequest(clientId: AppConfig.traktClientID)
+            )
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func pollForToken() async {
+        guard let code = deviceCode?.deviceCode else { return }
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            guard let url = URL(string: "\(baseURL)/oauth/device/token") else { return }
+            let response: DeviceTokenResponse = try await client.request(
+                url,
+                method: "POST",
+                headers: ["trakt-api-version": "2", "trakt-api-key": AppConfig.traktClientID],
+                body: DeviceTokenRequest(code: code, clientId: AppConfig.traktClientID)
+            )
+            let newToken = TraktToken(
+                accessToken: response.accessToken,
+                refreshToken: response.refreshToken,
+                expiresAt: Date().addingTimeInterval(TimeInterval(response.expiresIn))
+            )
+            try keychain.save(newToken, account: tokenAccount)
+            token = newToken
+            deviceCode = nil
+            errorMessage = nil
+            await loadWatchlist()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func disconnect() {
+        token = nil
+        watchlist = []
+        deviceCode = nil
+        keychain.delete(account: tokenAccount)
+    }
+
+    func loadWatchlist() async {
+        guard let token else { return }
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            guard let url = URL(string: "\(baseURL)/sync/watchlist") else { return }
+            watchlist = try await client.request(
+                url,
+                headers: [
+                    "trakt-api-version": "2",
+                    "trakt-api-key": AppConfig.traktClientID,
+                    "Authorization": "Bearer \(token.accessToken)"
+                ]
+            )
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/iosApp/ARVIO/WatchlistView.swift
+++ b/iosApp/ARVIO/WatchlistView.swift
@@ -1,11 +1,83 @@
 import SwiftUI
 
 struct WatchlistView: View {
+    @EnvironmentObject private var appState: AppState
+
     var body: some View {
-        CatalogView(
-            title: "Watchlist",
-            subtitle: "Movies and shows saved for later.",
-            items: featuredItems + continueWatchingItems
-        )
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                HStack {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Watchlist")
+                            .font(.system(size: 38, weight: .bold))
+                            .foregroundStyle(ArvioTheme.textPrimary)
+                        Text(appState.trakt.isConnected ? "Synced from Trakt." : "Connect Trakt in Settings to sync your Android watchlist.")
+                            .font(.system(size: 17))
+                            .foregroundStyle(ArvioTheme.textSecondary)
+                    }
+                    Spacer()
+                    Button("Refresh") {
+                        Task { await appState.trakt.loadWatchlist() }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(ArvioTheme.gold)
+                }
+
+                if appState.trakt.watchlist.isEmpty {
+                    EmptyStatePanel(
+                        title: "No synced watchlist yet",
+                        message: appState.trakt.isConnected ? "Trakt returned no saved items." : "Your Android watchlist syncs here after Trakt is connected."
+                    )
+                } else {
+                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 210), spacing: 16)], spacing: 16) {
+                        ForEach(appState.trakt.watchlist) { item in
+                            VStack(alignment: .leading, spacing: 10) {
+                                PosterBackdrop(item: MediaItem(
+                                    title: item.title,
+                                    subtitle: item.type.capitalized,
+                                    year: item.year.map(String.init) ?? "",
+                                    duration: "Trakt",
+                                    rating: "",
+                                    kind: item.type == "movie" ? .movie : .series,
+                                    progress: 0,
+                                    palette: ["#10202a", "#071017"]
+                                ))
+                                .frame(width: 210, height: 118)
+                                .clipShape(RoundedRectangle(cornerRadius: 8))
+                                Text(item.title)
+                                    .font(.system(size: 16, weight: .semibold))
+                                    .foregroundStyle(ArvioTheme.textPrimary)
+                                    .lineLimit(1)
+                                Text(([item.type.capitalized] + (item.year.map { [String($0)] } ?? [])).joined(separator: " - "))
+                                    .font(.system(size: 13, weight: .medium))
+                                    .foregroundStyle(ArvioTheme.textTertiary)
+                            }
+                            .frame(width: 210, alignment: .leading)
+                        }
+                    }
+                }
+            }
+            .padding(28)
+        }
+    }
+}
+
+struct EmptyStatePanel: View {
+    let title: String
+    let message: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.system(size: 20, weight: .bold))
+                .foregroundStyle(ArvioTheme.textPrimary)
+            Text(message)
+                .font(.system(size: 15))
+                .foregroundStyle(ArvioTheme.textSecondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(22)
+        .background(RoundedRectangle(cornerRadius: 8).fill(ArvioTheme.panel))
+        .overlay(RoundedRectangle(cornerRadius: 8).stroke(ArvioTheme.border, lineWidth: 1))
     }
 }

--- a/iosApp/ci/cleanup-signing.mjs
+++ b/iosApp/ci/cleanup-signing.mjs
@@ -1,0 +1,78 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import https from "node:https";
+
+const keyId = process.env.APP_STORE_CONNECT_KEY_ID;
+const issuerId = process.env.APP_STORE_CONNECT_ISSUER_ID;
+const keyPath = process.env.ASC_KEY_PATH;
+const certificateId = process.env.IOS_CREATED_CERTIFICATE_ID;
+const profileId = process.env.IOS_CREATED_PROFILE_ID;
+
+if (!keyId || !issuerId || !keyPath) {
+  console.log("App Store Connect credentials unavailable; skipping signing cleanup.");
+  process.exit(0);
+}
+
+function base64Url(input) {
+  return Buffer.from(input)
+    .toString("base64")
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+function createJwt() {
+  const now = Math.floor(Date.now() / 1000);
+  const header = base64Url(JSON.stringify({ alg: "ES256", kid: keyId, typ: "JWT" }));
+  const payload = base64Url(JSON.stringify({
+    iss: issuerId,
+    iat: now,
+    exp: now + 1200,
+    aud: "appstoreconnect-v1",
+  }));
+  const unsignedToken = `${header}.${payload}`;
+  const signature = crypto.sign("sha256", Buffer.from(unsignedToken), {
+    key: fs.readFileSync(keyPath, "utf8"),
+    dsaEncoding: "ieee-p1363",
+  });
+  return `${unsignedToken}.${base64Url(signature)}`;
+}
+
+function deleteResource(path) {
+  return new Promise((resolve, reject) => {
+    const request = https.request(new URL(`https://api.appstoreconnect.apple.com/v1${path}`), {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${createJwt()}`,
+        Accept: "application/json",
+      },
+    }, (response) => {
+      let body = "";
+      response.setEncoding("utf8");
+      response.on("data", (chunk) => { body += chunk; });
+      response.on("end", () => {
+        if ((response.statusCode >= 200 && response.statusCode < 300) || response.statusCode === 404) {
+          resolve(response.statusCode);
+          return;
+        }
+        reject(new Error(`DELETE ${path} failed with ${response.statusCode}: ${body}`));
+      });
+    });
+    request.on("error", reject);
+    request.end();
+  });
+}
+
+async function main() {
+  if (profileId) {
+    console.log(`Deleted profile ${profileId}: ${await deleteResource(`/profiles/${profileId}`)}`);
+  }
+  if (certificateId) {
+    console.log(`Deleted certificate ${certificateId}: ${await deleteResource(`/certificates/${certificateId}`)}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
Adds real iOS parity foundations for ARVIO: Supabase email auth/session restore, cloud account sync payload access, addon install/list/remove with cloud persistence, Trakt device linking/watchlist sync, runtime secret injection for TestFlight, and automatic cleanup of temporary Apple signing assets.