### PR TITLE
Fix non-Trakt Continue Watching movie visibility

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
@@ -2822,14 +2822,24 @@ class HomeViewModel @Inject constructor(
             }.mapNotNull { entry ->
                 val mediaType = if (entry.media_type == "tv") MediaType.TV else MediaType.MOVIE
                 val storedPct = (entry.progress * 100f).toInt()
-                val derivedPct = if (storedPct <= 0 && entry.duration_seconds > 0 && entry.position_seconds > 0) {
-                    ((entry.position_seconds.toFloat() / entry.duration_seconds.toFloat()) * 100f).toInt()
-                } else {
-                    storedPct
+                val hasResumePosition = entry.position_seconds > 0L
+                val derivedPct = when {
+                    storedPct > 0 -> storedPct
+                    entry.duration_seconds > 0 && hasResumePosition ->
+                        ((entry.position_seconds.toFloat() / entry.duration_seconds.toFloat()) * 100f).toInt()
+                    hasResumePosition -> 1
+                    else -> 0
                 }
+                val resolvedTitle = entry.title
+                    ?.trim()
+                    ?.takeIf { it.isNotBlank() }
+                    ?: entry.episode_title
+                        ?.trim()
+                        ?.takeIf { it.isNotBlank() }
+                    ?: "Untitled"
                 ContinueWatchingItem(
                     id = entry.show_tmdb_id,
-                    title = entry.title ?: return@mapNotNull null,
+                    title = resolvedTitle,
                     mediaType = mediaType,
                     progress = derivedPct.coerceIn(0, 100),
                     resumePositionSeconds = entry.position_seconds.coerceAtLeast(0L),
@@ -2856,14 +2866,24 @@ class HomeViewModel @Inject constructor(
             }.mapNotNull { entry ->
                 val mediaType = if (entry.media_type == "tv") MediaType.TV else MediaType.MOVIE
                 val storedPct = (entry.progress * 100f).toInt()
-                val derivedPct = if (storedPct <= 0 && entry.duration_seconds > 0 && entry.position_seconds > 0) {
-                    ((entry.position_seconds.toFloat() / entry.duration_seconds.toFloat()) * 100f).toInt()
-                } else {
-                    storedPct
+                val hasResumePosition = entry.position_seconds > 0L
+                val derivedPct = when {
+                    storedPct > 0 -> storedPct
+                    entry.duration_seconds > 0 && hasResumePosition ->
+                        ((entry.position_seconds.toFloat() / entry.duration_seconds.toFloat()) * 100f).toInt()
+                    hasResumePosition -> 1
+                    else -> 0
                 }
+                val resolvedTitle = entry.title
+                    ?.trim()
+                    ?.takeIf { it.isNotBlank() }
+                    ?: entry.episode_title
+                        ?.trim()
+                        ?.takeIf { it.isNotBlank() }
+                    ?: "Untitled"
                 ContinueWatchingItem(
                     id = entry.show_tmdb_id,
-                    title = entry.title ?: return@mapNotNull null,
+                    title = resolvedTitle,
                     mediaType = mediaType,
                     progress = derivedPct.coerceIn(0, 100),
                     resumePositionSeconds = entry.position_seconds.coerceAtLeast(0L),
@@ -2946,7 +2966,7 @@ class HomeViewModel @Inject constructor(
                 dismissedContinueWatchingKeys.contains(showKey) || persistedDismissedKeys.contains(showKey)
             }
             .filter { item ->
-                if (isTraktAuthenticated) true else item.progress in 1..99
+                if (isTraktAuthenticated) true else item.progress in 1..99 || item.resumePositionSeconds > 0L
             }
             .take(Constants.MAX_CONTINUE_WATCHING)
     }
@@ -2984,7 +3004,7 @@ class HomeViewModel @Inject constructor(
                 dismissedContinueWatchingKeys.contains(showKey) || persistedDismissedKeys.contains(showKey)
             }
             .filter { item ->
-                if (isTraktAuthenticated) true else item.progress in 1..99
+                if (isTraktAuthenticated) true else item.progress in 1..99 || item.resumePositionSeconds > 0L
             }
             .take(Constants.MAX_CONTINUE_WATCHING)
     }
@@ -4047,4 +4067,3 @@ class HomeViewModel @Inject constructor(
         updateStatusManager.reset()
     }
 }
-


### PR DESCRIPTION
## Summary
Fixes missing movie entries in Continue Watching for non-Trakt users.

## Changes
- Keep non-Trakt CW items when `resumePositionSeconds > 0`, even if `progress` is missing or zero.
- Derive a minimal in-progress value when only position metadata exists.
- Stop dropping entries when `title` is blank by using a safe fallback title.

## Why
Some in-progress movies were never shown on Home because filtering relied only on progress percentage and mapping dropped entries with incomplete metadata.

## Scope
Only non-Trakt Continue Watching movie visibility behavior.
