### PR TITLE
perf: debounce syncAddonCatalogs() with addon list fingerprint

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/CatalogRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/CatalogRepository.kt
@@ -53,6 +53,12 @@ class CatalogRepository @Inject constructor(
         MediaRepository.buildPreinstalledDefaults().associateBy { it.id }
     }
 
+    // Debounce guard: skip syncAddonCatalogs() when addon list hasn't changed.
+    // syncAddonCatalogs() iterates every addon manifest, flatMaps catalogs, and
+    // diffs against persisted state — all of which is wasted work when the
+    // installed addon list is identical between calls.
+    @Volatile private var lastSyncedAddonFingerprint: String? = null
+
     private val bundledPreinstalledCatalogIds by lazy(LazyThreadSafetyMode.NONE) {
         bundledPreinstalledCatalogsById.keys
     }
@@ -426,6 +432,11 @@ class CatalogRepository @Inject constructor(
     }
 
     suspend fun syncAddonCatalogs(addons: List<Addon>): Boolean {
+        // Debounce: skip if addon list hasn't changed since last sync.
+        val fingerprint = addons.joinToString(",") { it.id }
+        if (fingerprint == lastSyncedAddonFingerprint) return false
+        lastSyncedAddonFingerprint = fingerprint
+
         val profileId = activeProfileId()
         val hiddenAddonIds = context.settingsDataStore.data
             .first()

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/CatalogRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/CatalogRepository.kt
@@ -432,12 +432,15 @@ class CatalogRepository @Inject constructor(
     }
 
     suspend fun syncAddonCatalogs(addons: List<Addon>): Boolean {
-        // Debounce: skip if addon list hasn't changed since last sync.
-        val fingerprint = addons.joinToString(",") { it.id }
+        val profileId = activeProfileId()
+        // Debounce: skip if addon manifest state hasn't changed since last sync.
+        // Includes profile ID + fields that affect the sync outcome so that
+        // switching profiles, toggling addon enable-state, or manifest catalog
+        // changes always trigger a fresh sync.
+        val fingerprint = buildAddonFingerprint(profileId, addons)
         if (fingerprint == lastSyncedAddonFingerprint) return false
         lastSyncedAddonFingerprint = fingerprint
 
-        val profileId = activeProfileId()
         val hiddenAddonIds = context.settingsDataStore.data
             .first()
             .let { prefs -> decodeHiddenAddon(profileId, prefs) }
@@ -503,6 +506,39 @@ class CatalogRepository @Inject constructor(
             saveCatalogs(current)
         }
         return changed
+    }
+
+    /**
+     * Builds a fingerprint for [syncAddonCatalogs] debouncing that captures all fields
+     * affecting the sync outcome. Unlike the previous ID-only fingerprint, this includes:
+     * - Active profile ID (so profile switches always trigger a fresh sync)
+     * - Addon installed/enabled state, type, and URL
+     * - Manifest catalog contents (catalog type + ID per addon)
+     *
+     * This ensures that toggling an addon, switching profiles, or manifest catalog
+     * changes never leave stale/missing catalogs.
+     */
+    private fun buildAddonFingerprint(profileId: String, addons: List<Addon>): String {
+        return buildString {
+            append(profileId)
+            append('|')
+            addons.forEach { addon ->
+                append(addon.id)
+                append(':')
+                append(if (addon.isInstalled) '1' else '0')
+                append(if (addon.isEnabled) '1' else '0')
+                append(addon.type.name)
+                append(addon.url ?: "")
+                addon.manifest?.catalogs?.forEach { catalog ->
+                    append('[')
+                    append(catalog.type)
+                    append(':')
+                    append(catalog.id)
+                    append(']')
+                }
+                append(',')
+            }
+        }
     }
 
     suspend fun syncHomeServerCatalogs(candidates: List<HomeServerCatalogCandidate>): Boolean {


### PR DESCRIPTION
## perf/debounce-sync-catalogs

Debounce `syncAddonCatalogs()` with addon list fingerprint.

`syncAddonCatalogs()` iterates every addon manifest, flatMaps `manifest.catalogs`, constructs `CatalogConfig` entries, reads hidden-addon preferences from DataStore, diffs against persisted catalogs, and optionally writes back to DataStore — all of which is wasted work when the installed addon list is identical between calls.

Added a `@Volatile` `lastSyncedAddonFingerprint` field. On entry, a joinToString fingerprint of addon IDs is compared; if unchanged since last sync, returns `false` immediately.

**Impact**: Sub-millisecond exit path for redundant calls. `syncAddonCatalogs()` is called on every `loadHomeData()` invocation; when the addon setup is stable (which is the common case), the entire ~50-line processing pipeline is bypassed.

