### PR TITLE
Feature/catalog move to top bottom

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/CatalogRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/CatalogRepository.kt
@@ -824,6 +824,36 @@ class CatalogRepository @Inject constructor(
         return true
     }
 
+    suspend fun moveCatalogToTop(catalogId: String): Boolean {
+        val current = getCatalogs().toMutableList()
+        val visible = current.filter { isVisibleCatalogInSettings(it) }
+        val visibleIndex = visible.indexOfFirst { it.id == catalogId }
+        if (visibleIndex <= 0) return false
+        val currentIndex = current.indexOfFirst { it.id == catalogId }
+        if (currentIndex < 0) return false
+        val moved = current.removeAt(currentIndex)
+        val firstVisibleId = visible.first().id
+        val firstIndex = current.indexOfFirst { it.id == firstVisibleId }
+        current.add(firstIndex.coerceAtLeast(0), moved)
+        saveCatalogs(current)
+        return true
+    }
+
+    suspend fun moveCatalogToBottom(catalogId: String): Boolean {
+        val current = getCatalogs().toMutableList()
+        val visible = current.filter { isVisibleCatalogInSettings(it) }
+        val visibleIndex = visible.indexOfFirst { it.id == catalogId }
+        if (visibleIndex < 0 || visibleIndex >= visible.lastIndex) return false
+        val currentIndex = current.indexOfFirst { it.id == catalogId }
+        if (currentIndex < 0) return false
+        val moved = current.removeAt(currentIndex)
+        val lastVisibleId = visible.last().id
+        val lastIndex = current.indexOfFirst { it.id == lastVisibleId }
+        current.add((lastIndex + 1).coerceAtMost(current.size), moved)
+        saveCatalogs(current)
+        return true
+    }
+
     suspend fun replaceCatalogsForActiveProfile(catalogs: List<CatalogConfig>) {
         val sanitized = catalogs
             .distinctBy { it.id }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -73,6 +73,8 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowUpward
 import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.SkipPrevious
+import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Speaker
@@ -291,7 +293,7 @@ fun SettingsScreen(
 
     // Sub-focus for addon rows: 0 = toggle, 1 = delete
     var addonActionIndex by remember { mutableIntStateOf(0) }
-    // Sub-focus for catalog rows: 0 = edit, 1 = up, 2 = down, 3 = layout, 4 = delete
+    // Sub-focus for catalog rows: 0 = edit, 1 = to top, 2 = up, 3 = down, 4 = to bottom, 5 = layout, 6 = delete
     var catalogActionIndex by remember { mutableIntStateOf(0) }
     // Sub-focus for IPTV rows: 0 = enable, 1 = edit, 2 = up, 3 = down, 4 = delete
     var iptvActionIndex by remember { mutableIntStateOf(0) }
@@ -683,7 +685,7 @@ fun SettingsScreen(
                                         addonActionIndex = 1
                                     } else if (currentSection == "iptv" && contentFocusIndex in 1..uiState.iptvPlaylists.size && iptvActionIndex < 4) {
                                         iptvActionIndex++
-} else if (currentSection == "catalogs" && contentFocusIndex > 0 && catalogActionIndex < 4) {
+} else if (currentSection == "catalogs" && contentFocusIndex > 0 && catalogActionIndex < 6) {
                                         catalogActionIndex++
                                     }
                                 }
@@ -889,9 +891,11 @@ fun SettingsScreen(
                                                             renameCatalogTitle = catalog.title
                                                             showCatalogRename = true
                                                         }
-                                                        1 -> viewModel.moveCatalogUp(catalog.id)
-                                                        2 -> viewModel.moveCatalogDown(catalog.id)
-                                                        3 -> scope.launch {
+                                                        1 -> viewModel.moveCatalogToTop(catalog.id)
+                                                        2 -> viewModel.moveCatalogUp(catalog.id)
+                                                        3 -> viewModel.moveCatalogDown(catalog.id)
+                                                        4 -> viewModel.moveCatalogToBottom(catalog.id)
+                                                        5 -> scope.launch {
                                                             if (catalog.kind != CatalogKind.COLLECTION_RAIL) {
                                                                 toggleCatalogueRowLayoutMode(context, catalogueLayoutRowKey(catalog))
                                                             }
@@ -1303,8 +1307,10 @@ fun SettingsScreen(
                                 renameCatalogTitle = catalog.title
                                 showCatalogRename = true
                             },
+                            onMoveCatalogToTop = { catalog -> viewModel.moveCatalogToTop(catalog.id) },
                             onMoveCatalogUp = { catalog -> viewModel.moveCatalogUp(catalog.id) },
                             onMoveCatalogDown = { catalog -> viewModel.moveCatalogDown(catalog.id) },
+                            onMoveCatalogToBottom = { catalog -> viewModel.moveCatalogToBottom(catalog.id) },
                             onDeleteCatalog = { catalog -> viewModel.removeCatalog(catalog.id) }
                         )
                         "stremio" -> StremioAddonsSettings(
@@ -3511,8 +3517,10 @@ private fun MobileSettingsSubPage(
                     focusedActionIndex = 0,
                     onAddCatalog = onAddCatalogClick,
                     onRenameCatalog = onRenameCatalogClick,
+                    onMoveCatalogToTop = { viewModel.moveCatalogToTop(it.id) },
                     onMoveCatalogUp = { viewModel.moveCatalogUp(it.id) },
                     onMoveCatalogDown = { viewModel.moveCatalogDown(it.id) },
+                    onMoveCatalogToBottom = { viewModel.moveCatalogToBottom(it.id) },
                     onDeleteCatalog = { viewModel.removeCatalog(it.id) }
                 )
             }
@@ -6611,8 +6619,10 @@ private fun CatalogsSettings(
     focusedActionIndex: Int,
     onAddCatalog: () -> Unit,
     onRenameCatalog: (CatalogConfig) -> Unit,
+    onMoveCatalogToTop: (CatalogConfig) -> Unit,
     onMoveCatalogUp: (CatalogConfig) -> Unit,
     onMoveCatalogDown: (CatalogConfig) -> Unit,
+    onMoveCatalogToBottom: (CatalogConfig) -> Unit,
     onDeleteCatalog: (CatalogConfig) -> Unit
 ) {
     val isMobile = LocalDeviceType.current.isTouchDevice()
@@ -6828,26 +6838,38 @@ private fun CatalogsSettings(
                     )
                     Spacer(modifier = Modifier.width(6.dp))
                     CatalogActionChip(
-                        icon = Icons.Default.ArrowUpward,
+                        icon = Icons.Default.SkipPrevious,
                         isFocused = isRowFocused && focusedActionIndex == 1,
+                        onClick = { onMoveCatalogToTop(catalog) }
+                    )
+                    Spacer(modifier = Modifier.width(6.dp))
+                    CatalogActionChip(
+                        icon = Icons.Default.ArrowUpward,
+                        isFocused = isRowFocused && focusedActionIndex == 2,
                         onClick = { onMoveCatalogUp(catalog) }
                     )
                     Spacer(modifier = Modifier.width(6.dp))
                     CatalogActionChip(
                         icon = Icons.Default.ArrowDownward,
-                        isFocused = isRowFocused && focusedActionIndex == 2,
+                        isFocused = isRowFocused && focusedActionIndex == 3,
                         onClick = { onMoveCatalogDown(catalog) }
+                    )
+                    Spacer(modifier = Modifier.width(6.dp))
+                    CatalogActionChip(
+                        icon = Icons.Default.SkipNext,
+                        isFocused = isRowFocused && focusedActionIndex == 4,
+                        onClick = { onMoveCatalogToBottom(catalog) }
                     )
                     Spacer(modifier = Modifier.width(6.dp))
                     CatalogueRowLayoutToggleButton(
                         rowKey = layoutRowKey,
                         enabled = layoutToggleEnabled,
-                        forceFocused = isRowFocused && focusedActionIndex == 3
+                        forceFocused = isRowFocused && focusedActionIndex == 5
                     )
                     Spacer(modifier = Modifier.width(6.dp))
                     CatalogActionChip(
                         icon = Icons.Default.Delete,
-                        isFocused = isRowFocused && focusedActionIndex == 4,
+                        isFocused = isRowFocused && focusedActionIndex == 6,
                         isDestructive = true,
                         enabled = true,
                         onClick = { onDeleteCatalog(catalog) }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -1676,6 +1676,20 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
+    fun moveCatalogToTop(catalogId: String) {
+        viewModelScope.launch {
+            catalogRepository.moveCatalogToTop(catalogId)
+            syncLocalStateToCloud(silent = true)
+        }
+    }
+
+    fun moveCatalogToBottom(catalogId: String) {
+        viewModelScope.launch {
+            catalogRepository.moveCatalogToBottom(catalogId)
+            syncLocalStateToCloud(silent = true)
+        }
+    }
+
     fun saveIptvConfig(m3uUrl: String, epgUrl: String) {
         viewModelScope.launch {
             val trimmedM3u = m3uUrl.trim()


### PR DESCRIPTION
## Add "Move to Top" / "Move to Bottom" buttons for catalog reordering

### Summary
Adds two new action buttons to the catalog context menu in Settings — "Move to Top" (SkipPrevious icon) and "Move to Bottom" (SkipNext icon) — allowing users to jump a catalog directly to either end of the visible list without repeatedly pressing the existing single-step Up/Down buttons.

### Changes

**CatalogRepository.kt** (lines 825+)
- Added `moveCatalogToTop(catalogId: String): Boolean` — removes the catalog from its current position and inserts it at the position of the first visible catalog
- Added `moveCatalogToBottom(catalogId: String): Boolean` — removes the catalog and inserts it after the last visible catalog
- Both methods filter for visible catalogs (hidden catalogs are not reordered) and map visible indices back to full-list indices

**SettingsViewModel.kt** (lines 1692+)
- Added `moveCatalogToTop(catalogId: String)` and `moveCatalogToBottom(catalogId: String)` delegates that launch coroutines calling the repository methods with `syncLocalStateToCloud(silent = true)`

**SettingsScreen.kt** (multiple locations)
- Updated D-pad focus action indices from 5 to 7 actions per catalog row:
  - `0` = Edit, `1` = Move to Top, `2` = Move Up, `3` = Move Down, `4` = Move to Bottom, `5` = Layout, `6` = Delete
- Added `SkipPrevious` icon chip before ArrowUp and `SkipNext` icon chip after ArrowDown
- Updated all D-pad boundary checks (`catalogActionIndex < 4` → `< 6`)
- Updated `when (catalogActionIndex)` dispatch to handle new indices 1 and 4
- Updated both `CatalogsSettings` call sites with new `onMoveCatalogToTop`/`onMoveCatalogToBottom` callbacks

### Testing
- ✅ Kotlin compilation passes (`compileSideloadDebugKotlin` — `BUILD SUCCESSFUL in 6s`)
- D-pad focus flows predictably: Edit → **Top** → Up → Down → **Bottom** → Layout → Delete
- Existing single-step Up/Down behavior is unchanged

### Notes
- `material-icons-extended` was already a dependency; `SkipPrevious`/`SkipNext` icons available without additional imports
- Follows the same pattern as the existing IPTV `moveGroupToTop`/`moveGroupToBottom` in `IptvRepository.kt`
