### PR TITLE
Add iOS playback, Live TV, and profiles

### DIFF
--- a/iosApp/ARVIO/AddonService.swift
+++ b/iosApp/ARVIO/AddonService.swift
@@ -8,6 +8,80 @@ struct InstalledAddon: Codable, Identifiable, Hashable {
     let description: String?
     let catalogs: [String]
     let resources: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case version
+        case manifestURL
+        case description
+        case catalogs
+        case resources
+        case url
+        case transportUrl
+        case manifest
+    }
+
+    init(
+        id: String,
+        name: String,
+        version: String,
+        manifestURL: String,
+        description: String?,
+        catalogs: [String],
+        resources: [String]
+    ) {
+        self.id = id
+        self.name = name
+        self.version = version
+        self.manifestURL = manifestURL
+        self.description = description
+        self.catalogs = catalogs
+        self.resources = resources
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = (try? container.decode(String.self, forKey: .id)) ?? UUID().uuidString
+        name = (try? container.decode(String.self, forKey: .name)) ?? "Addon"
+        version = (try? container.decode(String.self, forKey: .version)) ?? "1.0.0"
+        description = try? container.decode(String.self, forKey: .description)
+        let rawManifestURL = try? container.decode(String.self, forKey: .manifestURL)
+        let url = try? container.decode(String.self, forKey: .url)
+        let transportURL = try? container.decode(String.self, forKey: .transportUrl)
+        manifestURL = Self.normalizedManifestURL(rawManifestURL ?? url ?? transportURL ?? "")
+
+        if let androidManifest = try? container.decode(AddonManifest.self, forKey: .manifest) {
+            catalogs = androidManifest.catalogs?.compactMap { $0.name ?? $0.id ?? $0.type } ?? []
+            resources = androidManifest.resources?.map(\.displayName) ?? []
+        } else {
+            catalogs = (try? container.decode([String].self, forKey: .catalogs)) ?? []
+            resources = (try? container.decode([String].self, forKey: .resources)) ?? []
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(name, forKey: .name)
+        try container.encode(version, forKey: .version)
+        try container.encode(manifestURL, forKey: .manifestURL)
+        try container.encode(description, forKey: .description)
+        try container.encode(catalogs, forKey: .catalogs)
+        try container.encode(resources, forKey: .resources)
+        try container.encode(manifestBaseURL(manifestURL), forKey: .url)
+        try container.encode(manifestBaseURL(manifestURL), forKey: .transportUrl)
+    }
+
+    private static func normalizedManifestURL(_ rawURL: String) -> String {
+        guard !rawURL.isEmpty else { return "" }
+        if rawURL.hasSuffix("/manifest.json") { return rawURL }
+        return rawURL.trimmingCharacters(in: CharacterSet(charactersIn: "/")) + "/manifest.json"
+    }
+
+    private func manifestBaseURL(_ rawURL: String) -> String {
+        rawURL.replacingOccurrences(of: "/manifest.json", with: "")
+    }
 }
 
 private struct AddonManifest: Codable {
@@ -71,6 +145,7 @@ final class AddonService: ObservableObject {
 
     private let cloud: CloudSyncService
     private let storageKey = "arvio.ios.installedAddons"
+    private var activeProfileId: String?
 
     init(cloud: CloudSyncService) {
         self.cloud = cloud
@@ -78,10 +153,19 @@ final class AddonService: ObservableObject {
     }
 
     func loadFromCloud() {
-        if !cloud.payload.addons.isEmpty {
-            addons = cloud.payload.addons
+        let profileAddons = activeProfileId.flatMap { cloud.payload.addonsByProfile?[$0] }
+        let mergedByProfile = cloud.payload.addonsByProfile?.values.flatMap { $0 } ?? []
+        let resolved = profileAddons ?? (!mergedByProfile.isEmpty ? mergedByProfile : cloud.payload.addons)
+        let valid = deduplicate(resolved).filter { !$0.manifestURL.isEmpty }
+        if !valid.isEmpty {
+            addons = valid
             saveLocal()
         }
+    }
+
+    func setActiveProfileId(_ profileId: String?) {
+        activeProfileId = profileId
+        loadFromCloud()
     }
 
     func install() async {
@@ -97,7 +181,7 @@ final class AddonService: ObservableObject {
             installURL = ""
             errorMessage = nil
             saveLocal()
-            await cloud.save(addons: addons)
+            await cloud.save(addons: addons, profileId: activeProfileId)
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -106,7 +190,7 @@ final class AddonService: ObservableObject {
     func remove(_ addon: InstalledAddon) async {
         addons.removeAll { $0.id == addon.id }
         saveLocal()
-        await cloud.save(addons: addons)
+        await cloud.save(addons: addons, profileId: activeProfileId)
     }
 
     private func fetchAddon(from rawURL: String) async throws -> InstalledAddon {
@@ -150,5 +234,15 @@ final class AddonService: ObservableObject {
     private func saveLocal() {
         guard let data = try? JSONEncoder().encode(addons) else { return }
         UserDefaults.standard.set(data, forKey: storageKey)
+    }
+
+    private func deduplicate(_ values: [InstalledAddon]) -> [InstalledAddon] {
+        var seen = Set<String>()
+        return values.filter { addon in
+            let key = addon.id + "|" + addon.manifestURL
+            if seen.contains(key) { return false }
+            seen.insert(key)
+            return true
+        }
     }
 }

--- a/iosApp/ARVIO/AppConfig.swift
+++ b/iosApp/ARVIO/AppConfig.swift
@@ -5,6 +5,14 @@ enum AppConfig {
     static let supabaseAnonKey = "__SUPABASE_ANON_KEY__"
     static let traktClientID = "__TRAKT_CLIENT_ID__"
 
+    static var tmdbProxyURL: String {
+        "\(supabaseURL)/functions/v1/tmdb-proxy"
+    }
+
+    static var traktProxyURL: String {
+        "\(supabaseURL)/functions/v1/trakt-proxy"
+    }
+
     static var isCloudConfigured: Bool {
         supabaseURL.hasPrefix("https://") &&
         supabaseURL.contains(".supabase.co") &&

--- a/iosApp/ARVIO/AppConfig.swift
+++ b/iosApp/ARVIO/AppConfig.swift
@@ -20,6 +20,6 @@ enum AppConfig {
     }
 
     static var isTraktConfigured: Bool {
-        !traktClientID.isEmpty && !traktClientID.hasPrefix("__")
+        isCloudConfigured
     }
 }

--- a/iosApp/ARVIO/AppState.swift
+++ b/iosApp/ARVIO/AppState.swift
@@ -9,6 +9,8 @@ final class AppState: ObservableObject {
     let trakt: TraktService
     let tmdb: TmdbService
     let streams: StreamResolver
+    let iptv: IptvService
+    let profiles: ProfileService
     @Published var selectedMedia: MediaItem?
     @Published var selectedStream: ResolvedStream?
     private var cancellables: Set<AnyCancellable> = []
@@ -20,14 +22,21 @@ final class AppState: ObservableObject {
         let trakt = TraktService()
         let tmdb = TmdbService()
         let streams = StreamResolver(tmdb: tmdb, addons: addons)
+        let iptv = IptvService(cloud: cloud)
+        let profiles = ProfileService(cloud: cloud)
         self.auth = auth
         self.cloud = cloud
         self.addons = addons
         self.trakt = trakt
         self.tmdb = tmdb
         self.streams = streams
+        self.iptv = iptv
+        self.profiles = profiles
+        profiles.onActiveProfileChanged = { profileId in
+            iptv.setActiveProfileId(profileId)
+        }
 
-        [auth.objectWillChange, cloud.objectWillChange, addons.objectWillChange, trakt.objectWillChange, tmdb.objectWillChange, streams.objectWillChange]
+        [auth.objectWillChange, cloud.objectWillChange, addons.objectWillChange, trakt.objectWillChange, tmdb.objectWillChange, streams.objectWillChange, iptv.objectWillChange, profiles.objectWillChange]
             .forEach { publisher in
                 publisher
                     .sink { [weak self] _ in self?.objectWillChange.send() }
@@ -39,6 +48,9 @@ final class AppState: ObservableObject {
         await auth.restore()
         await cloud.pull()
         addons.loadFromCloud()
+        profiles.loadFromCloud()
+        profiles.ensureDefault(email: auth.session?.email)
+        iptv.setActiveProfileId(profiles.activeProfile?.id)
         if trakt.isConnected {
             await trakt.loadWatchlist()
         }

--- a/iosApp/ARVIO/AppState.swift
+++ b/iosApp/ARVIO/AppState.swift
@@ -11,6 +11,7 @@ final class AppState: ObservableObject {
     let streams: StreamResolver
     let iptv: IptvService
     let profiles: ProfileService
+    let watchHistory: WatchHistoryService
     @Published var selectedMedia: MediaItem?
     @Published var selectedStream: ResolvedStream?
     private var cancellables: Set<AnyCancellable> = []
@@ -24,6 +25,7 @@ final class AppState: ObservableObject {
         let streams = StreamResolver(tmdb: tmdb, addons: addons)
         let iptv = IptvService(cloud: cloud)
         let profiles = ProfileService(cloud: cloud)
+        let watchHistory = WatchHistoryService(auth: auth, trakt: trakt)
         self.auth = auth
         self.cloud = cloud
         self.addons = addons
@@ -32,11 +34,15 @@ final class AppState: ObservableObject {
         self.streams = streams
         self.iptv = iptv
         self.profiles = profiles
+        self.watchHistory = watchHistory
         profiles.onActiveProfileChanged = { profileId in
+            addons.setActiveProfileId(profileId)
             iptv.setActiveProfileId(profileId)
+            watchHistory.setActiveProfileId(profileId)
+            Task { await watchHistory.load() }
         }
 
-        [auth.objectWillChange, cloud.objectWillChange, addons.objectWillChange, trakt.objectWillChange, tmdb.objectWillChange, streams.objectWillChange, iptv.objectWillChange, profiles.objectWillChange]
+        [auth.objectWillChange, cloud.objectWillChange, addons.objectWillChange, trakt.objectWillChange, tmdb.objectWillChange, streams.objectWillChange, iptv.objectWillChange, profiles.objectWillChange, watchHistory.objectWillChange]
             .forEach { publisher in
                 publisher
                     .sink { [weak self] _ in self?.objectWillChange.send() }
@@ -50,10 +56,13 @@ final class AppState: ObservableObject {
         addons.loadFromCloud()
         profiles.loadFromCloud()
         profiles.ensureDefault(email: auth.session?.email)
+        addons.setActiveProfileId(profiles.activeProfile?.id)
         iptv.setActiveProfileId(profiles.activeProfile?.id)
+        watchHistory.setActiveProfileId(profiles.activeProfile?.id)
         if trakt.isConnected {
             await trakt.loadWatchlist()
         }
+        await watchHistory.load()
         await tmdb.loadHome()
     }
 }

--- a/iosApp/ARVIO/AppState.swift
+++ b/iosApp/ARVIO/AppState.swift
@@ -12,6 +12,7 @@ final class AppState: ObservableObject {
     let iptv: IptvService
     let profiles: ProfileService
     let watchHistory: WatchHistoryService
+    let settings: SettingsService
     @Published var selectedMedia: MediaItem?
     @Published var selectedStream: ResolvedStream?
     private var cancellables: Set<AnyCancellable> = []
@@ -26,6 +27,7 @@ final class AppState: ObservableObject {
         let iptv = IptvService(cloud: cloud)
         let profiles = ProfileService(cloud: cloud)
         let watchHistory = WatchHistoryService(auth: auth, trakt: trakt)
+        let settings = SettingsService(cloud: cloud)
         self.auth = auth
         self.cloud = cloud
         self.addons = addons
@@ -35,14 +37,16 @@ final class AppState: ObservableObject {
         self.iptv = iptv
         self.profiles = profiles
         self.watchHistory = watchHistory
+        self.settings = settings
         profiles.onActiveProfileChanged = { profileId in
             addons.setActiveProfileId(profileId)
             iptv.setActiveProfileId(profileId)
             watchHistory.setActiveProfileId(profileId)
+            settings.setActiveProfileId(profileId)
             Task { await watchHistory.load() }
         }
 
-        [auth.objectWillChange, cloud.objectWillChange, addons.objectWillChange, trakt.objectWillChange, tmdb.objectWillChange, streams.objectWillChange, iptv.objectWillChange, profiles.objectWillChange, watchHistory.objectWillChange]
+        [auth.objectWillChange, cloud.objectWillChange, addons.objectWillChange, trakt.objectWillChange, tmdb.objectWillChange, streams.objectWillChange, iptv.objectWillChange, profiles.objectWillChange, watchHistory.objectWillChange, settings.objectWillChange]
             .forEach { publisher in
                 publisher
                     .sink { [weak self] _ in self?.objectWillChange.send() }
@@ -52,17 +56,22 @@ final class AppState: ObservableObject {
 
     func bootstrap() async {
         await auth.restore()
-        await cloud.pull()
-        addons.loadFromCloud()
-        profiles.loadFromCloud()
-        profiles.ensureDefault(email: auth.session?.email)
-        addons.setActiveProfileId(profiles.activeProfile?.id)
-        iptv.setActiveProfileId(profiles.activeProfile?.id)
-        watchHistory.setActiveProfileId(profiles.activeProfile?.id)
+        await reloadCloudState()
         if trakt.isConnected {
             await trakt.loadWatchlist()
         }
         await watchHistory.load()
         await tmdb.loadHome()
+    }
+
+    func reloadCloudState() async {
+        await cloud.pull()
+        profiles.loadFromCloud()
+        profiles.ensureDefault(email: auth.session?.email)
+        let profileId = profiles.activeProfile?.id
+        addons.setActiveProfileId(profileId)
+        iptv.setActiveProfileId(profileId)
+        watchHistory.setActiveProfileId(profileId)
+        settings.setActiveProfileId(profileId)
     }
 }

--- a/iosApp/ARVIO/AppState.swift
+++ b/iosApp/ARVIO/AppState.swift
@@ -7,17 +7,27 @@ final class AppState: ObservableObject {
     let cloud: CloudSyncService
     let addons: AddonService
     let trakt: TraktService
+    let tmdb: TmdbService
+    let streams: StreamResolver
+    @Published var selectedMedia: MediaItem?
+    @Published var selectedStream: ResolvedStream?
     private var cancellables: Set<AnyCancellable> = []
 
     init() {
         let auth = AuthService()
         let cloud = CloudSyncService(auth: auth)
+        let addons = AddonService(cloud: cloud)
+        let trakt = TraktService()
+        let tmdb = TmdbService()
+        let streams = StreamResolver(tmdb: tmdb, addons: addons)
         self.auth = auth
         self.cloud = cloud
-        self.addons = AddonService(cloud: cloud)
-        self.trakt = TraktService()
+        self.addons = addons
+        self.trakt = trakt
+        self.tmdb = tmdb
+        self.streams = streams
 
-        [auth.objectWillChange, cloud.objectWillChange, addons.objectWillChange, trakt.objectWillChange]
+        [auth.objectWillChange, cloud.objectWillChange, addons.objectWillChange, trakt.objectWillChange, tmdb.objectWillChange, streams.objectWillChange]
             .forEach { publisher in
                 publisher
                     .sink { [weak self] _ in self?.objectWillChange.send() }
@@ -32,5 +42,6 @@ final class AppState: ObservableObject {
         if trakt.isConnected {
             await trakt.loadWatchlist()
         }
+        await tmdb.loadHome()
     }
 }

--- a/iosApp/ARVIO/CloudSyncService.swift
+++ b/iosApp/ARVIO/CloudSyncService.swift
@@ -3,9 +3,67 @@ import Foundation
 struct CloudPayload: Codable {
     var version: Int
     var addons: [InstalledAddon]
+    var activeProfileId: String?
+    var profiles: [ArvioProfile]?
+    var iptvByProfile: [String: IptvCloudProfileState]?
+    var iptvM3uUrl: String?
+    var iptvEpgUrl: String?
+    var iptvFavoriteGroups: [String]?
+    var iptvFavoriteChannels: [String]?
     var updatedAt: TimeInterval
 
     static let empty = CloudPayload(version: 1, addons: [], updatedAt: Date().timeIntervalSince1970)
+
+    enum CodingKeys: String, CodingKey {
+        case version
+        case addons
+        case activeProfileId
+        case profiles
+        case iptvByProfile
+        case iptvM3uUrl
+        case iptvEpgUrl
+        case iptvFavoriteGroups
+        case iptvFavoriteChannels
+        case updatedAt
+    }
+
+    init(
+        version: Int,
+        addons: [InstalledAddon],
+        activeProfileId: String? = nil,
+        profiles: [ArvioProfile]? = nil,
+        iptvByProfile: [String: IptvCloudProfileState]? = nil,
+        iptvM3uUrl: String? = nil,
+        iptvEpgUrl: String? = nil,
+        iptvFavoriteGroups: [String]? = nil,
+        iptvFavoriteChannels: [String]? = nil,
+        updatedAt: TimeInterval
+    ) {
+        self.version = version
+        self.addons = addons
+        self.activeProfileId = activeProfileId
+        self.profiles = profiles
+        self.iptvByProfile = iptvByProfile
+        self.iptvM3uUrl = iptvM3uUrl
+        self.iptvEpgUrl = iptvEpgUrl
+        self.iptvFavoriteGroups = iptvFavoriteGroups
+        self.iptvFavoriteChannels = iptvFavoriteChannels
+        self.updatedAt = updatedAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        version = (try? container.decode(Int.self, forKey: .version)) ?? 1
+        addons = (try? container.decode([InstalledAddon].self, forKey: .addons)) ?? []
+        activeProfileId = try? container.decode(String.self, forKey: .activeProfileId)
+        profiles = try? container.decode([ArvioProfile].self, forKey: .profiles)
+        iptvByProfile = try? container.decode([String: IptvCloudProfileState].self, forKey: .iptvByProfile)
+        iptvM3uUrl = try? container.decode(String.self, forKey: .iptvM3uUrl)
+        iptvEpgUrl = try? container.decode(String.self, forKey: .iptvEpgUrl)
+        iptvFavoriteGroups = try? container.decode([String].self, forKey: .iptvFavoriteGroups)
+        iptvFavoriteChannels = try? container.decode([String].self, forKey: .iptvFavoriteChannels)
+        updatedAt = (try? container.decode(TimeInterval.self, forKey: .updatedAt)) ?? Date().timeIntervalSince1970
+    }
 }
 
 private struct AccountSyncRow: Codable {
@@ -41,6 +99,7 @@ final class CloudSyncService: ObservableObject {
     private let auth: AuthService
     private let decoder = JSONDecoder()
     private let encoder = JSONEncoder()
+    private var rawPayloadObject: [String: Any] = [:]
 
     init(auth: AuthService) {
         self.auth = auth
@@ -60,6 +119,7 @@ final class CloudSyncService: ObservableObject {
                let data = rawPayload.data(using: .utf8),
                let decoded = try? decoder.decode(CloudPayload.self, from: data) {
                 payload = decoded
+                rawPayloadObject = (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
             }
             lastError = nil
         } catch {
@@ -68,13 +128,53 @@ final class CloudSyncService: ObservableObject {
     }
 
     func save(addons: [InstalledAddon]) async {
+        await save(addons: addons, iptv: nil)
+    }
+
+    func save(iptv: IptvCloudProfileState, profileId: String) async {
+        await save(addons: nil, iptv: iptv, iptvProfileId: profileId)
+    }
+
+    func save(profiles: [ArvioProfile], activeProfileId: String?) async {
+        await save(addons: nil, iptv: nil, profiles: profiles, activeProfileId: activeProfileId)
+    }
+
+    private func save(
+        addons: [InstalledAddon]?,
+        iptv: IptvCloudProfileState?,
+        iptvProfileId: String? = nil,
+        profiles: [ArvioProfile]? = nil,
+        activeProfileId: String? = nil
+    ) async {
         guard let session = auth.session else { return }
         isSyncing = true
         defer { isSyncing = false }
         do {
             let token = try await auth.accessToken()
-            payload = CloudPayload(version: 1, addons: addons, updatedAt: Date().timeIntervalSince1970)
-            let data = try encoder.encode(payload)
+            var object = rawPayloadObject
+            object["version"] = 1
+            object["updatedAt"] = Date().timeIntervalSince1970
+            if let addons {
+                object["addons"] = try jsonObject(addons)
+            }
+            if let iptv {
+                object["iptvM3uUrl"] = iptv.m3uUrl
+                object["iptvEpgUrl"] = iptv.epgUrl
+                object["iptvFavoriteGroups"] = iptv.favoriteGroups
+                object["iptvFavoriteChannels"] = iptv.favoriteChannels
+                var byProfile = object["iptvByProfile"] as? [String: Any] ?? [:]
+                byProfile[iptvProfileId ?? session.userId] = try jsonObject(iptv)
+                object["iptvByProfile"] = byProfile
+            }
+            if let profiles {
+                object["profiles"] = try jsonObject(profiles)
+                if let activeProfileId = activeProfileId ?? profiles.first?.id {
+                    object["activeProfileId"] = activeProfileId
+                } else {
+                    object["activeProfileId"] = NSNull()
+                }
+            }
+            let data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
             let raw = String(data: data, encoding: .utf8) ?? "{}"
             let body = AccountSyncUpsert(
                 userId: session.userId,
@@ -85,12 +185,19 @@ final class CloudSyncService: ObservableObject {
                 "/rest/v1/account_sync_state",
                 method: "POST",
                 token: token,
-                prefer: "resolution=merge-duplicates",
+                prefer: "return=minimal,resolution=merge-duplicates",
                 body: body
             )
+            rawPayloadObject = object
+            payload = (try? decoder.decode(CloudPayload.self, from: data)) ?? payload
             lastError = nil
         } catch {
             lastError = error.localizedDescription
         }
+    }
+
+    private func jsonObject<T: Encodable>(_ value: T) throws -> Any {
+        let data = try encoder.encode(value)
+        return try JSONSerialization.jsonObject(with: data)
     }
 }

--- a/iosApp/ARVIO/CloudSyncService.swift
+++ b/iosApp/ARVIO/CloudSyncService.swift
@@ -3,14 +3,32 @@ import Foundation
 struct CloudPayload: Codable {
     var version: Int
     var addons: [InstalledAddon]
-    var addonsByProfile: [String: [InstalledAddon]]?
-    var activeProfileId: String?
-    var profiles: [ArvioProfile]?
-    var iptvByProfile: [String: IptvCloudProfileState]?
-    var iptvM3uUrl: String?
-    var iptvEpgUrl: String?
-    var iptvFavoriteGroups: [String]?
-    var iptvFavoriteChannels: [String]?
+    var addonsByProfile: [String: [InstalledAddon]]? = nil
+    var activeProfileId: String? = nil
+    var profiles: [ArvioProfile]? = nil
+    var profileSettingsById: [String: CloudProfileSettings]? = nil
+    var defaultSubtitle: String? = nil
+    var defaultAudioLanguage: String? = nil
+    var cardLayoutMode: String? = nil
+    var frameRateMatchingMode: String? = nil
+    var autoPlayNext: Bool? = nil
+    var autoPlaySingleSource: Bool? = nil
+    var autoPlayMinQuality: String? = nil
+    var includeSpecials: Bool? = nil
+    var dnsProvider: String? = nil
+    var subtitleUsageJson: String? = nil
+    var subtitleSettingsUpdatedAt: Int? = nil
+    var skipProfileSelection: Bool? = nil
+    var subtitleAiEnabled: Bool? = nil
+    var subtitleAiAutoSelect: Bool? = nil
+    var subtitleAiApiKey: String? = nil
+    var subtitleAiModel: String? = nil
+    var subtitleRemoveHearingImpaired: Bool? = nil
+    var iptvByProfile: [String: IptvCloudProfileState]? = nil
+    var iptvM3uUrl: String? = nil
+    var iptvEpgUrl: String? = nil
+    var iptvFavoriteGroups: [String]? = nil
+    var iptvFavoriteChannels: [String]? = nil
     var updatedAt: TimeInterval
 
     static let empty = CloudPayload(version: 1, addons: [], updatedAt: Date().timeIntervalSince1970)
@@ -21,6 +39,24 @@ struct CloudPayload: Codable {
         case addonsByProfile
         case activeProfileId
         case profiles
+        case profileSettingsById
+        case defaultSubtitle
+        case defaultAudioLanguage
+        case cardLayoutMode
+        case frameRateMatchingMode
+        case autoPlayNext
+        case autoPlaySingleSource
+        case autoPlayMinQuality
+        case includeSpecials
+        case dnsProvider
+        case subtitleUsageJson
+        case subtitleSettingsUpdatedAt
+        case skipProfileSelection
+        case subtitleAiEnabled
+        case subtitleAiAutoSelect
+        case subtitleAiApiKey
+        case subtitleAiModel
+        case subtitleRemoveHearingImpaired
         case iptvByProfile
         case iptvM3uUrl
         case iptvEpgUrl
@@ -35,6 +71,7 @@ struct CloudPayload: Codable {
         addonsByProfile: [String: [InstalledAddon]]? = nil,
         activeProfileId: String? = nil,
         profiles: [ArvioProfile]? = nil,
+        profileSettingsById: [String: CloudProfileSettings]? = nil,
         iptvByProfile: [String: IptvCloudProfileState]? = nil,
         iptvM3uUrl: String? = nil,
         iptvEpgUrl: String? = nil,
@@ -47,6 +84,7 @@ struct CloudPayload: Codable {
         self.addonsByProfile = addonsByProfile
         self.activeProfileId = activeProfileId
         self.profiles = profiles
+        self.profileSettingsById = profileSettingsById
         self.iptvByProfile = iptvByProfile
         self.iptvM3uUrl = iptvM3uUrl
         self.iptvEpgUrl = iptvEpgUrl
@@ -62,6 +100,24 @@ struct CloudPayload: Codable {
         addonsByProfile = try? container.decode([String: [InstalledAddon]].self, forKey: .addonsByProfile)
         activeProfileId = try? container.decode(String.self, forKey: .activeProfileId)
         profiles = try? container.decode([ArvioProfile].self, forKey: .profiles)
+        profileSettingsById = try? container.decode([String: CloudProfileSettings].self, forKey: .profileSettingsById)
+        defaultSubtitle = try? container.decode(String.self, forKey: .defaultSubtitle)
+        defaultAudioLanguage = try? container.decode(String.self, forKey: .defaultAudioLanguage)
+        cardLayoutMode = try? container.decode(String.self, forKey: .cardLayoutMode)
+        frameRateMatchingMode = try? container.decode(String.self, forKey: .frameRateMatchingMode)
+        autoPlayNext = try? container.decode(Bool.self, forKey: .autoPlayNext)
+        autoPlaySingleSource = try? container.decode(Bool.self, forKey: .autoPlaySingleSource)
+        autoPlayMinQuality = try? container.decode(String.self, forKey: .autoPlayMinQuality)
+        includeSpecials = try? container.decode(Bool.self, forKey: .includeSpecials)
+        dnsProvider = try? container.decode(String.self, forKey: .dnsProvider)
+        subtitleUsageJson = try? container.decode(String.self, forKey: .subtitleUsageJson)
+        subtitleSettingsUpdatedAt = try? container.decode(Int.self, forKey: .subtitleSettingsUpdatedAt)
+        skipProfileSelection = try? container.decode(Bool.self, forKey: .skipProfileSelection)
+        subtitleAiEnabled = try? container.decode(Bool.self, forKey: .subtitleAiEnabled)
+        subtitleAiAutoSelect = try? container.decode(Bool.self, forKey: .subtitleAiAutoSelect)
+        subtitleAiApiKey = try? container.decode(String.self, forKey: .subtitleAiApiKey)
+        subtitleAiModel = try? container.decode(String.self, forKey: .subtitleAiModel)
+        subtitleRemoveHearingImpaired = try? container.decode(Bool.self, forKey: .subtitleRemoveHearingImpaired)
         iptvByProfile = try? container.decode([String: IptvCloudProfileState].self, forKey: .iptvByProfile)
         iptvM3uUrl = try? container.decode(String.self, forKey: .iptvM3uUrl)
         iptvEpgUrl = try? container.decode(String.self, forKey: .iptvEpgUrl)
@@ -144,13 +200,20 @@ final class CloudSyncService: ObservableObject {
         await save(addons: nil, iptv: nil, profiles: profiles, activeProfileId: activeProfileId)
     }
 
+    func save(settings: CloudProfileSettings, globalSettings: GlobalCloudSettings, profileId: String) async {
+        await save(addons: nil, iptv: nil, settings: settings, globalSettings: globalSettings, settingsProfileId: profileId)
+    }
+
     private func save(
         addons: [InstalledAddon]?,
         addonProfileId: String? = nil,
         iptv: IptvCloudProfileState?,
         iptvProfileId: String? = nil,
         profiles: [ArvioProfile]? = nil,
-        activeProfileId: String? = nil
+        activeProfileId: String? = nil,
+        settings: CloudProfileSettings? = nil,
+        globalSettings: GlobalCloudSettings? = nil,
+        settingsProfileId: String? = nil
     ) async {
         guard let session = auth.session else { return }
         isSyncing = true
@@ -184,6 +247,31 @@ final class CloudSyncService: ObservableObject {
                 } else {
                     object["activeProfileId"] = NSNull()
                 }
+            }
+            if let settings {
+                let profileId = settingsProfileId ?? session.userId
+                var byProfile = object["profileSettingsById"] as? [String: Any] ?? [:]
+                byProfile[profileId] = try jsonObject(settings)
+                object["profileSettingsById"] = byProfile
+                object["defaultSubtitle"] = settings.defaultSubtitle
+                object["defaultAudioLanguage"] = settings.defaultAudioLanguage
+                object["cardLayoutMode"] = settings.cardLayoutMode
+                object["frameRateMatchingMode"] = settings.frameRateMatchingMode
+                object["autoPlayNext"] = settings.autoPlayNext
+                object["autoPlaySingleSource"] = settings.autoPlaySingleSource
+                object["autoPlayMinQuality"] = settings.autoPlayMinQuality
+                object["includeSpecials"] = settings.includeSpecials
+                object["dnsProvider"] = settings.dnsProvider
+                object["subtitleUsageJson"] = settings.subtitleUsageJson
+                object["subtitleSettingsUpdatedAt"] = settings.subtitleSettingsUpdatedAt
+            }
+            if let globalSettings {
+                object["subtitleAiEnabled"] = globalSettings.subtitleAiEnabled
+                object["subtitleAiAutoSelect"] = globalSettings.subtitleAiAutoSelect
+                object["subtitleAiApiKey"] = globalSettings.subtitleAiApiKey
+                object["subtitleAiModel"] = globalSettings.subtitleAiModel
+                object["subtitleRemoveHearingImpaired"] = globalSettings.subtitleRemoveHearingImpaired
+                object["skipProfileSelection"] = globalSettings.skipProfileSelection
             }
             let data = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
             let raw = String(data: data, encoding: .utf8) ?? "{}"

--- a/iosApp/ARVIO/CloudSyncService.swift
+++ b/iosApp/ARVIO/CloudSyncService.swift
@@ -3,6 +3,7 @@ import Foundation
 struct CloudPayload: Codable {
     var version: Int
     var addons: [InstalledAddon]
+    var addonsByProfile: [String: [InstalledAddon]]?
     var activeProfileId: String?
     var profiles: [ArvioProfile]?
     var iptvByProfile: [String: IptvCloudProfileState]?
@@ -17,6 +18,7 @@ struct CloudPayload: Codable {
     enum CodingKeys: String, CodingKey {
         case version
         case addons
+        case addonsByProfile
         case activeProfileId
         case profiles
         case iptvByProfile
@@ -30,6 +32,7 @@ struct CloudPayload: Codable {
     init(
         version: Int,
         addons: [InstalledAddon],
+        addonsByProfile: [String: [InstalledAddon]]? = nil,
         activeProfileId: String? = nil,
         profiles: [ArvioProfile]? = nil,
         iptvByProfile: [String: IptvCloudProfileState]? = nil,
@@ -41,6 +44,7 @@ struct CloudPayload: Codable {
     ) {
         self.version = version
         self.addons = addons
+        self.addonsByProfile = addonsByProfile
         self.activeProfileId = activeProfileId
         self.profiles = profiles
         self.iptvByProfile = iptvByProfile
@@ -55,6 +59,7 @@ struct CloudPayload: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         version = (try? container.decode(Int.self, forKey: .version)) ?? 1
         addons = (try? container.decode([InstalledAddon].self, forKey: .addons)) ?? []
+        addonsByProfile = try? container.decode([String: [InstalledAddon]].self, forKey: .addonsByProfile)
         activeProfileId = try? container.decode(String.self, forKey: .activeProfileId)
         profiles = try? container.decode([ArvioProfile].self, forKey: .profiles)
         iptvByProfile = try? container.decode([String: IptvCloudProfileState].self, forKey: .iptvByProfile)
@@ -127,8 +132,8 @@ final class CloudSyncService: ObservableObject {
         }
     }
 
-    func save(addons: [InstalledAddon]) async {
-        await save(addons: addons, iptv: nil)
+    func save(addons: [InstalledAddon], profileId: String?) async {
+        await save(addons: addons, addonProfileId: profileId, iptv: nil)
     }
 
     func save(iptv: IptvCloudProfileState, profileId: String) async {
@@ -141,6 +146,7 @@ final class CloudSyncService: ObservableObject {
 
     private func save(
         addons: [InstalledAddon]?,
+        addonProfileId: String? = nil,
         iptv: IptvCloudProfileState?,
         iptvProfileId: String? = nil,
         profiles: [ArvioProfile]? = nil,
@@ -156,6 +162,11 @@ final class CloudSyncService: ObservableObject {
             object["updatedAt"] = Date().timeIntervalSince1970
             if let addons {
                 object["addons"] = try jsonObject(addons)
+                if let addonProfileId {
+                    var byProfile = object["addonsByProfile"] as? [String: Any] ?? [:]
+                    byProfile[addonProfileId] = try jsonObject(addons)
+                    object["addonsByProfile"] = byProfile
+                }
             }
             if let iptv {
                 object["iptvM3uUrl"] = iptv.m3uUrl

--- a/iosApp/ARVIO/Components.swift
+++ b/iosApp/ARVIO/Components.swift
@@ -4,54 +4,73 @@ struct PosterBackdrop: View {
     let item: MediaItem
 
     var body: some View {
-        LinearGradient(
-            colors: item.palette.map(Color.init(hex:)),
-            startPoint: .topLeading,
-            endPoint: .bottomTrailing
-        )
-        .overlay(
-            RadialGradient(colors: [Color.white.opacity(0.24), Color.clear], center: .topTrailing, startRadius: 10, endRadius: 320)
-        )
-        .overlay(alignment: .center) {
-            Text(item.title.uppercased())
-                .font(.system(size: 27, weight: .bold, design: .serif))
-                .foregroundStyle(Color.white.opacity(0.86))
-                .multilineTextAlignment(.center)
-                .padding(18)
+        ZStack {
+            LinearGradient(
+                colors: item.palette.map(Color.init(hex:)),
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+
+            if let url = item.backdropURL ?? item.posterURL {
+                AsyncImage(url: url) { phase in
+                    if let image = phase.image {
+                        image
+                            .resizable()
+                            .scaledToFill()
+                    }
+                }
+            }
+
+            LinearGradient(colors: [Color.black.opacity(0.05), Color.black.opacity(0.52)], startPoint: .top, endPoint: .bottom)
+
+            if item.backdropURL == nil && item.posterURL == nil {
+                Text(item.title.uppercased())
+                    .font(.system(size: 27, weight: .bold, design: .serif))
+                    .foregroundStyle(Color.white.opacity(0.86))
+                    .multilineTextAlignment(.center)
+                    .padding(18)
+            }
         }
+        .clipped()
     }
 }
 
 struct MediaCard: View {
     let item: MediaItem
+    var onSelect: ((MediaItem) -> Void)?
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            PosterBackdrop(item: item)
-                .frame(width: 210, height: 118)
-                .clipShape(RoundedRectangle(cornerRadius: 8))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 8)
-                        .stroke(ArvioTheme.border, lineWidth: 1)
-                )
+        Button {
+            onSelect?(item)
+        } label: {
+            VStack(alignment: .leading, spacing: 10) {
+                PosterBackdrop(item: item)
+                    .frame(width: 210, height: 118)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(ArvioTheme.border, lineWidth: 1)
+                    )
 
-            Text(item.title)
-                .font(.system(size: 16, weight: .semibold))
-                .foregroundStyle(ArvioTheme.textPrimary)
-                .lineLimit(1)
+                Text(item.title)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(ArvioTheme.textPrimary)
+                    .lineLimit(1)
 
-            Text(item.subtitle)
-                .font(.system(size: 13, weight: .medium))
-                .foregroundStyle(ArvioTheme.textTertiary)
-                .lineLimit(1)
+                Text(item.subtitle)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(ArvioTheme.textTertiary)
+                    .lineLimit(1)
 
-            if item.progress > 0 {
-                ProgressView(value: item.progress)
-                    .tint(ArvioTheme.gold)
-                    .frame(width: 210)
+                if item.progress > 0 {
+                    ProgressView(value: item.progress)
+                        .tint(ArvioTheme.gold)
+                        .frame(width: 210)
+                }
             }
+            .frame(width: 210, alignment: .leading)
         }
-        .frame(width: 210, alignment: .leading)
+        .buttonStyle(.plain)
     }
 }
 

--- a/iosApp/ARVIO/DetailsView.swift
+++ b/iosApp/ARVIO/DetailsView.swift
@@ -31,7 +31,11 @@ struct DetailsView: View {
                         HStack(spacing: 12) {
                             Button("Play") {
                                 Task {
-                                    await appState.streams.resolve(item: item, season: selectedSeason, episode: 1)
+                                    await appState.streams.resolve(
+                                        item: item,
+                                        season: item.season ?? selectedSeason,
+                                        episode: item.episode ?? 1
+                                    )
                                 }
                             }
                             .buttonStyle(.borderedProminent)
@@ -63,6 +67,7 @@ struct DetailsView: View {
             .padding(28)
         }
         .task {
+            selectedSeason = item.season ?? selectedSeason
             async let loadedDetails = try? appState.tmdb.details(for: item)
             async let loadedRecommendations = try? appState.tmdb.recommendations(for: item)
             details = await loadedDetails ?? details

--- a/iosApp/ARVIO/DetailsView.swift
+++ b/iosApp/ARVIO/DetailsView.swift
@@ -36,6 +36,12 @@ struct DetailsView: View {
                                         season: item.season ?? selectedSeason,
                                         episode: item.episode ?? 1
                                     )
+                                    let playable = appState.streams.streams.filter {
+                                        $0.isPlayable && meetsMinimumQuality($0.quality, minimum: appState.settings.profileSettings.autoPlayMinQuality)
+                                    }
+                                    if appState.settings.profileSettings.autoPlaySingleSource, playable.count == 1 {
+                                        appState.selectedStream = playable[0]
+                                    }
                                 }
                             }
                             .buttonStyle(.borderedProminent)
@@ -83,6 +89,18 @@ struct DetailsView: View {
             details?.episodeRunTime?.first.map { "\($0)m" } ??
             item.duration
         return [String(year), rating.isEmpty ? nil : "TMDB \(rating)", runtime.isEmpty ? nil : runtime, genres].compactMap { $0 }.joined(separator: " - ")
+    }
+
+    private func meetsMinimumQuality(_ quality: String, minimum: String) -> Bool {
+        qualityRank(quality) >= qualityRank(minimum)
+    }
+
+    private func qualityRank(_ value: String) -> Int {
+        if value.localizedCaseInsensitiveContains("4K") || value.contains("2160") { return 4 }
+        if value.contains("1080") { return 3 }
+        if value.contains("720") { return 2 }
+        if value == "Any" || value == "Unknown" { return 0 }
+        return 1
     }
 }
 

--- a/iosApp/ARVIO/DetailsView.swift
+++ b/iosApp/ARVIO/DetailsView.swift
@@ -47,7 +47,9 @@ struct DetailsView: View {
                             .buttonStyle(.borderedProminent)
                             .tint(ArvioTheme.gold)
 
-                            Button("Watchlist") { }
+                            Button("Watchlist") {
+                                Task { await appState.trakt.addToWatchlist(item: item) }
+                            }
                                 .buttonStyle(.bordered)
                         }
                     }
@@ -143,7 +145,7 @@ struct SourceSelector: View {
                                     Text(stream.sourceName)
                                         .font(.system(size: 16, weight: .bold))
                                         .foregroundStyle(ArvioTheme.textPrimary)
-                                    Text([stream.addonName, stream.quality, stream.size, stream.isPlayable ? "Playable" : "Unsupported on iOS"].filter { !$0.isEmpty }.joined(separator: " - "))
+                                    Text([stream.addonName, stream.quality, stream.size, stream.isPlayable ? "Playable" : "Needs direct stream"].filter { !$0.isEmpty }.joined(separator: " - "))
                                         .font(.system(size: 13))
                                         .foregroundStyle(ArvioTheme.textSecondary)
                                         .lineLimit(1)

--- a/iosApp/ARVIO/DetailsView.swift
+++ b/iosApp/ARVIO/DetailsView.swift
@@ -1,0 +1,141 @@
+import SwiftUI
+
+struct DetailsView: View {
+    @EnvironmentObject private var appState: AppState
+    let item: MediaItem
+    @State private var details: TmdbDetails?
+    @State private var recommendations: [MediaItem] = []
+    @State private var selectedSeason = 1
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                ZStack(alignment: .bottomLeading) {
+                    PosterBackdrop(item: item)
+                        .frame(height: 420)
+                    LinearGradient(colors: [Color.black.opacity(0.0), Color.black.opacity(0.9)], startPoint: .center, endPoint: .bottom)
+                    VStack(alignment: .leading, spacing: 14) {
+                        Button("Back") { appState.selectedMedia = nil }
+                            .buttonStyle(.bordered)
+                        Text(details?.title ?? details?.name ?? item.title)
+                            .font(.system(size: 46, weight: .bold))
+                            .foregroundStyle(ArvioTheme.textPrimary)
+                        Text(metadata)
+                            .font(.system(size: 16, weight: .medium))
+                            .foregroundStyle(ArvioTheme.textSecondary)
+                        Text(details?.overview ?? item.overview ?? "")
+                            .font(.system(size: 16))
+                            .foregroundStyle(ArvioTheme.textSecondary)
+                            .lineLimit(3)
+                            .frame(maxWidth: 760, alignment: .leading)
+                        HStack(spacing: 12) {
+                            Button("Play") {
+                                Task {
+                                    await appState.streams.resolve(item: item, season: selectedSeason, episode: 1)
+                                }
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .tint(ArvioTheme.gold)
+
+                            Button("Watchlist") { }
+                                .buttonStyle(.bordered)
+                        }
+                    }
+                    .padding(28)
+                }
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+
+                if item.kind == .series, let seasons = details?.seasons?.filter({ $0.seasonNumber > 0 }) {
+                    Picker("Season", selection: $selectedSeason) {
+                        ForEach(seasons) { season in
+                            Text(season.name ?? "Season \(season.seasonNumber)").tag(season.seasonNumber)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                SourceSelector()
+
+                if !recommendations.isEmpty {
+                    MediaRail(title: "More Like This", items: recommendations)
+                }
+            }
+            .padding(28)
+        }
+        .task {
+            async let loadedDetails = try? appState.tmdb.details(for: item)
+            async let loadedRecommendations = try? appState.tmdb.recommendations(for: item)
+            details = await loadedDetails ?? details
+            recommendations = await loadedRecommendations ?? []
+        }
+    }
+
+    private var metadata: String {
+        let year = details?.releaseDate?.prefix(4) ?? details?.firstAirDate?.prefix(4) ?? Substring(item.year)
+        let rating = details?.voteAverage.map { String(format: "%.1f", $0) } ?? item.rating
+        let genres = details?.genres?.prefix(3).map(\.name).joined(separator: ", ") ?? item.subtitle
+        let runtime = details?.runtime.map { "\($0)m" } ??
+            details?.episodeRunTime?.first.map { "\($0)m" } ??
+            item.duration
+        return [String(year), rating.isEmpty ? nil : "TMDB \(rating)", runtime.isEmpty ? nil : runtime, genres].compactMap { $0 }.joined(separator: " - ")
+    }
+}
+
+struct SourceSelector: View {
+    @EnvironmentObject private var appState: AppState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Sources")
+                    .font(.system(size: 22, weight: .bold))
+                    .foregroundStyle(ArvioTheme.textPrimary)
+                Spacer()
+                if appState.streams.isLoading {
+                    ProgressView()
+                }
+            }
+
+            if let error = appState.streams.errorMessage {
+                Text(error)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(Color.red.opacity(0.9))
+            }
+
+            if appState.streams.streams.isEmpty && !appState.streams.isLoading {
+                EmptyStatePanel(
+                    title: "No sources loaded",
+                    message: appState.addons.addons.isEmpty ? "Install stream addons first." : "Press Play to resolve addon sources."
+                )
+            } else {
+                LazyVStack(spacing: 10) {
+                    ForEach(appState.streams.streams) { stream in
+                        Button {
+                            if stream.isPlayable {
+                                appState.selectedStream = stream
+                            }
+                        } label: {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 6) {
+                                    Text(stream.sourceName)
+                                        .font(.system(size: 16, weight: .bold))
+                                        .foregroundStyle(ArvioTheme.textPrimary)
+                                    Text([stream.addonName, stream.quality, stream.size, stream.isPlayable ? "Playable" : "Unsupported on iOS"].filter { !$0.isEmpty }.joined(separator: " - "))
+                                        .font(.system(size: 13))
+                                        .foregroundStyle(ArvioTheme.textSecondary)
+                                        .lineLimit(1)
+                                }
+                                Spacer()
+                            }
+                            .padding(16)
+                            .background(RoundedRectangle(cornerRadius: 8).fill(ArvioTheme.panel))
+                            .overlay(RoundedRectangle(cornerRadius: 8).stroke(stream.isPlayable ? ArvioTheme.gold.opacity(0.7) : ArvioTheme.border, lineWidth: 1))
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(!stream.isPlayable)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/iosApp/ARVIO/HomeView.swift
+++ b/iosApp/ARVIO/HomeView.swift
@@ -6,13 +6,45 @@ struct HomeView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 28) {
-                HeroSection(item: appState.tmdb.trendingMovies.first ?? featuredItems[0])
-                MediaRail(title: "Continue Watching", items: continueWatchingItems)
-                MediaRail(title: "Trending Movies", items: appState.tmdb.trendingMovies.isEmpty ? featuredItems : appState.tmdb.trendingMovies)
-                MediaRail(title: "Trending Series", items: appState.tmdb.trendingSeries.isEmpty ? featuredItems : appState.tmdb.trendingSeries)
+                if let hero = appState.tmdb.trendingMovies.first ?? appState.watchHistory.continueWatching.first {
+                    HeroSection(item: hero)
+                } else {
+                    BrandHeroSection()
+                }
+                if !appState.watchHistory.continueWatching.isEmpty {
+                    MediaRail(title: "Continue Watching", items: appState.watchHistory.continueWatching)
+                }
+                MediaRail(title: "Trending Movies", items: appState.tmdb.trendingMovies)
+                MediaRail(title: "Trending Series", items: appState.tmdb.trendingSeries)
             }
             .padding(.horizontal, 28)
             .padding(.bottom, 36)
+        }
+    }
+}
+
+struct BrandHeroSection: View {
+    var body: some View {
+        ZStack(alignment: .bottomLeading) {
+            Image("ARVIOTVBanner")
+                .resizable()
+                .scaledToFill()
+                .frame(height: 360)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+
+            LinearGradient(colors: [Color.black.opacity(0.05), Color.black.opacity(0.86)], startPoint: .center, endPoint: .bottom)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+
+            VStack(alignment: .leading, spacing: 12) {
+                Image("ARVIOFeatureGraphic")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 260)
+                Text("ARVIO")
+                    .font(.system(size: 42, weight: .bold))
+                    .foregroundStyle(ArvioTheme.textPrimary)
+            }
+            .padding(28)
         }
     }
 }
@@ -76,6 +108,9 @@ struct MediaRail: View {
 
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 14) {
+                    if items.isEmpty {
+                        EmptyStatePanel(title: "Nothing here yet", message: "Content will appear here after sync finishes.")
+                    }
                     ForEach(items) { item in
                         MediaCard(item: item) { selected in
                             appState.selectedMedia = selected
@@ -104,7 +139,10 @@ struct CatalogView: View {
                     .foregroundStyle(ArvioTheme.textSecondary)
 
                 LazyVGrid(columns: [GridItem(.adaptive(minimum: 210), spacing: 16)], spacing: 16) {
-                    ForEach(items.isEmpty ? featuredItems : items) { item in
+                    if items.isEmpty {
+                        EmptyStatePanel(title: "Nothing here yet", message: "Refresh or check your cloud connection.")
+                    }
+                    ForEach(items) { item in
                         MediaCard(item: item) { selected in
                             appState.selectedMedia = selected
                         }

--- a/iosApp/ARVIO/HomeView.swift
+++ b/iosApp/ARVIO/HomeView.swift
@@ -1,12 +1,15 @@
 import SwiftUI
 
 struct HomeView: View {
+    @EnvironmentObject private var appState: AppState
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 28) {
-                HeroSection(item: featuredItems[0])
+                HeroSection(item: appState.tmdb.trendingMovies.first ?? featuredItems[0])
                 MediaRail(title: "Continue Watching", items: continueWatchingItems)
-                MediaRail(title: "Featured", items: featuredItems)
+                MediaRail(title: "Trending Movies", items: appState.tmdb.trendingMovies.isEmpty ? featuredItems : appState.tmdb.trendingMovies)
+                MediaRail(title: "Trending Series", items: appState.tmdb.trendingSeries.isEmpty ? featuredItems : appState.tmdb.trendingSeries)
             }
             .padding(.horizontal, 28)
             .padding(.bottom, 36)
@@ -61,6 +64,7 @@ struct HeroSection: View {
 }
 
 struct MediaRail: View {
+    @EnvironmentObject private var appState: AppState
     let title: String
     let items: [MediaItem]
 
@@ -73,7 +77,9 @@ struct MediaRail: View {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 14) {
                     ForEach(items) { item in
-                        MediaCard(item: item)
+                        MediaCard(item: item) { selected in
+                            appState.selectedMedia = selected
+                        }
                     }
                 }
             }
@@ -82,6 +88,7 @@ struct MediaRail: View {
 }
 
 struct CatalogView: View {
+    @EnvironmentObject private var appState: AppState
     let title: String
     let subtitle: String
     let items: [MediaItem]
@@ -98,7 +105,9 @@ struct CatalogView: View {
 
                 LazyVGrid(columns: [GridItem(.adaptive(minimum: 210), spacing: 16)], spacing: 16) {
                     ForEach(items.isEmpty ? featuredItems : items) { item in
-                        MediaCard(item: item)
+                        MediaCard(item: item) { selected in
+                            appState.selectedMedia = selected
+                        }
                     }
                 }
                 .padding(.top, 8)

--- a/iosApp/ARVIO/IptvService.swift
+++ b/iosApp/ARVIO/IptvService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CryptoKit
 
 struct IptvPlaylistEntry: Codable, Identifiable, Hashable {
     let id: String
@@ -190,7 +191,7 @@ final class IptvService: ObservableObject {
                 let meta = pending ?? ("Channel \(result.count + 1)", "Uncategorized", nil, nil, "")
                 result.append(
                     IptvChannel(
-                        id: stableChannelId(name: meta.name, epgId: meta.epgId, streamUrl: line, index: result.count),
+                        id: stableChannelId(epgId: meta.epgId, streamUrl: line),
                         name: meta.name,
                         streamUrl: line,
                         group: meta.group,
@@ -205,10 +206,19 @@ final class IptvService: ObservableObject {
         return result
     }
 
-    private func stableChannelId(name: String, epgId: String?, streamUrl: String, index: Int) -> String {
-        let source = (epgId?.nilIfBlank ?? name + streamUrl).lowercased()
-        let cleaned = source.unicodeScalars.map { CharacterSet.alphanumerics.contains($0) ? Character($0) : "-" }
-        return String(cleaned).replacingOccurrences(of: "--", with: "-") + "-\(index)"
+    private func stableChannelId(epgId: String?, streamUrl: String) -> String {
+        let normalizedEpg = epgId?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+        let streamKey = stableStreamKey(streamUrl)
+        return normalizedEpg.isEmpty ? "m3u:\(streamKey)" : "m3u:\(normalizedEpg):\(streamKey)"
+    }
+
+    private func stableStreamKey(_ streamUrl: String) -> String {
+        let normalized = streamUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else { return "empty" }
+        let digest = Insecure.SHA1.hash(data: Data(normalized.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+        return "\(normalized.count)-\(String(digest.prefix(16)))"
     }
 
     private func deduplicate(_ values: [IptvChannel]) -> [IptvChannel] {

--- a/iosApp/ARVIO/IptvService.swift
+++ b/iosApp/ARVIO/IptvService.swift
@@ -37,10 +37,25 @@ struct IptvChannel: Identifiable, Codable, Hashable {
     let rawTitle: String
 }
 
+struct IptvProgram: Identifiable, Hashable {
+    let id: String
+    let channelKey: String
+    let title: String
+    let description: String
+    let start: Date
+    let stop: Date
+}
+
+struct IptvNowNext: Hashable {
+    let now: IptvProgram?
+    let next: IptvProgram?
+}
+
 @MainActor
 final class IptvService: ObservableObject {
     @Published private(set) var state = IptvCloudProfileState()
     @Published private(set) var channels: [IptvChannel] = []
+    @Published private(set) var nowNextByChannelId: [String: IptvNowNext] = [:]
     @Published private(set) var selectedGroup = "All"
     @Published private(set) var isLoading = false
     @Published private(set) var progressMessage = ""
@@ -126,6 +141,7 @@ final class IptvService: ObservableObject {
                 loaded.append(contentsOf: try await fetchPlaylist(playlist))
             }
             channels = deduplicate(loaded)
+            nowNextByChannelId = try await loadGuide(for: channels, playlists: playlists)
             if !groups.contains(selectedGroup) {
                 selectedGroup = "All"
             }
@@ -174,6 +190,46 @@ final class IptvService: ObservableObject {
         }
         progressMessage = "Parsing channels..."
         return parseM3U(text)
+    }
+
+    private func loadGuide(for channels: [IptvChannel], playlists: [IptvPlaylistEntry]) async throws -> [String: IptvNowNext] {
+        let epgUrls = Array(Set(playlists.map(\.epgUrl).filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }))
+        guard !epgUrls.isEmpty, !channels.isEmpty else { return [:] }
+        progressMessage = "Loading guide..."
+
+        var programs: [IptvProgram] = []
+        for rawUrl in epgUrls {
+            guard let url = URL(string: rawUrl) else { continue }
+            let (data, response) = try await URLSession.shared.data(from: url)
+            guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else { continue }
+            programs.append(contentsOf: XMLTVParser.parse(data: data))
+        }
+
+        let now = Date()
+        var channelLookup: [String: String] = [:]
+        for channel in channels {
+            channelLookup[channel.name.normalizedGuideKey] = channel.id
+            if let epgId = channel.epgId?.nilIfBlank {
+                channelLookup[epgId.normalizedGuideKey] = channel.id
+            }
+        }
+
+        var grouped: [String: [IptvProgram]] = [:]
+        for program in programs {
+            guard let channelId = channelLookup[program.channelKey.normalizedGuideKey] else { continue }
+            grouped[channelId, default: []].append(program)
+        }
+
+        var result: [String: IptvNowNext] = [:]
+        for (channelId, values) in grouped {
+            let sorted = values.sorted { $0.start < $1.start }
+            let current = sorted.last { $0.start <= now && $0.stop > now }
+            let next = sorted.first { $0.start > now }
+            if current != nil || next != nil {
+                result[channelId] = IptvNowNext(now: current, next: next)
+            }
+        }
+        return result
     }
 
     private func parseM3U(_ text: String) -> [IptvChannel] {
@@ -281,5 +337,93 @@ private extension String {
     var nilIfBlank: String? {
         let value = trimmingCharacters(in: .whitespacesAndNewlines)
         return value.isEmpty ? nil : value
+    }
+
+    var normalizedGuideKey: String {
+        trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}
+
+private final class XMLTVParser: NSObject, XMLParserDelegate {
+    private var programs: [IptvProgram] = []
+    private var currentChannel = ""
+    private var currentStart: Date?
+    private var currentStop: Date?
+    private var currentTitle = ""
+    private var currentDescription = ""
+    private var activeElement = ""
+    private static let formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyyMMddHHmmss Z"
+        return formatter
+    }()
+
+    static func parse(data: Data) -> [IptvProgram] {
+        let delegate = XMLTVParser()
+        let parser = XMLParser(data: data)
+        parser.delegate = delegate
+        parser.parse()
+        return delegate.programs
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?,
+        attributes attributeDict: [String: String] = [:]
+    ) {
+        activeElement = elementName
+        if elementName == "programme" {
+            currentChannel = attributeDict["channel"] ?? ""
+            currentStart = Self.parseDate(attributeDict["start"])
+            currentStop = Self.parseDate(attributeDict["stop"])
+            currentTitle = ""
+            currentDescription = ""
+        }
+    }
+
+    func parser(_ parser: XMLParser, foundCharacters string: String) {
+        if activeElement == "title" {
+            currentTitle += string
+        } else if activeElement == "desc" {
+            currentDescription += string
+        }
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didEndElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?
+    ) {
+        if elementName == "programme",
+           let start = currentStart,
+           let stop = currentStop,
+           !currentChannel.isEmpty,
+           !currentTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            programs.append(
+                IptvProgram(
+                    id: "\(currentChannel)-\(start.timeIntervalSince1970)",
+                    channelKey: currentChannel,
+                    title: currentTitle.trimmingCharacters(in: .whitespacesAndNewlines),
+                    description: currentDescription.trimmingCharacters(in: .whitespacesAndNewlines),
+                    start: start,
+                    stop: stop
+                )
+            )
+        }
+        activeElement = ""
+    }
+
+    private static func parseDate(_ value: String?) -> Date? {
+        guard let value else { return nil }
+        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let date = formatter.date(from: normalized) {
+            return date
+        }
+        let compact = String(normalized.prefix(14)) + " +0000"
+        return formatter.date(from: compact)
     }
 }

--- a/iosApp/ARVIO/IptvService.swift
+++ b/iosApp/ARVIO/IptvService.swift
@@ -1,0 +1,275 @@
+import Foundation
+
+struct IptvPlaylistEntry: Codable, Identifiable, Hashable {
+    let id: String
+    var name: String
+    var m3uUrl: String
+    var epgUrl: String
+    var enabled: Bool
+}
+
+struct IptvCloudProfileState: Codable, Equatable {
+    var m3uUrl: String = ""
+    var epgUrl: String = ""
+    var favoriteGroups: [String] = []
+    var favoriteChannels: [String] = []
+    var hiddenGroups: [String] = []
+    var groupOrder: [String] = []
+    var playlists: [IptvPlaylistEntry] = []
+    var tvSession: IptvTvSessionState = IptvTvSessionState()
+}
+
+struct IptvTvSessionState: Codable, Equatable {
+    var lastChannelId: String = ""
+    var lastGroupName: String = ""
+    var lastFocusedZone: String = "GUIDE"
+    var lastOpenedAt: Int64 = 0
+}
+
+struct IptvChannel: Identifiable, Codable, Hashable {
+    let id: String
+    let name: String
+    let streamUrl: String
+    let group: String
+    let logo: String?
+    let epgId: String?
+    let rawTitle: String
+}
+
+@MainActor
+final class IptvService: ObservableObject {
+    @Published private(set) var state = IptvCloudProfileState()
+    @Published private(set) var channels: [IptvChannel] = []
+    @Published private(set) var selectedGroup = "All"
+    @Published private(set) var isLoading = false
+    @Published private(set) var progressMessage = ""
+    @Published var searchText = ""
+    @Published var errorMessage: String?
+
+    private let cloud: CloudSyncService
+    private let storageKey = "arvio.ios.iptvState"
+    private var activeProfileId = "default"
+
+    init(cloud: CloudSyncService) {
+        self.cloud = cloud
+        loadLocal()
+    }
+
+    var groups: [String] {
+        let rawGroups = channels.map { $0.group.isEmpty ? "Uncategorized" : $0.group }
+        let unique = Array(Set(rawGroups)).sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+        return ["All", "Favorites"] + unique
+    }
+
+    var visibleChannels: [IptvChannel] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        return channels.filter { channel in
+            let groupMatches = selectedGroup == "All" ||
+                (selectedGroup == "Favorites" && state.favoriteChannels.contains(channel.id)) ||
+                channel.group == selectedGroup
+            let searchMatches = query.isEmpty || channel.name.localizedCaseInsensitiveContains(query)
+            return groupMatches && searchMatches
+        }
+    }
+
+    func loadFromCloud() {
+        let payload = cloud.payload
+        let cloudState = payload.iptvByProfile?[activeProfileId] ??
+            payload.iptvByProfile?.values.first ??
+            legacyState(from: payload)
+        guard let cloudState else { return }
+        state = cloudState
+        selectedGroup = cloudState.tvSession.lastGroupName.isEmpty ? selectedGroup : cloudState.tvSession.lastGroupName
+        saveLocal()
+    }
+
+    func setActiveProfileId(_ profileId: String?) {
+        activeProfileId = profileId?.nilIfBlank ?? "default"
+        loadFromCloud()
+    }
+
+    func setGroup(_ group: String) {
+        selectedGroup = group
+        state.tvSession.lastGroupName = group
+        saveLocal()
+    }
+
+    func saveConfig(m3uUrl: String, epgUrl: String) async {
+        let m3u = m3uUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+        let epg = epgUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+        state.m3uUrl = m3u
+        state.epgUrl = epg
+        state.playlists = m3u.isEmpty ? [] : [
+            IptvPlaylistEntry(id: "list_1", name: "List 1", m3uUrl: m3u, epgUrl: epg, enabled: true)
+        ]
+        saveLocal()
+        await cloud.save(iptv: state, profileId: activeProfileId)
+        await reload()
+    }
+
+    func reload() async {
+        let playlists = activePlaylists()
+        guard !playlists.isEmpty else {
+            errorMessage = "Add an M3U playlist to load Live TV"
+            return
+        }
+        isLoading = true
+        progressMessage = "Loading channels..."
+        defer {
+            isLoading = false
+            progressMessage = ""
+        }
+        do {
+            var loaded: [IptvChannel] = []
+            for playlist in playlists {
+                loaded.append(contentsOf: try await fetchPlaylist(playlist))
+            }
+            channels = deduplicate(loaded)
+            if !groups.contains(selectedGroup) {
+                selectedGroup = "All"
+            }
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func toggleFavorite(_ channel: IptvChannel) async {
+        if state.favoriteChannels.contains(channel.id) {
+            state.favoriteChannels.removeAll { $0 == channel.id }
+        } else {
+            state.favoriteChannels.append(channel.id)
+        }
+        saveLocal()
+        await cloud.save(iptv: state, profileId: activeProfileId)
+    }
+
+    func markOpened(_ channel: IptvChannel) {
+        state.tvSession.lastChannelId = channel.id
+        state.tvSession.lastGroupName = channel.group
+        state.tvSession.lastFocusedZone = "PLAYER"
+        state.tvSession.lastOpenedAt = Int64(Date().timeIntervalSince1970 * 1000)
+        saveLocal()
+    }
+
+    private func activePlaylists() -> [IptvPlaylistEntry] {
+        let configured = state.playlists.filter { $0.enabled && !$0.m3uUrl.isEmpty }
+        if !configured.isEmpty { return configured }
+        guard !state.m3uUrl.isEmpty else { return [] }
+        return [IptvPlaylistEntry(id: "list_1", name: "List 1", m3uUrl: state.m3uUrl, epgUrl: state.epgUrl, enabled: true)]
+    }
+
+    private func fetchPlaylist(_ playlist: IptvPlaylistEntry) async throws -> [IptvChannel] {
+        guard let url = URL(string: playlist.m3uUrl) else {
+            throw ArvioError.invalidURL(playlist.m3uUrl)
+        }
+        progressMessage = "Downloading \(playlist.name)..."
+        let (data, response) = try await URLSession.shared.data(from: url)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw ArvioError.requestFailed("Playlist failed to load")
+        }
+        guard let text = String(data: data, encoding: .utf8) ?? String(data: data, encoding: .isoLatin1) else {
+            throw ArvioError.decodingFailed
+        }
+        progressMessage = "Parsing channels..."
+        return parseM3U(text)
+    }
+
+    private func parseM3U(_ text: String) -> [IptvChannel] {
+        var result: [IptvChannel] = []
+        var pending: (name: String, group: String, logo: String?, epgId: String?, raw: String)?
+        for rawLine in text.components(separatedBy: .newlines) {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            if line.hasPrefix("#EXTINF") {
+                let attributes = Self.attributes(from: line)
+                let commaName = line.split(separator: ",", maxSplits: 1).last.map(String.init) ?? "Channel"
+                let name = attributes["tvg-name"]?.nilIfBlank ?? commaName.nilIfBlank ?? "Channel"
+                let group = attributes["group-title"]?.nilIfBlank ?? "Uncategorized"
+                pending = (name, group, attributes["tvg-logo"]?.nilIfBlank, attributes["tvg-id"]?.nilIfBlank, line)
+            } else if line.hasPrefix("http") {
+                let meta = pending ?? ("Channel \(result.count + 1)", "Uncategorized", nil, nil, "")
+                result.append(
+                    IptvChannel(
+                        id: stableChannelId(name: meta.name, epgId: meta.epgId, streamUrl: line, index: result.count),
+                        name: meta.name,
+                        streamUrl: line,
+                        group: meta.group,
+                        logo: meta.logo,
+                        epgId: meta.epgId,
+                        rawTitle: meta.raw
+                    )
+                )
+                pending = nil
+            }
+        }
+        return result
+    }
+
+    private func stableChannelId(name: String, epgId: String?, streamUrl: String, index: Int) -> String {
+        let source = (epgId?.nilIfBlank ?? name + streamUrl).lowercased()
+        let cleaned = source.unicodeScalars.map { CharacterSet.alphanumerics.contains($0) ? Character($0) : "-" }
+        return String(cleaned).replacingOccurrences(of: "--", with: "-") + "-\(index)"
+    }
+
+    private func deduplicate(_ values: [IptvChannel]) -> [IptvChannel] {
+        var seen = Set<String>()
+        return values.filter { channel in
+            let key = channel.name.lowercased() + "|" + channel.streamUrl
+            if seen.contains(key) { return false }
+            seen.insert(key)
+            return true
+        }
+    }
+
+    private func legacyState(from payload: CloudPayload) -> IptvCloudProfileState? {
+        guard payload.iptvM3uUrl?.isEmpty == false || payload.iptvEpgUrl?.isEmpty == false else { return nil }
+        return IptvCloudProfileState(
+            m3uUrl: payload.iptvM3uUrl ?? "",
+            epgUrl: payload.iptvEpgUrl ?? "",
+            favoriteGroups: payload.iptvFavoriteGroups ?? [],
+            favoriteChannels: payload.iptvFavoriteChannels ?? [],
+            playlists: [
+                IptvPlaylistEntry(
+                    id: "list_1",
+                    name: "List 1",
+                    m3uUrl: payload.iptvM3uUrl ?? "",
+                    epgUrl: payload.iptvEpgUrl ?? "",
+                    enabled: true
+                )
+            ].filter { !$0.m3uUrl.isEmpty }
+        )
+    }
+
+    private func loadLocal() {
+        guard let data = UserDefaults.standard.data(forKey: storageKey),
+              let decoded = try? JSONDecoder().decode(IptvCloudProfileState.self, from: data) else {
+            return
+        }
+        state = decoded
+        selectedGroup = decoded.tvSession.lastGroupName.isEmpty ? "All" : decoded.tvSession.lastGroupName
+    }
+
+    private func saveLocal() {
+        guard let data = try? JSONEncoder().encode(state) else { return }
+        UserDefaults.standard.set(data, forKey: storageKey)
+    }
+
+    private static func attributes(from text: String) -> [String: String] {
+        let pattern = #"([A-Za-z0-9_-]+)="([^"]*)""#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [:] }
+        let nsText = text as NSString
+        let matches = regex.matches(in: text, range: NSRange(location: 0, length: nsText.length))
+        var values: [String: String] = [:]
+        for match in matches where match.numberOfRanges == 3 {
+            values[nsText.substring(with: match.range(at: 1))] = nsText.substring(with: match.range(at: 2))
+        }
+        return values
+    }
+}
+
+private extension String {
+    var nilIfBlank: String? {
+        let value = trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+}

--- a/iosApp/ARVIO/LiveTVView.swift
+++ b/iosApp/ARVIO/LiveTVView.swift
@@ -239,7 +239,8 @@ private struct ChannelTile: View {
             quality: "Live",
             size: "",
             url: URL(string: channel.streamUrl),
-            isPlayable: true
+            isPlayable: true,
+            resumePositionSeconds: nil
         )
     }
 }

--- a/iosApp/ARVIO/LiveTVView.swift
+++ b/iosApp/ARVIO/LiveTVView.swift
@@ -1,0 +1,245 @@
+import SwiftUI
+
+struct LiveTVView: View {
+    @EnvironmentObject private var appState: AppState
+    @State private var m3uUrl = ""
+    @State private var epgUrl = ""
+
+    var body: some View {
+        HStack(spacing: 0) {
+            groupRail
+                .frame(width: 250)
+
+            VStack(alignment: .leading, spacing: 18) {
+                header
+                if appState.iptv.channels.isEmpty {
+                    setupPanel
+                } else {
+                    channelGrid
+                }
+            }
+            .padding(28)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        }
+        .onAppear {
+            m3uUrl = appState.iptv.state.m3uUrl
+            epgUrl = appState.iptv.state.epgUrl
+            if appState.iptv.channels.isEmpty && !appState.iptv.state.m3uUrl.isEmpty {
+                Task { await appState.iptv.reload() }
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .bottom) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Live TV")
+                    .font(.system(size: 42, weight: .bold))
+                    .foregroundStyle(ArvioTheme.textPrimary)
+                Text("\(appState.iptv.channels.count) channels synced with ARVIO cloud")
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(ArvioTheme.textSecondary)
+            }
+
+            Spacer()
+
+            TextField(
+                "Search channels",
+                text: Binding(
+                    get: { appState.iptv.searchText },
+                    set: { appState.iptv.searchText = $0 }
+                )
+            )
+                .textInputAutocapitalization(.never)
+                .padding(13)
+                .frame(width: 300)
+                .background(RoundedRectangle(cornerRadius: 8).fill(Color.black.opacity(0.3)))
+                .overlay(RoundedRectangle(cornerRadius: 8).stroke(ArvioTheme.border, lineWidth: 1))
+                .foregroundStyle(ArvioTheme.textPrimary)
+
+            Button {
+                Task { await appState.iptv.reload() }
+            } label: {
+                SecondaryButton(title: appState.iptv.isLoading ? "Loading" : "Refresh")
+            }
+            .buttonStyle(.plain)
+            .disabled(appState.iptv.isLoading)
+        }
+    }
+
+    private var groupRail: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            BrandMark()
+                .padding(.bottom, 16)
+
+            ForEach(appState.iptv.groups, id: \.self) { group in
+                Button {
+                    appState.iptv.setGroup(group)
+                } label: {
+                    HStack {
+                        Text(group)
+                            .font(.system(size: 16, weight: group == appState.iptv.selectedGroup ? .bold : .semibold))
+                            .lineLimit(1)
+                        Spacer()
+                        Text(countLabel(for: group))
+                            .font(.system(size: 12, weight: .bold))
+                            .foregroundStyle(ArvioTheme.textTertiary)
+                    }
+                    .foregroundStyle(group == appState.iptv.selectedGroup ? ArvioTheme.textPrimary : ArvioTheme.textSecondary)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 13)
+                    .background(RoundedRectangle(cornerRadius: 8).fill(group == appState.iptv.selectedGroup ? ArvioTheme.gold.opacity(0.15) : Color.clear))
+                    .overlay(RoundedRectangle(cornerRadius: 8).stroke(group == appState.iptv.selectedGroup ? ArvioTheme.gold.opacity(0.85) : Color.clear, lineWidth: 1))
+                }
+                .buttonStyle(.plain)
+            }
+
+            Spacer()
+        }
+        .padding(24)
+        .background(Color.black.opacity(0.28))
+        .overlay(Rectangle().fill(ArvioTheme.border).frame(width: 1), alignment: .trailing)
+    }
+
+    private var setupPanel: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("IPTV playlist")
+                .font(.system(size: 22, weight: .bold))
+                .foregroundStyle(ArvioTheme.textPrimary)
+            Text("Add the same M3U and EPG URLs you use on Android. ARVIO stores them in your cloud sync profile.")
+                .font(.system(size: 15))
+                .foregroundStyle(ArvioTheme.textSecondary)
+
+            TextField("M3U URL", text: $m3uUrl)
+                .textInputAutocapitalization(.never)
+                .settingsField()
+            TextField("EPG URL (optional)", text: $epgUrl)
+                .textInputAutocapitalization(.never)
+                .settingsField()
+
+            HStack {
+                Button {
+                    Task { await appState.iptv.saveConfig(m3uUrl: m3uUrl, epgUrl: epgUrl) }
+                } label: {
+                    PrimaryButton(title: "Save and Load")
+                }
+                .buttonStyle(.plain)
+
+                if appState.iptv.isLoading {
+                    Text(appState.iptv.progressMessage)
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(ArvioTheme.textSecondary)
+                }
+            }
+
+            if let error = appState.iptv.errorMessage {
+                Text(error)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(Color.red.opacity(0.9))
+            }
+        }
+        .padding(22)
+        .frame(maxWidth: 720, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 8).fill(ArvioTheme.panel))
+        .overlay(RoundedRectangle(cornerRadius: 8).stroke(ArvioTheme.border, lineWidth: 1))
+    }
+
+    private var channelGrid: some View {
+        ScrollView {
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 250), spacing: 14)], spacing: 14) {
+                ForEach(appState.iptv.visibleChannels) { channel in
+                    ChannelTile(channel: channel)
+                }
+            }
+            .padding(.bottom, 36)
+        }
+        .overlay(alignment: .topLeading) {
+            if let error = appState.iptv.errorMessage {
+                Text(error)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(Color.red.opacity(0.9))
+                    .padding(12)
+                    .background(RoundedRectangle(cornerRadius: 8).fill(Color.black.opacity(0.55)))
+            }
+        }
+    }
+
+    private func countLabel(for group: String) -> String {
+        if group == "All" { return "\(appState.iptv.channels.count)" }
+        if group == "Favorites" { return "\(appState.iptv.state.favoriteChannels.count)" }
+        return "\(appState.iptv.channels.filter { $0.group == group }.count)"
+    }
+}
+
+private struct ChannelTile: View {
+    @EnvironmentObject private var appState: AppState
+    let channel: IptvChannel
+
+    var body: some View {
+        Button {
+            play()
+        } label: {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(spacing: 12) {
+                    AsyncImage(url: channel.logo.flatMap(URL.init(string:))) { phase in
+                        if let image = phase.image {
+                            image.resizable().scaledToFit()
+                        } else {
+                            Image("ARVIOAppIcon").resizable().scaledToFit().opacity(0.8)
+                        }
+                    }
+                    .frame(width: 48, height: 48)
+                    .padding(8)
+                    .background(RoundedRectangle(cornerRadius: 8).fill(Color.black.opacity(0.28)))
+
+                    VStack(alignment: .leading, spacing: 5) {
+                        Text(channel.name)
+                            .font(.system(size: 17, weight: .bold))
+                            .foregroundStyle(ArvioTheme.textPrimary)
+                            .lineLimit(2)
+                        Text(channel.group)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(ArvioTheme.textTertiary)
+                            .lineLimit(1)
+                    }
+                    Spacer()
+                }
+
+                HStack {
+                    Text("LIVE")
+                        .font(.system(size: 11, weight: .black))
+                        .foregroundStyle(Color.black)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Capsule().fill(ArvioTheme.gold))
+                    Spacer()
+                    Button {
+                        Task { await appState.iptv.toggleFavorite(channel) }
+                    } label: {
+                        Text(appState.iptv.state.favoriteChannels.contains(channel.id) ? "Saved" : "Save")
+                            .font(.system(size: 12, weight: .bold))
+                    }
+                    .buttonStyle(.bordered)
+                }
+            }
+            .padding(14)
+            .frame(minHeight: 132, alignment: .topLeading)
+            .background(RoundedRectangle(cornerRadius: 8).fill(ArvioTheme.panel))
+            .overlay(RoundedRectangle(cornerRadius: 8).stroke(ArvioTheme.border, lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func play() {
+        appState.iptv.markOpened(channel)
+        appState.selectedStream = ResolvedStream(
+            addonName: "Live TV",
+            sourceName: channel.group,
+            title: channel.name,
+            quality: "Live",
+            size: "",
+            url: URL(string: channel.streamUrl),
+            isPlayable: true
+        )
+    }
+}

--- a/iosApp/ARVIO/LiveTVView.swift
+++ b/iosApp/ARVIO/LiveTVView.swift
@@ -12,10 +12,10 @@ struct LiveTVView: View {
 
             VStack(alignment: .leading, spacing: 18) {
                 header
-                if appState.iptv.channels.isEmpty {
-                    setupPanel
-                } else {
-                    channelGrid
+            if appState.iptv.channels.isEmpty {
+                setupPanel
+            } else {
+                channelGrid
                 }
             }
             .padding(28)
@@ -148,7 +148,7 @@ struct LiveTVView: View {
         ScrollView {
             LazyVGrid(columns: [GridItem(.adaptive(minimum: 250), spacing: 14)], spacing: 14) {
                 ForEach(appState.iptv.visibleChannels) { channel in
-                    ChannelTile(channel: channel)
+                    ChannelTile(channel: channel, guide: appState.iptv.nowNextByChannelId[channel.id])
                 }
             }
             .padding(.bottom, 36)
@@ -174,6 +174,7 @@ struct LiveTVView: View {
 private struct ChannelTile: View {
     @EnvironmentObject private var appState: AppState
     let channel: IptvChannel
+    let guide: IptvNowNext?
 
     var body: some View {
         Button {
@@ -201,6 +202,12 @@ private struct ChannelTile: View {
                             .font(.system(size: 13, weight: .medium))
                             .foregroundStyle(ArvioTheme.textTertiary)
                             .lineLimit(1)
+                        if let title = guide?.now?.title {
+                            Text(title)
+                                .font(.system(size: 13, weight: .semibold))
+                                .foregroundStyle(ArvioTheme.gold)
+                                .lineLimit(1)
+                        }
                     }
                     Spacer()
                 }
@@ -221,6 +228,12 @@ private struct ChannelTile: View {
                     }
                     .buttonStyle(.bordered)
                 }
+                if let next = guide?.next {
+                    Text("Next: \(next.title)")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(ArvioTheme.textTertiary)
+                        .lineLimit(1)
+                }
             }
             .padding(14)
             .frame(minHeight: 132, alignment: .topLeading)
@@ -233,6 +246,7 @@ private struct ChannelTile: View {
     private func play() {
         appState.iptv.markOpened(channel)
         appState.selectedStream = ResolvedStream(
+            addonId: nil,
             addonName: "Live TV",
             sourceName: channel.group,
             title: channel.name,

--- a/iosApp/ARVIO/Models.swift
+++ b/iosApp/ARVIO/Models.swift
@@ -33,6 +33,11 @@ struct MediaItem: Identifiable, Hashable {
     let posterPath: String?
     let backdropPath: String?
     let overview: String?
+    let season: Int?
+    let episode: Int?
+    let episodeTitle: String?
+    let positionSeconds: Int?
+    let durationSeconds: Int?
 
     init(
         id: String = UUID().uuidString,
@@ -47,7 +52,12 @@ struct MediaItem: Identifiable, Hashable {
         palette: [String],
         posterPath: String? = nil,
         backdropPath: String? = nil,
-        overview: String? = nil
+        overview: String? = nil,
+        season: Int? = nil,
+        episode: Int? = nil,
+        episodeTitle: String? = nil,
+        positionSeconds: Int? = nil,
+        durationSeconds: Int? = nil
     ) {
         self.id = id
         self.tmdbId = tmdbId
@@ -62,6 +72,11 @@ struct MediaItem: Identifiable, Hashable {
         self.posterPath = posterPath
         self.backdropPath = backdropPath
         self.overview = overview
+        self.season = season
+        self.episode = episode
+        self.episodeTitle = episodeTitle
+        self.positionSeconds = positionSeconds
+        self.durationSeconds = durationSeconds
     }
 
     var backdropURL: URL? {
@@ -75,15 +90,3 @@ struct MediaItem: Identifiable, Hashable {
     }
 }
 
-let featuredItems: [MediaItem] = [
-    MediaItem(title: "Echoes of Dawn", subtitle: "S1 • E6 • New episode", year: "2026", duration: "45m", rating: "8.7", kind: .series, progress: 0.72, palette: ["#d99b4f", "#4b2b19"]),
-    MediaItem(title: "Neon Paradox", subtitle: "Cyber noir thriller", year: "2025", duration: "2h 10m", rating: "8.2", kind: .movie, progress: 0.0, palette: ["#2276ff", "#141b3c"]),
-    MediaItem(title: "Beyond the Wilds", subtitle: "S2 • E3", year: "2026", duration: "50m", rating: "8.0", kind: .series, progress: 0.28, palette: ["#9cbf6a", "#1d2d21"]),
-    MediaItem(title: "The Architect", subtitle: "Premium action cinema", year: "2025", duration: "1h 58m", rating: "7.9", kind: .movie, progress: 0.0, palette: ["#d64a36", "#241112"])
-]
-
-let continueWatchingItems: [MediaItem] = [
-    MediaItem(title: "Night Watch", subtitle: "Resume episode", year: "2026", duration: "47m left", rating: "8.4", kind: .series, progress: 0.41, palette: ["#315f8d", "#081826"]),
-    MediaItem(title: "Deep Current", subtitle: "S1 • E4", year: "2026", duration: "19m left", rating: "8.1", kind: .series, progress: 0.64, palette: ["#1a9ec0", "#06242c"]),
-    MediaItem(title: "The Long Orbit", subtitle: "Continue movie", year: "2025", duration: "54m left", rating: "7.8", kind: .movie, progress: 0.52, palette: ["#7961c8", "#18152d"])
-]

--- a/iosApp/ARVIO/Models.swift
+++ b/iosApp/ARVIO/Models.swift
@@ -3,10 +3,25 @@ import Foundation
 enum MediaKind: String {
     case movie = "Movie"
     case series = "TV Series"
+
+    var tmdbPath: String {
+        switch self {
+        case .movie: return "movie"
+        case .series: return "tv"
+        }
+    }
+
+    var stremioType: String {
+        switch self {
+        case .movie: return "movie"
+        case .series: return "series"
+        }
+    }
 }
 
 struct MediaItem: Identifiable, Hashable {
-    let id = UUID()
+    let id: String
+    let tmdbId: Int?
     let title: String
     let subtitle: String
     let year: String
@@ -15,6 +30,49 @@ struct MediaItem: Identifiable, Hashable {
     let kind: MediaKind
     let progress: Double
     let palette: [String]
+    let posterPath: String?
+    let backdropPath: String?
+    let overview: String?
+
+    init(
+        id: String = UUID().uuidString,
+        tmdbId: Int? = nil,
+        title: String,
+        subtitle: String,
+        year: String,
+        duration: String,
+        rating: String,
+        kind: MediaKind,
+        progress: Double,
+        palette: [String],
+        posterPath: String? = nil,
+        backdropPath: String? = nil,
+        overview: String? = nil
+    ) {
+        self.id = id
+        self.tmdbId = tmdbId
+        self.title = title
+        self.subtitle = subtitle
+        self.year = year
+        self.duration = duration
+        self.rating = rating
+        self.kind = kind
+        self.progress = progress
+        self.palette = palette
+        self.posterPath = posterPath
+        self.backdropPath = backdropPath
+        self.overview = overview
+    }
+
+    var backdropURL: URL? {
+        guard let backdropPath else { return nil }
+        return URL(string: "https://image.tmdb.org/t/p/w1280\(backdropPath)")
+    }
+
+    var posterURL: URL? {
+        guard let posterPath else { return nil }
+        return URL(string: "https://image.tmdb.org/t/p/w780\(posterPath)")
+    }
 }
 
 let featuredItems: [MediaItem] = [

--- a/iosApp/ARVIO/PlayerView.swift
+++ b/iosApp/ARVIO/PlayerView.swift
@@ -6,6 +6,7 @@ struct PlayerView: View {
     let stream: ResolvedStream
     @State private var player: AVPlayer?
     @State private var didSeek = false
+    @State private var didSaveProgress = false
 
     var body: some View {
         ZStack(alignment: .topLeading) {
@@ -15,7 +16,7 @@ struct PlayerView: View {
                     .ignoresSafeArea()
             }
             Button("Close") {
-                appState.selectedStream = nil
+                Task { await closePlayer() }
             }
             .buttonStyle(.borderedProminent)
             .tint(ArvioTheme.gold)
@@ -32,8 +33,30 @@ struct PlayerView: View {
             created.play()
         }
         .onDisappear {
+            Task { await saveProgressIfNeeded() }
             player?.pause()
             player = nil
         }
+    }
+
+    private func closePlayer() async {
+        await saveProgressIfNeeded()
+        appState.selectedStream = nil
+    }
+
+    private func saveProgressIfNeeded() async {
+        guard !didSaveProgress, let media = appState.selectedMedia, let player else { return }
+        let current = player.currentTime().seconds
+        let rawDuration = player.currentItem?.duration.seconds ?? 0
+        let fallbackDuration = Double(media.durationSeconds ?? 0)
+        let duration = rawDuration.isFinite && rawDuration > 0 ? rawDuration : fallbackDuration
+        guard current.isFinite, current > 5, duration > 30 else { return }
+        didSaveProgress = true
+        await appState.watchHistory.saveProgress(
+            item: media,
+            stream: stream,
+            positionSeconds: Int(current.rounded()),
+            durationSeconds: Int(duration.rounded())
+        )
     }
 }

--- a/iosApp/ARVIO/PlayerView.swift
+++ b/iosApp/ARVIO/PlayerView.swift
@@ -1,0 +1,23 @@
+import AVKit
+import SwiftUI
+
+struct PlayerView: View {
+    @EnvironmentObject private var appState: AppState
+    let stream: ResolvedStream
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            Color.black.ignoresSafeArea()
+            if let url = stream.url {
+                VideoPlayer(player: AVPlayer(url: url))
+                    .ignoresSafeArea()
+            }
+            Button("Close") {
+                appState.selectedStream = nil
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(ArvioTheme.gold)
+            .padding(24)
+        }
+    }
+}

--- a/iosApp/ARVIO/PlayerView.swift
+++ b/iosApp/ARVIO/PlayerView.swift
@@ -4,12 +4,14 @@ import SwiftUI
 struct PlayerView: View {
     @EnvironmentObject private var appState: AppState
     let stream: ResolvedStream
+    @State private var player: AVPlayer?
+    @State private var didSeek = false
 
     var body: some View {
         ZStack(alignment: .topLeading) {
             Color.black.ignoresSafeArea()
-            if let url = stream.url {
-                VideoPlayer(player: AVPlayer(url: url))
+            if let player {
+                VideoPlayer(player: player)
                     .ignoresSafeArea()
             }
             Button("Close") {
@@ -18,6 +20,20 @@ struct PlayerView: View {
             .buttonStyle(.borderedProminent)
             .tint(ArvioTheme.gold)
             .padding(24)
+        }
+        .task(id: stream.id) {
+            guard let url = stream.url else { return }
+            let created = AVPlayer(url: url)
+            player = created
+            if let seconds = stream.resumePositionSeconds, seconds > 5, !didSeek {
+                didSeek = true
+                created.seek(to: CMTime(seconds: Double(seconds), preferredTimescale: 600))
+            }
+            created.play()
+        }
+        .onDisappear {
+            player?.pause()
+            player = nil
         }
     }
 }

--- a/iosApp/ARVIO/ProfileSelectionView.swift
+++ b/iosApp/ARVIO/ProfileSelectionView.swift
@@ -1,0 +1,143 @@
+import SwiftUI
+
+struct ProfileSelectionView: View {
+    @EnvironmentObject private var appState: AppState
+
+    var body: some View {
+        ZStack {
+            ArvioTheme.background.ignoresSafeArea()
+            LinearGradient(
+                colors: [Color.black.opacity(0.45), Color(hex: "#07131f").opacity(0.8)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .ignoresSafeArea()
+
+            VStack(spacing: 30) {
+                HStack {
+                    BrandMark()
+                    Spacer()
+                    Button("Close") {
+                        appState.profiles.isSwitcherVisible = false
+                    }
+                    .buttonStyle(.bordered)
+                }
+
+                Text("Who's watching?")
+                    .font(.system(size: 46, weight: .bold))
+                    .foregroundStyle(ArvioTheme.textPrimary)
+
+                HStack(spacing: 22) {
+                    ForEach(appState.profiles.profiles) { profile in
+                        profileButton(profile)
+                    }
+                    addProfileCard
+                }
+
+                if let error = appState.profiles.errorMessage {
+                    Text(error)
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundStyle(Color.red.opacity(0.9))
+                }
+            }
+            .padding(48)
+
+            if appState.profiles.pendingLockedProfile != nil {
+                pinPanel
+            }
+        }
+    }
+
+    private func profileButton(_ profile: ArvioProfile) -> some View {
+        VStack(spacing: 14) {
+            Button {
+                appState.profiles.requestSelect(profile)
+            } label: {
+                VStack(spacing: 12) {
+                    Circle()
+                        .fill(
+                            LinearGradient(
+                                colors: [Color(hex: profile.swiftUIColorHex), Color.white.opacity(0.18)],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            )
+                        )
+                        .frame(width: 118, height: 118)
+                        .overlay {
+                            Text(String(profile.name.prefix(1)).uppercased())
+                                .font(.system(size: 44, weight: .black))
+                                .foregroundStyle(Color.white)
+                        }
+                        .overlay(Circle().stroke(profile.id == appState.profiles.activeProfile?.id ? ArvioTheme.gold : ArvioTheme.border, lineWidth: 3))
+
+                    Text(profile.name)
+                        .font(.system(size: 18, weight: .bold))
+                        .foregroundStyle(ArvioTheme.textPrimary)
+                        .lineLimit(1)
+                }
+            }
+            .buttonStyle(.plain)
+
+            if appState.profiles.profiles.count > 1 {
+                Button("Delete") {
+                    Task { await appState.profiles.delete(profile) }
+                }
+                .font(.system(size: 12, weight: .semibold))
+                .buttonStyle(.borderless)
+            }
+        }
+        .frame(width: 150)
+    }
+
+    private var addProfileCard: some View {
+        VStack(spacing: 12) {
+            TextField("Name", text: Binding(
+                get: { appState.profiles.newProfileName },
+                set: { appState.profiles.newProfileName = $0 }
+            ))
+            .multilineTextAlignment(.center)
+            .padding(12)
+            .frame(width: 150)
+            .background(RoundedRectangle(cornerRadius: 8).fill(Color.black.opacity(0.25)))
+            .overlay(RoundedRectangle(cornerRadius: 8).stroke(ArvioTheme.border, lineWidth: 1))
+
+            Button {
+                Task { await appState.profiles.createProfile() }
+            } label: {
+                SecondaryButton(title: "Add Profile")
+            }
+            .buttonStyle(.plain)
+        }
+        .frame(width: 170)
+    }
+
+    private var pinPanel: some View {
+        VStack(spacing: 16) {
+            Text("Enter PIN")
+                .font(.system(size: 24, weight: .bold))
+                .foregroundStyle(ArvioTheme.textPrimary)
+            SecureField("PIN", text: Binding(
+                get: { appState.profiles.pinEntry },
+                set: { appState.profiles.pinEntry = $0 }
+            ))
+            .keyboardType(.numberPad)
+            .multilineTextAlignment(.center)
+            .settingsField()
+            .frame(width: 220)
+            HStack {
+                Button("Cancel") {
+                    appState.profiles.pendingLockedProfile = nil
+                }
+                .buttonStyle(.bordered)
+                Button("Unlock") {
+                    appState.profiles.confirmPin()
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(ArvioTheme.gold)
+            }
+        }
+        .padding(24)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Color.black.opacity(0.86)))
+        .overlay(RoundedRectangle(cornerRadius: 8).stroke(ArvioTheme.border, lineWidth: 1))
+    }
+}

--- a/iosApp/ARVIO/ProfileService.swift
+++ b/iosApp/ARVIO/ProfileService.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+struct ArvioProfile: Codable, Identifiable, Hashable {
+    let id: String
+    var name: String
+    var avatarColor: Int64
+    var avatarId: Int
+    var avatarImageVersion: Int64
+    var avatarImageStoragePath: String?
+    var isKidsProfile: Bool
+    var pin: String?
+    var isLocked: Bool
+    var createdAt: Int64
+    var lastUsedAt: Int64
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case avatarColor
+        case avatarId
+        case avatarImageVersion
+        case avatarImageStoragePath
+        case isKidsProfile
+        case pin
+        case isLocked
+        case createdAt
+        case lastUsedAt
+    }
+
+    static func make(name: String, color: Int64 = 0xFF3B82F6) -> ArvioProfile {
+        let now = Int64(Date().timeIntervalSince1970 * 1000)
+        return ArvioProfile(
+            id: UUID().uuidString,
+            name: name,
+            avatarColor: color,
+            avatarId: 0,
+            avatarImageVersion: 0,
+            avatarImageStoragePath: nil,
+            isKidsProfile: false,
+            pin: nil,
+            isLocked: false,
+            createdAt: now,
+            lastUsedAt: now
+        )
+    }
+
+    var swiftUIColorHex: String {
+        let masked = avatarColor & 0x00FF_FFFF
+        return String(format: "#%06llX", masked)
+    }
+}
+
+@MainActor
+final class ProfileService: ObservableObject {
+    @Published private(set) var profiles: [ArvioProfile] = []
+    @Published private(set) var activeProfileId: String?
+    @Published var isSwitcherVisible = false
+    @Published var newProfileName = ""
+    @Published var pinEntry = ""
+    @Published var pendingLockedProfile: ArvioProfile?
+    @Published var errorMessage: String?
+
+    private let cloud: CloudSyncService
+    private let storageKey = "arvio.ios.profiles"
+    private let activeKey = "arvio.ios.activeProfileId"
+    var onActiveProfileChanged: ((String?) -> Void)?
+
+    init(cloud: CloudSyncService) {
+        self.cloud = cloud
+        loadLocal()
+    }
+
+    var activeProfile: ArvioProfile? {
+        profiles.first { $0.id == activeProfileId } ?? profiles.first
+    }
+
+    func ensureDefault(email: String?) {
+        guard profiles.isEmpty else { return }
+        profiles = [ArvioProfile.make(name: email?.split(separator: "@").first.map(String.init) ?? "ARVIO")]
+        activeProfileId = profiles.first?.id
+        onActiveProfileChanged?(activeProfileId)
+        saveLocal()
+    }
+
+    func loadFromCloud() {
+        if let cloudProfiles = cloud.payload.profiles, !cloudProfiles.isEmpty {
+            profiles = cloudProfiles
+            activeProfileId = cloud.payload.activeProfileId ?? activeProfileId ?? cloudProfiles.first?.id
+            onActiveProfileChanged?(activeProfileId)
+            saveLocal()
+        }
+    }
+
+    func createProfile() async {
+        let name = newProfileName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else {
+            errorMessage = "Profile name is required"
+            return
+        }
+        let colors: [Int64] = [0xFFE50914, 0xFF1DB954, 0xFF3B82F6, 0xFFF59E0B, 0xFF8B5CF6, 0xFFEC4899, 0xFF14B8A6, 0xFF6366F1]
+        profiles.append(ArvioProfile.make(name: name, color: colors[profiles.count % colors.count]))
+        newProfileName = ""
+        errorMessage = nil
+        saveLocal()
+        await cloud.save(profiles: profiles, activeProfileId: activeProfileId)
+    }
+
+    func requestSelect(_ profile: ArvioProfile) {
+        if profile.isLocked {
+            pendingLockedProfile = profile
+            pinEntry = ""
+        } else {
+            select(profile)
+        }
+    }
+
+    func confirmPin() {
+        guard let profile = pendingLockedProfile else { return }
+        guard profile.pin == pinEntry else {
+            errorMessage = "Incorrect PIN"
+            return
+        }
+        pendingLockedProfile = nil
+        pinEntry = ""
+        select(profile)
+    }
+
+    func select(_ profile: ArvioProfile) {
+        activeProfileId = profile.id
+        onActiveProfileChanged?(profile.id)
+        if let index = profiles.firstIndex(where: { $0.id == profile.id }) {
+            profiles[index].lastUsedAt = Int64(Date().timeIntervalSince1970 * 1000)
+        }
+        isSwitcherVisible = false
+        errorMessage = nil
+        saveLocal()
+        Task { await cloud.save(profiles: profiles, activeProfileId: profile.id) }
+    }
+
+    func delete(_ profile: ArvioProfile) async {
+        guard profiles.count > 1 else {
+            errorMessage = "At least one profile is required"
+            return
+        }
+        profiles.removeAll { $0.id == profile.id }
+        if activeProfileId == profile.id {
+            activeProfileId = profiles.first?.id
+            onActiveProfileChanged?(activeProfileId)
+        }
+        saveLocal()
+        await cloud.save(profiles: profiles, activeProfileId: activeProfileId)
+    }
+
+    private func loadLocal() {
+        if let data = UserDefaults.standard.data(forKey: storageKey),
+           let decoded = try? JSONDecoder().decode([ArvioProfile].self, from: data) {
+            profiles = decoded
+        }
+        activeProfileId = UserDefaults.standard.string(forKey: activeKey)
+    }
+
+    private func saveLocal() {
+        if let data = try? JSONEncoder().encode(profiles) {
+            UserDefaults.standard.set(data, forKey: storageKey)
+        }
+        UserDefaults.standard.set(activeProfileId, forKey: activeKey)
+    }
+}

--- a/iosApp/ARVIO/RootView.swift
+++ b/iosApp/ARVIO/RootView.swift
@@ -27,29 +27,37 @@ struct RootView: View {
             .ignoresSafeArea()
 
             VStack(spacing: 0) {
-                TopNavigation(selectedTab: $selectedTab)
-
-                Group {
-                    switch selectedTab {
-                    case .home:
-                        HomeView()
-                    case .movies:
-                        CatalogView(title: "Movies", subtitle: "Curated cinema and recent releases.", items: featuredItems.filter { $0.kind == .movie })
-                    case .series:
-                        CatalogView(title: "Series", subtitle: "Continue seasons and discover premium TV.", items: featuredItems.filter { $0.kind == .series })
-                    case .liveTV:
-                        CatalogView(title: "Live TV", subtitle: "IPTV guide and channels are next in the iOS parity queue.", items: featuredItems)
-                    case .watchlist:
-                        WatchlistView()
-                    case .search:
-                        SearchView()
-                    case .addons:
-                        AddonsView()
-                    case .settings:
-                        SettingsView()
-                    }
+                if appState.selectedStream == nil && appState.selectedMedia == nil {
+                    TopNavigation(selectedTab: $selectedTab)
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+                if let stream = appState.selectedStream {
+                    PlayerView(stream: stream)
+                } else if let media = appState.selectedMedia {
+                    DetailsView(item: media)
+                } else {
+                    Group {
+                        switch selectedTab {
+                        case .home:
+                            HomeView()
+                        case .movies:
+                            CatalogView(title: "Movies", subtitle: "Curated cinema and recent releases.", items: appState.tmdb.trendingMovies)
+                        case .series:
+                            CatalogView(title: "Series", subtitle: "Continue seasons and discover premium TV.", items: appState.tmdb.trendingSeries)
+                        case .liveTV:
+                            CatalogView(title: "Live TV", subtitle: "IPTV guide and channels are next in the iOS parity queue.", items: featuredItems)
+                        case .watchlist:
+                            WatchlistView()
+                        case .search:
+                            SearchView()
+                        case .addons:
+                            AddonsView()
+                        case .settings:
+                            SettingsView()
+                        }
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
             }
         }
     }

--- a/iosApp/ARVIO/RootView.swift
+++ b/iosApp/ARVIO/RootView.swift
@@ -45,7 +45,7 @@ struct RootView: View {
                         case .series:
                             CatalogView(title: "Series", subtitle: "Continue seasons and discover premium TV.", items: appState.tmdb.trendingSeries)
                         case .liveTV:
-                            CatalogView(title: "Live TV", subtitle: "IPTV guide and channels are next in the iOS parity queue.", items: featuredItems)
+                            LiveTVView()
                         case .watchlist:
                             WatchlistView()
                         case .search:
@@ -59,16 +59,30 @@ struct RootView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
             }
+
+            if appState.profiles.isSwitcherVisible {
+                ProfileSelectionView()
+                    .transition(.opacity)
+            }
         }
     }
 }
 
 struct TopNavigation: View {
+    @EnvironmentObject private var appState: AppState
     @Binding var selectedTab: ArvioTab
 
     var body: some View {
         HStack(spacing: 20) {
-            BrandMark()
+            Button {
+                appState.profiles.isSwitcherVisible = true
+            } label: {
+                HStack(spacing: 10) {
+                    ProfileDot(profile: appState.profiles.activeProfile)
+                    BrandMark()
+                }
+            }
+            .buttonStyle(.plain)
 
             ForEach(ArvioTab.allCases, id: \.self) { tab in
                 Button {
@@ -110,5 +124,21 @@ struct BrandMark: View {
             .scaledToFit()
             .frame(width: 42, height: 42)
             .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+}
+
+struct ProfileDot: View {
+    let profile: ArvioProfile?
+
+    var body: some View {
+        Circle()
+            .fill(Color(hex: profile?.swiftUIColorHex ?? "#3B82F6"))
+            .frame(width: 34, height: 34)
+            .overlay {
+                Text(String((profile?.name ?? "A").prefix(1)).uppercased())
+                    .font(.system(size: 14, weight: .black))
+                    .foregroundStyle(Color.white)
+            }
+            .overlay(Circle().stroke(ArvioTheme.gold.opacity(0.85), lineWidth: 1))
     }
 }

--- a/iosApp/ARVIO/SearchView.swift
+++ b/iosApp/ARVIO/SearchView.swift
@@ -23,7 +23,10 @@ struct SearchView: View {
                     Task { await appState.tmdb.search(value) }
                 }
 
-            MediaRail(title: query.isEmpty ? "Suggested" : "Results", items: query.isEmpty ? featuredItems : appState.tmdb.searchResults)
+            MediaRail(
+                title: query.isEmpty ? "Suggested" : "Results",
+                items: query.isEmpty ? appState.tmdb.trendingMovies + appState.tmdb.trendingSeries : appState.tmdb.searchResults
+            )
 
             Spacer()
         }

--- a/iosApp/ARVIO/SearchView.swift
+++ b/iosApp/ARVIO/SearchView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct SearchView: View {
+    @EnvironmentObject private var appState: AppState
     @State private var query = ""
 
     var body: some View {
@@ -15,8 +16,14 @@ struct SearchView: View {
                 .background(RoundedRectangle(cornerRadius: 8).fill(ArvioTheme.panel))
                 .overlay(RoundedRectangle(cornerRadius: 8).stroke(ArvioTheme.border, lineWidth: 1))
                 .foregroundStyle(ArvioTheme.textPrimary)
+                .onSubmit {
+                    Task { await appState.tmdb.search(query) }
+                }
+                .onChange(of: query) { _, value in
+                    Task { await appState.tmdb.search(value) }
+                }
 
-            MediaRail(title: query.isEmpty ? "Suggested" : "Results", items: featuredItems)
+            MediaRail(title: query.isEmpty ? "Suggested" : "Results", items: query.isEmpty ? featuredItems : appState.tmdb.searchResults)
 
             Spacer()
         }

--- a/iosApp/ARVIO/SettingsService.swift
+++ b/iosApp/ARVIO/SettingsService.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+struct CloudProfileSettings: Codable, Equatable {
+    var defaultSubtitle: String = "Off"
+    var defaultAudioLanguage: String = "Auto (Original)"
+    var contentLanguage: String = "en-US"
+    var subtitleSize: String = "Medium"
+    var subtitleColor: String = "White"
+    var subtitleStyle: String = "Bold"
+    var subtitleOffset: String = "Low"
+    var subtitleStylized: Bool = true
+    var cardLayoutMode: String = "Landscape"
+    var frameRateMatchingMode: String = "Off"
+    var autoPlayNext: Bool = true
+    var autoPlaySingleSource: Bool = true
+    var autoPlayMinQuality: String = "Any"
+    var trailerAutoPlay: Bool = false
+    var trailerSoundEnabled: Bool = false
+    var clockFormat: String = "24h"
+    var showBudget: Bool = true
+    var spoilerBlurEnabled: Bool = false
+    var volumeBoostDb: Int = 0
+    var includeSpecials: Bool = false
+    var dnsProvider: String = "system"
+    var subtitleUsageJson: String = ""
+    var subtitleSettingsUpdatedAt: Int64 = 0
+    var iptvHiddenGroups: String = ""
+    var iptvGroupOrder: String = ""
+    var secondarySubtitle: String = "Off"
+    var filterSubtitlesByLanguage: Bool = true
+    var homeServerConnectionJson: String?
+    var catalogueRowLayoutModes: [String: String] = [:]
+}
+
+struct GlobalCloudSettings: Codable, Equatable {
+    var subtitleAiEnabled: Bool = false
+    var subtitleAiAutoSelect: Bool = false
+    var subtitleAiApiKey: String = ""
+    var subtitleAiModel: String = "GROQ_LLAMA_70B"
+    var subtitleRemoveHearingImpaired: Bool = true
+    var skipProfileSelection: Bool = false
+}
+
+@MainActor
+final class SettingsService: ObservableObject {
+    @Published private(set) var profileSettings = CloudProfileSettings()
+    @Published private(set) var globalSettings = GlobalCloudSettings()
+    @Published var isSaving = false
+    @Published var errorMessage: String?
+
+    private let cloud: CloudSyncService
+    private var activeProfileId = "default"
+
+    init(cloud: CloudSyncService) {
+        self.cloud = cloud
+    }
+
+    func setActiveProfileId(_ profileId: String?) {
+        let trimmed = profileId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        activeProfileId = trimmed.isEmpty ? "default" : trimmed
+        loadFromCloud()
+    }
+
+    func loadFromCloud() {
+        if let byProfile = cloud.payload.profileSettingsById,
+           let settings = byProfile[activeProfileId] ?? byProfile.values.first {
+            profileSettings = settings
+        } else {
+            profileSettings = CloudProfileSettings(
+                defaultSubtitle: cloud.payload.defaultSubtitle ?? "Off",
+                defaultAudioLanguage: cloud.payload.defaultAudioLanguage ?? "Auto (Original)",
+                cardLayoutMode: cloud.payload.cardLayoutMode ?? "Landscape",
+                frameRateMatchingMode: cloud.payload.frameRateMatchingMode ?? "Off",
+                autoPlayNext: cloud.payload.autoPlayNext ?? true,
+                autoPlaySingleSource: cloud.payload.autoPlaySingleSource ?? true,
+                autoPlayMinQuality: cloud.payload.autoPlayMinQuality ?? "Any",
+                includeSpecials: cloud.payload.includeSpecials ?? false,
+                dnsProvider: cloud.payload.dnsProvider ?? "system",
+                subtitleUsageJson: cloud.payload.subtitleUsageJson ?? "",
+                subtitleSettingsUpdatedAt: Int64(cloud.payload.subtitleSettingsUpdatedAt ?? 0)
+            )
+        }
+        globalSettings = GlobalCloudSettings(
+            subtitleAiEnabled: cloud.payload.subtitleAiEnabled ?? false,
+            subtitleAiAutoSelect: cloud.payload.subtitleAiAutoSelect ?? false,
+            subtitleAiApiKey: cloud.payload.subtitleAiApiKey ?? "",
+            subtitleAiModel: cloud.payload.subtitleAiModel ?? "GROQ_LLAMA_70B",
+            subtitleRemoveHearingImpaired: cloud.payload.subtitleRemoveHearingImpaired ?? true,
+            skipProfileSelection: cloud.payload.skipProfileSelection ?? false
+        )
+    }
+
+    func updateProfile(_ mutate: (inout CloudProfileSettings) -> Void) async {
+        var updated = profileSettings
+        mutate(&updated)
+        updated.volumeBoostDb = min(max(updated.volumeBoostDb, 0), 15)
+        updated.subtitleSettingsUpdatedAt = Int64(Date().timeIntervalSince1970 * 1000)
+        profileSettings = updated
+        await save()
+    }
+
+    func updateGlobal(_ mutate: (inout GlobalCloudSettings) -> Void) async {
+        var updated = globalSettings
+        mutate(&updated)
+        globalSettings = updated
+        await save()
+    }
+
+    private func save() async {
+        isSaving = true
+        defer { isSaving = false }
+        await cloud.save(
+            settings: profileSettings,
+            globalSettings: globalSettings,
+            profileId: activeProfileId
+        )
+        errorMessage = cloud.lastError
+    }
+}

--- a/iosApp/ARVIO/SettingsView.swift
+++ b/iosApp/ARVIO/SettingsView.swift
@@ -14,9 +14,11 @@ struct SettingsView: View {
 
                 cloudPanel
                 traktPanel
+                profilePanel
                 SettingsRow(title: "Cloud sync", value: appState.cloud.isSyncing ? "Syncing" : (appState.auth.isAuthenticated ? "Connected" : "Disconnected"))
                 SettingsRow(title: "Addons", value: "\(appState.addons.addons.count) installed")
-                SettingsRow(title: "Playback", value: "AVPlayer parity work pending")
+                SettingsRow(title: "Live TV", value: appState.iptv.channels.isEmpty ? "No channels loaded" : "\(appState.iptv.channels.count) channels")
+                SettingsRow(title: "Playback", value: "Direct AVPlayer, stream source picker")
             }
             .padding(28)
         }
@@ -117,6 +119,27 @@ struct SettingsView: View {
         }
         .settingsPanel()
     }
+
+    private var profilePanel: some View {
+        HStack(spacing: 14) {
+            ProfileDot(profile: appState.profiles.activeProfile)
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Profiles")
+                    .font(.system(size: 20, weight: .bold))
+                    .foregroundStyle(ArvioTheme.textPrimary)
+                Text(appState.profiles.activeProfile?.name ?? "Default")
+                    .font(.system(size: 14))
+                    .foregroundStyle(ArvioTheme.textSecondary)
+            }
+            Spacer()
+            Button("Switch") {
+                appState.profiles.isSwitcherVisible = true
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(ArvioTheme.gold)
+        }
+        .settingsPanel()
+    }
 }
 
 struct SettingsRow: View {
@@ -139,7 +162,7 @@ struct SettingsRow: View {
     }
 }
 
-private extension View {
+extension View {
     func settingsPanel() -> some View {
         padding(18)
             .background(RoundedRectangle(cornerRadius: 8).fill(ArvioTheme.panel))

--- a/iosApp/ARVIO/SettingsView.swift
+++ b/iosApp/ARVIO/SettingsView.swift
@@ -15,10 +15,11 @@ struct SettingsView: View {
                 cloudPanel
                 traktPanel
                 profilePanel
-                SettingsRow(title: "Cloud sync", value: appState.cloud.isSyncing ? "Syncing" : (appState.auth.isAuthenticated ? "Connected" : "Disconnected"))
-                SettingsRow(title: "Addons", value: "\(appState.addons.addons.count) installed")
-                SettingsRow(title: "Live TV", value: appState.iptv.channels.isEmpty ? "No channels loaded" : "\(appState.iptv.channels.count) channels")
-                SettingsRow(title: "Playback", value: "Direct AVPlayer, stream source picker")
+                playbackPanel
+                subtitlePanel
+                interfacePanel
+                aiSubtitlePanel
+                syncSummaryPanel
             }
             .padding(28)
         }
@@ -51,13 +52,20 @@ struct SettingsView: View {
                     .settingsField()
                 HStack {
                     Button("Sign in") {
-                        Task { await appState.auth.signIn(email: email, password: password) }
+                        Task {
+                            await appState.auth.signIn(email: email, password: password)
+                            await appState.reloadCloudState()
+                            await appState.watchHistory.load()
+                        }
                     }
                     .buttonStyle(.borderedProminent)
                     .tint(ArvioTheme.gold)
 
                     Button("Create account") {
-                        Task { await appState.auth.signUp(email: email, password: password) }
+                        Task {
+                            await appState.auth.signUp(email: email, password: password)
+                            await appState.reloadCloudState()
+                        }
                     }
                     .buttonStyle(.bordered)
                 }
@@ -79,7 +87,7 @@ struct SettingsView: View {
                     Text("Trakt")
                         .font(.system(size: 20, weight: .bold))
                         .foregroundStyle(ArvioTheme.textPrimary)
-                    Text(appState.trakt.isConnected ? "Connected. Watchlist sync is active." : "Link Trakt to mirror Android watchlist/history.")
+                    Text(appState.trakt.isConnected ? "Connected. Watchlist and playback sync are active." : "Link Trakt to mirror Android watchlist/history.")
                         .font(.system(size: 14))
                         .foregroundStyle(ArvioTheme.textSecondary)
                 }
@@ -142,6 +150,155 @@ struct SettingsView: View {
             .tint(ArvioTheme.gold)
         }
         .settingsPanel()
+    }
+
+    private var playbackPanel: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            panelHeader("Playback", "Matches Android playback preferences saved in ARVIO cloud.")
+            SettingsToggle("Auto-play next episode", isOn: profileBinding(\.autoPlayNext))
+            SettingsToggle("Auto-play when one source exists", isOn: profileBinding(\.autoPlaySingleSource))
+            SettingsPicker(title: "Minimum auto-play quality", selection: profileBinding(\.autoPlayMinQuality), values: ["Any", "720p", "1080p", "4K"])
+            SettingsPicker(title: "Frame-rate matching", selection: profileBinding(\.frameRateMatchingMode), values: ["Off", "Seamless", "Non-seamless"])
+            Stepper(value: profileBinding(\.volumeBoostDb), in: 0...15) {
+                SettingsValueLabel(title: "Volume boost", value: "\(appState.settings.profileSettings.volumeBoostDb)dB")
+            }
+            SettingsToggle("Include specials", isOn: profileBinding(\.includeSpecials))
+        }
+        .settingsPanel()
+    }
+
+    private var subtitlePanel: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            panelHeader("Subtitles", "Profile subtitle defaults synced with Android.")
+            SettingsPicker(title: "Default subtitle", selection: profileBinding(\.defaultSubtitle), values: ["Off", "English", "Dutch", "Spanish", "French", "German", "Auto"])
+            SettingsPicker(title: "Secondary subtitle", selection: profileBinding(\.secondarySubtitle), values: ["Off", "English", "Dutch", "Spanish", "French", "German"])
+            SettingsPicker(title: "Audio language", selection: profileBinding(\.defaultAudioLanguage), values: ["Auto (Original)", "English", "Dutch", "Spanish", "French", "German", "Japanese"])
+            SettingsPicker(title: "Subtitle size", selection: profileBinding(\.subtitleSize), values: ["Small", "Medium", "Large", "Extra Large"])
+            SettingsPicker(title: "Subtitle color", selection: profileBinding(\.subtitleColor), values: ["White", "Yellow", "Cyan", "Green"])
+            SettingsPicker(title: "Subtitle style", selection: profileBinding(\.subtitleStyle), values: ["Regular", "Bold", "Outline", "Shadow"])
+            SettingsPicker(title: "Subtitle offset", selection: profileBinding(\.subtitleOffset), values: ["Low", "Medium", "High"])
+            SettingsToggle("Stylized subtitles", isOn: profileBinding(\.subtitleStylized))
+            SettingsToggle("Filter subtitles by language", isOn: profileBinding(\.filterSubtitlesByLanguage))
+            SettingsToggle("Remove hearing-impaired subtitles", isOn: globalBinding(\.subtitleRemoveHearingImpaired))
+        }
+        .settingsPanel()
+    }
+
+    private var interfacePanel: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            panelHeader("Interface", "Home, catalog, profile, and network preferences.")
+            SettingsPicker(title: "Card layout", selection: profileBinding(\.cardLayoutMode), values: ["Landscape", "Portrait", "Compact"])
+            SettingsPicker(title: "Content language", selection: profileBinding(\.contentLanguage), values: ["en-US", "nl-NL", "es-ES", "fr-FR", "de-DE"])
+            SettingsPicker(title: "Clock format", selection: profileBinding(\.clockFormat), values: ["24h", "12h"])
+            SettingsPicker(title: "DNS provider", selection: profileBinding(\.dnsProvider), values: ["system", "cloudflare", "google", "quad9"])
+            SettingsToggle("Show budget", isOn: profileBinding(\.showBudget))
+            SettingsToggle("Blur spoilers", isOn: profileBinding(\.spoilerBlurEnabled))
+            SettingsToggle("Skip profile selection", isOn: globalBinding(\.skipProfileSelection))
+        }
+        .settingsPanel()
+    }
+
+    private var aiSubtitlePanel: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            panelHeader("AI Subtitles", "The same cloud keys Android uses for AI subtitle generation.")
+            SettingsToggle("Enable AI subtitles", isOn: globalBinding(\.subtitleAiEnabled))
+            SettingsToggle("Auto-select AI subtitles", isOn: globalBinding(\.subtitleAiAutoSelect))
+            SettingsPicker(title: "AI model", selection: globalBinding(\.subtitleAiModel), values: ["GROQ_LLAMA_70B", "OPENAI_GPT_4O_MINI", "OPENAI_GPT_4O"])
+            SecureField("API key", text: globalBinding(\.subtitleAiApiKey))
+                .settingsField()
+        }
+        .settingsPanel()
+    }
+
+    private var syncSummaryPanel: some View {
+        VStack(spacing: 0) {
+            SettingsRow(title: "Cloud sync", value: appState.cloud.isSyncing ? "Syncing" : (appState.auth.isAuthenticated ? "Connected" : "Disconnected"))
+            SettingsRow(title: "Addons", value: "\(appState.addons.addons.count) installed")
+            SettingsRow(title: "Live TV", value: appState.iptv.channels.isEmpty ? "No channels loaded" : "\(appState.iptv.channels.count) channels")
+            SettingsRow(title: "Playback", value: appState.selectedStream == nil ? "Ready" : "Playing")
+        }
+    }
+
+    private func panelHeader(_ title: String, _ subtitle: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.system(size: 20, weight: .bold))
+                .foregroundStyle(ArvioTheme.textPrimary)
+            Text(subtitle)
+                .font(.system(size: 14))
+                .foregroundStyle(ArvioTheme.textSecondary)
+        }
+    }
+
+    private func profileBinding<Value>(_ keyPath: WritableKeyPath<CloudProfileSettings, Value>) -> Binding<Value> {
+        Binding(
+            get: { appState.settings.profileSettings[keyPath: keyPath] },
+            set: { value in
+                Task { await appState.settings.updateProfile { $0[keyPath: keyPath] = value } }
+            }
+        )
+    }
+
+    private func globalBinding<Value>(_ keyPath: WritableKeyPath<GlobalCloudSettings, Value>) -> Binding<Value> {
+        Binding(
+            get: { appState.settings.globalSettings[keyPath: keyPath] },
+            set: { value in
+                Task { await appState.settings.updateGlobal { $0[keyPath: keyPath] = value } }
+            }
+        )
+    }
+}
+
+private struct SettingsToggle: View {
+    let title: String
+    @Binding var isOn: Bool
+
+    init(_ title: String, isOn: Binding<Bool>) {
+        self.title = title
+        self._isOn = isOn
+    }
+
+    var body: some View {
+        Toggle(title, isOn: $isOn)
+            .font(.system(size: 16, weight: .semibold))
+            .foregroundStyle(ArvioTheme.textPrimary)
+            .tint(ArvioTheme.gold)
+    }
+}
+
+private struct SettingsPicker: View {
+    let title: String
+    @Binding var selection: String
+    let values: [String]
+
+    var body: some View {
+        HStack {
+            SettingsValueLabel(title: title, value: selection)
+            Spacer()
+            Picker(title, selection: $selection) {
+                ForEach(values, id: \.self) { value in
+                    Text(value).tag(value)
+                }
+            }
+            .pickerStyle(.menu)
+            .tint(ArvioTheme.gold)
+        }
+    }
+}
+
+private struct SettingsValueLabel: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(title)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(ArvioTheme.textPrimary)
+            Text(value)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(ArvioTheme.textTertiary)
+        }
     }
 }
 

--- a/iosApp/ARVIO/SettingsView.swift
+++ b/iosApp/ARVIO/SettingsView.swift
@@ -105,7 +105,10 @@ struct SettingsView: View {
                         .font(.system(size: 14, weight: .medium))
                         .foregroundStyle(ArvioTheme.textSecondary)
                     Button("I approved it") {
-                        Task { await appState.trakt.pollForToken() }
+                        Task {
+                            await appState.trakt.pollForToken()
+                            await appState.watchHistory.load()
+                        }
                     }
                     .buttonStyle(.bordered)
                 }

--- a/iosApp/ARVIO/StreamResolver.swift
+++ b/iosApp/ARVIO/StreamResolver.swift
@@ -2,6 +2,7 @@ import Foundation
 
 struct ResolvedStream: Identifiable, Hashable {
     let id = UUID()
+    let addonId: String?
     let addonName: String
     let sourceName: String
     let title: String
@@ -75,6 +76,7 @@ final class StreamResolver: ObservableObject {
             }
             streams = resolved.map { stream in
                 ResolvedStream(
+                    addonId: stream.addonId,
                     addonName: stream.addonName,
                     sourceName: stream.sourceName,
                     title: stream.title,
@@ -113,6 +115,7 @@ final class StreamResolver: ObservableObject {
                 let playableURL = rawURL.flatMap(URL.init(string:))
                 let title = stream.title ?? stream.name ?? addon.name
                 return ResolvedStream(
+                    addonId: addon.id,
                     addonName: addon.name,
                     sourceName: stream.name ?? addon.name,
                     title: title,

--- a/iosApp/ARVIO/StreamResolver.swift
+++ b/iosApp/ARVIO/StreamResolver.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+struct ResolvedStream: Identifiable, Hashable {
+    let id = UUID()
+    let addonName: String
+    let sourceName: String
+    let title: String
+    let quality: String
+    let size: String
+    let url: URL?
+    let isPlayable: Bool
+}
+
+private struct StremioStreamResponse: Decodable {
+    let streams: [StremioStream]?
+}
+
+private struct StremioStream: Decodable {
+    let name: String?
+    let title: String?
+    let description: String?
+    let url: String?
+    let externalUrl: String?
+    let infoHash: String?
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case title
+        case description
+        case url
+        case externalUrl
+        case infoHash
+    }
+}
+
+@MainActor
+final class StreamResolver: ObservableObject {
+    @Published private(set) var streams: [ResolvedStream] = []
+    @Published private(set) var isLoading = false
+    @Published var errorMessage: String?
+
+    private let tmdb: TmdbService
+    private let addons: AddonService
+
+    init(tmdb: TmdbService, addons: AddonService) {
+        self.tmdb = tmdb
+        self.addons = addons
+    }
+
+    func resolve(item: MediaItem, season: Int = 1, episode: Int = 1) async {
+        isLoading = true
+        streams = []
+        defer { isLoading = false }
+        do {
+            let externalIds = try await tmdb.externalIds(for: item)
+            guard let imdbId = externalIds.imdbId, !imdbId.isEmpty else {
+                throw ArvioError.requestFailed("No IMDB id available for source lookup")
+            }
+            let contentId = item.kind == .movie ? imdbId : "\(imdbId):\(season):\(episode)"
+            let type = item.kind.stremioType
+
+            let resolved = await withTaskGroup(of: [ResolvedStream].self) { group in
+                for addon in addons.addons {
+                    group.addTask {
+                        await Self.fetchStreams(addon: addon, type: type, contentId: contentId)
+                    }
+                }
+
+                var all: [ResolvedStream] = []
+                for await addonStreams in group {
+                    all.append(contentsOf: addonStreams)
+                }
+                return all
+            }
+            streams = resolved.sorted { left, right in
+                score(left) > score(right)
+            }
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func score(_ stream: ResolvedStream) -> Int {
+        var value = stream.isPlayable ? 100 : 0
+        if stream.quality.contains("4K") || stream.quality.contains("2160") { value += 40 }
+        if stream.quality.contains("1080") { value += 25 }
+        if stream.quality.contains("720") { value += 10 }
+        return value
+    }
+
+    private static func fetchStreams(addon: InstalledAddon, type: String, contentId: String) async -> [ResolvedStream] {
+        guard let url = streamURL(addon: addon, type: type, contentId: contentId) else { return [] }
+        do {
+            let (data, response) = try await URLSession.shared.data(from: url)
+            guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else { return [] }
+            let decoded = try JSONDecoder().decode(StremioStreamResponse.self, from: data)
+            return decoded.streams?.map { stream in
+                let rawURL = stream.url ?? stream.externalUrl
+                let playableURL = rawURL.flatMap(URL.init(string:))
+                let title = stream.title ?? stream.name ?? addon.name
+                return ResolvedStream(
+                    addonName: addon.name,
+                    sourceName: stream.name ?? addon.name,
+                    title: title,
+                    quality: quality(from: [title, stream.description].compactMap { $0 }.joined(separator: " ")),
+                    size: size(from: [title, stream.description].compactMap { $0 }.joined(separator: " ")),
+                    url: playableURL,
+                    isPlayable: playableURL.map(isDirectPlayable(url:)) ?? false
+                )
+            } ?? []
+        } catch {
+            return []
+        }
+    }
+
+    private static func streamURL(addon: InstalledAddon, type: String, contentId: String) -> URL? {
+        guard var components = URLComponents(string: addon.manifestURL) else { return nil }
+        let query = components.percentEncodedQuery
+        var path = components.path
+        if path.hasSuffix("/manifest.json") {
+            path.removeLast("/manifest.json".count)
+        }
+        components.path = path + "/stream/\(type)/\(contentId).json"
+        components.percentEncodedQuery = query
+        return components.url
+    }
+
+    private static func quality(from text: String) -> String {
+        if text.range(of: "2160p|4K", options: [.regularExpression, .caseInsensitive]) != nil { return "4K" }
+        if text.range(of: "1080p", options: [.regularExpression, .caseInsensitive]) != nil { return "1080p" }
+        if text.range(of: "720p", options: [.regularExpression, .caseInsensitive]) != nil { return "720p" }
+        if text.range(of: "480p", options: [.regularExpression, .caseInsensitive]) != nil { return "480p" }
+        return "Unknown"
+    }
+
+    private static func size(from text: String) -> String {
+        let pattern = #"(\d+\.?\d*)\s*(GB|MB|TB|KB)"#
+        guard let match = text.range(of: pattern, options: [.regularExpression, .caseInsensitive]) else {
+            return ""
+        }
+        return String(text[match])
+    }
+
+    private static func isDirectPlayable(url: URL) -> Bool {
+        let value = url.absoluteString.lowercased()
+        return value.hasPrefix("http") &&
+            (value.contains(".m3u8") ||
+             value.contains(".mp4") ||
+             value.contains(".mov") ||
+             value.contains(".m4v") ||
+             value.contains("googlevideo.com") ||
+             value.contains("cloudflare") ||
+             value.contains("akamaized"))
+    }
+}

--- a/iosApp/ARVIO/StreamResolver.swift
+++ b/iosApp/ARVIO/StreamResolver.swift
@@ -9,6 +9,7 @@ struct ResolvedStream: Identifiable, Hashable {
     let size: String
     let url: URL?
     let isPlayable: Bool
+    let resumePositionSeconds: Int?
 }
 
 private struct StremioStreamResponse: Decodable {
@@ -72,7 +73,19 @@ final class StreamResolver: ObservableObject {
                 }
                 return all
             }
-            streams = resolved.sorted { left, right in
+            streams = resolved.map { stream in
+                ResolvedStream(
+                    addonName: stream.addonName,
+                    sourceName: stream.sourceName,
+                    title: stream.title,
+                    quality: stream.quality,
+                    size: stream.size,
+                    url: stream.url,
+                    isPlayable: stream.isPlayable,
+                    resumePositionSeconds: item.positionSeconds
+                )
+            }
+            .sorted { left, right in
                 score(left) > score(right)
             }
             errorMessage = nil
@@ -106,7 +119,8 @@ final class StreamResolver: ObservableObject {
                     quality: quality(from: [title, stream.description].compactMap { $0 }.joined(separator: " ")),
                     size: size(from: [title, stream.description].compactMap { $0 }.joined(separator: " ")),
                     url: playableURL,
-                    isPlayable: playableURL.map(isDirectPlayable(url:)) ?? false
+                    isPlayable: playableURL.map(isDirectPlayable(url:)) ?? false,
+                    resumePositionSeconds: nil
                 )
             } ?? []
         } catch {

--- a/iosApp/ARVIO/TmdbService.swift
+++ b/iosApp/ARVIO/TmdbService.swift
@@ -1,0 +1,212 @@
+import Foundation
+
+struct TmdbListResponse: Decodable {
+    let results: [TmdbMedia]
+}
+
+struct TmdbMedia: Decodable {
+    let id: Int
+    let title: String?
+    let name: String?
+    let overview: String?
+    let releaseDate: String?
+    let firstAirDate: String?
+    let posterPath: String?
+    let backdropPath: String?
+    let voteAverage: Double?
+    let mediaType: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case name
+        case overview
+        case releaseDate = "release_date"
+        case firstAirDate = "first_air_date"
+        case posterPath = "poster_path"
+        case backdropPath = "backdrop_path"
+        case voteAverage = "vote_average"
+        case mediaType = "media_type"
+    }
+
+    func asMediaItem(defaultKind: MediaKind? = nil) -> MediaItem? {
+        let resolvedKind: MediaKind
+        if let defaultKind {
+            resolvedKind = defaultKind
+        } else if mediaType == "movie" {
+            resolvedKind = .movie
+        } else if mediaType == "tv" {
+            resolvedKind = .series
+        } else {
+            return nil
+        }
+
+        let resolvedTitle = title ?? name ?? "Untitled"
+        let date = releaseDate ?? firstAirDate ?? ""
+        let year = String(date.prefix(4))
+        let rating = voteAverage.map { String(format: "%.1f", $0) } ?? ""
+        return MediaItem(
+            id: "\(resolvedKind.tmdbPath)-\(id)",
+            tmdbId: id,
+            title: resolvedTitle,
+            subtitle: resolvedKind.rawValue,
+            year: year,
+            duration: "",
+            rating: rating,
+            kind: resolvedKind,
+            progress: 0,
+            palette: ["#10202a", "#071017"],
+            posterPath: posterPath,
+            backdropPath: backdropPath,
+            overview: overview
+        )
+    }
+}
+
+struct TmdbGenre: Decodable, Hashable {
+    let id: Int
+    let name: String
+}
+
+struct TmdbDetails: Decodable {
+    let id: Int
+    let title: String?
+    let name: String?
+    let overview: String?
+    let releaseDate: String?
+    let firstAirDate: String?
+    let posterPath: String?
+    let backdropPath: String?
+    let voteAverage: Double?
+    let runtime: Int?
+    let numberOfSeasons: Int?
+    let numberOfEpisodes: Int?
+    let episodeRunTime: [Int]?
+    let genres: [TmdbGenre]?
+    let seasons: [TmdbSeason]?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case name
+        case overview
+        case releaseDate = "release_date"
+        case firstAirDate = "first_air_date"
+        case posterPath = "poster_path"
+        case backdropPath = "backdrop_path"
+        case voteAverage = "vote_average"
+        case runtime
+        case numberOfSeasons = "number_of_seasons"
+        case numberOfEpisodes = "number_of_episodes"
+        case episodeRunTime = "episode_run_time"
+        case genres
+        case seasons
+    }
+}
+
+struct TmdbSeason: Decodable, Identifiable, Hashable {
+    let id: Int
+    let seasonNumber: Int
+    let episodeCount: Int?
+    let name: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case seasonNumber = "season_number"
+        case episodeCount = "episode_count"
+        case name
+    }
+}
+
+struct TmdbExternalIds: Decodable {
+    let imdbId: String?
+    let tvdbId: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case imdbId = "imdb_id"
+        case tvdbId = "tvdb_id"
+    }
+}
+
+@MainActor
+final class TmdbService: ObservableObject {
+    @Published private(set) var trendingMovies: [MediaItem] = []
+    @Published private(set) var trendingSeries: [MediaItem] = []
+    @Published private(set) var searchResults: [MediaItem] = []
+    @Published private(set) var isLoading = false
+    @Published var errorMessage: String?
+
+    private let client = JSONClient()
+
+    func loadHome() async {
+        guard trendingMovies.isEmpty && trendingSeries.isEmpty else { return }
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            async let movies: TmdbListResponse = tmdb(path: "/trending/movie/day", query: ["language": "en-US"])
+            async let series: TmdbListResponse = tmdb(path: "/trending/tv/day", query: ["language": "en-US"])
+            trendingMovies = try await movies.results.compactMap { $0.asMediaItem(defaultKind: .movie) }
+            trendingSeries = try await series.results.compactMap { $0.asMediaItem(defaultKind: .series) }
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func search(_ query: String) async {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count >= 2 else {
+            searchResults = []
+            return
+        }
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            let response: TmdbListResponse = try await tmdb(path: "/search/multi", query: ["query": trimmed, "language": "en-US"])
+            searchResults = response.results.compactMap { $0.asMediaItem() }
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func details(for item: MediaItem) async throws -> TmdbDetails {
+        guard let tmdbId = item.tmdbId else {
+            throw ArvioError.requestFailed("Missing TMDB id")
+        }
+        return try await tmdb(path: "/\(item.kind.tmdbPath)/\(tmdbId)", query: ["language": "en-US"])
+    }
+
+    func externalIds(for item: MediaItem) async throws -> TmdbExternalIds {
+        guard let tmdbId = item.tmdbId else {
+            throw ArvioError.requestFailed("Missing TMDB id")
+        }
+        return try await tmdb(path: "/\(item.kind.tmdbPath)/\(tmdbId)/external_ids", query: [:])
+    }
+
+    func recommendations(for item: MediaItem) async throws -> [MediaItem] {
+        guard let tmdbId = item.tmdbId else { return [] }
+        let response: TmdbListResponse = try await tmdb(path: "/\(item.kind.tmdbPath)/\(tmdbId)/recommendations", query: ["language": "en-US"])
+        return response.results.compactMap { $0.asMediaItem(defaultKind: item.kind) }
+    }
+
+    private func tmdb<T: Decodable>(path: String, query: [String: String]) async throws -> T {
+        guard AppConfig.isCloudConfigured else {
+            throw ArvioError.missingConfiguration("Supabase")
+        }
+        var components = URLComponents(string: AppConfig.tmdbProxyURL)
+        components?.queryItems = [URLQueryItem(name: "path", value: path)] + query.map {
+            URLQueryItem(name: $0.key, value: $0.value)
+        }
+        guard let url = components?.url else {
+            throw ArvioError.invalidURL(path)
+        }
+        return try await client.request(
+            url,
+            headers: [
+                "apikey": AppConfig.supabaseAnonKey,
+                "Authorization": "Bearer \(AppConfig.supabaseAnonKey)"
+            ]
+        )
+    }
+}

--- a/iosApp/ARVIO/TraktService.swift
+++ b/iosApp/ARVIO/TraktService.swift
@@ -33,6 +33,7 @@ struct TraktWatchlistItem: Identifiable, Decodable, Hashable {
     let type: String
     let title: String
     let year: Int?
+    let tmdbId: Int?
 
     enum RootKeys: String, CodingKey {
         case type
@@ -43,6 +44,7 @@ struct TraktWatchlistItem: Identifiable, Decodable, Hashable {
     enum MediaKeys: String, CodingKey {
         case title
         case year
+        case ids
     }
 
     init(from decoder: Decoder) throws {
@@ -51,14 +53,36 @@ struct TraktWatchlistItem: Identifiable, Decodable, Hashable {
         if let movie = try? root.nestedContainer(keyedBy: MediaKeys.self, forKey: .movie) {
             title = (try? movie.decode(String.self, forKey: .title)) ?? "Untitled"
             year = try? movie.decode(Int.self, forKey: .year)
+            tmdbId = (try? movie.decode(TraktWatchlistIds.self, forKey: .ids))?.tmdb
         } else if let show = try? root.nestedContainer(keyedBy: MediaKeys.self, forKey: .show) {
             title = (try? show.decode(String.self, forKey: .title)) ?? "Untitled"
             year = try? show.decode(Int.self, forKey: .year)
+            tmdbId = (try? show.decode(TraktWatchlistIds.self, forKey: .ids))?.tmdb
         } else {
             title = "Untitled"
             year = nil
+            tmdbId = nil
         }
     }
+
+    func asMediaItem() -> MediaItem {
+        MediaItem(
+            id: "\(type)-\(tmdbId ?? 0)-\(title)",
+            tmdbId: tmdbId,
+            title: title,
+            subtitle: type.capitalized,
+            year: year.map(String.init) ?? "",
+            duration: "Trakt",
+            rating: "",
+            kind: type == "movie" ? .movie : .series,
+            progress: 0,
+            palette: ["#10202a", "#071017"]
+        )
+    }
+}
+
+private struct TraktWatchlistIds: Decodable {
+    let tmdb: Int?
 }
 
 private struct DeviceCodeRequest: Encodable {
@@ -112,6 +136,22 @@ private struct TraktScrobbleBody: Encodable {
         try container.encodeIfPresent(show, forKey: .show)
         try container.encodeIfPresent(episode, forKey: .episode)
         try container.encode(progress, forKey: .progress)
+    }
+}
+
+private struct TraktWatchlistMutationBody: Encodable {
+    let movies: [TraktScrobbleMedia]?
+    let shows: [TraktScrobbleMedia]?
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(movies, forKey: .movies)
+        try container.encodeIfPresent(shows, forKey: .shows)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case movies
+        case shows
     }
 }
 
@@ -213,6 +253,30 @@ final class TraktService: ObservableObject {
             url,
             headers: proxyHeaders(userToken: token.accessToken)
         )
+    }
+
+    func addToWatchlist(item: MediaItem) async {
+        guard let token, let tmdbId = item.tmdbId else { return }
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            guard let url = proxyURL(path: "/sync/watchlist", method: "POST") else { return }
+            let media = TraktScrobbleMedia(ids: TraktScrobbleIds(tmdb: tmdbId))
+            let body = TraktWatchlistMutationBody(
+                movies: item.kind == .movie ? [media] : nil,
+                shows: item.kind == .series ? [media] : nil
+            )
+            let _: EmptyResponse = try await client.request(
+                url,
+                method: "POST",
+                headers: proxyHeaders(userToken: token.accessToken),
+                body: body
+            )
+            await loadWatchlist()
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
     }
 
     func scrobblePause(item: MediaItem, progressPercent: Double) async throws {

--- a/iosApp/ARVIO/TraktService.swift
+++ b/iosApp/ARVIO/TraktService.swift
@@ -62,21 +62,10 @@ struct TraktWatchlistItem: Identifiable, Decodable, Hashable {
 }
 
 private struct DeviceCodeRequest: Encodable {
-    let clientId: String
-
-    enum CodingKeys: String, CodingKey {
-        case clientId = "client_id"
-    }
 }
 
 private struct DeviceTokenRequest: Encodable {
     let code: String
-    let clientId: String
-
-    enum CodingKeys: String, CodingKey {
-        case code
-        case clientId = "client_id"
-    }
 }
 
 private struct DeviceTokenResponse: Decodable {
@@ -102,7 +91,6 @@ final class TraktService: ObservableObject {
     private let client = JSONClient()
     private let keychain = KeychainStore()
     private let tokenAccount = "trakt-token"
-    private let baseURL = "https://api.trakt.tv"
 
     init() {
         token = keychain.load(TraktToken.self, account: tokenAccount)
@@ -120,12 +108,12 @@ final class TraktService: ObservableObject {
         isLoading = true
         defer { isLoading = false }
         do {
-            guard let url = URL(string: "\(baseURL)/oauth/device/code") else { return }
+            guard let url = proxyURL(path: "/oauth/device/code", method: "POST") else { return }
             deviceCode = try await client.request(
                 url,
                 method: "POST",
-                headers: ["trakt-api-version": "2", "trakt-api-key": AppConfig.traktClientID],
-                body: DeviceCodeRequest(clientId: AppConfig.traktClientID)
+                headers: proxyHeaders(),
+                body: DeviceCodeRequest()
             )
             errorMessage = nil
         } catch {
@@ -138,12 +126,12 @@ final class TraktService: ObservableObject {
         isLoading = true
         defer { isLoading = false }
         do {
-            guard let url = URL(string: "\(baseURL)/oauth/device/token") else { return }
+            guard let url = proxyURL(path: "/oauth/device/token", method: "POST") else { return }
             let response: DeviceTokenResponse = try await client.request(
                 url,
                 method: "POST",
-                headers: ["trakt-api-version": "2", "trakt-api-key": AppConfig.traktClientID],
-                body: DeviceTokenRequest(code: code, clientId: AppConfig.traktClientID)
+                headers: proxyHeaders(),
+                body: DeviceTokenRequest(code: code)
             )
             let newToken = TraktToken(
                 accessToken: response.accessToken,
@@ -172,18 +160,34 @@ final class TraktService: ObservableObject {
         isLoading = true
         defer { isLoading = false }
         do {
-            guard let url = URL(string: "\(baseURL)/sync/watchlist") else { return }
+            guard let url = proxyURL(path: "/sync/watchlist") else { return }
             watchlist = try await client.request(
                 url,
-                headers: [
-                    "trakt-api-version": "2",
-                    "trakt-api-key": AppConfig.traktClientID,
-                    "Authorization": "Bearer \(token.accessToken)"
-                ]
+                headers: proxyHeaders(userToken: token.accessToken)
             )
             errorMessage = nil
         } catch {
             errorMessage = error.localizedDescription
         }
+    }
+
+    private func proxyURL(path: String, method: String = "GET") -> URL? {
+        var components = URLComponents(string: AppConfig.traktProxyURL)
+        components?.queryItems = [
+            URLQueryItem(name: "path", value: path),
+            URLQueryItem(name: "method", value: method)
+        ]
+        return components?.url
+    }
+
+    private func proxyHeaders(userToken: String? = nil) -> [String: String] {
+        var headers = [
+            "apikey": AppConfig.supabaseAnonKey,
+            "Authorization": "Bearer \(AppConfig.supabaseAnonKey)"
+        ]
+        if let userToken {
+            headers["x-user-token"] = userToken
+        }
+        return headers
     }
 }

--- a/iosApp/ARVIO/TraktService.swift
+++ b/iosApp/ARVIO/TraktService.swift
@@ -80,6 +80,41 @@ private struct DeviceTokenResponse: Decodable {
     }
 }
 
+private struct TraktScrobbleMedia: Encodable {
+    let ids: TraktScrobbleIds
+}
+
+private struct TraktScrobbleEpisode: Encodable {
+    let season: Int
+    let number: Int
+}
+
+private struct TraktScrobbleIds: Encodable {
+    let tmdb: Int
+}
+
+private struct TraktScrobbleBody: Encodable {
+    let movie: TraktScrobbleMedia?
+    let show: TraktScrobbleMedia?
+    let episode: TraktScrobbleEpisode?
+    let progress: Double
+
+    enum CodingKeys: String, CodingKey {
+        case movie
+        case show
+        case episode
+        case progress
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(movie, forKey: .movie)
+        try container.encodeIfPresent(show, forKey: .show)
+        try container.encodeIfPresent(episode, forKey: .episode)
+        try container.encode(progress, forKey: .progress)
+    }
+}
+
 @MainActor
 final class TraktService: ObservableObject {
     @Published private(set) var token: TraktToken?
@@ -177,6 +212,35 @@ final class TraktService: ObservableObject {
         return try await client.request(
             url,
             headers: proxyHeaders(userToken: token.accessToken)
+        )
+    }
+
+    func scrobblePause(item: MediaItem, progressPercent: Double) async throws {
+        guard let token, let tmdbId = item.tmdbId else { return }
+        guard let url = proxyURL(path: "/scrobble/pause", method: "POST") else { return }
+        let progress = min(max(progressPercent, 0), 100)
+        let body: TraktScrobbleBody
+        if item.kind == .movie {
+            body = TraktScrobbleBody(
+                movie: TraktScrobbleMedia(ids: TraktScrobbleIds(tmdb: tmdbId)),
+                show: nil,
+                episode: nil,
+                progress: progress
+            )
+        } else {
+            guard let season = item.season, let episode = item.episode else { return }
+            body = TraktScrobbleBody(
+                movie: nil,
+                show: TraktScrobbleMedia(ids: TraktScrobbleIds(tmdb: tmdbId)),
+                episode: TraktScrobbleEpisode(season: season, number: episode),
+                progress: progress
+            )
+        }
+        let _: EmptyResponse = try await client.request(
+            url,
+            method: "POST",
+            headers: proxyHeaders(userToken: token.accessToken),
+            body: body
         )
     }
 

--- a/iosApp/ARVIO/TraktService.swift
+++ b/iosApp/ARVIO/TraktService.swift
@@ -171,6 +171,15 @@ final class TraktService: ObservableObject {
         }
     }
 
+    func loadPlaybackProgress() async throws -> [TraktPlaybackItem] {
+        guard let token else { return [] }
+        guard let url = proxyURL(path: "/sync/playback") else { return [] }
+        return try await client.request(
+            url,
+            headers: proxyHeaders(userToken: token.accessToken)
+        )
+    }
+
     private func proxyURL(path: String, method: String = "GET") -> URL? {
         var components = URLComponents(string: AppConfig.traktProxyURL)
         components?.queryItems = [

--- a/iosApp/ARVIO/WatchHistoryService.swift
+++ b/iosApp/ARVIO/WatchHistoryService.swift
@@ -154,6 +154,50 @@ struct TraktIds: Decodable, Hashable {
     let imdb: String?
 }
 
+private struct WatchHistoryUpsert: Encodable {
+    let userId: String
+    let profileId: String
+    let mediaType: String
+    let showTmdbId: Int?
+    let season: Int?
+    let episode: Int?
+    let progress: Double
+    let positionSeconds: Int
+    let durationSeconds: Int
+    let pausedAt: String
+    let updatedAt: String
+    let source: String
+    let title: String
+    let episodeTitle: String?
+    let backdropPath: String?
+    let posterPath: String?
+    let streamKey: String?
+    let streamAddonId: String?
+    let streamTitle: String?
+
+    enum CodingKeys: String, CodingKey {
+        case userId = "user_id"
+        case profileId = "profile_id"
+        case mediaType = "media_type"
+        case showTmdbId = "show_tmdb_id"
+        case season
+        case episode
+        case progress
+        case positionSeconds = "position_seconds"
+        case durationSeconds = "duration_seconds"
+        case pausedAt = "paused_at"
+        case updatedAt = "updated_at"
+        case source
+        case title
+        case episodeTitle = "episode_title"
+        case backdropPath = "backdrop_path"
+        case posterPath = "poster_path"
+        case streamKey = "stream_key"
+        case streamAddonId = "stream_addon_id"
+        case streamTitle = "stream_title"
+    }
+}
+
 @MainActor
 final class WatchHistoryService: ObservableObject {
     @Published private(set) var cloudContinueWatching: [MediaItem] = []
@@ -218,6 +262,48 @@ final class WatchHistoryService: ObservableObject {
         do {
             let items = try await trakt.loadPlaybackProgress()
             traktContinueWatching = items.compactMap { $0.asMediaItem() }
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func saveProgress(item: MediaItem, stream: ResolvedStream, positionSeconds: Int, durationSeconds: Int) async {
+        guard let session = auth.session, durationSeconds > 0, positionSeconds > 0 else { return }
+        let progress = min(max(Double(positionSeconds) / Double(durationSeconds), 0), 1)
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+        let record = WatchHistoryUpsert(
+            userId: session.userId,
+            profileId: activeProfileId,
+            mediaType: item.kind == .movie ? "movie" : "tv",
+            showTmdbId: item.tmdbId,
+            season: item.kind == .series ? item.season : nil,
+            episode: item.kind == .series ? item.episode : nil,
+            progress: progress,
+            positionSeconds: positionSeconds,
+            durationSeconds: durationSeconds,
+            pausedAt: timestamp,
+            updatedAt: timestamp,
+            source: "arvio",
+            title: item.title,
+            episodeTitle: item.episodeTitle,
+            backdropPath: item.backdropPath,
+            posterPath: item.posterPath,
+            streamKey: stream.url?.absoluteString,
+            streamAddonId: stream.addonId,
+            streamTitle: stream.title
+        )
+        do {
+            let token = try await auth.accessToken()
+            let _: EmptyResponse = try await auth.supabaseRequest(
+                "/rest/v1/watch_history",
+                method: "POST",
+                token: token,
+                prefer: "return=minimal,resolution=merge-duplicates",
+                body: record
+            )
+            try? await trakt.scrobblePause(item: item, progressPercent: progress * 100)
+            await load()
             errorMessage = nil
         } catch {
             errorMessage = error.localizedDescription

--- a/iosApp/ARVIO/WatchHistoryService.swift
+++ b/iosApp/ARVIO/WatchHistoryService.swift
@@ -1,0 +1,236 @@
+import Foundation
+
+struct WatchHistoryEntry: Decodable, Identifiable, Hashable {
+    let id: String?
+    let userId: String?
+    let profileId: String?
+    let mediaType: String
+    let showTmdbId: Int
+    let season: Int?
+    let episode: Int?
+    let title: String?
+    let episodeTitle: String?
+    let progress: Double
+    let durationSeconds: Int?
+    let positionSeconds: Int?
+    let pausedAt: String?
+    let updatedAt: String?
+    let source: String?
+    let backdropPath: String?
+    let posterPath: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case userId = "user_id"
+        case profileId = "profile_id"
+        case mediaType = "media_type"
+        case showTmdbId = "show_tmdb_id"
+        case season
+        case episode
+        case title
+        case episodeTitle = "episode_title"
+        case progress
+        case durationSeconds = "duration_seconds"
+        case positionSeconds = "position_seconds"
+        case pausedAt = "paused_at"
+        case updatedAt = "updated_at"
+        case source
+        case backdropPath = "backdrop_path"
+        case posterPath = "poster_path"
+    }
+
+    var stableId: String {
+        id ?? "\(mediaType)-\(showTmdbId)-\(season ?? 0)-\(episode ?? 0)-\(updatedAt ?? "")"
+    }
+
+    func asMediaItem() -> MediaItem {
+        let kind: MediaKind = mediaType == "movie" ? .movie : .series
+        let seasonEpisode = season.flatMap { season in episode.map { "S\(season) E\($0)" } }
+        let subtitle = [seasonEpisode, episodeTitle].compactMap { $0 }.joined(separator: " - ")
+        return MediaItem(
+            id: stableId,
+            tmdbId: showTmdbId,
+            title: title ?? "Continue Watching",
+            subtitle: subtitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? kind.rawValue : subtitle,
+            year: "",
+            duration: positionLabel,
+            rating: "",
+            kind: kind,
+            progress: progress,
+            palette: ["#10202a", "#071017"],
+            posterPath: posterPath,
+            backdropPath: backdropPath,
+            overview: nil,
+            season: season,
+            episode: episode,
+            episodeTitle: episodeTitle,
+            positionSeconds: positionSeconds,
+            durationSeconds: durationSeconds
+        )
+    }
+
+    private var positionLabel: String {
+        guard let positionSeconds, positionSeconds > 0 else { return "Resume" }
+        return "\(positionSeconds / 60)m watched"
+    }
+}
+
+struct TraktPlaybackItem: Decodable, Identifiable, Hashable {
+    let id: Int?
+    let progress: Double
+    let pausedAt: String?
+    let type: String
+    let movie: TraktMedia?
+    let show: TraktMedia?
+    let episode: TraktEpisode?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case progress
+        case pausedAt = "paused_at"
+        case type
+        case movie
+        case show
+        case episode
+    }
+
+    var stableId: String {
+        "\(type)-\(movie?.ids.tmdb ?? show?.ids.tmdb ?? 0)-\(episode?.season ?? 0)-\(episode?.number ?? 0)"
+    }
+
+    func asMediaItem() -> MediaItem? {
+        let normalizedProgress = min(max(progress / 100.0, 0), 1)
+        if type == "movie", let movie, let tmdb = movie.ids.tmdb {
+            return MediaItem(
+                id: stableId,
+                tmdbId: tmdb,
+                title: movie.title,
+                subtitle: "Trakt Continue Watching",
+                year: movie.year.map(String.init) ?? "",
+                duration: "\(Int(progress.rounded()))% watched",
+                rating: "",
+                kind: .movie,
+                progress: normalizedProgress,
+                palette: ["#10202a", "#071017"]
+            )
+        }
+        if type == "episode", let show, let tmdb = show.ids.tmdb, let episode {
+            return MediaItem(
+                id: stableId,
+                tmdbId: tmdb,
+                title: show.title,
+                subtitle: "S\(episode.season) E\(episode.number) - \(episode.title ?? "Episode")",
+                year: show.year.map(String.init) ?? "",
+                duration: "\(Int(progress.rounded()))% watched",
+                rating: "",
+                kind: .series,
+                progress: normalizedProgress,
+                palette: ["#10202a", "#071017"],
+                season: episode.season,
+                episode: episode.number,
+                episodeTitle: episode.title
+            )
+        }
+        return nil
+    }
+}
+
+struct TraktMedia: Decodable, Hashable {
+    let title: String
+    let year: Int?
+    let ids: TraktIds
+}
+
+struct TraktEpisode: Decodable, Hashable {
+    let season: Int
+    let number: Int
+    let title: String?
+    let ids: TraktIds?
+}
+
+struct TraktIds: Decodable, Hashable {
+    let trakt: Int?
+    let tmdb: Int?
+    let imdb: String?
+}
+
+@MainActor
+final class WatchHistoryService: ObservableObject {
+    @Published private(set) var cloudContinueWatching: [MediaItem] = []
+    @Published private(set) var traktContinueWatching: [MediaItem] = []
+    @Published private(set) var isLoading = false
+    @Published var errorMessage: String?
+
+    private let auth: AuthService
+    private let trakt: TraktService
+    private var activeProfileId = "default"
+
+    init(auth: AuthService, trakt: TraktService) {
+        self.auth = auth
+        self.trakt = trakt
+    }
+
+    var continueWatching: [MediaItem] {
+        var seen = Set<String>()
+        return (traktContinueWatching + cloudContinueWatching).filter { item in
+            let key = "\(item.kind.rawValue)-\(item.tmdbId ?? 0)-\(item.season ?? 0)-\(item.episode ?? 0)"
+            if seen.contains(key) { return false }
+            seen.insert(key)
+            return true
+        }
+    }
+
+    func setActiveProfileId(_ profileId: String?) {
+        let trimmed = profileId?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        activeProfileId = trimmed.isEmpty ? "default" : trimmed
+    }
+
+    func load() async {
+        isLoading = true
+        defer { isLoading = false }
+        await loadCloudContinueWatching()
+        await loadTraktContinueWatching()
+    }
+
+    func loadCloudContinueWatching() async {
+        guard let session = auth.session else { return }
+        do {
+            let token = try await auth.accessToken()
+            let rows: [WatchHistoryEntry] = try await auth.supabaseRequest(
+                "/rest/v1/watch_history?user_id=eq.\(session.userId)&select=*&order=updated_at.desc&limit=500",
+                token: token
+            )
+            cloudContinueWatching = rows
+                .filter { isInActiveProfile($0) }
+                .filter { $0.progress > 0 && $0.progress < 0.9 }
+                .map { $0.asMediaItem() }
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func loadTraktContinueWatching() async {
+        guard trakt.isConnected else {
+            traktContinueWatching = []
+            return
+        }
+        do {
+            let items = try await trakt.loadPlaybackProgress()
+            traktContinueWatching = items.compactMap { $0.asMediaItem() }
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func isInActiveProfile(_ entry: WatchHistoryEntry) -> Bool {
+        if let profileId = entry.profileId, !profileId.isEmpty {
+            return profileId == activeProfileId
+        }
+        if let source = entry.source, source.hasPrefix("profile:") {
+            return source.hasPrefix("profile:\(activeProfileId):")
+        }
+        return activeProfileId == "default"
+    }
+}

--- a/iosApp/ARVIO/WatchlistView.swift
+++ b/iosApp/ARVIO/WatchlistView.swift
@@ -31,28 +31,24 @@ struct WatchlistView: View {
                 } else {
                     LazyVGrid(columns: [GridItem(.adaptive(minimum: 210), spacing: 16)], spacing: 16) {
                         ForEach(appState.trakt.watchlist) { item in
-                            VStack(alignment: .leading, spacing: 10) {
-                                PosterBackdrop(item: MediaItem(
-                                    title: item.title,
-                                    subtitle: item.type.capitalized,
-                                    year: item.year.map(String.init) ?? "",
-                                    duration: "Trakt",
-                                    rating: "",
-                                    kind: item.type == "movie" ? .movie : .series,
-                                    progress: 0,
-                                    palette: ["#10202a", "#071017"]
-                                ))
-                                .frame(width: 210, height: 118)
-                                .clipShape(RoundedRectangle(cornerRadius: 8))
-                                Text(item.title)
-                                    .font(.system(size: 16, weight: .semibold))
-                                    .foregroundStyle(ArvioTheme.textPrimary)
-                                    .lineLimit(1)
-                                Text(([item.type.capitalized] + (item.year.map { [String($0)] } ?? [])).joined(separator: " - "))
-                                    .font(.system(size: 13, weight: .medium))
-                                    .foregroundStyle(ArvioTheme.textTertiary)
+                            Button {
+                                appState.selectedMedia = item.asMediaItem()
+                            } label: {
+                                VStack(alignment: .leading, spacing: 10) {
+                                    PosterBackdrop(item: item.asMediaItem())
+                                        .frame(width: 210, height: 118)
+                                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                                    Text(item.title)
+                                        .font(.system(size: 16, weight: .semibold))
+                                        .foregroundStyle(ArvioTheme.textPrimary)
+                                        .lineLimit(1)
+                                    Text(([item.type.capitalized] + (item.year.map { [String($0)] } ?? [])).joined(separator: " - "))
+                                        .font(.system(size: 13, weight: .medium))
+                                        .foregroundStyle(ArvioTheme.textTertiary)
+                                }
+                                .frame(width: 210, alignment: .leading)
                             }
-                            .frame(width: 210, alignment: .leading)
+                            .buttonStyle(.plain)
                         }
                     }
                 }


### PR DESCRIPTION
Adds the next iOS parity layer on top of the TestFlight scaffold.\n\nChanges:\n- Adds TMDB-backed catalog details, source resolution, and AVPlayer playback.\n- Adds Live TV with M3U loading, channel grouping, favorites, and direct playback.\n- Adds cloud-aware profiles and an iOS profile switcher using the Android cloud payload shape.\n- Routes Trakt through the Supabase trakt-proxy and preserves existing Android cloud sync keys when iOS saves.\n\nValidation:\n- git diff --check\n- iOS archive/TestFlight upload will run through the existing macOS workflow.