### PR TITLE
feat: load IPTV and home-server sources in parallel for source selection

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
@@ -471,6 +471,28 @@ class PlayerViewModel @Inject constructor(
                         playbackUrl = resolvedProvidedUrl
                     )
                 }
+                // Load IPTV and home-server sources from cache in parallel so the
+                // source picker in the player shows alternatives immediately.
+                homeServerAppendJob?.cancel()
+                homeServerAppendJob = launch {
+                    appendHomeServerSourcesInBackground(
+                        mediaType = mediaType,
+                        imdbId = currentImdbId,
+                        seasonNumber = seasonNumber,
+                        episodeNumber = episodeNumber,
+                        timeoutMs = 5_000L
+                    )
+                }
+                vodAppendJob?.cancel()
+                vodAppendJob = launch {
+                    appendVodSourceInBackground(
+                        mediaType = mediaType,
+                        imdbId = currentImdbId,
+                        seasonNumber = seasonNumber,
+                        episodeNumber = episodeNumber,
+                        timeoutMs = 15_000L
+                    )
+                }
                 // Fetch metadata in background
                 launch { fetchMediaMetadata(mediaType, mediaId) }
                 // Fetch skip intervals in background (needs IMDB id)
@@ -2604,7 +2626,7 @@ class PlayerViewModel @Inject constructor(
 
     private suspend fun appendHomeServerSourcesInBackground(
         mediaType: MediaType,
-        imdbId: String,
+        imdbId: String?,
         seasonNumber: Int?,
         episodeNumber: Int?,
         timeoutMs: Long
@@ -2664,7 +2686,7 @@ class PlayerViewModel @Inject constructor(
 
     private suspend fun appendVodSourceInBackground(
         mediaType: MediaType,
-        imdbId: String,
+        imdbId: String?,
         seasonNumber: Int?,
         episodeNumber: Int?,
         timeoutMs: Long


### PR DESCRIPTION
Problem: When the player was opened with a providedStreamUrl (e.g., user tapped a stream from the details page source picker), the player never launched vodAppendJob or homeServerAppendJob. So even though commit 7c2f595601a2ed47659e21ae4b0639bc76f66fbf cached the IPTV source picker results, the player had no code path to load those cached sources.                                
                                                                                                                                  
Fix — three small changes to PlayerViewModel.kt:                                                                                
                                                                                                                                
1. appendHomeServerSourcesInBackground — signature changed from imdbId: String → imdbId: String? (the downstream              
StreamRepository calls already accepted nullable)
2. appendVodSourceInBackground — same signature change
3. In the providedStreamUrl != null path, two new background jobs are launched right after the provided stream is set:          
  - homeServerAppendJob — fetches home-server sources (5s timeout)                                                            
  - vodAppendJob — fetches IPTV/VOD sources (15s timeout, but near-instant on a cache hit)                                      
                                                                                                                                
With the IPTV source cache, the VOD job hits the cache key profileIdHash|imdbId|tmdbId|"" and returns immediately, so the sources appear in the player's source list almost before the video even starts loading. 