### PR TITLE
feat: add safer custom User-Agent setting

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ArflixApplication.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ArflixApplication.kt
@@ -82,13 +82,17 @@ class ArflixApplication : Application(), Configuration.Provider, ImageLoaderFact
         // a single volatile assignment.
         OkHttpProvider.init(this)
 
-        // Initialize global DNS provider from DataStore before network calls.
+        // Initialize global DNS provider and user agent from DataStore before network calls.
         appScope.launch(Dispatchers.IO) {
             val prefs = settingsDataStore.data.first()
             val dnsKey = androidx.datastore.preferences.core.stringPreferencesKey(OkHttpProvider.DNS_PROVIDER_PREF_KEY)
             val dnsPref = prefs[dnsKey]
             val provider = OkHttpProvider.parseDnsProvider(dnsPref)
             OkHttpProvider.setDnsProvider(provider)
+
+            val uaKey = androidx.datastore.preferences.core.stringPreferencesKey(OkHttpProvider.USER_AGENT_PREF_KEY)
+            val savedUserAgent = prefs[uaKey].orEmpty()
+            OkHttpProvider.setCustomUserAgent(savedUserAgent)
 
             runCatching { OkHttpProvider.dns.lookup("image.tmdb.org") }
         }

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/CatalogRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/CatalogRepository.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
+import com.arflix.tv.network.OkHttpProvider
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.net.URI
@@ -1005,7 +1006,7 @@ class CatalogRepository @Inject constructor(
         return withContext(Dispatchers.IO) {
             val request = Request.Builder()
                 .url(url)
-                .header("User-Agent", "Mozilla/5.0 (Android TV; ARVIO)")
+                .header("User-Agent", OkHttpProvider.userAgentOr("Mozilla/5.0 (Android TV; ARVIO)"))
                 .build()
             runCatching {
                 okHttpClient.newCall(request).execute().use { response ->

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
@@ -4029,7 +4029,7 @@ class IptvRepository @Inject constructor(
     ): T? = suspendCancellableCoroutine { continuation ->
         val request = Request.Builder()
             .url(url)
-            .header("User-Agent", "VLC/3.0.20 LibVLC/3.0.20")
+            .header("User-Agent", OkHttpProvider.userAgentOr(IPTV_USER_AGENT))
             .header("Accept", "application/json,*/*")
             .get()
             .build()
@@ -4073,7 +4073,7 @@ class IptvRepository @Inject constructor(
     ): List<IptvChannel> {
         val request = Request.Builder()
             .url(url)
-            .header("User-Agent", "VLC/3.0.20 LibVLC/3.0.20")
+            .header("User-Agent", OkHttpProvider.userAgentOr(IPTV_USER_AGENT))
             .header("Accept", "*/*")
             .get()
             .build()
@@ -4126,15 +4126,13 @@ class IptvRepository @Inject constructor(
                 .build()
         }
 
-        var response = iptvHttpClient.newCall(epgRequest(url, "VLC/3.0.20 LibVLC/3.0.20")).execute()
+        val primaryUserAgent = OkHttpProvider.userAgentOr(IPTV_USER_AGENT)
+        val fallbackUserAgent = OkHttpProvider.userAgentOr(BROWSER_USER_AGENT)
+        var response = iptvHttpClient.newCall(epgRequest(url, primaryUserAgent)).execute()
         if (!response.isSuccessful && response.code in setOf(511, 403, 401)) {
             response.close()
             response = iptvHttpClient.newCall(
-                epgRequest(
-                    url,
-                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
-                        "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
-                )
+                epgRequest(url, fallbackUserAgent)
             ).execute()
         }
         response.use { safeResponse ->
@@ -4159,7 +4157,7 @@ class IptvRepository @Inject constructor(
                 try {
                     // Re-download
                     val retryResponse = iptvHttpClient.newCall(
-                        epgRequest(url, "VLC/3.0.20 LibVLC/3.0.20")
+                        epgRequest(url, primaryUserAgent)
                     ).execute()
                     retryResponse.use { rr ->
                         val retryStream = rr.body?.byteStream()
@@ -6059,6 +6057,8 @@ class IptvRepository @Inject constructor(
         const val ANDROID_KEYSTORE = "AndroidKeyStore"
         const val CONFIG_KEY_ALIAS = "arvio_iptv_config_v1"
         const val MAX_IPTV_CACHE_BYTES = 25L * 1024L * 1024L
+        const val IPTV_USER_AGENT = "VLC/3.0.20 LibVLC/3.0.20"
+        const val BROWSER_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
 
         val BRACKET_CONTENT_REGEX = Regex("""\[[^\]]*]""")
         val PAREN_CONTENT_REGEX = Regex("""\([^\)]*\)""")

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/MediaRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/MediaRepository.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.withContext
 import org.json.JSONArray
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import com.arflix.tv.network.OkHttpProvider
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.net.URLDecoder
@@ -3274,7 +3275,7 @@ class MediaRepository @Inject constructor(
     private fun fetchUrl(url: String): String? {
         val request = Request.Builder()
             .url(url)
-            .header("User-Agent", "Mozilla/5.0 (Android TV; ARVIO)")
+            .header("User-Agent", OkHttpProvider.userAgentOr("Mozilla/5.0 (Android TV; ARVIO)"))
             .build()
         return runCatching {
             okHttpClient.newCall(request).execute().use { response ->

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
@@ -2405,8 +2405,7 @@ class StreamRepository @Inject constructor(
             withTimeout(STREAM_REDIRECT_RESOLUTION_TIMEOUT_MS) {
                 val requestHeaders = headers.toMutableMap()
                 if (requestHeaders.keys.none { it.equals("User-Agent", ignoreCase = true) }) {
-                    requestHeaders["User-Agent"] =
-                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+                    requestHeaders["User-Agent"] = OkHttpProvider.userAgent
                 }
                 if (requestHeaders.keys.none { it.equals("Accept", ignoreCase = true) }) {
                     requestHeaders["Accept"] = "*/*"
@@ -2443,8 +2442,7 @@ class StreamRepository @Inject constructor(
             extra = emptyMap()
         ).toMutableMap()
         if (headers.keys.none { it.equals("User-Agent", ignoreCase = true) }) {
-            headers["User-Agent"] =
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+            headers["User-Agent"] = OkHttpProvider.userAgent
         }
         if (headers.keys.none { it.equals("Accept", ignoreCase = true) }) {
             headers["Accept"] = "*/*"
@@ -2649,8 +2647,7 @@ class StreamRepository @Inject constructor(
             ).toMutableMap()
 
             if (headers.keys.none { it.equals("User-Agent", ignoreCase = true) }) {
-                headers["User-Agent"] =
-                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+                headers["User-Agent"] = OkHttpProvider.userAgent
             }
             if (headers.keys.none { it.equals("Accept", ignoreCase = true) }) {
                 headers["Accept"] = "*/*"

--- a/app/src/main/kotlin/com/arflix/tv/network/OkHttpProvider.kt
+++ b/app/src/main/kotlin/com/arflix/tv/network/OkHttpProvider.kt
@@ -51,6 +51,8 @@ object OkHttpProvider {
     private const val ADGUARD_DOH_URL = "https://dns.adguard-dns.com/dns-query"
 
     const val DNS_PROVIDER_PREF_KEY = "dns_provider_global"
+    const val DEFAULT_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    const val USER_AGENT_PREF_KEY = "custom_user_agent_global"
 
     enum class AppDnsProvider {
         SYSTEM,
@@ -72,6 +74,20 @@ object OkHttpProvider {
 
     @Volatile
     private var selectedDnsProvider: AppDnsProvider = AppDnsProvider.SYSTEM
+
+    @Volatile
+    private var _customUserAgent: String = ""
+
+    val customUserAgent: String get() = _customUserAgent
+    val userAgent: String get() = userAgentOr(DEFAULT_USER_AGENT)
+
+    fun setCustomUserAgent(value: String) {
+        _customUserAgent = value.trim()
+    }
+
+    fun userAgentOr(defaultUserAgent: String): String {
+        return _customUserAgent.ifBlank { defaultUserAgent }
+    }
 
     private val dnsScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val clientLock = Any()
@@ -184,6 +200,7 @@ object OkHttpProvider {
         }
 
         val builder = OkHttpClient.Builder()
+            .addInterceptor(customUserAgentInterceptor)
             // TMDB/Trakt calls are proxied when Supabase proxy config is present.
             // Contributors can still use direct calls with their own local keys.
             .addInterceptor(ApiProxyInterceptor())
@@ -208,6 +225,7 @@ object OkHttpProvider {
 
     private fun buildPlaybackClient(): OkHttpClient {
         return OkHttpClient.Builder()
+            .addInterceptor(customUserAgentInterceptor)
             .connectionPool(playbackConnectionPool)
             .followRedirects(true)
             .followSslRedirects(true)
@@ -218,6 +236,16 @@ object OkHttpProvider {
             .writeTimeout(20, TimeUnit.SECONDS)
             .cache(null)
             .build()
+    }
+
+    private val customUserAgentInterceptor = Interceptor { chain ->
+        val request = chain.request()
+        val customUserAgent = _customUserAgent
+        if (customUserAgent.isBlank() || request.header("User-Agent") != null) {
+            chain.proceed(request)
+        } else {
+            chain.proceed(request.newBuilder().header("User-Agent", customUserAgent).build())
+        }
     }
 
     private fun getOrCreateHttpCache(context: Context): Cache {

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -487,7 +487,7 @@ fun PlayerScreen(
     }
     val httpDataSourceFactory = remember(playbackHttpClient) {
         OkHttpDataSource.Factory(playbackHttpClient)
-            .setUserAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+            .setUserAgent(OkHttpProvider.userAgent)
             .setDefaultRequestProperties(baseRequestHeaders)
     }
     val mediaCache = remember(context) { PlaybackCacheSingleton.getInstance(context) }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -169,6 +169,7 @@ import com.arflix.tv.ui.theme.TextSecondary
 import kotlin.math.abs
 import androidx.compose.ui.res.stringResource
 import com.arflix.tv.R
+import com.arflix.tv.network.OkHttpProvider
 
 /**
  * Per-section registry of [BringIntoViewRequester]s keyed by the row's
@@ -209,7 +210,7 @@ private fun tvGeneralRowsForSection(section: String): List<Int> {
         "playback" -> listOf(10, 11, 12, 13, 14, 34, 16, 15, 27)
         "appearance" -> listOf(17, 18, 20, 21, 24, 23, 22)
         "profiles" -> listOf(19)
-        "network" -> listOf(25, 26)
+        "network" -> listOf(25, 26, 35)
         else -> emptyList()
     }
 }
@@ -221,6 +222,12 @@ private fun openExternalUrl(context: Context, url: String) {
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         )
     }
+}
+
+private fun formatUserAgentPreview(value: String, maxLength: Int): String {
+    val displayValue = value.ifBlank { "Default" }
+    val preview = displayValue.take(maxLength)
+    return if (displayValue.length > maxLength) "$preview..." else preview
 }
 
 /**
@@ -331,6 +338,7 @@ fun SettingsScreen(
     var qualityFilterDeviceName by remember { mutableStateOf("") }
     var showAiModelDialog by remember { mutableStateOf(false) }
     var showAiApiKeyDialog by remember { mutableStateOf(false) }
+    var showCustomUserAgentDialog by remember { mutableStateOf(false) }
     var qualityFilterRegexPattern by remember { mutableStateOf("") }
     var showHomeServerInput by remember { mutableStateOf(false) }
     var showPlexHomeServerInput by remember { mutableStateOf(false) }
@@ -596,6 +604,7 @@ fun SettingsScreen(
         showUiModeWarningDialog ||
         showAiModelDialog ||
         showAiApiKeyDialog ||
+        showCustomUserAgentDialog ||
         uiState.aiKeyServerState.isActive ||
         uiState.showCloudPairDialog ||
         uiState.showCloudEmailPasswordDialog ||
@@ -793,6 +802,7 @@ fun SettingsScreen(
                                                 24 -> viewModel.cycleFocusBorderColor()
                                                 25 -> openDnsProviderPicker()
                                                 26 -> viewModel.setShowLoadingStats(!uiState.showLoadingStats)
+                                                35 -> showCustomUserAgentDialog = true
                                                 27 -> viewModel.cycleVolumeBoost()
                                                 28 -> viewModel.setSubtitleAiEnabled(!uiState.subtitleAiEnabled)
                                                 29 -> showAiModelDialog = true
@@ -1003,7 +1013,8 @@ fun SettingsScreen(
                     plexHomeServerUrl = ""
                     showPlexHomeServerInput = true
                 },
-                onAddCustomAddonClick = { showCustomAddonInput = true }
+                onAddCustomAddonClick = { showCustomAddonInput = true },
+                openCustomUserAgentDialog = { showCustomUserAgentDialog = true }
             )
         } else {
             AppTopBar(
@@ -1193,7 +1204,9 @@ fun SettingsScreen(
                             onSubtitleAiAutoSelectToggle = { viewModel.setSubtitleAiAutoSelect(it) },
                             onSubtitleRemoveHearingImpairedToggle = { viewModel.setSubtitleRemoveHearingImpaired(it) },
                             onSubtitleAiApiKeyClick = { showAiApiKeyDialog = true },
-                            onSubtitleAiQrClick = { viewModel.startAiKeyServer() }
+                            onSubtitleAiQrClick = { viewModel.startAiKeyServer() },
+                            customUserAgent = uiState.customUserAgent,
+                            onCustomUserAgentClick = { showCustomUserAgentDialog = true }
                         )
                         if (showAiModelDialog) {
                             AiModelDialog(
@@ -1214,6 +1227,16 @@ fun SettingsScreen(
                                     showAiApiKeyDialog = false
                                 },
                                 onDismiss = { showAiApiKeyDialog = false }
+                            )
+                        }
+                        if (showCustomUserAgentDialog) {
+                            CustomUserAgentDialog(
+                                currentValue = uiState.customUserAgent,
+                                onSave = { value ->
+                                    viewModel.setCustomUserAgent(value)
+                                    showCustomUserAgentDialog = false
+                                },
+                                onDismiss = { showCustomUserAgentDialog = false }
                             )
                         }
                         if (uiState.aiKeyServerState.isActive) {
@@ -1710,6 +1733,17 @@ fun SettingsScreen(
                     showAiApiKeyDialog = false
                 },
                 onDismiss = { showAiApiKeyDialog = false }
+            )
+        }
+
+        if (isTouchDevice && showCustomUserAgentDialog) {
+            CustomUserAgentDialog(
+                currentValue = uiState.customUserAgent,
+                onSave = { value ->
+                    viewModel.setCustomUserAgent(value)
+                    showCustomUserAgentDialog = false
+                },
+                onDismiss = { showCustomUserAgentDialog = false }
             )
         }
 
@@ -2987,7 +3021,8 @@ private fun MobileSettingsLayout(
     onRenameCatalogClick: (CatalogConfig) -> Unit,
     onConnectHomeServerClick: () -> Unit,
     onConnectPlexHomeServerClick: () -> Unit,
-    onAddCustomAddonClick: () -> Unit
+    onAddCustomAddonClick: () -> Unit,
+    openCustomUserAgentDialog: () -> Unit = {}
 ) {
     BackHandler(enabled = page != "MAIN") {
         onNavigate("MAIN")
@@ -3070,7 +3105,8 @@ private fun MobileSettingsLayout(
                 onRenameCatalogClick = onRenameCatalogClick,
                 onConnectHomeServerClick = onConnectHomeServerClick,
                 onConnectPlexHomeServerClick = onConnectPlexHomeServerClick,
-                onAddCustomAddonClick = onAddCustomAddonClick
+                onAddCustomAddonClick = onAddCustomAddonClick,
+                openCustomUserAgentDialog = openCustomUserAgentDialog
             )
         }
     }
@@ -3232,7 +3268,8 @@ private fun MobileSettingsSubPage(
     onRenameCatalogClick: (CatalogConfig) -> Unit,
     onConnectHomeServerClick: () -> Unit,
     onConnectPlexHomeServerClick: () -> Unit,
-    onAddCustomAddonClick: () -> Unit
+    onAddCustomAddonClick: () -> Unit,
+    openCustomUserAgentDialog: () -> Unit = {}
 ) {
     val scrollState = rememberScrollState()
     Column(
@@ -3316,8 +3353,15 @@ private fun MobileSettingsSubPage(
                         title = stringResource(R.string.dns_provider),
                         value = uiState.dnsProvider,
                         isFocused = false,
-                        showDivider = false,
                         onClick = openDnsProviderPicker
+                    )
+                    MobileSettingsRow(
+                        icon = Icons.Default.Language,
+                        title = stringResource(R.string.custom_user_agent),
+                        value = formatUserAgentPreview(uiState.customUserAgent, 20),
+                        isFocused = false,
+                        showDivider = false,
+                        onClick = openCustomUserAgentDialog
                     )
                 }
             }
@@ -4186,7 +4230,8 @@ private fun tvSettingsPanelFacts(
         )
         "network" -> listOf(
             "DNS" to uiState.dnsProvider,
-            "Loading stats" to if (uiState.showLoadingStats) "On" else "Off"
+            "Loading stats" to if (uiState.showLoadingStats) "On" else "Off",
+            "User-Agent" to formatUserAgentPreview(uiState.customUserAgent, 40)
         )
         "iptv" -> listOf(
             "Playlists" to "${uiState.iptvPlaylists.size}/3",
@@ -4348,7 +4393,9 @@ private fun TvGeneralSettingsRows(
     onSubtitleAiAutoSelectToggle: (Boolean) -> Unit = {},
     onSubtitleRemoveHearingImpairedToggle: (Boolean) -> Unit = {},
     onSubtitleAiApiKeyClick: () -> Unit = {},
-    onSubtitleAiQrClick: () -> Unit = {}
+    onSubtitleAiQrClick: () -> Unit = {},
+    customUserAgent: String = "",
+    onCustomUserAgentClick: () -> Unit = {}
 ) {
     Column {
         tvGeneralRowsForSection(section).forEachIndexed { localIndex, rowId ->
@@ -4453,6 +4500,7 @@ private fun TvGeneralSettingsRows(
                 32 -> SettingsRow(Icons.Default.VpnKey, stringResource(R.string.ai_api_key_title), stringResource(R.string.ai_api_key_desc), maskAiApiKey(subtitleAiApiKey, stringResource(R.string.ai_key_not_set)), focusedIndex == localIndex, onSubtitleAiApiKeyClick, Modifier.settingsFocusSlot(localIndex).alpha(if (subtitleAiEnabled) 1f else 0.4f))
                 33 -> SettingsRow(Icons.Default.QrCode, stringResource(R.string.ai_scan_qr_title), stringResource(R.string.ai_scan_qr_desc), "", focusedIndex == localIndex, onSubtitleAiQrClick, Modifier.settingsFocusSlot(localIndex).alpha(if (subtitleAiEnabled) 1f else 0.4f))
                 34 -> SettingsRow(Icons.Default.Schedule, stringResource(R.string.trailer_delay), stringResource(R.string.trailer_delay_desc), "${trailerDelaySeconds}s", focusedIndex == localIndex, onTrailerDelayClick, Modifier.settingsFocusSlot(localIndex))
+                35 -> SettingsRow(Icons.Default.Language, stringResource(R.string.custom_user_agent), stringResource(R.string.custom_user_agent_desc), formatUserAgentPreview(customUserAgent, 30), focusedIndex == localIndex, onCustomUserAgentClick, Modifier.settingsFocusSlot(localIndex))
             }
         }
     }
@@ -4528,7 +4576,9 @@ private fun GeneralSettings(
     onSubtitleAiAutoSelectToggle: (Boolean) -> Unit = {},
     onSubtitleRemoveHearingImpairedToggle: (Boolean) -> Unit = {},
     onSubtitleAiApiKeyClick: () -> Unit = {},
-    onSubtitleAiQrClick: () -> Unit = {}
+    onSubtitleAiQrClick: () -> Unit = {},
+    customUserAgent: String = "",
+    onCustomUserAgentClick: () -> Unit = {}
 ) {
     Column {
         // ── Language & Subtitles ──
@@ -4831,6 +4881,16 @@ private fun GeneralSettings(
             onToggle = onShowLoadingStatsToggle,
             modifier = Modifier.settingsFocusSlot(26)
         )
+        Spacer(modifier = Modifier.height(10.dp))
+        SettingsRow(
+            icon = Icons.Default.Language,
+            title = stringResource(R.string.custom_user_agent),
+            subtitle = stringResource(R.string.custom_user_agent_desc),
+            value = formatUserAgentPreview(customUserAgent, 30),
+            isFocused = focusedIndex == 35,
+            onClick = onCustomUserAgentClick,
+            modifier = Modifier.settingsFocusSlot(35)
+        )
 
         // ── Audio ──
         Spacer(modifier = Modifier.height(24.dp))
@@ -5114,6 +5174,108 @@ private fun AiApiKeyDialog(
                             textAlign = androidx.compose.ui.text.style.TextAlign.Center,
                             color = Pink
                         )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CustomUserAgentDialog(
+    currentValue: String,
+    onSave: (String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val isMobile = LocalDeviceType.current.isTouchDevice()
+    var value by remember(currentValue) { mutableStateOf(currentValue) }
+    val inputFocusRequester = remember { FocusRequester() }
+    BackHandler { onDismiss() }
+    LaunchedEffect(Unit) {
+        kotlinx.coroutines.delay(100)
+        inputFocusRequester.requestFocus()
+    }
+    androidx.compose.ui.window.Dialog(onDismissRequest = onDismiss) {
+        Box(
+            modifier = Modifier
+                .then(
+                    if (isMobile) Modifier.fillMaxWidth().padding(horizontal = 16.dp)
+                    else Modifier.width(520.dp)
+                )
+                .clip(RoundedCornerShape(16.dp))
+                .background(BackgroundElevated)
+        ) {
+            Column(modifier = Modifier.fillMaxWidth().padding(24.dp)) {
+                Text(text = stringResource(R.string.custom_user_agent), style = ArflixTypography.sectionTitle, color = TextPrimary)
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = stringResource(R.string.custom_user_agent_desc),
+                    style = ArflixTypography.caption,
+                    color = TextSecondary
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                androidx.compose.material3.OutlinedTextField(
+                    value = value,
+                    onValueChange = { value = it },
+                    placeholder = { Text(OkHttpProvider.DEFAULT_USER_AGENT, color = TextSecondary.copy(alpha = 0.4f)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth().focusRequester(inputFocusRequester),
+                    colors = androidx.compose.material3.OutlinedTextFieldDefaults.colors(
+                        focusedTextColor = TextPrimary,
+                        unfocusedTextColor = TextPrimary,
+                        focusedBorderColor = Pink,
+                        unfocusedBorderColor = TextSecondary.copy(alpha = 0.3f)
+                    )
+                )
+                Spacer(modifier = Modifier.height(20.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    val cancelFocus = remember { FocusRequester() }
+                    val saveFocus = remember { FocusRequester() }
+                    Surface(
+                        onClick = onDismiss,
+                        modifier = Modifier.weight(1f).focusRequester(cancelFocus),
+                        colors = ClickableSurfaceDefaults.colors(
+                            containerColor = BackgroundElevated,
+                            focusedContainerColor = BackgroundElevated.copy(alpha = 0.8f)
+                        ),
+                        shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(8.dp)),
+                        border = ClickableSurfaceDefaults.border(
+                            border = androidx.tv.material3.Border(
+                                border = androidx.compose.foundation.BorderStroke(1.dp, TextSecondary.copy(alpha = 0.3f))
+                            )
+                        )
+                    ) {
+                        Text(
+                            text = stringResource(R.string.cancel),
+                            modifier = Modifier.padding(vertical = 12.dp).fillMaxWidth(),
+                            textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                            color = TextSecondary
+                        )
+                    }
+                    Surface(
+                        onClick = { onSave(value) },
+                        modifier = Modifier.weight(1f).focusRequester(saveFocus),
+                        colors = ClickableSurfaceDefaults.colors(
+                            containerColor = Pink.copy(alpha = 0.15f),
+                            focusedContainerColor = Pink.copy(alpha = 0.25f)
+                        ),
+                        shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(8.dp)),
+                        border = ClickableSurfaceDefaults.border(
+                            border = androidx.tv.material3.Border(
+                                border = androidx.compose.foundation.BorderStroke(1.dp, Pink.copy(alpha = 0.4f))
+                            )
+                        )
+                    ) {
+                        Text(
+                            text = stringResource(R.string.save),
+                            modifier = Modifier.padding(vertical = 12.dp).fillMaxWidth(),
+                            textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                            color = Pink
+                        )
+                    }
+                    LaunchedEffect(Unit) {
+                        kotlinx.coroutines.delay(150)
+                        inputFocusRequester.requestFocus()
                     }
                 }
             }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -99,6 +99,7 @@ data class SettingsUiState(
     val autoPlayMinQuality: String = "Any",
     val dnsProvider: String = "System DNS",
     val dnsProviderOptions: List<String> = listOf("System DNS", "Cloudflare", "Google", "AdGuard"),
+    val customUserAgent: String = "",
     val subtitleSize: String = "Medium",
     val subtitleColor: String = "White",
     val subtitleStyle: String = "Bold",
@@ -269,6 +270,7 @@ class SettingsViewModel @Inject constructor(
     private fun filterSubtitlesByLanguageKey() = profileManager.profileBooleanKey("filter_subtitles_by_lang")
     private fun secondarySubtitleKey() = profileManager.profileStringKey("secondary_subtitle")
     private val dnsProviderKey = stringPreferencesKey(OkHttpProvider.DNS_PROVIDER_PREF_KEY)
+    private val customUserAgentKey = stringPreferencesKey(OkHttpProvider.USER_AGENT_PREF_KEY)
     private fun includeSpecialsKey() = profileManager.profileBooleanKey("include_specials")
     private val qualityFiltersKey = stringPreferencesKey("quality_filters")
 
@@ -429,6 +431,8 @@ class SettingsViewModel @Inject constructor(
             val filterSubtitlesByLanguage = prefs[filterSubtitlesByLanguageKey()] ?: true
             val secondarySubtitle = prefs[secondarySubtitleKey()]?.trim()?.takeIf { it.isNotBlank() } ?: "Off"
             val dnsProviderValue = normalizeDnsProviderValue(prefs[dnsProviderKey])
+            val customUserAgent = prefs[customUserAgentKey].orEmpty().trim()
+            OkHttpProvider.setCustomUserAgent(customUserAgent)
             val includeSpecials = prefs[includeSpecialsKey()] ?: false
             val qualityFilters = runCatching {
                 val json = prefs[qualityFiltersKey].orEmpty()
@@ -494,6 +498,7 @@ class SettingsViewModel @Inject constructor(
                 filterSubtitlesByLanguage = filterSubtitlesByLanguage,
                 secondarySubtitle = secondarySubtitle,
                 dnsProvider = dnsProviderLabel(dnsProviderValue),
+                customUserAgent = customUserAgent,
                 includeSpecials = includeSpecials,
                 spoilerBlurEnabled = spoilerBlurEnabled,
                 isLoggedIn = isLoggedIn,
@@ -1273,6 +1278,23 @@ class SettingsViewModel @Inject constructor(
                 OkHttpProvider.createCoilImageLoader(context)
             }
             Coil.setImageLoader(imageLoader)
+        }
+    }
+
+    fun setCustomUserAgent(value: String) {
+        val trimmed = value.trim()
+        viewModelScope.launch {
+            context.settingsDataStore.edit { prefs ->
+                if (trimmed.isBlank()) {
+                    prefs.remove(customUserAgentKey)
+                } else {
+                    prefs[customUserAgentKey] = trimmed
+                }
+            }
+            OkHttpProvider.setCustomUserAgent(trimmed)
+            _uiState.value = _uiState.value.copy(
+                customUserAgent = trimmed
+            )
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,6 +131,8 @@
     <string name="show_loading_stats">Show Loading Stats</string>
     <string name="volume_boost">Volume Boost</string>
     <string name="dns_provider">DNS Provider</string>
+    <string name="custom_user_agent">Custom User-Agent</string>
+    <string name="custom_user_agent_desc">Leave blank to use ARVIO defaults. Custom values apply when a source does not provide its own User-Agent.</string>
     <string name="add_playlist">Add Playlist</string>
     <string name="refresh_iptv">Refresh IPTV Data</string>
     <string name="delete_iptv">Delete IPTV Playlists</string>


### PR DESCRIPTION
## Summary

- Adds a custom User-Agent setting under Network settings on TV and mobile
- Stores a blank-by-default custom value in DataStore and applies it through `OkHttpProvider`
- Preserves existing default request behavior when the setting is blank
- Avoids overwriting source-specific User-Agent headers in OkHttp interceptors
- Keeps IPTV/M3U/EPG VLC and browser fallback behavior intact unless the user sets a custom value

This is a hardened replacement for #215, which was not mergeable against latest `main` and could change existing IPTV/default header behavior.

## Checks

- `:app:compileSideloadDebugKotlin`
- `:app:compilePlayDebugKotlin`
- `git diff --check HEAD~1..HEAD`