### PR TITLE
feat: add pause overlay animation with NOW PLAYING slide-in and shimmer

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -2306,6 +2306,7 @@ fun PlayerScreen(
                             }
                         }
                     }
+                    } // closes inner Row (NOW PLAYING + content column)
 
                     // Right side - Ends At + Clock
                     Column(horizontalAlignment = Alignment.End, modifier = Modifier.padding(end = 8.dp)) {

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -2194,39 +2194,36 @@ fun PlayerScreen(
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.Top
                 ) {
-                    // Left side - clearlogo/title and episode info
-                    Column(modifier = Modifier.weight(1f)) {
+                    // Left side - clearlogo/title, episode info, and source info
+                    Row(modifier = Modifier.weight(1f)) {
                         val isPaused = hasPlaybackStarted && !isPlaying
 
-                        if (!uiState.logoUrl.isNullOrBlank()) {
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                modifier = Modifier.height(32.dp)
-                            ) {
-                                // "NOW PLAYING" slides in from the left when paused, pushes logo right
-                                AnimatedVisibility(
-                                    visible = isPaused,
-                                    enter = slideInHorizontally(
-                                        animationSpec = animTween(300, easing = FastOutSlowInEasing)
-                                    ) { -it },
-                                    exit = slideOutHorizontally(
-                                        animationSpec = animTween(250, easing = FastOutSlowInEasing)
-                                    ) { -it }
-                                ) {
-                                    Text(
-                                        text = "NOW PLAYING",
-                                        style = ArflixTypography.body.copy(
-                                            fontSize = 18.sp,
-                                            fontWeight = FontWeight.Bold
-                                        ),
-                                        color = playerAccent,
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis,
-                                        modifier = Modifier.padding(end = 12.dp)
-                                    )
-                                }
+                        // "NOW PLAYING" slides in from the left when paused,
+                        // pushing ALL left-side content (logo, S/E, quality) right as a unit
+                        AnimatedVisibility(
+                            visible = isPaused,
+                            enter = slideInHorizontally(
+                                animationSpec = animTween(300, easing = FastOutSlowInEasing)
+                            ) { -it },
+                            exit = slideOutHorizontally(
+                                animationSpec = animTween(250, easing = FastOutSlowInEasing)
+                            ) { -it }
+                        ) {
+                            Text(
+                                text = "NOW PLAYING",
+                                style = ArflixTypography.body.copy(
+                                    fontSize = 18.sp,
+                                    fontWeight = FontWeight.Bold
+                                ),
+                                color = playerAccent,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.padding(end = 12.dp)
+                            )
+                        }
 
-                                // Clear logo with shimmer overlay when paused
+                        Column {
+                            if (!uiState.logoUrl.isNullOrBlank()) {
                                 Box {
                                     AsyncImage(
                                         model = uiState.logoUrl,
@@ -2244,50 +2241,49 @@ fun PlayerScreen(
                                         )
                                     }
                                 }
-                            }
-                        } else {
-                            Text(
-                                text = uiState.title,
-                                style = ArflixTypography.sectionTitle.copy(
-                                    fontSize = 24.sp,
-                                    fontWeight = FontWeight.Bold
-                                ),
-                                color = TextPrimary,
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis
-                            )
-                        }
-                        if (seasonNumber != null && episodeNumber != null) {
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(8.dp)
-                                    ,
-                                modifier = Modifier.padding(top = 6.dp)
-                            ) {
+                            } else {
                                 Text(
-                                    text = "S$seasonNumber E$episodeNumber",
-                                    style = ArflixTypography.body.copy(fontSize = 16.sp),
-                                    color = TextSecondary,
+                                    text = uiState.title,
+                                    style = ArflixTypography.sectionTitle.copy(
+                                        fontSize = 24.sp,
+                                        fontWeight = FontWeight.Bold
+                                    ),
+                                    color = TextPrimary,
                                     maxLines = 1,
                                     overflow = TextOverflow.Ellipsis
                                 )
-                                // Episode title would be shown here if available
                             }
-                        }
-                        // Source info
-                        uiState.selectedStream?.let { stream ->
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                modifier = Modifier.padding(top = 4.dp)
-                            ) {
-                                Text(
-                                    text = stream.quality,
-                                    style = ArflixTypography.caption.copy(fontSize = 12.sp),
-                                    color = playerAccent,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis
-                                )
+                            if (seasonNumber != null && episodeNumber != null) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                        ,
+                                    modifier = Modifier.padding(top = 6.dp)
+                                ) {
+                                    Text(
+                                        text = "S$seasonNumber E$episodeNumber",
+                                        style = ArflixTypography.body.copy(fontSize = 16.sp),
+                                        color = TextSecondary,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis
+                                    )
+                                    // Episode title would be shown here if available
+                                }
+                            }
+                            // Source info
+                            uiState.selectedStream?.let { stream ->
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                    modifier = Modifier.padding(top = 4.dp)
+                                ) {
+                                    Text(
+                                        text = stream.quality,
+                                        style = ArflixTypography.caption.copy(fontSize = 12.sp),
+                                        color = playerAccent,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis
+                                    )
                                 stream.sizeBytes?.let { size ->
                                     Text(
                                         text = "•",

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -4460,7 +4460,7 @@ private class PlaybackCookieJar : CookieJar {
 // ── Shimmer constants ──────────────────────────────────────────────────
 private const val SHIMMER_START_OFFSET = -0.5f
 private const val SHIMMER_END_OFFSET = 1.5f
-private const val SHIMMER_DURATION_MS = 1500L
+private const val SHIMMER_DURATION_MS = 1500
 private const val SHIMMER_WIDTH_FRACTION = 0.45f
 
 /**

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -2195,11 +2195,16 @@ fun PlayerScreen(
                     verticalAlignment = Alignment.Top
                 ) {
                     // Left side - clearlogo/title, episode info, and source info
-                    Row(modifier = Modifier.weight(1f)) {
+                    Row(
+                        modifier = Modifier.weight(1f),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
                         val isPaused = hasPlaybackStarted && !isPlaying
 
                         // "NOW PLAYING" slides in from the left when paused,
-                        // pushing ALL left-side content (logo, S/E, quality) right as a unit
+                        // pushing ALL left-side content (logo, S/E, quality) right as a unit.
+                        // Text is vertically centered against the full block height and sized
+                        // at 22sp to visually balance the 32dp clear logo.
                         AnimatedVisibility(
                             visible = isPaused,
                             enter = slideInHorizontally(
@@ -2212,13 +2217,13 @@ fun PlayerScreen(
                             Text(
                                 text = "NOW PLAYING",
                                 style = ArflixTypography.body.copy(
-                                    fontSize = 18.sp,
+                                    fontSize = 22.sp,
                                     fontWeight = FontWeight.Bold
                                 ),
                                 color = playerAccent,
                                 maxLines = 1,
                                 overflow = TextOverflow.Ellipsis,
-                                modifier = Modifier.padding(end = 12.dp)
+                                modifier = Modifier.padding(end = 16.dp)
                             )
                         }
 

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween as animTween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -2194,16 +2196,55 @@ fun PlayerScreen(
                 ) {
                     // Left side - clearlogo/title and episode info
                     Column(modifier = Modifier.weight(1f)) {
+                        val isPaused = hasPlaybackStarted && !isPlaying
+
                         if (!uiState.logoUrl.isNullOrBlank()) {
-                            AsyncImage(
-                                model = uiState.logoUrl,
-                                contentDescription = uiState.title,
-                                alignment = Alignment.CenterStart,
-                                contentScale = ContentScale.Fit,
-                                modifier = Modifier
-                                    .height(32.dp)
-                                    .width(240.dp)
-                            )
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier.height(32.dp)
+                            ) {
+                                // "NOW PLAYING" slides in from the left when paused, pushes logo right
+                                AnimatedVisibility(
+                                    visible = isPaused,
+                                    enter = slideInHorizontally(
+                                        animationSpec = animTween(300, easing = FastOutSlowInEasing)
+                                    ) { -it },
+                                    exit = slideOutHorizontally(
+                                        animationSpec = animTween(250, easing = FastOutSlowInEasing)
+                                    ) { -it }
+                                ) {
+                                    Text(
+                                        text = "NOW PLAYING",
+                                        style = ArflixTypography.body.copy(
+                                            fontSize = 18.sp,
+                                            fontWeight = FontWeight.Bold
+                                        ),
+                                        color = playerAccent,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                        modifier = Modifier.padding(end = 12.dp)
+                                    )
+                                }
+
+                                // Clear logo with shimmer overlay when paused
+                                Box {
+                                    AsyncImage(
+                                        model = uiState.logoUrl,
+                                        contentDescription = uiState.title,
+                                        alignment = Alignment.CenterStart,
+                                        contentScale = ContentScale.Fit,
+                                        modifier = Modifier
+                                            .height(32.dp)
+                                            .width(240.dp)
+                                    )
+                                    // Shimmer effect sweeps over the logo when paused
+                                    if (isPaused) {
+                                        PauseShimmerOverlay(
+                                            modifier = Modifier.matchParentSize()
+                                        )
+                                    }
+                                }
+                            }
                         } else {
                             Text(
                                 text = uiState.title,
@@ -4412,6 +4453,46 @@ private class PlaybackCookieJar : CookieJar {
             }
         }
         return valid
+    }
+}
+
+/**
+ * Animated shimmer overlay that sweeps a glossy highlight across the clear logo
+ * while the player is paused. Uses a linear gradient that translates left-to-right
+ * in an infinite repeat loop.
+ */
+@Composable
+private fun PauseShimmerOverlay(modifier: Modifier = Modifier) {
+    val infiniteTransition = rememberInfiniteTransition(label = "pauseShimmer")
+    val shimmerProgress by infiniteTransition.animateFloat(
+        initialValue = -0.5f,
+        targetValue = 1.5f,
+        animationSpec = infiniteRepeatable(
+            animation = animTween(durationMillis = 1500, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "shimmerProgress"
+    )
+
+    Box(modifier = modifier) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val shimmerWidth = size.width * 0.45f
+            val offsetX = size.width * shimmerProgress
+            drawRect(
+                brush = Brush.linearGradient(
+                    colors = listOf(
+                        Color.Transparent,
+                        Color.White.copy(alpha = 0.10f),
+                        Color.White.copy(alpha = 0.30f),
+                        Color.White.copy(alpha = 0.10f),
+                        Color.Transparent
+                    ),
+                    start = Offset(offsetX, 0f),
+                    end = Offset(offsetX + shimmerWidth, size.height)
+                ),
+                size = size
+            )
+        }
     }
 }
 

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -2215,7 +2215,7 @@ fun PlayerScreen(
                             ) { -it }
                         ) {
                             Text(
-                                text = "NOW PLAYING",
+                                text = stringResource(R.string.now_playing),
                                 style = ArflixTypography.body.copy(
                                     fontSize = 22.sp,
                                     fontWeight = FontWeight.Bold
@@ -2261,8 +2261,7 @@ fun PlayerScreen(
                             if (seasonNumber != null && episodeNumber != null) {
                                 Row(
                                     verticalAlignment = Alignment.CenterVertically,
-                                    horizontalArrangement = Arrangement.spacedBy(8.dp)
-                                        ,
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
                                     modifier = Modifier.padding(top = 6.dp)
                                 ) {
                                     Text(
@@ -4458,37 +4457,49 @@ private class PlaybackCookieJar : CookieJar {
     }
 }
 
+// ── Shimmer constants ──────────────────────────────────────────────────
+private const val SHIMMER_START_OFFSET = -0.5f
+private const val SHIMMER_END_OFFSET = 1.5f
+private const val SHIMMER_DURATION_MS = 1500L
+private const val SHIMMER_WIDTH_FRACTION = 0.45f
+
 /**
  * Animated shimmer overlay that sweeps a glossy highlight across the clear logo
  * while the player is paused. Uses a linear gradient that translates left-to-right
- * in an infinite repeat loop.
+ * in an infinite repeat loop. Colors are hoisted with [remember] to avoid
+ * per-frame allocations.
  */
 @Composable
 private fun PauseShimmerOverlay(modifier: Modifier = Modifier) {
     val infiniteTransition = rememberInfiniteTransition(label = "pauseShimmer")
     val shimmerProgress by infiniteTransition.animateFloat(
-        initialValue = -0.5f,
-        targetValue = 1.5f,
+        initialValue = SHIMMER_START_OFFSET,
+        targetValue = SHIMMER_END_OFFSET,
         animationSpec = infiniteRepeatable(
-            animation = animTween(durationMillis = 1500, easing = FastOutSlowInEasing),
+            animation = animTween(durationMillis = SHIMMER_DURATION_MS, easing = FastOutSlowInEasing),
             repeatMode = RepeatMode.Restart
         ),
         label = "shimmerProgress"
     )
 
+    // Hoist gradient colors to avoid per-frame allocations
+    val shimmerColors = remember {
+        listOf(
+            Color.Transparent,
+            Color.White.copy(alpha = 0.10f),
+            Color.White.copy(alpha = 0.30f),
+            Color.White.copy(alpha = 0.10f),
+            Color.Transparent
+        )
+    }
+
     Box(modifier = modifier) {
         Canvas(modifier = Modifier.fillMaxSize()) {
-            val shimmerWidth = size.width * 0.45f
+            val shimmerWidth = size.width * SHIMMER_WIDTH_FRACTION
             val offsetX = size.width * shimmerProgress
             drawRect(
                 brush = Brush.linearGradient(
-                    colors = listOf(
-                        Color.Transparent,
-                        Color.White.copy(alpha = 0.10f),
-                        Color.White.copy(alpha = 0.30f),
-                        Color.White.copy(alpha = 0.10f),
-                        Color.Transparent
-                    ),
+                    colors = shimmerColors,
                     start = Offset(offsetX, 0f),
                     end = Offset(offsetX + shimmerWidth, size.height)
                 ),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">ARVIO</string>
+    <string name="now_playing">NOW PLAYING</string>
 
     <!-- Navigation -->
     <string name="home">Home</string>


### PR DESCRIPTION
## Summary

Adds a pause overlay animation to the player OSD. When the user pauses playback, **"NOW PLAYING"** slides in from the left, pushing the entire left-side content block (clear logo, season/episode info, stream quality/size) to the right. A shimmer effect sweeps across the logo to draw attention. On resume playback, the text slides back out and all content returns to its original position.

## Changes

### `PlayerScreen.kt`

**Imports** (lines 26-27):
- Added `slideInHorizontally` / `slideOutHorizontally` for the horizontal slide animation.

**Left-side OSD layout** (lines 2197-2295) — restructured to an outer `Row` (with `verticalAlignment = CenterVertically`) containing "NOW PLAYING" text + a `Column` of all existing content:
- `val isPaused = hasPlaybackStarted && !isPlaying` — detects the paused state.
- `AnimatedVisibility(visible = isPaused)` slides "NOW PLAYING" in/out horizontally (300ms enter, 250ms exit, `FastOutSlowInEasing`).
- The text is **vertically centered** against the full content block (logo + S/E + quality), not just top-aligned with the logo.
- Font sized at **22sp Bold** (`playerAccent` color) to visually balance the 32dp clear logo on TV.
- The clear logo sits in a `Box` with `PauseShimmerOverlay` overlaid via `matchParentSize()` when paused.

**`PauseShimmerOverlay` composable** (lines 4459-4497):
- `rememberInfiniteTransition` drives `shimmerProgress` (-0.5 → 1.5) with `infiniteRepeatable` + `tween(1500ms)`.
- Draws a `Brush.linearGradient` (transparent → white(0.10) → white(0.30) → white(0.10) → transparent) sweeping left-to-right at 45% width.

## Animation States

| State | "NOW PLAYING" | All left-side content | Shimmer |
|-------|---------------|----------------------|---------|
| **Playing** | Hidden | At left edge | Off |
| **Paused** | Slides in from left (300ms) | Shifted right as a unit | Sweeping L→R (1.5s loop) |
| **Resume** | Slides out to left (250ms) | Returns to left edge | Off |

## Behavior Notes

- Only activates when `hasPlaybackStarted && !isPlaying` — avoids loading/buffering states.
- Existing auto-hide `LaunchedEffect` gates on `isPlaying`, so `showControls` stays `true` while paused — no lifecycle changes needed.
- When `logoUrl` is null (no clear logo), the fallback title text is shown without the pause overlay.
- All animations are pure Compose — no resource leaks, no touch patterns, fully D-pad compatible.
