### PR TITLE
Bugs fixes

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/model/Models.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/model/Models.kt
@@ -197,7 +197,8 @@ data class Subtitle(
     val provider: String = "",
     val isEmbedded: Boolean = false,
     val groupIndex: Int? = null,
-    val trackIndex: Int? = null
+    val trackIndex: Int? = null,
+    val isForced: Boolean = false,
 ) : Serializable
 
 /**

--- a/app/src/main/kotlin/com/arflix/tv/ui/components/StreamSelector.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/StreamSelector.kt
@@ -105,6 +105,7 @@ fun StreamSelector(
     title: String = "",
     subtitle: String = "",
     hasStreamingAddons: Boolean = true,
+    addonOrderedIds: List<String> = emptyList(),
     onFocusedStream: (StreamSource) -> Unit = {},
     onSelect: (StreamSource) -> Unit = {},
     onClose: () -> Unit = {}
@@ -131,7 +132,7 @@ fun StreamSelector(
     data class AddonTab(val id: String, val label: String)
 
     // Build addon tabs using addonId so multiple instances of the same addon are shown separately.
-    val addonTabs = remember(streams) {
+    val addonTabs = remember(streams, addonOrderedIds) {
         val baseNameById = LinkedHashMap<String, String>()
         streams.forEach { stream ->
             val baseName = stream.addonName.split(" - ").firstOrNull()?.trim() ?: stream.addonName
@@ -147,6 +148,12 @@ fun StreamSelector(
                 baseName
             }
             AddonTab(id, label)
+        }.let { tabs ->
+            if (addonOrderedIds.isEmpty()) tabs
+            else tabs.sortedBy { tab ->
+                val pos = addonOrderedIds.indexOfFirst { tab.id.contains(it) || it.contains(tab.id) }
+                if (pos >= 0) pos else Int.MAX_VALUE
+            }
         }
     }
 
@@ -158,10 +165,23 @@ fun StreamSelector(
     val presentations = remember(streams) { streams.map(::presentSource) }
 
     // Sort streams with richer heuristics:
-    // cached/direct first, then resolution, then release type, then size.
-    val sortedStreams = remember(presentations) {
+    // cached/direct first, then resolution, then release type, then addon order, then size.
+    val addonOrder = remember(addonTabs, addonOrderedIds) {
+        if (addonOrderedIds.isNotEmpty()) {
+            // Use the user's configured addon order: map each stream's addonId to its
+            // position in the user's installed-addons list.
+            addonTabs.associate { tab ->
+                val pos = addonOrderedIds.indexOfFirst { tab.id.contains(it) || it.contains(tab.id) }
+                tab.id to if (pos >= 0) pos else Int.MAX_VALUE
+            }
+        } else {
+            addonTabs.mapIndexed { index, tab -> tab.id to index }.toMap()
+        }
+    }
+    val sortedStreams = remember(presentations, addonOrder) {
         presentations.sortedWith(compareByDescending<SourcePresentation> { it.sortCached }
             .thenByDescending { it.sortDirect }
+            .thenBy { addonOrder[sourceTabId(it.stream)] ?: Int.MAX_VALUE }
             .thenByDescending { it.resolutionScore }
             .thenByDescending { it.releaseScore }
             .thenByDescending { it.sizeBytes }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
@@ -903,6 +903,7 @@ fun DetailsScreen(
             selectedStream = null,
             isLoading = uiState.isLoadingStreams,
             hasStreamingAddons = uiState.hasStreamingAddons,
+            addonOrderedIds = uiState.addonOrderedIds,
             onFocusedStream = { stream ->
                 viewModel.prewarmStreamsAround(stream, uiState.streams)
             },

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
@@ -63,6 +63,7 @@ data class DetailsUiState(
     val subtitles: List<Subtitle> = emptyList(),
     val isLoadingStreams: Boolean = false,
     val hasStreamingAddons: Boolean = true,
+    val addonOrderedIds: List<String> = emptyList(),
     val isInWatchlist: Boolean = false,
     // Toast
     val toastMessage: String? = null,
@@ -1353,10 +1354,14 @@ class DetailsViewModel @Inject constructor(
             }
             val resolvedImdbId = currentImdbId
 
+            val orderedAddonIds = streamRepository.installedAddons.first()
+                .filter { it.isEnabled && it.type != com.arflix.tv.data.model.AddonType.SUBTITLE }
+                .map { it.id }
             _uiState.value = _uiState.value.copy(
                 isLoadingStreams = true,
                 streams = emptyList(),
-                subtitles = emptyList()
+                subtitles = emptyList(),
+                addonOrderedIds = orderedAddonIds
             )
 
             if (requestMediaType == MediaType.MOVIE) {

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -827,6 +827,7 @@ fun PlayerScreen(
                                     val lang = format.language ?: matched?.lang ?: "und"
                                     val label = format.label ?: matched?.label ?: getFullLanguageName(lang)
                                     val isExternal = matched?.url?.isNotBlank() == true
+                                    val isForced = format.selectionFlags and C.SELECTION_FLAG_FORCED != 0
                                     textTracks.add(Subtitle(
                                         id = matched?.id ?: formatTrackId.ifBlank { "embedded_${groupIndex}_$i" },
                                         url = matched?.url.orEmpty(),
@@ -835,7 +836,8 @@ fun PlayerScreen(
                                         provider = matched?.provider.orEmpty(),
                                         isEmbedded = !isExternal,
                                         groupIndex = groupIndex,
-                                        trackIndex = i
+                                        trackIndex = i,
+                                        isForced = isForced,
                                     ))
                                 }
                             }
@@ -3526,7 +3528,10 @@ private fun SubtitleMenu(
                                         val badge: String?
                                         val detail: String?
                                         if (subtitle.isEmbedded && subtitle.url.isBlank()) {
-                                            badge = "Built-in"
+                                            val langFullName = getFullLanguageName(subtitle.lang)
+                                            val trackLabel = subtitle.label.takeIf { it.isNotBlank() &&
+                                                !it.equals(langFullName, ignoreCase = true) }
+                                            badge = if (trackLabel != null) "Built-in · $trackLabel" else "Built-in"
                                             detail = null
                                         } else {
                                             badge = subtitle.provider.ifBlank { null }
@@ -3783,7 +3788,11 @@ private fun SubtitleMenu(
                                     val langFullName = getFullLanguageName(sub.lang)
                                     val displayName = if (score > 0) "$langFullName ($score%)" else langFullName
                                     val description = when {
-                                        sub.isEmbedded && sub.url.isBlank() -> "Built-in"
+                                        sub.isEmbedded && sub.url.isBlank() -> {
+                                            val trackLabel = sub.label.takeIf { it.isNotBlank() &&
+                                                !it.equals(langFullName, ignoreCase = true) }
+                                            if (trackLabel != null) "Built-in · $trackLabel" else "Built-in"
+                                        }
                                         sub.provider.isNotBlank() -> sub.provider
                                         else -> null
                                     }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
@@ -1166,6 +1166,12 @@ class PlayerViewModel @Inject constructor(
             if (candidates.isEmpty()) return null
             val sorted = candidates.sortedWith(
                 compareByDescending<Subtitle> { if (it.isEmbedded) 1 else 0 }
+                    // Prefer plain subs over SDH (accessibility) over forced-only tracks
+                    .thenBy { when {
+                        it.isForced -> 2
+                        it.label.equals("SDH", ignoreCase = true) || it.label.equals("CC", ignoreCase = true) -> 1
+                        else -> 0
+                    }}
                     .thenByDescending { matchScore(it) }
                     .thenBy { it.groupIndex ?: Int.MAX_VALUE }
                     .thenBy { it.trackIndex ?: Int.MAX_VALUE }
@@ -1253,10 +1259,18 @@ class PlayerViewModel @Inject constructor(
     }
 
     private fun findAiSourceSubtitle(subtitles: List<Subtitle>): Subtitle? {
+        fun List<Subtitle>.bestEmbedded(): Subtitle? {
+            val embedded = filter { it.isEmbedded }
+            // Prefer plain > SDH/CC > forced-only
+            return embedded.firstOrNull { !it.isForced && !it.label.equals("SDH", ignoreCase = true) && !it.label.equals("CC", ignoreCase = true) }
+                ?: embedded.firstOrNull { !it.isForced }
+                ?: embedded.firstOrNull()
+        }
+
         // Prefer English embedded > any embedded with lang > any embedded > any subtitle
-        return subtitles.firstOrNull { it.isEmbedded && normalizeLanguage(it.lang) == "en" }
-            ?: subtitles.firstOrNull { it.isEmbedded && it.lang.isNotBlank() }
-            ?: subtitles.firstOrNull { it.isEmbedded }
+        return subtitles.filter { normalizeLanguage(it.lang) == "en" }.bestEmbedded()
+            ?: subtitles.filter { it.lang.isNotBlank() }.bestEmbedded()
+            ?: subtitles.bestEmbedded()
             ?: subtitles.firstOrNull()
     }
 

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -2558,6 +2558,11 @@ private fun CloudPairModal(
     }
     // Focus order: 0 cancel, 1 email/password
     var focusedIndex by remember { mutableIntStateOf(1) }
+    val modalFocusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        modalFocusRequester.requestFocus()
+    }
 
     androidx.compose.ui.window.Dialog(
         onDismissRequest = onDismiss,
@@ -2582,6 +2587,8 @@ private fun CloudPairModal(
                     )
                     .background(BackgroundElevated, RoundedCornerShape(16.dp))
                     .padding(horizontal = if (isMobile) 20.dp else 24.dp, vertical = if (isMobile) 24.dp else 20.dp)
+                    .focusRequester(modalFocusRequester)
+                    .focusable()
                     .onPreviewKeyEvent { event ->
                         if (event.type == KeyEventType.KeyDown) {
                             when (event.key) {


### PR DESCRIPTION
  - Cloud pairing "Use Email/Password" button unresponsive on TV — modal was missing FocusRequester + LaunchedEffect, so D-pad events never reached it
  - Built-in subtitle auto-selection picking "Forced" track — added isForced field to Subtitle model (from ExoPlayer's SELECTION_FLAG_FORCED bit), then deprioritized forced and SDH tracks in bestMatch sort
  - AI translation sourcing from the "Forced" built-in — findAiSourceSubtitle now applies the same plain → SDH → forced priority when choosing the source track
  - Subtitle picker not showing track type labels — embedded tracks now display Built-in · Forced, Built-in · SDH, etc. when the track has a meaningful label
  - Source selector not respecting addon order — streams and sidebar tabs now sort by the user's configured addon order (from installedAddons) rather than whichever addon's network response arrived first