### PR TITLE
fix: respect device screen timeout; keep screen on only during playback

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/MainActivity.kt
+++ b/app/src/main/kotlin/com/arflix/tv/MainActivity.kt
@@ -212,9 +212,6 @@ class MainActivity : ComponentActivity() {
             DeviceType.PHONE -> ActivityInfo.SCREEN_ORIENTATION_FULL_USER
         }
 
-        // Keep screen on during playback
-        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-
         // All devices use edge-to-edge (setDecorFitsSystemWindows=false).
         // TV hides the bars; mobile keeps them visible and Compose handles
         // insets via systemBarsPadding() in the root layout.

--- a/app/src/main/kotlin/com/arflix/tv/ui/components/KeepScreenOn.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/KeepScreenOn.kt
@@ -1,0 +1,30 @@
+package com.arflix.tv.ui.components
+
+import android.app.Activity
+import android.content.ContextWrapper
+import android.view.WindowManager
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.platform.LocalContext
+
+/**
+ * Keeps the screen on while this composable is in the composition and [active] is true.
+ * Releases the flag when [active] becomes false or the composable leaves composition.
+ *
+ * Use in any screen where media is playing (player, live TV, trailer).
+ */
+@Composable
+fun KeepScreenOn(active: Boolean = true) {
+    val context = LocalContext.current
+    DisposableEffect(active) {
+        if (!active) return@DisposableEffect onDispose {}
+        val window = generateSequence(context) { (it as? ContextWrapper)?.baseContext }
+            .filterIsInstance<Activity>()
+            .firstOrNull()
+            ?.window
+        window?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        onDispose {
+            window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
@@ -133,6 +133,7 @@ import com.arflix.tv.data.model.MediaType
 import com.arflix.tv.data.model.Review
 import com.arflix.tv.network.OkHttpProvider
 import com.arflix.tv.ui.components.EpisodeContextMenu
+import com.arflix.tv.ui.components.KeepScreenOn
 import com.arflix.tv.ui.components.SeasonContextMenu
 import com.arflix.tv.ui.components.LoadingIndicator
 import com.arflix.tv.ui.components.AppTopBar
@@ -228,6 +229,7 @@ fun DetailsScreen(
     // Stream Selector state
     var showStreamSelector by remember { mutableStateOf(false) }
     var showTrailerPlayer by remember { mutableStateOf(false) }
+    KeepScreenOn(active = showTrailerPlayer)
     var pendingAutoPlayRequest by remember { mutableStateOf<PendingAutoPlayRequest?>(null) }
     
     // Episode Context Menu state

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -137,6 +137,7 @@ import com.arflix.tv.network.OkHttpProvider
 import com.arflix.tv.data.model.MediaType
 import com.arflix.tv.data.model.StreamSource
 import com.arflix.tv.data.model.Subtitle
+import com.arflix.tv.ui.components.KeepScreenOn
 import com.arflix.tv.ui.components.LoadingIndicator
 import com.arflix.tv.ui.components.Toast
 import com.arflix.tv.ui.components.ToastType
@@ -302,6 +303,7 @@ fun PlayerScreen(
         onDispose { }
     }
 
+    KeepScreenOn()
     var isPlaying by remember { mutableStateOf(false) }
     var isBuffering by remember { mutableStateOf(true) }
     var hasPlaybackStarted by remember { mutableStateOf(false) }  // Track if playback has actually started

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/TvScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/TvScreen.kt
@@ -119,6 +119,7 @@ import com.arflix.tv.data.model.IptvNowNext
 import com.arflix.tv.data.model.IptvProgram
 import com.arflix.tv.network.OkHttpProvider
 import com.arflix.tv.ui.components.AppTopBar
+import com.arflix.tv.ui.components.KeepScreenOn
 import com.arflix.tv.ui.components.AppTopBarContentTopInset
 import com.arflix.tv.util.LocalDeviceType
 import com.arflix.tv.ui.components.SidebarItem
@@ -240,6 +241,7 @@ fun TvScreen(
     var channelIndex by rememberSaveable { mutableIntStateOf(0) }
     var selectedChannelId by rememberSaveable { mutableStateOf<String?>(null) }
     var playingChannelId by rememberSaveable { mutableStateOf<String?>(null) }
+    KeepScreenOn(active = playingChannelId != null)
     var showGroupContextMenu by remember { mutableStateOf(false) }
     // When launched from Home with a stream URL, start in fullscreen immediately
     // to avoid a flash of the TV page channel list.

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvScreen.kt
@@ -82,6 +82,7 @@ import com.arflix.tv.ui.screens.tv.TvUiState
 import com.arflix.tv.ui.screens.tv.TvViewModel
 import com.arflix.tv.network.OkHttpProvider
 import com.arflix.tv.ui.components.AppTopBar
+import com.arflix.tv.ui.components.KeepScreenOn
 import com.arflix.tv.ui.components.AppTopBarHeight
 import com.arflix.tv.ui.components.SidebarItem
 import com.arflix.tv.ui.components.topBarFocusedItem
@@ -519,6 +520,7 @@ fun LiveTvScreen(
     // channel of the first non-empty category.
     val rememberedChannelByCategory = remember { mutableMapOf<String, String>() }
     var playingChannelId by rememberSaveable { mutableStateOf<String?>(initialChannelId) }
+    KeepScreenOn(active = playingChannelId != null)
     var focusedChannelId by rememberSaveable { mutableStateOf<String?>(initialChannelId) }
     var epgPrefetchAnchorId by rememberSaveable { mutableStateOf<String?>(initialChannelId) }
     var startupChannelApplied by rememberSaveable(selectedProviderId) { mutableStateOf(false) }


### PR DESCRIPTION
## Summary

- `MainActivity` was calling `window.addFlags(FLAG_KEEP_SCREEN_ON)` unconditionally at app launch and never clearing it, so the device screen timeout was completely ignored app-wide
- Introduced a `KeepScreenOn(active: Boolean)` composable that uses `DisposableEffect` to add/clear the window flag reactively
- Applied it to every playback surface so the screen stays on exactly when something is playing and not otherwise

## Affected screens

| Screen | Condition |
|---|---|
| `PlayerScreen` | Always (screen is a full video player) |
| `TvScreen` | `playingChannelId != null` |
| `LiveTvScreen` | `playingChannelId != null` |
| `DetailsScreen` | `showTrailerPlayer == true` |

PiP is also covered — `PlayerScreen` stays in composition during PiP, so the flag remains set while video plays in the PiP window.

## Test plan

- [ ] Open the app and leave it idle on Home/Search/Details — screen should time out per device setting
- [ ] Start playback in `PlayerScreen` — screen should stay on indefinitely
- [ ] Enter/exit PiP — screen should stay on while PiP video is playing
- [ ] Open a live TV channel in `TvScreen` / `LiveTvScreen` — screen stays on; navigating away releases the flag
- [ ] Open a trailer on a Details screen — screen stays on while trailer is open, times out after closing it

🤖 Generated with [Claude Code](https://claude.com/claude-code)