### PR TITLE
Fix/pause overlay movie title episode overview

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -4421,6 +4421,9 @@ private fun PlayerMetadataChrome(
         else -> uiState.title
     }
     val metaLine = buildPlaybackMetaLine(uiState, mediaType, seasonNumber, episodeNumber)
+    // `overview` is already resolved by the ViewModel:
+    //   - For TV → populated from the season episode TMDB details (episode-specific synopsis)
+    //   - For movies → populated from the movie TMDB details
     val overview = uiState.overview?.trim().orEmpty()
     val logoHeight = 44.dp
     val logoWidth = 230.dp
@@ -4469,7 +4472,10 @@ private fun PlayerMetadataChrome(
                 )
             }
 
-            if (!uiState.logoUrl.isNullOrBlank() && displayTitle.isNotBlank()) {
+            // For TV, show the episode title under the series clearlogo (useful context).
+            // For movies, the clearlogo itself is the movie title logo, so showing the
+            // text title underneath is redundant.
+            if (mediaType == MediaType.TV && !uiState.logoUrl.isNullOrBlank() && displayTitle.isNotBlank()) {
                 Text(
                     text = displayTitle,
                     style = ArflixTypography.sectionTitle.copy(

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
@@ -113,7 +113,9 @@ data class PlayerUiState(
     val aiErrorToast: String? = null,
     // Episode title for TV shows (e.g. "The Devil's Verdict"), populated from TMDB season details
     val episodeTitle: String? = null,
-    // Plot synopsis from TMDB, used in the pause overlay metadata block
+    // Plot synopsis from TMDB, used in the pause overlay metadata block.
+    // For TV shows, the ViewModel populates this from the season episode TMDB details
+    // (episode-specific synopsis) rather than the series-level overview.
     val overview: String? = null,
     // Release year extracted from TMDB releaseDate/firstAirDate (e.g. "2023")
     val releaseYear: String? = null
@@ -927,14 +929,18 @@ class PlayerViewModel @Inject constructor(
                 overview = tvDetails.overview
                 releaseYear = tvDetails.firstAirDate?.take(4)
 
-                // Keep episode title aligned with saved progress rows for TV playback sessions.
+                // Keep episode title and overview aligned with saved progress rows for TV playback sessions.
                 val season = currentSeason
                 val episode = currentEpisode
                 if (season != null && episode != null) {
-                    currentEpisodeTitle = runCatching {
-                        val seasonDetails = tmdbApi.getTvSeason(mediaId, season, Constants.TMDB_API_KEY)
-                        seasonDetails.episodes.firstOrNull { it.episodeNumber == episode }?.name
+                    val seasonDetails = runCatching {
+                        tmdbApi.getTvSeason(mediaId, season, Constants.TMDB_API_KEY)
                     }.getOrNull()
+                    if (seasonDetails != null) {
+                        val matchingEpisode = seasonDetails.episodes.firstOrNull { it.episodeNumber == episode }
+                        currentEpisodeTitle = matchingEpisode?.name
+                        overview = matchingEpisode?.overview?.takeIf { !it.isNullOrBlank() } ?: overview
+                    }
                 }
             } else {
                 val movieDetails = details as com.arflix.tv.data.api.TmdbMovieDetails


### PR DESCRIPTION
## Fix pause overlay: redundant movie title + episode-specific synopsis

Two small fixes for the pause overlay metadata block (`PlayerMetadataChrome`):

### Fix 1: Hide redundant movie title under clearlogo
[`PlayerScreen.kt:4475-4478`](ArvioGitlab/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt:4475)

The title text block below the clearlogo is now gated to `MediaType.TV` only.
- **Movies**: clearlogo *is* the movie title logo → showing the text title underneath is redundant.
- **TV**: clearlogo is the *series* logo → showing the episode title underneath provides useful context.

### Fix 2: Episode-specific synopsis for TV shows
[`PlayerViewModel.kt:932-943`](ArvioGitlab/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt:932)

`fetchMediaMetadata()` already fetches season episode details to extract the episode title. Now it also extracts the episode-specific `overview` from the same response. Falls back to the series-level overview if the episode has no synopsis. No new state fields needed — flows through the existing `PlayerUiState.overview` field.

### Testing
- **Movies with clearlogo**: Verify pause overlay shows clearlogo without duplicate title text beneath it.
- **Movies without clearlogo**: Verify title text still displays correctly (no regression).
- **TV with clearlogo**: Verify episode title still shows under the series clearlogo.
- **TV episodes**: Verify pause overlay shows the episode-specific synopsis, not the series overview.
- **TV episodes without overview**: Verify falls back gracefully (no crash, no blank block).
