### PR TITLE
fix addon sources selection

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/model/Models.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/model/Models.kt
@@ -162,7 +162,8 @@ data class StreamSource(
     val subtitles: List<Subtitle> = emptyList(),
     // Stremio "sources" are commonly tracker URLs. Keeping them helps P2P playback (TorrServer) work
     // across more addons.
-    val sources: List<String> = emptyList()
+    val sources: List<String> = emptyList(),
+    val description: String? = null
 ) : Serializable
 
 /**

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
@@ -1839,7 +1839,8 @@ class StreamRepository @Inject constructor(
                         )
                     },
                     subtitles = embeddedSubs,
-                    sources = stream.sources ?: emptyList()
+                    sources = stream.sources ?: emptyList(),
+                    description = stream.description?.trim()?.takeIf { it.isNotBlank() }
                 )
             }
     }

--- a/app/src/main/kotlin/com/arflix/tv/ui/components/StreamSelector.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/StreamSelector.kt
@@ -106,6 +106,8 @@ fun StreamSelector(
     subtitle: String = "",
     hasStreamingAddons: Boolean = true,
     addonOrderedIds: List<String> = emptyList(),
+    completedAddons: Int = 0,
+    totalAddons: Int = 0,
     onFocusedStream: (StreamSource) -> Unit = {},
     onSelect: (StreamSource) -> Unit = {},
     onClose: () -> Unit = {}
@@ -435,22 +437,8 @@ fun StreamSelector(
                         modifier = Modifier.padding(horizontal = 8.dp, vertical = 12.dp)
                     )
 
-                    if (isLoading) {
-                        Box(
-                            modifier = Modifier.fillMaxSize(),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                LoadingIndicator(color = Pink, size = 48.dp)
-                                Spacer(modifier = Modifier.height(16.dp))
-                                Text(
-                                    text = stringResource(R.string.finding_sources),
-                                    style = ArflixTypography.body.copy(fontSize = 14.sp),
-                                    color = TextSecondary
-                                )
-                            }
-                        }
-                    } else if (streams.isEmpty()) {
+                    if (streams.isEmpty()) {
+                        val stillSearching = isLoading || (completedAddons < totalAddons && totalAddons > 0)
                         Box(
                             modifier = Modifier.fillMaxSize(),
                             contentAlignment = Alignment.Center
@@ -462,39 +450,52 @@ fun StreamSelector(
                                     .border(1.dp, GlassBorder, RoundedCornerShape(20.dp))
                                     .padding(40.dp)
                             ) {
-                                val iconColor = if (!hasStreamingAddons) Color(0xFF3B82F6) else TextSecondary.copy(alpha = 0.5f)
-                                Box(
-                                    modifier = Modifier
-                                        .size(64.dp)
-                                        .background(iconColor.copy(alpha = 0.1f), CircleShape),
-                                    contentAlignment = Alignment.Center
-                                ) {
-                                    Icon(
-                                        imageVector = if (!hasStreamingAddons) Icons.Default.Settings else Icons.Default.Cloud,
-                                        contentDescription = null,
-                                        tint = iconColor,
-                                        modifier = Modifier.size(32.dp)
+                                if (stillSearching) {
+                                    LoadingIndicator(color = Pink, size = 48.dp)
+                                    Spacer(modifier = Modifier.height(16.dp))
+                                    Text(
+                                        text = if (totalAddons > 0) "Searching addons ($completedAddons/$totalAddons)..." else stringResource(R.string.finding_sources),
+                                        style = ArflixTypography.body.copy(
+                                            fontSize = 16.sp,
+                                            fontWeight = FontWeight.Medium
+                                        ),
+                                        color = TextSecondary
+                                    )
+                                } else {
+                                    val iconColor = if (!hasStreamingAddons) Color(0xFF3B82F6) else TextSecondary.copy(alpha = 0.5f)
+                                    Box(
+                                        modifier = Modifier
+                                            .size(64.dp)
+                                            .background(iconColor.copy(alpha = 0.1f), CircleShape),
+                                        contentAlignment = Alignment.Center
+                                    ) {
+                                        Icon(
+                                            imageVector = if (!hasStreamingAddons) Icons.Default.Settings else Icons.Default.Cloud,
+                                            contentDescription = null,
+                                            tint = iconColor,
+                                            modifier = Modifier.size(32.dp)
+                                        )
+                                    }
+                                    Spacer(modifier = Modifier.height(16.dp))
+                                    Text(
+                                        text = if (!hasStreamingAddons) "No Streaming Addons" else "No sources found",
+                                        style = ArflixTypography.body.copy(
+                                            fontSize = 16.sp,
+                                            fontWeight = FontWeight.Medium
+                                        ),
+                                        color = TextSecondary
+                                    )
+                                    Spacer(modifier = Modifier.height(4.dp))
+                                    Text(
+                                        text = if (!hasStreamingAddons)
+                                            "Go to Settings \u2192 Addons to add\na streaming addon"
+                                        else
+                                            "Try adding more addons",
+                                        style = ArflixTypography.caption.copy(fontSize = 12.sp),
+                                        color = TextSecondary.copy(alpha = 0.6f),
+                                        textAlign = androidx.compose.ui.text.style.TextAlign.Center
                                     )
                                 }
-                                Spacer(modifier = Modifier.height(16.dp))
-                                Text(
-                                    text = if (!hasStreamingAddons) "No Streaming Addons" else "No sources found",
-                                    style = ArflixTypography.body.copy(
-                                        fontSize = 16.sp,
-                                        fontWeight = FontWeight.Medium
-                                    ),
-                                    color = TextSecondary
-                                )
-                                Spacer(modifier = Modifier.height(4.dp))
-                                Text(
-                                    text = if (!hasStreamingAddons)
-                                        "Go to Settings \u2192 Addons to add\na streaming addon"
-                                    else
-                                        "Try adding more addons",
-                                    style = ArflixTypography.caption.copy(fontSize = 12.sp),
-                                    color = TextSecondary.copy(alpha = 0.6f),
-                                    textAlign = androidx.compose.ui.text.style.TextAlign.Center
-                                )
                             }
                         }
                     } else {
@@ -612,24 +613,8 @@ fun StreamSelector(
                     }
 
                     // Stream list or loading/empty states
-                    if (isLoading) {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .weight(1f),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                LoadingIndicator(color = Pink, size = 40.dp)
-                                Spacer(modifier = Modifier.height(12.dp))
-                                Text(
-                                    text = stringResource(R.string.finding_sources),
-                                    style = ArflixTypography.body.copy(fontSize = 14.sp),
-                                    color = TextSecondary
-                                )
-                            }
-                        }
-                    } else if (streams.isEmpty()) {
+                    if (streams.isEmpty()) {
+                        val stillSearching = isLoading || (completedAddons < totalAddons && totalAddons > 0)
                         Box(
                             modifier = Modifier
                                 .fillMaxSize()
@@ -643,39 +628,52 @@ fun StreamSelector(
                                     .border(1.dp, GlassBorder, RoundedCornerShape(16.dp))
                                     .padding(32.dp)
                             ) {
-                                val iconColor = if (!hasStreamingAddons) Color(0xFF3B82F6) else TextSecondary.copy(alpha = 0.5f)
-                                Box(
-                                    modifier = Modifier
-                                        .size(48.dp)
-                                        .background(iconColor.copy(alpha = 0.1f), CircleShape),
-                                    contentAlignment = Alignment.Center
-                                ) {
-                                    Icon(
-                                        imageVector = if (!hasStreamingAddons) Icons.Default.Settings else Icons.Default.Cloud,
-                                        contentDescription = null,
-                                        tint = iconColor,
-                                        modifier = Modifier.size(24.dp)
+                                if (stillSearching) {
+                                    LoadingIndicator(color = Pink, size = 40.dp)
+                                    Spacer(modifier = Modifier.height(12.dp))
+                                    Text(
+                                        text = if (totalAddons > 0) "Searching addons ($completedAddons/$totalAddons)..." else stringResource(R.string.finding_sources),
+                                        style = ArflixTypography.body.copy(
+                                            fontSize = 14.sp,
+                                            fontWeight = FontWeight.Medium
+                                        ),
+                                        color = TextSecondary
+                                    )
+                                } else {
+                                    val iconColor = if (!hasStreamingAddons) Color(0xFF3B82F6) else TextSecondary.copy(alpha = 0.5f)
+                                    Box(
+                                        modifier = Modifier
+                                            .size(48.dp)
+                                            .background(iconColor.copy(alpha = 0.1f), CircleShape),
+                                        contentAlignment = Alignment.Center
+                                    ) {
+                                        Icon(
+                                            imageVector = if (!hasStreamingAddons) Icons.Default.Settings else Icons.Default.Cloud,
+                                            contentDescription = null,
+                                            tint = iconColor,
+                                            modifier = Modifier.size(24.dp)
+                                        )
+                                    }
+                                    Spacer(modifier = Modifier.height(12.dp))
+                                    Text(
+                                        text = if (!hasStreamingAddons) "No Streaming Addons" else "No sources found",
+                                        style = ArflixTypography.body.copy(
+                                            fontSize = 14.sp,
+                                            fontWeight = FontWeight.Medium
+                                        ),
+                                        color = TextSecondary
+                                    )
+                                    Spacer(modifier = Modifier.height(4.dp))
+                                    Text(
+                                        text = if (!hasStreamingAddons)
+                                            "Go to Settings \u2192 Addons to add\na streaming addon"
+                                        else
+                                            "Try adding more addons",
+                                        style = ArflixTypography.caption.copy(fontSize = 12.sp),
+                                        color = TextSecondary.copy(alpha = 0.6f),
+                                        textAlign = androidx.compose.ui.text.style.TextAlign.Center
                                     )
                                 }
-                                Spacer(modifier = Modifier.height(12.dp))
-                                Text(
-                                    text = if (!hasStreamingAddons) "No Streaming Addons" else "No sources found",
-                                    style = ArflixTypography.body.copy(
-                                        fontSize = 14.sp,
-                                        fontWeight = FontWeight.Medium
-                                    ),
-                                    color = TextSecondary
-                                )
-                                Spacer(modifier = Modifier.height(4.dp))
-                                Text(
-                                    text = if (!hasStreamingAddons)
-                                        "Go to Settings \u2192 Addons to add\na streaming addon"
-                                    else
-                                        "Try adding more addons",
-                                    style = ArflixTypography.caption.copy(fontSize = 12.sp),
-                                    color = TextSecondary.copy(alpha = 0.6f),
-                                    textAlign = androidx.compose.ui.text.style.TextAlign.Center
-                                )
                             }
                         }
                     } else {
@@ -721,7 +719,8 @@ private data class SourcePresentation(
     val qualityColor: Color,
     val sizeBytes: Long,
     val sortCached: Boolean,
-    val sortDirect: Boolean
+    val sortDirect: Boolean,
+    val description: String? = null
 )
 
 
@@ -900,8 +899,28 @@ private fun presentSource(stream: StreamSource): SourcePresentation {
         qualityColor = qualityColor,
         sizeBytes = getSizeBytes(stream),
         sortCached = stream.behaviorHints?.cached == true,
-        sortDirect = !stream.url.isNullOrBlank() && stream.url.startsWith("http", true)
+        sortDirect = !stream.url.isNullOrBlank() && stream.url.startsWith("http", true),
+        description = cleanStreamDescription(stream.description, title)
     )
+}
+
+private fun cleanStreamDescription(raw: String?, title: String): String? {
+    if (raw.isNullOrBlank()) return null
+    val sizeLinePattern = Regex("""^[╰└].*\d+(\.\d+)?\s*(GB|MB|KB|TB).*$""", RegexOption.IGNORE_CASE)
+    val channelTagPattern = Regex("""^\[.+]$""")
+    val mdNoise = Regex("""[`*_]{1,4}""")
+    val cleaned = raw.lines()
+        .map { it.trim() }
+        .filter { line ->
+            line.isNotBlank() &&
+            line != "None" &&
+            !line.equals(title, ignoreCase = true) &&
+            !sizeLinePattern.matches(line) &&
+            !channelTagPattern.matches(line)
+        }
+        .joinToString("\n") { line -> line.replace(mdNoise, "").trim() }
+        .trim()
+    return cleaned.takeIf { it.isNotBlank() }
 }
 
 @Composable
@@ -996,6 +1015,16 @@ private fun MobileStreamCard(
 
             Spacer(modifier = Modifier.height(8.dp))
             SourceMetadataChips(presentation = presentation, compact = true)
+            if (!presentation.description.isNullOrBlank()) {
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = presentation.description,
+                    style = ArflixTypography.caption.copy(fontSize = 12.sp),
+                    color = TextSecondary.copy(alpha = 0.75f),
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
         }
 
         if (isSelected) {
@@ -1159,6 +1188,16 @@ private fun GlassyStreamCard(
 
                 Spacer(modifier = Modifier.height(8.dp))
                 SourceMetadataChips(presentation = presentation, compact = false)
+                if (!presentation.description.isNullOrBlank()) {
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Text(
+                        text = presentation.description,
+                        style = ArflixTypography.caption.copy(fontSize = 11.sp),
+                        color = TextSecondary.copy(alpha = 0.7f),
+                        maxLines = 3,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
             }
 
             if (isSelected) {

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
@@ -313,7 +313,7 @@ fun DetailsScreen(
         val singleStream = validStreams.singleOrNull()
 
         when {
-            singleStream != null && qualityScoreForAutoPlay(singleStream.quality) >= minThreshold -> {
+            singleStream != null && uiState.autoPlaySingleSource && qualityScoreForAutoPlay(singleStream.quality) >= minThreshold -> {
                 onNavigateToPlayer(
                     mediaType,
                     mediaId,
@@ -624,10 +624,15 @@ fun DetailsScreen(
                                 FocusSection.EPISODES -> {
                                     val ep = uiState.episodes.getOrNull(episodeIndex)
                                     if (ep != null) {
-                                        onNavigateToPlayer(
-                                            mediaType, mediaId,
-                                            ep.seasonNumber, ep.episodeNumber, uiState.imdbId, null, null, null, null
-                                        )
+                                        if (!uiState.autoPlaySingleSource) {
+                                            showStreamSelector = true
+                                            viewModel.loadStreams(uiState.imdbId, ep.seasonNumber, ep.episodeNumber)
+                                        } else {
+                                            onNavigateToPlayer(
+                                                mediaType, mediaId,
+                                                ep.seasonNumber, ep.episodeNumber, uiState.imdbId, null, null, null, null
+                                            )
+                                        }
                                     }
                                 }
                                 FocusSection.SEASONS -> {
@@ -800,7 +805,7 @@ fun DetailsScreen(
                         val ep = uiState.episodes.getOrNull(idx)
                         if (ep != null) {
                             episodeIndex = idx
-                            if (isMobile) {
+                            if (isMobile || !uiState.autoPlaySingleSource) {
                                 showStreamSelector = true
                                 viewModel.loadStreams(uiState.imdbId, ep.seasonNumber, ep.episodeNumber)
                             } else {
@@ -899,6 +904,8 @@ fun DetailsScreen(
             isLoading = uiState.isLoadingStreams,
             hasStreamingAddons = uiState.hasStreamingAddons,
             addonOrderedIds = uiState.addonOrderedIds,
+            completedAddons = uiState.completedAddons,
+            totalAddons = uiState.totalAddons,
             onFocusedStream = { stream ->
                 viewModel.prewarmStreamsAround(stream, uiState.streams)
             },

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
@@ -62,6 +62,8 @@ data class DetailsUiState(
     val streams: List<StreamSource> = emptyList(),
     val subtitles: List<Subtitle> = emptyList(),
     val isLoadingStreams: Boolean = false,
+    val completedAddons: Int = 0,
+    val totalAddons: Int = 0,
     val hasStreamingAddons: Boolean = true,
     val addonOrderedIds: List<String> = emptyList(),
     val isInWatchlist: Boolean = false,
@@ -1336,6 +1338,15 @@ class DetailsViewModel @Inject constructor(
         focusedStreamPrewarmJob?.cancel()
         streamListPrewarmJob?.cancel()
         homeServerAppendJob?.cancel()
+        // Reset synchronously so the modal opens in loading state immediately,
+        // before the coroutine below gets a chance to run.
+        _uiState.value = _uiState.value.copy(
+            isLoadingStreams = true,
+            completedAddons = 0,
+            totalAddons = 0,
+            streams = emptyList(),
+            subtitles = emptyList()
+        )
         val requestId = ++loadStreamsRequestId
         val requestMediaType = currentMediaType
         val requestMediaId = currentMediaId
@@ -1364,12 +1375,19 @@ class DetailsViewModel @Inject constructor(
                 }
             }
             val resolvedImdbId = currentImdbId
+            val effectiveStreamId: String? = when {
+                !resolvedImdbId.isNullOrBlank() -> resolvedImdbId
+                requestMediaId > 0 -> "tmdb:$requestMediaId"
+                else -> null
+            }
 
             val orderedAddonIds = streamRepository.installedAddons.first()
                 .filter { it.isEnabled && it.type != com.arflix.tv.data.model.AddonType.SUBTITLE }
                 .map { it.id }
             _uiState.value = _uiState.value.copy(
                 isLoadingStreams = true,
+                completedAddons = 0,
+                totalAddons = 0,
                 streams = emptyList(),
                 subtitles = emptyList(),
                 addonOrderedIds = orderedAddonIds
@@ -1438,7 +1456,7 @@ class DetailsViewModel @Inject constructor(
                         )
                     }
 
-                    if (resolvedImdbId.isNullOrBlank()) {
+                    if (effectiveStreamId.isNullOrBlank()) {
                         Log.w(
                             TAG,
                             "[MovieSources] loadStreams skipped (missing imdbId) requestId=$requestId mediaId=$requestMediaId"
@@ -1454,7 +1472,7 @@ class DetailsViewModel @Inject constructor(
                         return@launch
                     }
                     streamRepository.resolveMovieStreamsProgressive(
-                        imdbId = resolvedImdbId,
+                        imdbId = effectiveStreamId,
                         title = item?.title.orEmpty(),
                         year = item?.year?.toIntOrNull()
                     ).collect { progressive ->
@@ -1476,6 +1494,8 @@ class DetailsViewModel @Inject constructor(
                         _uiState.value = _uiState.value.copy(
                             isLoadingStreams = mergedStreams.isEmpty() &&
                                 (!progressive.isFinal || hasHomeServerConnections || supplementalSourcesStillLoading),
+                            completedAddons = progressive.completedAddons,
+                            totalAddons = progressive.totalAddons,
                             streams = mergedStreams,
                             subtitles = progressive.subtitles,
                             hasStreamingAddons = addonCount > 0 || hasHomeServerConnections
@@ -1490,7 +1510,7 @@ class DetailsViewModel @Inject constructor(
                     }
                     return@launch
                 } else {
-                    if (resolvedImdbId.isNullOrBlank()) {
+                    if (effectiveStreamId.isNullOrBlank()) {
                         _uiState.value = _uiState.value.copy(
                             isLoadingStreams = false,
                             streams = emptyList(),
@@ -1507,7 +1527,7 @@ class DetailsViewModel @Inject constructor(
                         ?.airDate?.takeIf { it.isNotBlank() }
 
                     streamRepository.resolveEpisodeStreamsProgressive(
-                        imdbId = resolvedImdbId,
+                        imdbId = effectiveStreamId,
                         season = season ?: 1,
                         episode = episode ?: 1,
                         tmdbId = currentMediaId,
@@ -1530,6 +1550,8 @@ class DetailsViewModel @Inject constructor(
                         _uiState.value = _uiState.value.copy(
                             isLoadingStreams = mergedStreams.isEmpty() &&
                                 (!progressive.isFinal || hasHomeServerConnections || supplementalSourcesStillLoading),
+                            completedAddons = progressive.completedAddons,
+                            totalAddons = progressive.totalAddons,
                             streams = mergedStreams,
                             subtitles = progressive.subtitles,
                             hasStreamingAddons = addonCount > 0 || hasHomeServerConnections

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
@@ -598,27 +598,31 @@ class PlayerViewModel @Inject constructor(
                     currentTvdbId = externalIds.tvdbId
                     imdbId = externalIds.imdbId
                 }
-                if (imdbId.isNullOrBlank()) {
-                    AppLogger.recordException(
-                        throwable = IllegalStateException("Playback IMDB ID missing"),
-                        context = playbackDiagnosticContext("missing_imdb_id")
-                    )
-                    _uiState.value = _uiState.value.copy(
-                        isLoading = false,
-                        isLoadingStreams = false,
-                        sourceSearchActive = false,
-                        error = "Unable to resolve IMDB ID. Try again."
-                    )
-                    return@launch
+                val effectiveStreamId: String = when {
+                    !imdbId.isNullOrBlank() -> imdbId
+                    mediaId > 0 -> "tmdb:$mediaId"
+                    else -> {
+                        AppLogger.recordException(
+                            throwable = IllegalStateException("Playback IMDB ID missing"),
+                            context = playbackDiagnosticContext("missing_imdb_id")
+                        )
+                        _uiState.value = _uiState.value.copy(
+                            isLoading = false,
+                            isLoadingStreams = false,
+                            sourceSearchActive = false,
+                            error = "Unable to resolve IMDB ID. Try again."
+                        )
+                        return@launch
+                    }
                 }
-                if (cachedImdbId.isNullOrBlank()) {
+                if (!imdbId.isNullOrBlank() && cachedImdbId.isNullOrBlank()) {
                     mediaRepository.cacheImdbId(mediaType, mediaId, imdbId)
                 }
                 currentImdbId = imdbId
                 // Never block source loading on title hydration from TMDB.
                 // Fetch skip intervals in background. This should never block playback.
                 launch {
-                    if (mediaType == MediaType.TV && seasonNumber != null && episodeNumber != null) {
+                    if (mediaType == MediaType.TV && seasonNumber != null && episodeNumber != null && !imdbId.isNullOrBlank()) {
                         fetchSkipIntervals(imdbId, seasonNumber, episodeNumber)
                     }
                 }
@@ -664,13 +668,13 @@ class PlayerViewModel @Inject constructor(
                 val preferredLanguage = _uiState.value.preferredAudioLanguage.ifBlank { resolvePreferredAudioLanguage() }
                 val progressiveFlow = if (mediaType == MediaType.MOVIE) {
                     streamRepository.resolveMovieStreamsProgressive(
-                        imdbId = imdbId,
+                        imdbId = effectiveStreamId,
                         title = currentItemTitle,
                         year = null
                     )
                 } else {
                     streamRepository.resolveEpisodeStreamsProgressive(
-                        imdbId = imdbId,
+                        imdbId = effectiveStreamId,
                         season = seasonNumber ?: 1,
                         episode = episodeNumber ?: 1,
                         tmdbId = mediaId,
@@ -871,7 +875,7 @@ class PlayerViewModel @Inject constructor(
                     val fetchedSubs = runCatching {
                         streamRepository.fetchSubtitlesForSelectedStream(
                             mediaType = mediaType,
-                            imdbId = imdbId,
+                            imdbId = effectiveStreamId,
                             season = seasonNumber,
                             episode = episodeNumber,
                             stream = null


### PR DESCRIPTION
 - dont auto start movie if its disable via settings
  - The selector was showing "No sources found" immediately, then sources would appear 3–4 seconds later (when a slow addon like Stremiogram responded)
  - Added completedAddons/totalAddons tracking in DetailsUiState, updated progressively as each addon responds
  - Shows "Searching addons (X/Y)..." spinner while addons are still fetching and no sources have appeared yet
  - Once any sources appear, the list shows immediately — loading state never blocks visible results
  - Fixed a race condition where the modal opened with isLoadingStreams = false for one frame (state reset is now synchronous before the coroutine launches)