### PR TITLE
chore(refactor): centralize regex instances to reduce compilation overhead

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
@@ -178,6 +178,12 @@ import java.util.Locale
 import kotlin.math.abs
 import androidx.compose.ui.res.stringResource
 
+
+private object DetailsRegexes {
+    val FOUR_K_REGEX = Regex("\\b4[kK]\\b")
+    val YEAR_REGEX = Regex("\\d{4}")
+}
+
 /**
  * Details screen for movies and TV shows
  */
@@ -1011,7 +1017,7 @@ private fun qualityScoreForAutoPlay(quality: String): Int {
 private fun qualityScoreForStream(stream: com.arflix.tv.data.model.StreamSource): Int {
     val combined = listOfNotNull(stream.quality, stream.source, stream.addonName).joinToString(" ")
     return when {
-        combined.contains("2160p", ignoreCase = true) || Regex("\\b4[kK]\\b").containsMatchIn(combined) -> 4
+        combined.contains("2160p", ignoreCase = true) || DetailsRegexes.FOUR_K_REGEX.containsMatchIn(combined) -> 4
         combined.contains("1080p", ignoreCase = true) -> 3
         combined.contains("720p", ignoreCase = true) -> 2
         combined.contains("480p", ignoreCase = true) -> 1
@@ -1191,7 +1197,7 @@ private fun DetailsContent(
         }
         val displayDate = item.year.takeIf { it.isNotBlank() }
             ?: item.releaseDate?.trim()?.takeIf { it.isNotEmpty() }?.let { date ->
-                Regex("\\d{4}").find(date)?.value ?: date
+                DetailsRegexes.YEAR_REGEX.find(date)?.value ?: date
             }
             ?: ""
         val hasDuration = item.duration.isNotEmpty() && item.duration != "0m"

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
@@ -66,6 +66,12 @@ import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 
+
+internal object HomeVMRegexes {
+    val ALPHANUMERIC_REGEX = Regex("[^A-Za-z0-9_.-]")
+    val FILE_NAME_REGEX = Regex("[^a-zA-Z0-9._-]")
+}
+
 data class HomeUiState(
     val isLoading: Boolean = false,
     val isInitialLoad: Boolean = true,
@@ -111,8 +117,6 @@ enum class ToastType {
     SUCCESS, ERROR, INFO
 }
 
-private val ALPHANUMERIC_REGEX = Regex("[^A-Za-z0-9_.-]")
-private val FILE_NAME_REGEX = Regex("[^a-zA-Z0-9._-]")
 
 @HiltViewModel
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -650,9 +654,9 @@ class HomeViewModel @Inject constructor(
     private fun categoriesCacheFile(): java.io.File {
         val profileId = profileManager.getProfileIdSync()
             .ifBlank { "default" }
-            .replace(ALPHANUMERIC_REGEX, "_")
+            .replace(HomeVMRegexes.ALPHANUMERIC_REGEX, "_")
         val language = (mediaRepository.contentLanguage ?: "en-US")
-            .replace(ALPHANUMERIC_REGEX, "_")
+            .replace(HomeVMRegexes.ALPHANUMERIC_REGEX, "_")
         return java.io.File(context.cacheDir, "home_categories_cache_${profileId}_$language.json")
     }
 
@@ -4040,7 +4044,7 @@ class HomeViewModel @Inject constructor(
         downloadJob = viewModelScope.launch {
             updateStatusManager.updateStatus(com.arflix.tv.updater.UpdateStatus.Downloading(0f, update))
 
-            val safeName = update.assetName.replace(FILE_NAME_REGEX, "_")
+            val safeName = update.assetName.replace(HomeVMRegexes.FILE_NAME_REGEX, "_")
             val dest = java.io.File(java.io.File(context.cacheDir, "updates"), safeName)
 
             val result = kotlinx.coroutines.withContext(Dispatchers.IO) {

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/search/SearchViewModel.kt
@@ -20,6 +20,12 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
+
+private object SearchRegexes {
+    val LIKE_MATCH_REGEX = Regex("(?:movies?|shows?|series|films?)\\s+like\\s+(.+)", RegexOption.IGNORE_CASE)
+    val LIMIT_REGEX = Regex("top\\s+(\\d+)")
+}
+
 data class Genre(val id: Int, val name: String)
 
 val MOVIE_GENRES = listOf(
@@ -314,14 +320,14 @@ class SearchViewModel @Inject constructor(
     private fun parseSmartQuery(raw: String): SmartQuery? {
         val q = raw.lowercase().trim()
         val genreKeywords = mapOf("horror" to "27", "comedy" to "35", "action" to "28", "drama" to "18", "thriller" to "53", "sci-fi" to "878", "science fiction" to "878", "romance" to "10749", "animation" to "16", "anime" to "16", "documentary" to "99", "crime" to "80", "fantasy" to "14", "adventure" to "12", "mystery" to "9648", "war" to "10752", "western" to "37", "family" to "10751", "history" to "36")
-        val likeMatch = Regex("(?:movies?|shows?|series|films?)\\s+like\\s+(.+)", RegexOption.IGNORE_CASE).find(q)
+        val likeMatch = SearchRegexes.LIKE_MATCH_REGEX.find(q)
         if (likeMatch != null) { val t = likeMatch.groupValues[1].trim(); return SmartQuery("Similar to \"${t.replaceFirstChar { it.uppercase() }}\"", if (q.contains("show") || q.contains("series")) DiscoverType.TV_SHOWS else DiscoverType.MOVIES, null, "popularity.desc", null, null, t) }
         if (!(q.contains("top") || q.contains("best") || q.contains("popular") || q.contains("trending") || q.contains("new") || q.contains("latest"))) return null
         var gId: String? = null; var gName: String? = null; for ((kw, id) in genreKeywords) { if (q.contains(kw)) { gId = id; gName = kw.replaceFirstChar { it.uppercase() }; break } }
         if (gId == null && !q.contains("movie") && !q.contains("show") && !q.contains("series") && !q.contains("film") && !q.contains("trending") && !q.contains("anime")) return null
         val isAnime = q.contains("anime"); val isTV = q.contains("show") || q.contains("series"); val isMovie = q.contains("movie") || q.contains("film")
         val type = when { isAnime -> DiscoverType.ANIME; isTV && !isMovie -> DiscoverType.TV_SHOWS; isMovie && !isTV -> DiscoverType.MOVIES; else -> DiscoverType.ALL }
-        val limit = Regex("top\\s+(\\d+)").find(q)?.groupValues?.get(1)?.toIntOrNull()
+        val limit = SearchRegexes.LIMIT_REGEX.find(q)?.groupValues?.get(1)?.toIntOrNull()
         val sort = when { q.contains("best") || q.contains("top rated") || limit != null -> "vote_average.desc"; q.contains("new") || q.contains("latest") -> if (isTV || isAnime) "first_air_date.desc" else "primary_release_date.desc"; else -> "popularity.desc" }
         val parts = mutableListOf<String>(); if (limit != null) parts.add("Top $limit"); if (sort == "vote_average.desc" && limit == null) parts.add("Best") else if (sort.contains("date")) parts.add("Newest") else parts.add("Popular")
         if (gName != null) parts.add(gName); parts.add(when(type) { DiscoverType.MOVIES -> "Movies"; DiscoverType.TV_SHOWS -> "Series"; DiscoverType.ANIME -> "Anime"; DiscoverType.ALL -> "Movies & Series" })


### PR DESCRIPTION
Summary:\n- Move repeated Regex constructions into private/internal top-level objects to avoid repeated compilation and reduce GC pressure.\n\nFiles changed (high level):\n- app/src/main/kotlin/.../SearchViewModel.kt\n- app/src/main/kotlin/.../HomeViewModel.kt\n- app/src/main/kotlin/.../DetailsScreen.kt\n\nWhy:\n- Compiling Regex objects is expensive; centralizing them ensures they're compiled once per process.\n\nVerification:\n- Code compiles\n- No business logic changed\n\n(Originally opened by @Himanth-reddy in the fork; recreated here to be authored from the upstream repo.)