### PR TITLE
feat: navigate directly to Player from Continue Watching items

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/model/Models.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/model/Models.kt
@@ -55,6 +55,9 @@ data class MediaItem(
     val timeRemainingLabel: String? = null,
     // Continue Watching: true only when progress represents current movie/episode playback.
     val showPlaybackProgress: Boolean = true,
+    // Continue Watching: resume position in seconds for direct playback navigation.
+    // 0L means no resume position (first-time play or not a CW item).
+    val resumePositionSeconds: Long = 0L,
 ) : Serializable
 
 enum class MediaType {

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/TraktRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/TraktRepository.kt
@@ -3811,7 +3811,8 @@ data class ContinueWatchingItem(
             totalEpisodes = totalEpisodeCount,
             watchedEpisodes = watchedEpisodeCount,
             timeRemainingLabel = timeRemainingLabel,
-            showPlaybackProgress = showPlaybackProgress
+            showPlaybackProgress = showPlaybackProgress,
+            resumePositionSeconds = resumeSeconds
         )
     }
 }

--- a/app/src/main/kotlin/com/arflix/tv/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/arflix/tv/navigation/AppNavigation.kt
@@ -170,6 +170,17 @@ fun AppNavigation(
                 onNavigateToDetails = { mediaType, mediaId, initialSeason, initialEpisode ->
                     navController.navigate(Screen.Details.createRoute(mediaType, mediaId, initialSeason, initialEpisode))
                 },
+                onNavigateToPlayer = { mediaType, mediaId, seasonNumber, episodeNumber, startPositionMs ->
+                    navController.navigate(
+                        Screen.Player.createRoute(
+                            mediaType = mediaType,
+                            mediaId = mediaId,
+                            seasonNumber = seasonNumber,
+                            episodeNumber = episodeNumber,
+                            startPositionMs = startPositionMs
+                        )
+                    )
+                },
                 onNavigateToCollection = { catalogId ->
                     navController.navigate(Screen.CollectionDetails.createRoute(catalogId))
                 },

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
@@ -3387,11 +3387,12 @@ private fun ContentRow(
                 val onCardFocused = remember(item, index) {
                     { latestOnItemFocused.value(item, index) }
                 }
+                val latestOnNavigateToPlayer = rememberUpdatedState(onNavigateToPlayer)
                 val onCardClick = remember(item, isContinueWatching) {
                     {
                         if (isContinueWatching && item.resumePositionSeconds > 0L) {
                             // CW item with resume data: navigate directly to Player
-                            onNavigateToPlayer(
+                            latestOnNavigateToPlayer.value(
                                 item.mediaType,
                                 item.id,
                                 item.nextEpisode?.seasonNumber,

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
@@ -536,6 +536,7 @@ fun HomeScreen(
     preloadedLogoCache: Map<String, String> = emptyMap(),
     currentProfile: com.arflix.tv.data.model.Profile? = null,
     onNavigateToDetails: (MediaType, Int, Int?, Int?) -> Unit = { _, _, _, _ -> },
+    onNavigateToPlayer: (MediaType, Int, Int?, Int?, Long) -> Unit = { _, _, _, _, _ -> },
     onNavigateToCollection: (String) -> Unit = {},
     onNavigateToSearch: () -> Unit = {},
     onNavigateToWatchlist: () -> Unit = {},
@@ -1102,6 +1103,7 @@ fun HomeScreen(
             hasUpdateBadge = uiState.hasUpdateBadge,
             onItemFocusedPrefetch = {},
             onNavigateToDetails = onNavigateToDetails,
+            onNavigateToPlayer = onNavigateToPlayer,
             onNavigateToCollection = onNavigateToCollection,
             onNavigateToSearch = onNavigateToSearch,
             onNavigateToWatchlist = onNavigateToWatchlist,
@@ -2202,6 +2204,7 @@ private fun HomeInputLayer(
     hasUpdateBadge: Boolean = false,
     onItemFocusedPrefetch: (MediaItem) -> Unit = {},
     onNavigateToDetails: (MediaType, Int, Int?, Int?) -> Unit,
+    onNavigateToPlayer: (MediaType, Int, Int?, Int?, Long) -> Unit = { _, _, _, _, _ -> },
     onNavigateToCollection: (String) -> Unit,
     onNavigateToSearch: () -> Unit,
     onNavigateToWatchlist: () -> Unit,
@@ -2472,10 +2475,10 @@ private fun HomeInputLayer(
                                     focusState.currentItemIndex
                                 )
                                 currentItem?.takeIf { isActionableHomeItem(it) }?.let { item ->
+                                    val currentCategory = categories.getOrNull(focusState.currentRowIndex)
+                                    val isContinue = currentCategory?.id == "continue_watching"
                                     if (holdMs >= 500L) {
                                         // Long-press: open context menu
-                                        val currentCategory = categories.getOrNull(focusState.currentRowIndex)
-                                        val isContinue = currentCategory?.id == "continue_watching"
                                         onOpenContextMenu(item, isContinue)
                                     } else {
                                         // Short press: navigate. Must check collection:
@@ -2491,6 +2494,15 @@ private fun HomeInputLayer(
                                             onNavigateToTv(iptvId, getIptvStreamUrl(item.id))
                                         } else if (collectionId != null) {
                                             onNavigateToCollection(collectionId)
+                                        } else if (isContinue && item.resumePositionSeconds > 0L) {
+                                            // Continue Watching D-pad: navigate directly to Player
+                                            onNavigateToPlayer(
+                                                item.mediaType,
+                                                item.id,
+                                                item.nextEpisode?.seasonNumber,
+                                                item.nextEpisode?.episodeNumber,
+                                                item.resumePositionSeconds * 1000L // seconds → millis
+                                            )
                                         } else {
                                             onNavigateToDetails(item.mediaType, item.id, item.nextEpisode?.seasonNumber, item.nextEpisode?.episodeNumber)
                                         }
@@ -2549,6 +2561,7 @@ private fun HomeInputLayer(
             onPlay = onPlay,
             onDetails = onDetails,
             onNavigateToDetails = onNavigateToDetails,
+            onNavigateToPlayer = onNavigateToPlayer,
             onItemClick = { item ->
                 if (!isActionableHomeItem(item)) {
                     return@HomeRowsLayer
@@ -2559,6 +2572,15 @@ private fun HomeInputLayer(
                     onNavigateToTv(iptvId, getIptvStreamUrl(item.id))
                 } else if (collectionId != null) {
                     onNavigateToCollection(collectionId)
+                } else if (item.resumePositionSeconds > 0L) {
+                    // Continue Watching: navigate directly to Player with resume position
+                    onNavigateToPlayer(
+                        item.mediaType,
+                        item.id,
+                        item.nextEpisode?.seasonNumber,
+                        item.nextEpisode?.episodeNumber,
+                        item.resumePositionSeconds * 1000L // seconds → millis
+                    )
                 } else {
                     onNavigateToDetails(item.mediaType, item.id, item.nextEpisode?.seasonNumber, item.nextEpisode?.episodeNumber)
                 }
@@ -2584,6 +2606,7 @@ private fun HomeRowsLayer(
     onPlay: () -> Unit = {},
     onDetails: () -> Unit = {},
     onNavigateToDetails: (MediaType, Int, Int?, Int?) -> Unit = { _, _, _, _ -> },
+    onNavigateToPlayer: (MediaType, Int, Int?, Int?, Long) -> Unit = { _, _, _, _, _ -> },
     onItemClick: (MediaItem) -> Unit,
     onItemLongClick: ((MediaItem, Boolean) -> Unit)? = null
 ) {
@@ -2594,6 +2617,7 @@ private fun HomeRowsLayer(
             contentStartPadding = contentStartPadding,
             usePosterCards = usePosterCards,
             onNavigateToDetails = onNavigateToDetails,
+            onNavigateToPlayer = onNavigateToPlayer,
             onItemClick = onItemClick,
             onItemLongClick = onItemLongClick
         )
@@ -2607,7 +2631,8 @@ private fun HomeRowsLayer(
             fastScrollThresholdMs = fastScrollThresholdMs,
             usePosterCards = usePosterCards,
             onItemFocusedPrefetch = onItemFocusedPrefetch,
-            onItemClick = onItemClick
+            onItemClick = onItemClick,
+            onNavigateToPlayer = onNavigateToPlayer
         )
     }
 }
@@ -2620,6 +2645,7 @@ private fun MobileHomeRowsLayer(
     contentStartPadding: androidx.compose.ui.unit.Dp,
     usePosterCards: Boolean,
     onNavigateToDetails: (MediaType, Int, Int?, Int?) -> Unit = { _, _, _, _ -> },
+    onNavigateToPlayer: (MediaType, Int, Int?, Int?, Long) -> Unit = { _, _, _, _, _ -> },
     onItemClick: (MediaItem) -> Unit,
     onItemLongClick: ((MediaItem, Boolean) -> Unit)? = null
 ) {
@@ -2754,7 +2780,8 @@ private fun TvHomeRowsLayer(
     fastScrollThresholdMs: Long,
     usePosterCards: Boolean,
     onItemFocusedPrefetch: (MediaItem) -> Unit = {},
-    onItemClick: (MediaItem) -> Unit
+    onItemClick: (MediaItem) -> Unit,
+    onNavigateToPlayer: (MediaType, Int, Int?, Int?, Long) -> Unit = { _, _, _, _, _ -> }
 ) {
     // ── Focus-row stabilizer ──
     // Track the focused row by its category ID (stable) rather than integer
@@ -2925,7 +2952,8 @@ private fun TvHomeRowsLayer(
                                 focusState.currentItemIndex = itemIdx
                                 focusState.isSidebarFocused = false
                                 focusState.lastNavEventTime = SystemClock.elapsedRealtime()
-                            }
+                            },
+                            onNavigateToPlayer = onNavigateToPlayer
                         )
                     }
                 }
@@ -3192,7 +3220,8 @@ private fun ContentRow(
     isFastScrolling: Boolean,
     useViewportFocusOverlay: Boolean = false,
     onItemClick: (MediaItem) -> Unit,
-    onItemFocused: (MediaItem, Int) -> Unit
+    onItemFocused: (MediaItem, Int) -> Unit,
+    onNavigateToPlayer: (MediaType, Int, Int?, Int?, Long) -> Unit = { _, _, _, _, _ -> }
 ) {
     val isCollectionRow = category.id.startsWith("collection_row_")
     val rowState = rememberLazyListState()
@@ -3358,8 +3387,21 @@ private fun ContentRow(
                 val onCardFocused = remember(item, index) {
                     { latestOnItemFocused.value(item, index) }
                 }
-                val onCardClick = remember(item) {
-                    { latestOnItemClick.value(item) }
+                val onCardClick = remember(item, isContinueWatching) {
+                    {
+                        if (isContinueWatching && item.resumePositionSeconds > 0L) {
+                            // CW item with resume data: navigate directly to Player
+                            onNavigateToPlayer(
+                                item.mediaType,
+                                item.id,
+                                item.nextEpisode?.seasonNumber,
+                                item.nextEpisode?.episodeNumber,
+                                item.resumePositionSeconds * 1000L // seconds → millis
+                            )
+                        } else {
+                            latestOnItemClick.value(item)
+                        }
+                    }
                 }
                 if (isRanked && index < 10) {
                     // Top 10 rows should use the SAME card sizing as every other row.


### PR DESCRIPTION
## Summary

When selecting a movie or series from the Continue Watching row, skip the Details page and navigate directly to the Player at the item's resume position. This eliminates an unnecessary tap and provides a seamless playback experience.

## Changes

### Data layer
- **`MediaItem`** ([Models.kt](app/src/main/kotlin/com/arflix/tv/data/model/Models.kt)): Added `resumePositionSeconds: Long = 0L` field. Default 0L means non-CW items have no resume position.
- **`ContinueWatchingItem.toMediaItem()`** ([TraktRepository.kt](app/src/main/kotlin/com/arflix/tv/data/repository/TraktRepository.kt)): Passes the already-computed `resumeSeconds` value through to `MediaItem.resumePositionSeconds`.

### Navigation
- **`HomeScreen()`** ([HomeScreen.kt](app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt)): Added `onNavigateToPlayer: (MediaType, Int, Int?, Int?, Long) -> Unit` parameter.
- **`AppNavigation`** ([AppNavigation.kt](app/src/main/kotlin/com/arflix/tv/navigation/AppNavigation.kt)): Wired callback to `Screen.Player.createRoute(startPositionMs=...)`.

### Callback threading
The `onNavigateToPlayer` callback is threaded through the entire composable tree:
`HomeScreen()` → `HomeInputLayer` → `HomeRowsLayer` → (`MobileHomeRowsLayer` / `TvHomeRowsLayer`) → `ContentRow`

### CW detection (3 click paths)

| Path | Detection | Lines |
|------|-----------|-------|
| D-pad SELECT (TV) | `isContinue && item.resumePositionSeconds > 0L` | HomeScreen.kt:2495 |
| `onItemClick` (mobile analog) | `item.resumePositionSeconds > 0L` | HomeScreen.kt:2573 |
| `ContentRow` `onCardClick` (TV card grid) | `isContinueWatching && item.resumePositionSeconds > 0L` | HomeScreen.kt:3388 |

All three convert seconds to milliseconds (`* 1000L`) for `Screen.Player.createRoute()`.

## Testing
- ✅ Build verified (`assembleDebug` passes for both `playDebug` and `sideloadDebug` flavors)
- Continue Watching items with resume position → Player with position
- Continue Watching items without resume position → Details (fallback)
- Non-CW items → Details (unchanged)
- Long-press on CW items → Context menu (unchanged)
- IPTV/Collection items → respective destinations (unchanged)
- D-pad and touch click paths both covered

Closes #CW-direct-playback
