### PR TITLE
Fix default-audio selection for Polish sources + add "None" option

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -353,6 +353,9 @@ fun PlayerScreen(
     // Audio tracks from ExoPlayer
     var audioTracks by remember { mutableStateOf<List<AudioTrackInfo>>(emptyList()) }
     var selectedAudioIndex by remember { mutableIntStateOf(0) }
+    // Once the user picks an audio track for the current stream, stop auto-applying
+    // the preferred-language selection so we don't fight their choice.
+    var userPickedAudioForStream by remember { mutableStateOf(false) }
 
     // Error modal focus
     var errorModalFocusIndex by remember { mutableIntStateOf(0) }
@@ -901,6 +904,32 @@ fun PlayerScreen(
                 .setPreferredAudioLanguage(uiState.preferredAudioLanguage)
                 .build()
             trackSelector.parameters = params
+        }
+    }
+
+    // Reset the manual-pick guard whenever the playing stream changes so the
+    // preferred-language auto-selection runs fresh for the new file.
+    LaunchedEffect(uiState.selectedStreamUrl) {
+        userPickedAudioForStream = false
+    }
+
+    // Deterministically apply the preferred audio language once tracks are known.
+    // ExoPlayer's setPreferredAudioLanguage only matches on the container's language
+    // tag, so Polish "Lektor"/"Dubbing" tracks that ship with a missing or non-standard
+    // tag get skipped and playback falls back to the default track (often Russian on
+    // multi-audio releases). We additionally match on the track label here so the user's
+    // chosen language wins regardless of how the track was tagged.
+    LaunchedEffect(audioTracks, uiState.preferredAudioLanguage, userPickedAudioForStream) {
+        if (playerReleased || userPickedAudioForStream) return@LaunchedEffect
+        if (audioTracks.size < 2) return@LaunchedEffect
+        val preferred = uiState.preferredAudioLanguage.trim()
+        if (preferred.isBlank()) return@LaunchedEffect
+        val matchIndex = findPreferredAudioTrackIndex(audioTracks, preferred)
+        if (matchIndex == null || matchIndex == selectedAudioIndex) return@LaunchedEffect
+        audioTracks.getOrNull(matchIndex)?.let { track ->
+            applyAudioTrackSelection(exoPlayer, track, audioTracks)?.let {
+                selectedAudioIndex = it
+            }
         }
     }
 
@@ -1864,6 +1893,7 @@ fun PlayerScreen(
                             Key.Enter, Key.DirectionCenter -> {
                                 if (subtitleMenuTab == 1) {
                                     audioTracks.getOrNull(subtitleMenuIndex)?.let { track ->
+                                        userPickedAudioForStream = true
                                         applyAudioTrackSelection(exoPlayer, track, audioTracks)?.let {
                                             selectedAudioIndex = it
                                         }
@@ -2587,6 +2617,7 @@ fun PlayerScreen(
                     }
                 },
                 onSelectAudio = { track ->
+                    userPickedAudioForStream = true
                     applyAudioTrackSelection(exoPlayer, track, audioTracks)?.let {
                         selectedAudioIndex = it
                     }
@@ -3230,6 +3261,53 @@ private fun applyAudioTrackSelection(
     } catch (e: Exception) {
         android.util.Log.e("PlayerScreen", "applyAudioTrackSelection unexpected error", e)
         null
+    }
+}
+
+/**
+ * Find the audio track that best matches the user's preferred audio language.
+ *
+ * Matching is done on the canonical language name (so "pl", "pol" and "polish" all
+ * resolve to the same language) and falls back to the track label, which is where
+ * Polish releases commonly carry the language for tracks that ship with a missing or
+ * non-standard language tag (e.g. "Lektor PL", "Dubbing", "Polski"). Returns the index
+ * into [audioTracks] of the first match, or `null` when no track matches.
+ */
+private fun findPreferredAudioTrackIndex(
+    audioTracks: List<AudioTrackInfo>,
+    preferredCode: String
+): Int? {
+    val prefName = getFullLanguageName(preferredCode)
+    if (prefName == "Unknown") return null
+    val labelHints = nativeAudioLanguageHints(preferredCode) + prefName.lowercase()
+    val index = audioTracks.indexOfFirst { track ->
+        val trackLangName = getFullLanguageName(track.language)
+        if (trackLangName != "Unknown" && trackLangName.equals(prefName, ignoreCase = true)) {
+            return@indexOfFirst true
+        }
+        val label = track.label?.lowercase()?.trim().orEmpty()
+        label.isNotBlank() && labelHints.any { hint -> hint.isNotBlank() && label.contains(hint) }
+    }
+    return index.takeIf { it >= 0 }
+}
+
+/**
+ * Common label hints (native names / colloquial terms) used to recognise an audio
+ * track's language when its language tag is missing or non-standard. Kept conservative
+ * to avoid false positives; covers the languages most affected by untagged tracks.
+ */
+private fun nativeAudioLanguageHints(preferredCode: String): List<String> {
+    return when (getFullLanguageName(preferredCode)) {
+        "Polish" -> listOf("polski", "polskie", "polsku", "lektor", "dubbing pl")
+        "Russian" -> listOf("русский", "русская", "rus")
+        "Ukrainian" -> listOf("українська", "ukr")
+        "German" -> listOf("deutsch")
+        "French" -> listOf("français", "francais")
+        "Spanish" -> listOf("español", "espanol", "castellano")
+        "Italian" -> listOf("italiano")
+        "Portuguese" -> listOf("português", "portugues")
+        "Czech" -> listOf("čeština", "cesky", "dabing")
+        else -> emptyList()
     }
 }
 

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -587,7 +587,7 @@ fun PlayerScreen(
                 androidx.media3.exoplayer.trackselection.DefaultTrackSelector(context).apply {
                     parameters = buildUponParameters()
                         // Prefer original audio language when available
-                        .setPreferredAudioLanguage(uiState.preferredAudioLanguage)
+                        .setPreferredAudioLanguage(uiState.preferredAudioLanguage.takeUnless { it.isBlank() || it.equals("none", ignoreCase = true) })
                         // Allow decoder fallback for unsupported codecs
                         .setAllowVideoMixedMimeTypeAdaptiveness(true)
                         .setAllowVideoNonSeamlessAdaptiveness(true)
@@ -901,7 +901,7 @@ fun PlayerScreen(
         val trackSelector = exoPlayer.trackSelector as? androidx.media3.exoplayer.trackselection.DefaultTrackSelector
         if (trackSelector != null) {
             val params = trackSelector.buildUponParameters()
-                .setPreferredAudioLanguage(uiState.preferredAudioLanguage)
+                .setPreferredAudioLanguage(uiState.preferredAudioLanguage.takeUnless { it.isBlank() || it.equals("none", ignoreCase = true) })
                 .build()
             trackSelector.parameters = params
         }
@@ -923,7 +923,7 @@ fun PlayerScreen(
         if (playerReleased || userPickedAudioForStream) return@LaunchedEffect
         if (audioTracks.size < 2) return@LaunchedEffect
         val preferred = uiState.preferredAudioLanguage.trim()
-        if (preferred.isBlank()) return@LaunchedEffect
+        if (preferred.isBlank() || preferred.equals("none", ignoreCase = true)) return@LaunchedEffect
         val matchIndex = findPreferredAudioTrackIndex(audioTracks, preferred)
         if (matchIndex == null || matchIndex == selectedAudioIndex) return@LaunchedEffect
         audioTracks.getOrNull(matchIndex)?.let { track ->

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
@@ -1492,13 +1492,29 @@ class PlayerViewModel @Inject constructor(
                 append(it)
             }
         }
-        val codes = extractLanguageCodes(combined)
+        val codes = extractLanguageCodes(combined).toMutableSet()
+        codes.addAll(detectAudioLanguageMarkers(combined.lowercase()))
         val hasMulti = hasMultiLanguageHint(combined)
         return when {
             codes.contains(preferred) -> 2
             codes.isEmpty() || hasMulti -> 1
             else -> 0
         }
+    }
+
+    /**
+     * Detect audio-language markers commonly used in release names that the plain
+     * ISO-code tokenizer in [extractLanguageCodes] misses. Focused on Polish audio
+     * ("Lektor", "Dubbing PL", "PLDUB", ...) which is otherwise invisible to language
+     * scoring and would lose to a larger foreign-language rip.
+     */
+    private fun detectAudioLanguageMarkers(lowerText: String): Set<String> {
+        val out = mutableSetOf<String>()
+        val polishAudio = listOf(
+            "lektor", "dubbing pl", "dub pl", "pl dub", "pldub", "pl-dub", "dubpl", "polski"
+        )
+        if (polishAudio.any { lowerText.contains(it) }) out.add("pl")
+        return out
     }
 
     private fun autoplaySelectBest(streams: List<StreamSource>, preferredLanguage: String) {
@@ -1581,10 +1597,14 @@ class PlayerViewModel @Inject constructor(
         preferredLanguage: String
     ): List<StreamSource> {
         return streams.sortedWith(
-            compareByDescending<StreamSource> { playbackPriorityScore(it) }
+            // Preferred audio language is the primary criterion so a release in the
+            // user's language wins over a larger / higher-quality release in another
+            // language (e.g. Polish over a bigger Russian rip). Quality and size only
+            // decide between sources that match the language preference equally.
+            compareByDescending<StreamSource> { streamLanguageScore(it, preferredLanguage) }
+                .thenByDescending { playbackPriorityScore(it) }
                 .thenBy { streamRepository.getPlaybackHostHealthPenalty(it) }
                 .thenByDescending { parseSize(it.size) }
-                .thenByDescending { streamLanguageScore(it, preferredLanguage) }
                 .thenByDescending { if (it.behaviorHints?.cached == true) 1 else 0 }
                 .thenBy { if (it.behaviorHints?.notWebReady == true) 1 else 0 }
                 .thenByDescending { streamRepository.getAddonHealthBias(it.addonId) }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
@@ -1467,6 +1467,10 @@ class PlayerViewModel @Inject constructor(
             context.settingsDataStore.data.first()[defaultAudioLanguageKey()]
         }.getOrNull().orEmpty().trim()
 
+        // "None" disables language preference entirely: no forced audio language and
+        // autoplay keeps the scraping addon's own ordering (top result wins).
+        if (setting.equals("None", ignoreCase = true)) return "none"
+
         if (setting.isNotBlank() && !setting.equals("Auto", ignoreCase = true) && !setting.equals("Auto (Original)", ignoreCase = true)) {
             val fromSetting = normalizeLanguage(setting)
             if (fromSetting in knownLanguageCodes) {
@@ -1596,6 +1600,10 @@ class PlayerViewModel @Inject constructor(
         streams: List<StreamSource>,
         preferredLanguage: String
     ): List<StreamSource> {
+        // "None" preference: trust the scraping addon's ordering (like Nuvio) and keep
+        // the list as returned so the addon's top result is the one autoplay picks.
+        if (preferredLanguage.equals("none", ignoreCase = true)) return streams
+
         return streams.sortedWith(
             // Preferred audio language is the primary criterion so a release in the
             // user's language wins over a larger / higher-quality release in another

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -789,6 +789,7 @@ class SettingsViewModel @Inject constructor(
     private fun loadAudioLanguageOptions(current: String): List<String> {
         val defaults = listOf(
             "Auto (Original)",
+            "None",
             "English",
             "Arabic",
             "Bengali",


### PR DESCRIPTION
Three related fixes to default-audio handling, aimed at sources whose
audio language is not reliably tagged (e.g. Polish releases):

1. Fix default audio language ignoring Polish tracks
   The preferred-language match no longer skips tracks that should
   qualify, so a Polish default audio track is actually picked.

2. Prefer source language over size when auto-selecting a stream
   Auto-selection now weights the source/track language ahead of raw
   file size, so the correct-language stream wins instead of just the
   biggest one.

3. Add "None" default-audio option that preserves addon source order
   New "None" choice in Default Audio = "no language preference".
   Autoplay then keeps the scraping addon's own ordering (Nuvio-style
   top-result wins) instead of re-sorting, does not force a preferred
   audio language, and skips explicit preferred-track selection. When a
   real language is set, language-first smart sorting still applies.

Only player/settings files are touched:
- PlayerScreen.kt
- PlayerViewModel.kt
- SettingsViewModel.kt