### PR TITLE
fix: reset ContentRow scroll state when CW items change

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
@@ -3266,11 +3266,9 @@ private fun ContentRow(
     // Use smooth scroll (animated) for D-pad moves to avoid abrupt jumps.
     var lastScrollIndex by remember { mutableIntStateOf(-1) }
     var lastScrollOffset by remember { mutableIntStateOf(-1) }
-    LaunchedEffect(isCurrentRow) {
-        if (!isCurrentRow) {
-            lastScrollIndex = -1
-            lastScrollOffset = -1
-        }
+    LaunchedEffect(isCurrentRow, totalItems) {
+        lastScrollIndex = -1
+        lastScrollOffset = -1
     }
     LaunchedEffect(isCurrentRow, focusedItemIndex, totalItems) {
         if (!isCurrentRow || focusedItemIndex < 0 || totalItems == 0) return@LaunchedEffect


### PR DESCRIPTION
Root cause: When returning from playback, refreshContinueWatchingOnly()
inserts a newly watched item at index 0, shifting all existing items.
The ContentRow scroll LaunchedEffect keys on (isCurrentRow, focusedItemIndex,
totalItems) and re-runs when totalItems changes, but the internal
lastScrollIndex/lastScrollOffset caching (remember) prevents re-scroll
when scrollTargetIndex == lastScrollIndex (both 0). The stale scroll
state causes the LazyRow to not visually update to the new item layout.

Fix: Key the state-reset LaunchedEffect on (isCurrentRow, totalItems)
instead of just isCurrentRow, so lastScrollIndex/lastScrollOffset are
invalidated whenever the item count changes. This forces the scroll
LaunchedEffect to recalculate from scratch (lastScrollIndex == -1
branch), correctly scrolling to the focused item in the new arrangement.

Fixes the D-pad Left navigation lock where the user had to press
Right first then Left to reach the newly inserted CW item."
