### PR TITLE
Improve non-Trakt cross-device cloud sync responsiveness

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/RealtimeSyncManager.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/RealtimeSyncManager.kt
@@ -62,7 +62,8 @@ class RealtimeSyncManager @Inject constructor(
         // meaningfully increasing load (one GET every 45s while signed in).
         private const val PERIODIC_SYNC_INTERVAL_MS = 45_000L
         private const val DEBOUNCE_MS = 2_000L
-        private const val WATCH_HISTORY_DEBOUNCE_MS = 5_000L
+        private const val WATCH_HISTORY_DEBOUNCE_MS = 1_000L
+        private const val WATCH_HISTORY_SELF_ECHO_GUARD_MS = 1_500L
         // Reconnect with fresh token every 30 minutes to prevent silent auth expiry
         private const val TOKEN_REFRESH_INTERVAL_MS = 30 * 60 * 1000L
     }
@@ -392,7 +393,7 @@ class RealtimeSyncManager @Inject constructor(
     }
 
     private fun debouncedWatchHistoryEmit() {
-        if (System.currentTimeMillis() - lastLocalWatchHistoryWriteTimestamp < 3_000L) {
+        if (System.currentTimeMillis() - lastLocalWatchHistoryWriteTimestamp < WATCH_HISTORY_SELF_ECHO_GUARD_MS) {
             Log.d(TAG, "Skipping watch_history emit - recent local write")
             return
         }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
@@ -1095,7 +1095,7 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             realtimeSyncManager.watchHistoryEvents.collect {
                 // Fast path: directly update the progress bar on existing CW cards using
-                // Supabase watch_history data (which Device A writes every 15s). This gives
+                // Supabase watch_history data (which Device A writes every ~5s). This gives
                 // immediate visual feedback without waiting for the full Trakt re-fetch
                 // (which can take 10+ seconds for profiles with hundreds of watched items).
                 runCatching {
@@ -4047,4 +4047,3 @@ class HomeViewModel @Inject constructor(
         updateStatusManager.reset()
     }
 }
-

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
@@ -214,7 +214,7 @@ class PlayerViewModel @Inject constructor(
     private val SKIP_INTERVAL_MIN_VISIBLE_MS = 250L
 
     private val SCROBBLE_UPDATE_INTERVAL_MS = 20_000L
-    private val WATCH_HISTORY_UPDATE_INTERVAL_MS = 5_000L
+    private val WATCH_HISTORY_UPDATE_INTERVAL_MS = 10_000L
     private val CLOUD_PUSH_INTERVAL_MS = 60_000L // Push CW to cloud every 60s during active playback
 
     private var lastCloudPushTime = 0L

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
@@ -152,6 +152,7 @@ class PlayerViewModel @Inject constructor(
     private var currentPreferredBingeGroup: String? = null
     private var lastScrobbleTime: Long = 0
     private var lastWatchHistorySaveTime: Long = 0
+    private var lastWatchHistorySavedPositionSeconds: Long = -1L
     private var lastIsPlaying: Boolean = false
     private var hasMarkedWatched: Boolean = false
     private var hasManualSubtitleSelection: Boolean = false
@@ -213,7 +214,7 @@ class PlayerViewModel @Inject constructor(
     private val SKIP_INTERVAL_MIN_VISIBLE_MS = 250L
 
     private val SCROBBLE_UPDATE_INTERVAL_MS = 20_000L
-    private val WATCH_HISTORY_UPDATE_INTERVAL_MS = 15_000L
+    private val WATCH_HISTORY_UPDATE_INTERVAL_MS = 5_000L
     private val CLOUD_PUSH_INTERVAL_MS = 60_000L // Push CW to cloud every 60s during active playback
 
     private var lastCloudPushTime = 0L
@@ -300,6 +301,7 @@ class PlayerViewModel @Inject constructor(
         lastIsPlaying = false
         lastScrobbleTime = 0
         lastWatchHistorySaveTime = 0
+        lastWatchHistorySavedPositionSeconds = -1L
         subtitleRefreshJob?.cancel()
         subtitleSelectionJob?.cancel()
         vodAppendJob?.cancel()
@@ -2361,10 +2363,16 @@ class PlayerViewModel @Inject constructor(
             // the next-episode CW entry, and saving the finished episode's full position here
             // would contaminate the next episode's resume time via show-level history fallback.
             val isAtWatchedThreshold = progressPercent >= Constants.WATCHED_THRESHOLD
-            if ((!isPlaying || currentTime - lastWatchHistorySaveTime >= WATCH_HISTORY_UPDATE_INTERVAL_MS) && !isAtWatchedThreshold) {
+            val durationSeconds = (duration / 1000L).coerceAtLeast(1L)
+            val positionSeconds = (position / 1000L).coerceAtLeast(0L)
+            val hasSeekJump = lastWatchHistorySavedPositionSeconds >= 0L &&
+                kotlin.math.abs(positionSeconds - lastWatchHistorySavedPositionSeconds) >= 20L
+            val shouldPersistWatchHistory = !isPlaying ||
+                currentTime - lastWatchHistorySaveTime >= WATCH_HISTORY_UPDATE_INTERVAL_MS ||
+                hasSeekJump
+            if (shouldPersistWatchHistory && !isAtWatchedThreshold) {
                 lastWatchHistorySaveTime = currentTime
-                val durationSeconds = (duration / 1000L).coerceAtLeast(1L)
-                val positionSeconds = (position / 1000L).coerceAtLeast(0L)
+                lastWatchHistorySavedPositionSeconds = positionSeconds
                 val selectedStream = _uiState.value.selectedStream
                 val shouldPersistStreamAffinity = positionSeconds >= 30L
                 val streamKey = if (shouldPersistStreamAffinity) buildStreamKey(selectedStream) else null


### PR DESCRIPTION
## Summary
Improves non-Trakt cloud sync responsiveness for Continue Watching progress across devices (e.g., TV to phone resume).

## Changes
- Reduce watch-history save interval during active playback from 15s to 5s.
- Add immediate persistence when playback position changes significantly (seek jump >= 20s).
- Reduce realtime watch_history event debounce from 5s to 1s.
- Tighten local self-echo suppression window from 3s to 1.5s to avoid delaying legitimate remote updates.
- Update HomeViewModel inline comment to reflect the faster write cadence.

## Why
Previously, stacked throttles caused noticeably stale resume positions between devices for non-Trakt users. These changes shrink the stale window and make cross-device resume behavior feel much closer to instant.

## Scope
This PR is intentionally scoped to non-Trakt watch-progress sync paths and realtime propagation timing.
