### PR TITLE
perf: LRU eviction for preloaded image request cache

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
@@ -765,7 +765,7 @@ class HomeViewModel @Inject constructor(
     private val categoryPaginationStates = ConcurrentHashMap<String, CategoryPaginationState>()
     private val preloadedRequests: MutableSet<String> = run {
         val backingMap = object : java.util.LinkedHashMap<String, Boolean>(1200, 0.75f, true) {
-            override fun removeEldestEntry(eldest: java.util.Map.Entry<String, Boolean>?): Boolean {
+            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Boolean>): Boolean {
                 return size > 1200
             }
         }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
@@ -763,7 +763,14 @@ class HomeViewModel @Inject constructor(
     private val heroDetailsCache = ConcurrentHashMap<String, HeroDetailsSnapshot>()
     private val savedCatalogById = ConcurrentHashMap<String, CatalogConfig>()
     private val categoryPaginationStates = ConcurrentHashMap<String, CategoryPaginationState>()
-    private val preloadedRequests = Collections.synchronizedSet(mutableSetOf<String>())
+    private val preloadedRequests: MutableSet<String> = run {
+        val backingMap = object : java.util.LinkedHashMap<String, Boolean>(1200, 0.75f, true) {
+            override fun removeEldestEntry(eldest: java.util.Map.Entry<String, Boolean>?): Boolean {
+                return size > 1200
+            }
+        }
+        Collections.synchronizedSet(Collections.newSetFromMap(backingMap))
+    }
     private var logoCachePublishJob: Job? = null
     @Volatile
     private var pendingLogoPublishPriority: Boolean = false
@@ -2537,9 +2544,6 @@ class HomeViewModel @Inject constructor(
      * Uses target display sizes to reduce decode overhead.
      */
     private fun preloadImagesWithCoil(urls: List<String>, width: Int, height: Int, batchLimit: Int = 0) {
-        if (preloadedRequests.size > if (isLowRamDevice) 1_200 else 4_000) {
-            preloadedRequests.clear()
-        }
         // Bumped from 2/4 to 4/8 — enough to preload one full row of cards on
         // the home screen. The old limits left the majority of visible cards
         // without preloaded images on cold start.


### PR DESCRIPTION
---

## perf/lru-image-preload

LRU eviction for `preloadedRequests` image cache key set.

`preloadImagesWithCoil()` tracks which image URLs have been preloaded using a synchronized `HashSet<String>`. When the set exceeded 1,200 (low RAM) or 4,000 (normal) entries, the entire set was cleared — discarding all preload history at once and allowing duplicates to be re-added.

Replaced with a `LinkedHashMap`-backed `Set` using access-order=true. The set is capped at 1,200 entries with automatic eldest-entry eviction (`removeEldestEntry`). Recently-accessed image keys stay cached; stale ones naturally fall out.

**Impact**: Eliminates periodic O(n) full-clear that purged the entire preload history. Entry eviction is O(1). Thread safety preserved via `Collections.synchronizedSet()`.
