### PR TITLE
fix(network): prevent crash from malformed gzip responses

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/network/OkHttpProvider.kt
+++ b/app/src/main/kotlin/com/arflix/tv/network/OkHttpProvider.kt
@@ -21,10 +21,13 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import java.io.File
+import java.io.IOException
 import java.net.Inet4Address
 import java.net.InetAddress
 import java.net.UnknownHostException
 import java.util.concurrent.TimeUnit
+import java.util.zip.GZIPInputStream
+import okhttp3.ResponseBody.Companion.toResponseBody
 
 /**
  * Provides a configured OkHttpClient instance.
@@ -146,6 +149,31 @@ object OkHttpProvider {
         }
     }
 
+    // OkHttp's GzipSource (okio) throws "gzip finished without exhausting source" when the
+    // server leaves extra bytes after the gzip trailer (e.g. Content-Length mismatch, HTTP/2
+    // padding, or Supabase proxy artifacts).  Java's GZIPInputStream is lenient: on trailing
+    // bytes it tries to read a concatenated gzip stream, fails silently, and returns.
+    // Adding this as a network interceptor means it runs BEFORE BridgeInterceptor's GzipSource
+    // wrapper; stripping Content-Encoding prevents a second decompression attempt.
+    private val lenientGzipInterceptor = Interceptor { chain ->
+        val response = chain.proceed(chain.request())
+        if (!response.header("Content-Encoding").equals("gzip", ignoreCase = true)) {
+            return@Interceptor response
+        }
+        val body = response.body ?: return@Interceptor response
+        val decompressed = try {
+            GZIPInputStream(body.byteStream()).use { it.readBytes() }
+        } catch (_: IOException) {
+            return@Interceptor response
+        }
+        response.newBuilder()
+            .removeHeader("Content-Encoding")
+            .removeHeader("Content-Length")
+            .header("Content-Length", decompressed.size.toString())
+            .body(decompressed.toResponseBody(body.contentType()))
+            .build()
+    }
+
     private val apiDnsLoggingInterceptor = Interceptor { chain ->
         val request = chain.request()
         Log.i(
@@ -188,6 +216,9 @@ object OkHttpProvider {
             // Contributors can still use direct calls with their own local keys.
             .addInterceptor(ApiProxyInterceptor())
             .addInterceptor(loggingInterceptor)
+            // Network interceptor: decompress gzip with Java's lenient GZIPInputStream
+            // before BridgeInterceptor's strict GzipSource can see it.
+            .addNetworkInterceptor(lenientGzipInterceptor)
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
             .writeTimeout(30, TimeUnit.SECONDS)


### PR DESCRIPTION
## Problem

The app was crashing with:

```
java.io.IOException: gzip finished without exhausting source
  at okio.GzipSource.read(GzipSource.kt:89)
  ...
  at retrofit2.OkHttpCall$1.onResponse(OkHttpCall.java:153)
  at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:519)
```

This happens when TMDB (via the Supabase proxy) returns a response where extra bytes remain in the network stream after the gzip trailer — likely a Content-Length mismatch or proxy artifact. OkHttp's `GzipSource` (okio) is strict and throws on any trailing bytes.

The crash was fatal because the exception becomes an **undelivered exception**: OkHttp's callback fires on a thread-pool thread just as the Kotlin coroutine is being cancelled (user navigated away), so `continuation.resumeWithException(IOException)` has nowhere to deliver it and falls through to Android's `UncaughtExceptionHandler` → `Process.killProcess()`.

## Fix

Add `lenientGzipInterceptor` as a **network interceptor** in `OkHttpProvider.buildAppClient()`.

It intercepts gzip responses before OkHttp's `BridgeInterceptor` can wrap them with `GzipSource`. It decompresses using Java's `GZIPInputStream`, which is lenient on trailing bytes: it tries to parse them as a concatenated gzip stream, fails silently, and returns. The `Content-Encoding` header is stripped so `BridgeInterceptor` does not attempt a second decompression pass.

## Why a network interceptor and not an application interceptor?

Response processing order in OkHttp:

```
network call → network interceptors → CacheInterceptor → BridgeInterceptor (GzipSource) → application interceptors → Retrofit
```

A network interceptor runs before `BridgeInterceptor` and sees the raw gzip body. An application interceptor would run after `BridgeInterceptor` has already tried (and crashed with) `GzipSource`.

## Testing

Reproduced the `gzip finished without exhausting source` crash via logcat, applied the fix, and confirmed the same code path now completes without error.

## Checklist
- [x] Only `OkHttpProvider.kt` changed — no API, model, or UI impact
- [x] Builds clean (`assembleSideloadDebug`)
- [x] Fallback: if `GZIPInputStream` itself throws, the original response is returned unchanged