### PR TITLE
fix: InputModal buttons not visible on TV for TV settings

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -118,6 +118,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import kotlinx.coroutines.launch
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalView
@@ -7925,11 +7926,8 @@ private fun InputModal(
     var lastFocusedFieldIndex by remember(title, fields.size) { mutableStateOf<Int?>(null) }
     val totalItems = fields.size + 3 // inputs + paste + cancel + confirm
     val isTouchDevice = LocalDeviceType.current.isTouchDevice()
-    val formMaxHeight = when {
-        fields.size >= 5 -> if (isTouchDevice) 360.dp else 390.dp
-        fields.size >= 4 -> if (isTouchDevice) 330.dp else 350.dp
-        else -> 290.dp
-    }
+    val screenHeightDp = LocalConfiguration.current.screenHeightDp.dp
+    val maxDialogHeight = (screenHeightDp * 0.88f).coerceAtMost(if (isTouchDevice) 620.dp else 660.dp)
 
     val clipboardManager = LocalClipboardManager.current
     val context = LocalContext.current
@@ -7993,13 +7991,16 @@ private fun InputModal(
 
     // Auto-scroll the form so the focused field stays in view when D-pad navigates.
     // Each field is ~86dp tall (label 22dp + spacer 6dp + edittext 48dp + spacing 12dp).
-    // Scroll proportionally so the active field sits roughly in the middle of the viewport.
+    // Scroll so the focused field stays in view. Distribute proportionally across the actual
+    // scroll range so the calculation works at any screen density and form height.
     LaunchedEffect(focusedIndex) {
         if (focusedIndex in 0 until fields.size) {
             lastFocusedFieldIndex = focusedIndex
-            val approxFieldHeightPx = 260 // rough pixels per field at typical density
-            val targetScroll = (focusedIndex * approxFieldHeightPx).coerceAtLeast(0)
-            runCatching { formScrollState.animateScrollTo(targetScroll) }
+            val maxScroll = formScrollState.maxValue
+            if (maxScroll > 0 && fields.size > 1) {
+                val targetScroll = (focusedIndex.toFloat() / (fields.size - 1) * maxScroll).toInt()
+                runCatching { formScrollState.animateScrollTo(targetScroll) }
+            }
         } else if (focusedIndex >= fields.size) {
             // Focused on paste/cancel/confirm — scroll form to end so it's not blocking
             runCatching { formScrollState.animateScrollTo(formScrollState.maxValue) }
@@ -8031,7 +8032,7 @@ private fun InputModal(
                     )
                     .navigationBarsPadding()
                     .imePadding()
-                    .heightIn(max = if (isTouchDevice) 620.dp else 660.dp)
+                    .heightIn(max = maxDialogHeight)
                     .background(BackgroundElevated, RoundedCornerShape(14.dp))
                     .border(1.dp, Color.White.copy(alpha = 0.12f), RoundedCornerShape(14.dp))
                     .padding(horizontal = if (isTouchDevice) 16.dp else 20.dp, vertical = 18.dp)
@@ -8128,7 +8129,7 @@ private fun InputModal(
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .heightIn(max = formMaxHeight)
+                        .weight(1f, fill = false)
                         .verticalScroll(formScrollState)
                 ) {
                     fields.forEachIndexed { index, field ->
@@ -8343,7 +8344,9 @@ private fun InputModal(
                     Text(
                         text = "Paste into $pasteTargetLabel",
                         style = ArflixTypography.button,
-                        color = if (isPasteFocused) Color.Black else Color.White
+                        color = if (isPasteFocused) Color.Black else Color.White,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
                     )
                 }
 


### PR DESCRIPTION
## Summary

- **Add/Confirm button not visible**: On TV devices with smaller screen densities, the settings input dialog (IPTV username/password/EPG popup) would overflow the screen, pushing the Add/Confirm button off the bottom. Fixed by replacing hardcoded `formMaxHeight` tiers and `heightIn(max=660dp)` with a screen-aware cap (`screenHeight × 0.88`, capped at 660dp), and changing the scrollable form to `weight(1f, fill=false)` so the header and action buttons are always measured and pinned as visible.
- **Field scroll overshoot**: The D-pad auto-scroll used a hardcoded `approxFieldHeightPx = 260` that was uncalibrated for different screen densities, causing fields 2 and 3 to scroll out of view. Replaced with a proportional distribution across `formScrollState.maxValue` — density-independent and adapts to the actual form height.
- **Paste button text clipped**: Added `maxLines = 1` + `TextOverflow.Ellipsis` to the paste button label so long field names truncate gracefully instead of being sharply cut off.

## Test plan

- [x] Open Settings → Add TV Playlist (5-field IPTV form) on a TV device and verify the Add/Confirm button is visible without scrolling the outer dialog
- [x] D-pad navigate through all 5 fields and verify each field stays in view
- [x] Open Settings → Home Server (4-field form) and repeat
- [x] Check paste button label truncates with `…` on a narrow screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)