### PR TITLE
feat: add custom User-Agent setting

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ArflixApplication.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ArflixApplication.kt
@@ -82,13 +82,17 @@ class ArflixApplication : Application(), Configuration.Provider, ImageLoaderFact
         // a single volatile assignment.
         OkHttpProvider.init(this)
 
-        // Initialize global DNS provider from DataStore before network calls.
+        // Initialize global DNS provider and user agent from DataStore before network calls.
         appScope.launch(Dispatchers.IO) {
             val prefs = settingsDataStore.data.first()
             val dnsKey = androidx.datastore.preferences.core.stringPreferencesKey(OkHttpProvider.DNS_PROVIDER_PREF_KEY)
             val dnsPref = prefs[dnsKey]
             val provider = OkHttpProvider.parseDnsProvider(dnsPref)
             OkHttpProvider.setDnsProvider(provider)
+
+            val uaKey = androidx.datastore.preferences.core.stringPreferencesKey(OkHttpProvider.USER_AGENT_PREF_KEY)
+            val savedUserAgent = prefs[uaKey]?.takeIf { it.isNotBlank() } ?: OkHttpProvider.DEFAULT_USER_AGENT
+            OkHttpProvider.setCustomUserAgent(savedUserAgent)
 
             runCatching { OkHttpProvider.dns.lookup("image.tmdb.org") }
         }

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/CatalogRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/CatalogRepository.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
+import com.arflix.tv.network.OkHttpProvider
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.net.URI
@@ -958,7 +959,7 @@ class CatalogRepository @Inject constructor(
         return withContext(Dispatchers.IO) {
             val request = Request.Builder()
                 .url(url)
-                .header("User-Agent", "Mozilla/5.0 (Android TV; ARVIO)")
+                .header("User-Agent", OkHttpProvider.userAgent)
                 .build()
             runCatching {
                 okHttpClient.newCall(request).execute().use { response ->

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.Deferred
+import com.arflix.tv.network.OkHttpProvider
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.xmlpull.v1.XmlPullParser
@@ -3695,7 +3696,7 @@ class IptvRepository @Inject constructor(
     ): T? = suspendCancellableCoroutine { continuation ->
         val request = Request.Builder()
             .url(url)
-            .header("User-Agent", "VLC/3.0.20 LibVLC/3.0.20")
+            .header("User-Agent", OkHttpProvider.userAgent)
             .header("Accept", "application/json,*/*")
             .get()
             .build()
@@ -3739,7 +3740,7 @@ class IptvRepository @Inject constructor(
     ): List<IptvChannel> {
         val request = Request.Builder()
             .url(url)
-            .header("User-Agent", "VLC/3.0.20 LibVLC/3.0.20")
+            .header("User-Agent", OkHttpProvider.userAgent)
             .header("Accept", "*/*")
             .get()
             .build()
@@ -3792,15 +3793,11 @@ class IptvRepository @Inject constructor(
                 .build()
         }
 
-        var response = iptvHttpClient.newCall(epgRequest(url, "VLC/3.0.20 LibVLC/3.0.20")).execute()
+        var response = iptvHttpClient.newCall(epgRequest(url, OkHttpProvider.userAgent)).execute()
         if (!response.isSuccessful && response.code in setOf(511, 403, 401)) {
             response.close()
             response = iptvHttpClient.newCall(
-                epgRequest(
-                    url,
-                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
-                        "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
-                )
+                epgRequest(url, OkHttpProvider.userAgent)
             ).execute()
         }
         response.use { safeResponse ->
@@ -3825,7 +3822,7 @@ class IptvRepository @Inject constructor(
                 try {
                     // Re-download
                     val retryResponse = iptvHttpClient.newCall(
-                        epgRequest(url, "VLC/3.0.20 LibVLC/3.0.20")
+                        epgRequest(url, OkHttpProvider.userAgent)
                     ).execute()
                     retryResponse.use { rr ->
                         val retryStream = rr.body?.byteStream()

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/MediaRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/MediaRepository.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import com.arflix.tv.network.OkHttpProvider
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.net.URLDecoder
@@ -3272,7 +3273,7 @@ class MediaRepository @Inject constructor(
     private fun fetchUrl(url: String): String? {
         val request = Request.Builder()
             .url(url)
-            .header("User-Agent", "Mozilla/5.0 (Android TV; ARVIO)")
+            .header("User-Agent", OkHttpProvider.userAgent)
             .build()
         return runCatching {
             okHttpClient.newCall(request).execute().use { response ->

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
@@ -2343,8 +2343,7 @@ class StreamRepository @Inject constructor(
             withTimeout(STREAM_REDIRECT_RESOLUTION_TIMEOUT_MS) {
                 val requestHeaders = headers.toMutableMap()
                 if (requestHeaders.keys.none { it.equals("User-Agent", ignoreCase = true) }) {
-                    requestHeaders["User-Agent"] =
-                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+                    requestHeaders["User-Agent"] = OkHttpProvider.userAgent
                 }
                 if (requestHeaders.keys.none { it.equals("Accept", ignoreCase = true) }) {
                     requestHeaders["Accept"] = "*/*"
@@ -2381,8 +2380,7 @@ class StreamRepository @Inject constructor(
             extra = emptyMap()
         ).toMutableMap()
         if (headers.keys.none { it.equals("User-Agent", ignoreCase = true) }) {
-            headers["User-Agent"] =
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+            headers["User-Agent"] = OkHttpProvider.userAgent
         }
         if (headers.keys.none { it.equals("Accept", ignoreCase = true) }) {
             headers["Accept"] = "*/*"
@@ -2587,8 +2585,7 @@ class StreamRepository @Inject constructor(
             ).toMutableMap()
 
             if (headers.keys.none { it.equals("User-Agent", ignoreCase = true) }) {
-                headers["User-Agent"] =
-                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+                headers["User-Agent"] = OkHttpProvider.userAgent
             }
             if (headers.keys.none { it.equals("Accept", ignoreCase = true) }) {
                 headers["Accept"] = "*/*"

--- a/app/src/main/kotlin/com/arflix/tv/network/OkHttpProvider.kt
+++ b/app/src/main/kotlin/com/arflix/tv/network/OkHttpProvider.kt
@@ -51,7 +51,7 @@ object OkHttpProvider {
     private const val ADGUARD_DOH_URL = "https://dns.adguard-dns.com/dns-query"
 
     const val DNS_PROVIDER_PREF_KEY = "dns_provider_global"
-    const val DEFAULT_USER_AGENT = "Mozilla/5.0 (Android TV; ARVIO)"
+    const val DEFAULT_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
     const val USER_AGENT_PREF_KEY = "custom_user_agent_global"
 
     enum class AppDnsProvider {

--- a/app/src/main/kotlin/com/arflix/tv/network/OkHttpProvider.kt
+++ b/app/src/main/kotlin/com/arflix/tv/network/OkHttpProvider.kt
@@ -51,6 +51,8 @@ object OkHttpProvider {
     private const val ADGUARD_DOH_URL = "https://dns.adguard-dns.com/dns-query"
 
     const val DNS_PROVIDER_PREF_KEY = "dns_provider_global"
+    const val DEFAULT_USER_AGENT = "Mozilla/5.0 (Android TV; ARVIO)"
+    const val USER_AGENT_PREF_KEY = "custom_user_agent_global"
 
     enum class AppDnsProvider {
         SYSTEM,
@@ -72,6 +74,15 @@ object OkHttpProvider {
 
     @Volatile
     private var selectedDnsProvider: AppDnsProvider = AppDnsProvider.SYSTEM
+
+    @Volatile
+    private var _customUserAgent: String = DEFAULT_USER_AGENT
+
+    val userAgent: String get() = _customUserAgent
+
+    fun setCustomUserAgent(value: String) {
+        _customUserAgent = value
+    }
 
     private val dnsScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val clientLock = Any()
@@ -183,7 +194,13 @@ object OkHttpProvider {
             }
         }
 
+        val userAgentInterceptor = Interceptor { chain ->
+            val original = chain.request()
+            chain.proceed(original.newBuilder().header("User-Agent", _customUserAgent).build())
+        }
+
         val builder = OkHttpClient.Builder()
+            .addInterceptor(userAgentInterceptor)
             // TMDB/Trakt calls are proxied when Supabase proxy config is present.
             // Contributors can still use direct calls with their own local keys.
             .addInterceptor(ApiProxyInterceptor())
@@ -207,7 +224,12 @@ object OkHttpProvider {
     }
 
     private fun buildPlaybackClient(): OkHttpClient {
+        val userAgentInterceptor = Interceptor { chain ->
+            val original = chain.request()
+            chain.proceed(original.newBuilder().header("User-Agent", _customUserAgent).build())
+        }
         return OkHttpClient.Builder()
+            .addInterceptor(userAgentInterceptor)
             .connectionPool(playbackConnectionPool)
             .followRedirects(true)
             .followSslRedirects(true)

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -487,7 +487,7 @@ fun PlayerScreen(
     }
     val httpDataSourceFactory = remember(playbackHttpClient) {
         OkHttpDataSource.Factory(playbackHttpClient)
-            .setUserAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+            .setUserAgent(OkHttpProvider.userAgent)
             .setDefaultRequestProperties(baseRequestHeaders)
     }
     val mediaCache = remember(context) { PlaybackCacheSingleton.getInstance(context) }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -169,6 +169,7 @@ import com.arflix.tv.ui.theme.TextSecondary
 import kotlin.math.abs
 import androidx.compose.ui.res.stringResource
 import com.arflix.tv.R
+import com.arflix.tv.network.OkHttpProvider
 
 /**
  * Per-section registry of [BringIntoViewRequester]s keyed by the row's
@@ -209,7 +210,7 @@ private fun tvGeneralRowsForSection(section: String): List<Int> {
         "playback" -> listOf(10, 11, 12, 13, 14, 16, 15, 27)
         "appearance" -> listOf(17, 18, 20, 21, 24, 23, 22)
         "profiles" -> listOf(19)
-        "network" -> listOf(25, 26)
+        "network" -> listOf(25, 26, 34)
         else -> emptyList()
     }
 }
@@ -331,6 +332,7 @@ fun SettingsScreen(
     var qualityFilterDeviceName by remember { mutableStateOf("") }
     var showAiModelDialog by remember { mutableStateOf(false) }
     var showAiApiKeyDialog by remember { mutableStateOf(false) }
+    var showCustomUserAgentDialog by remember { mutableStateOf(false) }
     var qualityFilterRegexPattern by remember { mutableStateOf("") }
     var showHomeServerInput by remember { mutableStateOf(false) }
     var showPlexHomeServerInput by remember { mutableStateOf(false) }
@@ -596,6 +598,7 @@ fun SettingsScreen(
         showUiModeWarningDialog ||
         showAiModelDialog ||
         showAiApiKeyDialog ||
+        showCustomUserAgentDialog ||
         uiState.aiKeyServerState.isActive ||
         uiState.showCloudPairDialog ||
         uiState.showCloudEmailPasswordDialog ||
@@ -793,6 +796,7 @@ fun SettingsScreen(
                                                 24 -> viewModel.cycleFocusBorderColor()
                                                 25 -> openDnsProviderPicker()
                                                 26 -> viewModel.setShowLoadingStats(!uiState.showLoadingStats)
+                                                34 -> showCustomUserAgentDialog = true
                                                 27 -> viewModel.cycleVolumeBoost()
                                                 28 -> viewModel.setSubtitleAiEnabled(!uiState.subtitleAiEnabled)
                                                 29 -> showAiModelDialog = true
@@ -1002,7 +1006,8 @@ fun SettingsScreen(
                     plexHomeServerUrl = ""
                     showPlexHomeServerInput = true
                 },
-                onAddCustomAddonClick = { showCustomAddonInput = true }
+                onAddCustomAddonClick = { showCustomAddonInput = true },
+                openCustomUserAgentDialog = { showCustomUserAgentDialog = true }
             )
         } else {
             AppTopBar(
@@ -1190,7 +1195,9 @@ fun SettingsScreen(
                             onSubtitleAiAutoSelectToggle = { viewModel.setSubtitleAiAutoSelect(it) },
                             onSubtitleRemoveHearingImpairedToggle = { viewModel.setSubtitleRemoveHearingImpaired(it) },
                             onSubtitleAiApiKeyClick = { showAiApiKeyDialog = true },
-                            onSubtitleAiQrClick = { viewModel.startAiKeyServer() }
+                            onSubtitleAiQrClick = { viewModel.startAiKeyServer() },
+                            customUserAgent = uiState.customUserAgent,
+                            onCustomUserAgentClick = { showCustomUserAgentDialog = true }
                         )
                         if (showAiModelDialog) {
                             AiModelDialog(
@@ -1211,6 +1218,16 @@ fun SettingsScreen(
                                     showAiApiKeyDialog = false
                                 },
                                 onDismiss = { showAiApiKeyDialog = false }
+                            )
+                        }
+                        if (showCustomUserAgentDialog) {
+                            CustomUserAgentDialog(
+                                currentValue = uiState.customUserAgent,
+                                onSave = { value ->
+                                    viewModel.setCustomUserAgent(value)
+                                    showCustomUserAgentDialog = false
+                                },
+                                onDismiss = { showCustomUserAgentDialog = false }
                             )
                         }
                         if (uiState.aiKeyServerState.isActive) {
@@ -1707,6 +1724,17 @@ fun SettingsScreen(
                     showAiApiKeyDialog = false
                 },
                 onDismiss = { showAiApiKeyDialog = false }
+            )
+        }
+
+        if (isTouchDevice && showCustomUserAgentDialog) {
+            CustomUserAgentDialog(
+                currentValue = uiState.customUserAgent,
+                onSave = { value ->
+                    viewModel.setCustomUserAgent(value)
+                    showCustomUserAgentDialog = false
+                },
+                onDismiss = { showCustomUserAgentDialog = false }
             )
         }
 
@@ -2984,7 +3012,8 @@ private fun MobileSettingsLayout(
     onRenameCatalogClick: (CatalogConfig) -> Unit,
     onConnectHomeServerClick: () -> Unit,
     onConnectPlexHomeServerClick: () -> Unit,
-    onAddCustomAddonClick: () -> Unit
+    onAddCustomAddonClick: () -> Unit,
+    openCustomUserAgentDialog: () -> Unit = {}
 ) {
     BackHandler(enabled = page != "MAIN") {
         onNavigate("MAIN")
@@ -3067,7 +3096,8 @@ private fun MobileSettingsLayout(
                 onRenameCatalogClick = onRenameCatalogClick,
                 onConnectHomeServerClick = onConnectHomeServerClick,
                 onConnectPlexHomeServerClick = onConnectPlexHomeServerClick,
-                onAddCustomAddonClick = onAddCustomAddonClick
+                onAddCustomAddonClick = onAddCustomAddonClick,
+                openCustomUserAgentDialog = openCustomUserAgentDialog
             )
         }
     }
@@ -3229,7 +3259,8 @@ private fun MobileSettingsSubPage(
     onRenameCatalogClick: (CatalogConfig) -> Unit,
     onConnectHomeServerClick: () -> Unit,
     onConnectPlexHomeServerClick: () -> Unit,
-    onAddCustomAddonClick: () -> Unit
+    onAddCustomAddonClick: () -> Unit,
+    openCustomUserAgentDialog: () -> Unit = {}
 ) {
     val scrollState = rememberScrollState()
     Column(
@@ -3306,8 +3337,15 @@ private fun MobileSettingsSubPage(
                         title = stringResource(R.string.dns_provider),
                         value = uiState.dnsProvider,
                         isFocused = false,
-                        showDivider = false,
                         onClick = openDnsProviderPicker
+                    )
+                    MobileSettingsRow(
+                        icon = Icons.Default.Language,
+                        title = stringResource(R.string.custom_user_agent),
+                        value = uiState.customUserAgent.take(20).let { if (uiState.customUserAgent.length > 20) "$it…" else it },
+                        isFocused = false,
+                        showDivider = false,
+                        onClick = openCustomUserAgentDialog
                     )
                 }
             }
@@ -4176,7 +4214,8 @@ private fun tvSettingsPanelFacts(
         )
         "network" -> listOf(
             "DNS" to uiState.dnsProvider,
-            "Loading stats" to if (uiState.showLoadingStats) "On" else "Off"
+            "Loading stats" to if (uiState.showLoadingStats) "On" else "Off",
+            "User-Agent" to uiState.customUserAgent.take(40)
         )
         "iptv" -> listOf(
             "Playlists" to "${uiState.iptvPlaylists.size}/3",
@@ -4336,7 +4375,9 @@ private fun TvGeneralSettingsRows(
     onSubtitleAiAutoSelectToggle: (Boolean) -> Unit = {},
     onSubtitleRemoveHearingImpairedToggle: (Boolean) -> Unit = {},
     onSubtitleAiApiKeyClick: () -> Unit = {},
-    onSubtitleAiQrClick: () -> Unit = {}
+    onSubtitleAiQrClick: () -> Unit = {},
+    customUserAgent: String = OkHttpProvider.DEFAULT_USER_AGENT,
+    onCustomUserAgentClick: () -> Unit = {}
 ) {
     Column {
         tvGeneralRowsForSection(section).forEachIndexed { localIndex, rowId ->
@@ -4440,6 +4481,7 @@ private fun TvGeneralSettingsRows(
                 31 -> SettingsToggleRow(stringResource(R.string.ai_remove_hi_title), stringResource(R.string.ai_remove_hi_desc), subtitleRemoveHearingImpaired, focusedIndex == localIndex, onSubtitleRemoveHearingImpairedToggle, Modifier.settingsFocusSlot(localIndex).alpha(if (subtitleAiEnabled) 1f else 0.4f))
                 32 -> SettingsRow(Icons.Default.VpnKey, stringResource(R.string.ai_api_key_title), stringResource(R.string.ai_api_key_desc), maskAiApiKey(subtitleAiApiKey, stringResource(R.string.ai_key_not_set)), focusedIndex == localIndex, onSubtitleAiApiKeyClick, Modifier.settingsFocusSlot(localIndex).alpha(if (subtitleAiEnabled) 1f else 0.4f))
                 33 -> SettingsRow(Icons.Default.QrCode, stringResource(R.string.ai_scan_qr_title), stringResource(R.string.ai_scan_qr_desc), "", focusedIndex == localIndex, onSubtitleAiQrClick, Modifier.settingsFocusSlot(localIndex).alpha(if (subtitleAiEnabled) 1f else 0.4f))
+                34 -> SettingsRow(Icons.Default.Language, stringResource(R.string.custom_user_agent), stringResource(R.string.custom_user_agent_desc), customUserAgent.take(30).let { if (customUserAgent.length > 30) "$it…" else it }, focusedIndex == localIndex, onCustomUserAgentClick, Modifier.settingsFocusSlot(localIndex))
             }
         }
     }
@@ -4515,7 +4557,9 @@ private fun GeneralSettings(
     onSubtitleAiAutoSelectToggle: (Boolean) -> Unit = {},
     onSubtitleRemoveHearingImpairedToggle: (Boolean) -> Unit = {},
     onSubtitleAiApiKeyClick: () -> Unit = {},
-    onSubtitleAiQrClick: () -> Unit = {}
+    onSubtitleAiQrClick: () -> Unit = {},
+    customUserAgent: String = OkHttpProvider.DEFAULT_USER_AGENT,
+    onCustomUserAgentClick: () -> Unit = {}
 ) {
     Column {
         // ── Language & Subtitles ──
@@ -4818,6 +4862,16 @@ private fun GeneralSettings(
             onToggle = onShowLoadingStatsToggle,
             modifier = Modifier.settingsFocusSlot(26)
         )
+        Spacer(modifier = Modifier.height(10.dp))
+        SettingsRow(
+            icon = Icons.Default.Language,
+            title = stringResource(R.string.custom_user_agent),
+            subtitle = stringResource(R.string.custom_user_agent_desc),
+            value = customUserAgent.take(30).let { if (customUserAgent.length > 30) "$it…" else it },
+            isFocused = focusedIndex == 34,
+            onClick = onCustomUserAgentClick,
+            modifier = Modifier.settingsFocusSlot(34)
+        )
 
         // ── Audio ──
         Spacer(modifier = Modifier.height(24.dp))
@@ -5101,6 +5155,108 @@ private fun AiApiKeyDialog(
                             textAlign = androidx.compose.ui.text.style.TextAlign.Center,
                             color = Pink
                         )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CustomUserAgentDialog(
+    currentValue: String,
+    onSave: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val isMobile = LocalDeviceType.current.isTouchDevice()
+    var value by remember(currentValue) { mutableStateOf(currentValue) }
+    val inputFocusRequester = remember { FocusRequester() }
+    BackHandler { onDismiss() }
+    LaunchedEffect(Unit) {
+        kotlinx.coroutines.delay(100)
+        inputFocusRequester.requestFocus()
+    }
+    androidx.compose.ui.window.Dialog(onDismissRequest = onDismiss) {
+        Box(
+            modifier = Modifier
+                .then(
+                    if (isMobile) Modifier.fillMaxWidth().padding(horizontal = 16.dp)
+                    else Modifier.width(520.dp)
+                )
+                .clip(RoundedCornerShape(16.dp))
+                .background(BackgroundElevated)
+        ) {
+            Column(modifier = Modifier.fillMaxWidth().padding(24.dp)) {
+                Text(text = stringResource(R.string.custom_user_agent), style = ArflixTypography.sectionTitle, color = TextPrimary)
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = stringResource(R.string.custom_user_agent_desc),
+                    style = ArflixTypography.caption,
+                    color = TextSecondary
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                androidx.compose.material3.OutlinedTextField(
+                    value = value,
+                    onValueChange = { value = it },
+                    placeholder = { Text(OkHttpProvider.DEFAULT_USER_AGENT, color = TextSecondary.copy(alpha = 0.4f)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth().focusRequester(inputFocusRequester),
+                    colors = androidx.compose.material3.OutlinedTextFieldDefaults.colors(
+                        focusedTextColor = TextPrimary,
+                        unfocusedTextColor = TextPrimary,
+                        focusedBorderColor = Pink,
+                        unfocusedBorderColor = TextSecondary.copy(alpha = 0.3f)
+                    )
+                )
+                Spacer(modifier = Modifier.height(20.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    val cancelFocus = remember { FocusRequester() }
+                    val saveFocus = remember { FocusRequester() }
+                    Surface(
+                        onClick = onDismiss,
+                        modifier = Modifier.weight(1f).focusRequester(cancelFocus),
+                        colors = ClickableSurfaceDefaults.colors(
+                            containerColor = BackgroundElevated,
+                            focusedContainerColor = BackgroundElevated.copy(alpha = 0.8f)
+                        ),
+                        shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(8.dp)),
+                        border = ClickableSurfaceDefaults.border(
+                            border = androidx.tv.material3.Border(
+                                border = androidx.compose.foundation.BorderStroke(1.dp, TextSecondary.copy(alpha = 0.3f))
+                            )
+                        )
+                    ) {
+                        Text(
+                            text = stringResource(R.string.cancel),
+                            modifier = Modifier.padding(vertical = 12.dp).fillMaxWidth(),
+                            textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                            color = TextSecondary
+                        )
+                    }
+                    Surface(
+                        onClick = { onSave(value) },
+                        modifier = Modifier.weight(1f).focusRequester(saveFocus),
+                        colors = ClickableSurfaceDefaults.colors(
+                            containerColor = Pink.copy(alpha = 0.15f),
+                            focusedContainerColor = Pink.copy(alpha = 0.25f)
+                        ),
+                        shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(8.dp)),
+                        border = ClickableSurfaceDefaults.border(
+                            border = androidx.tv.material3.Border(
+                                border = androidx.compose.foundation.BorderStroke(1.dp, Pink.copy(alpha = 0.4f))
+                            )
+                        )
+                    ) {
+                        Text(
+                            text = stringResource(R.string.save),
+                            modifier = Modifier.padding(vertical = 12.dp).fillMaxWidth(),
+                            textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                            color = Pink
+                        )
+                    }
+                    LaunchedEffect(Unit) {
+                        kotlinx.coroutines.delay(150)
+                        inputFocusRequester.requestFocus()
                     }
                 }
             }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -99,6 +99,7 @@ data class SettingsUiState(
     val autoPlayMinQuality: String = "Any",
     val dnsProvider: String = "System DNS",
     val dnsProviderOptions: List<String> = listOf("System DNS", "Cloudflare", "Google", "AdGuard"),
+    val customUserAgent: String = OkHttpProvider.DEFAULT_USER_AGENT,
     val subtitleSize: String = "Medium",
     val subtitleColor: String = "White",
     val subtitleStyle: String = "Bold",
@@ -267,6 +268,7 @@ class SettingsViewModel @Inject constructor(
     private fun filterSubtitlesByLanguageKey() = profileManager.profileBooleanKey("filter_subtitles_by_lang")
     private fun secondarySubtitleKey() = profileManager.profileStringKey("secondary_subtitle")
     private val dnsProviderKey = stringPreferencesKey(OkHttpProvider.DNS_PROVIDER_PREF_KEY)
+    private val customUserAgentKey = stringPreferencesKey(OkHttpProvider.USER_AGENT_PREF_KEY)
     private fun includeSpecialsKey() = profileManager.profileBooleanKey("include_specials")
     private val qualityFiltersKey = stringPreferencesKey("quality_filters")
 
@@ -426,6 +428,8 @@ class SettingsViewModel @Inject constructor(
             val filterSubtitlesByLanguage = prefs[filterSubtitlesByLanguageKey()] ?: true
             val secondarySubtitle = prefs[secondarySubtitleKey()]?.trim()?.takeIf { it.isNotBlank() } ?: "Off"
             val dnsProviderValue = normalizeDnsProviderValue(prefs[dnsProviderKey])
+            val customUserAgent = prefs[customUserAgentKey]?.takeIf { it.isNotBlank() } ?: OkHttpProvider.DEFAULT_USER_AGENT
+            OkHttpProvider.setCustomUserAgent(customUserAgent)
             val includeSpecials = prefs[includeSpecialsKey()] ?: false
             val qualityFilters = runCatching {
                 val json = prefs[qualityFiltersKey].orEmpty()
@@ -490,6 +494,7 @@ class SettingsViewModel @Inject constructor(
                 filterSubtitlesByLanguage = filterSubtitlesByLanguage,
                 secondarySubtitle = secondarySubtitle,
                 dnsProvider = dnsProviderLabel(dnsProviderValue),
+                customUserAgent = customUserAgent,
                 includeSpecials = includeSpecials,
                 spoilerBlurEnabled = spoilerBlurEnabled,
                 isLoggedIn = isLoggedIn,
@@ -1254,6 +1259,19 @@ class SettingsViewModel @Inject constructor(
                 OkHttpProvider.createCoilImageLoader(context)
             }
             Coil.setImageLoader(imageLoader)
+        }
+    }
+
+    fun setCustomUserAgent(value: String) {
+        val trimmed = value.trim()
+        viewModelScope.launch {
+            context.settingsDataStore.edit { prefs ->
+                prefs[customUserAgentKey] = trimmed
+            }
+            OkHttpProvider.setCustomUserAgent(trimmed.ifBlank { OkHttpProvider.DEFAULT_USER_AGENT })
+            _uiState.value = _uiState.value.copy(
+                customUserAgent = trimmed.ifBlank { OkHttpProvider.DEFAULT_USER_AGENT }
+            )
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -130,6 +130,8 @@
     <string name="show_loading_stats">Show Loading Stats</string>
     <string name="volume_boost">Volume Boost</string>
     <string name="dns_provider">DNS Provider</string>
+    <string name="custom_user_agent">Custom User-Agent</string>
+    <string name="custom_user_agent_desc">Override the HTTP User-Agent for all requests</string>
     <string name="add_playlist">Add Playlist</string>
     <string name="refresh_iptv">Refresh IPTV Data</string>
     <string name="delete_iptv">Delete IPTV Playlists</string>


### PR DESCRIPTION
## Summary

- Adds a **Custom User-Agent** setting in the Network section of Settings (both TV and mobile layouts) that lets users override the HTTP User-Agent string sent with all requests
- Stores the value in DataStore (`custom_user_agent_global` key) and restores it on startup before any network calls
- Injects the configured value via an OkHttp interceptor on both the app client and the playback client — derived clients (IPTV, Xtream, stream resolution) inherit it automatically without a client rebuild

## Changes

**`OkHttpProvider`** — `DEFAULT_USER_AGENT` + `USER_AGENT_PREF_KEY` constants; `@Volatile _customUserAgent` with getter/setter; `userAgentInterceptor` as the first interceptor in `buildAppClient()` and `buildPlaybackClient()`

**`ArflixApplication`** — loads and applies the saved UA from DataStore at startup alongside DNS initialisation

**Repositories / Player** — replaced all hardcoded UA strings in `CatalogRepository`, `IptvRepository`, `MediaRepository`, `StreamRepository`, and `PlayerScreen` with `OkHttpProvider.userAgent`

**`SettingsViewModel`** — `customUserAgent` in `SettingsUiState`; loads, persists, and applies via `setCustomUserAgent()`

**`SettingsScreen`** — Custom User-Agent row in the Network section (TV D-pad + mobile); `CustomUserAgentDialog` text-input dialog; callbacks threaded through `MobileSettingsLayout` → `MobileSettingsSubPage`

**`strings.xml`** — `custom_user_agent` and `custom_user_agent_desc` resources

## Test plan

- [x] Settings → Network on TV: row present and D-pad navigable
- [x] Settings → Playback & Controls on mobile: row present under CONTROLS
- [x] Enter a custom value, restart — value persists
- [x] Verify UA appears in stream/IPTV requests (logcat or proxy)
- [x] Clear the field — app falls back to the default Chrome UA
- [x] No regression on DNS provider or other Network rows
