### PR TITLE
feat: cloud sync reliability & conflict resolution audit

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncRepository.kt
@@ -158,10 +158,11 @@ class CloudSyncRepository @Inject constructor(
         return isPushDirty || latestLocalDirtyAt > 0L || storedDirtyAt > 0L
     }
 
-    private suspend fun markCloudPayloadApplied(payload: String) {
+    private suspend fun markCloudPayloadApplied(payload: String, payloadHash: Int) {
         val cloudUpdatedAt = runCatching { JSONObject(payload).optLong("updatedAt", 0L) }.getOrDefault(0L)
         context.settingsDataStore.edit { prefs ->
             prefs[cloudSyncLastAppliedAtKey] = cloudUpdatedAt.takeIf { it > 0L } ?: System.currentTimeMillis()
+            prefs[androidx.datastore.preferences.core.intPreferencesKey("cloud_sync_last_applied_hash")] = payloadHash
         }
     }
 
@@ -648,11 +649,24 @@ class CloudSyncRepository @Inject constructor(
             return@withLock RestoreResult.NO_BACKUP
         }
 
+        val prefs = context.settingsDataStore.data.first()
+        val lastAppliedHash = prefs[androidx.datastore.preferences.core.intPreferencesKey("cloud_sync_last_applied_hash")]
+        val payloadHash = payload.hashCode()
+
+        if (lastAppliedHash == payloadHash) {
+            AppLogger.breadcrumb(
+                tag = "CloudSync",
+                message = "pull_skipped_identical_payload",
+                severity = "info"
+            )
+            return@withLock RestoreResult.RESTORED
+        }
+
         runCatching {
             invalidationBus.suppressDuringRemoteApply {
                 applyCloudPayload(payload)
             }
-            markCloudPayloadApplied(payload)
+            markCloudPayloadApplied(payload, payloadHash)
         }.fold(
             onSuccess = {
                 AppLogger.breadcrumb(
@@ -941,207 +955,222 @@ class CloudSyncRepository @Inject constructor(
         authRepository.saveAutoPlayNextToProfile(fallbackAutoPlayNext)
 
         // ── Trakt tokens ──
-        root.optJSONObject("traktTokens")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
-            val type = TypeToken.getParameterized(Map::class.java, String::class.java, TraktRepository.CloudTraktToken::class.java).type
-            val tokens: Map<String, TraktRepository.CloudTraktToken> = gson.fromJson(json, type) ?: emptyMap()
-            traktRepository.importTokensForProfiles(tokens)
-        }
+        runCatching {
+            root.optJSONObject("traktTokens")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
+                val type = TypeToken.getParameterized(Map::class.java, String::class.java, TraktRepository.CloudTraktToken::class.java).type
+                val tokens: Map<String, TraktRepository.CloudTraktToken> = gson.fromJson(json, type) ?: emptyMap()
+                traktRepository.importTokensForProfiles(tokens)
+            }
+        }.onFailure { AppLogger.recordException(it, mapOf("error_area" to "CloudSync", "cloud_flow" to "apply_trakt_tokens")) }
 
         // ── Addons ──
-        root.optJSONObject("addonsByProfile")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
-            val type = TypeToken.getParameterized(Map::class.java, String::class.java, TypeToken.getParameterized(List::class.java, Addon::class.java).type).type
-            val map: Map<String, List<Addon>> = gson.fromJson(json, type) ?: emptyMap()
-            val sharedAddons = mergeAddonsForSharedRestore(map.values)
-            if (sharedAddons.isNotEmpty()) {
-                streamRepository.replaceSharedAddonsFromCloud(sharedAddons)
-            }
-        }
-        root.optJSONArray("addons")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
-            if (!root.has("addonsByProfile")) {
-                val type = TypeToken.getParameterized(List::class.java, Addon::class.java).type
-                val addons: List<Addon> = gson.fromJson(json, type) ?: emptyList()
-                if (addons.isNotEmpty()) {
-                    streamRepository.replaceSharedAddonsFromCloud(addons)
+        runCatching {
+            root.optJSONObject("addonsByProfile")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
+                val type = TypeToken.getParameterized(Map::class.java, String::class.java, TypeToken.getParameterized(List::class.java, Addon::class.java).type).type
+                val map: Map<String, List<Addon>> = gson.fromJson(json, type) ?: emptyMap()
+                val sharedAddons = mergeAddonsForSharedRestore(map.values)
+                if (sharedAddons.isNotEmpty()) {
+                    streamRepository.replaceSharedAddonsFromCloud(sharedAddons)
                 }
             }
-        }
+            root.optJSONArray("addons")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
+                if (!root.has("addonsByProfile")) {
+                    val type = TypeToken.getParameterized(List::class.java, Addon::class.java).type
+                    val addons: List<Addon> = gson.fromJson(json, type) ?: emptyList()
+                    if (addons.isNotEmpty()) {
+                        streamRepository.replaceSharedAddonsFromCloud(addons)
+                    }
+                }
+            }
+        }.onFailure { AppLogger.recordException(it, mapOf("error_area" to "CloudSync", "cloud_flow" to "apply_addons")) }
 
         // ── Catalogs ──
-        root.optJSONObject("catalogsByProfile")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
-            val type = TypeToken.getParameterized(Map::class.java, String::class.java, TypeToken.getParameterized(List::class.java, CatalogConfig::class.java).type).type
-            val map: Map<String, List<CatalogConfig>> = gson.fromJson(json, type) ?: emptyMap()
-            map.forEach { (profileId, catalogs) ->
-                catalogRepository.replaceCatalogsForProfile(profileId, catalogs)
-            }
-        }
-        root.optJSONArray("catalogs")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
-            if (!root.has("catalogsByProfile")) {
-                val type = TypeToken.getParameterized(List::class.java, CatalogConfig::class.java).type
-                val catalogs: List<CatalogConfig> = gson.fromJson(json, type) ?: emptyList()
-                if (catalogs.isNotEmpty()) {
-                    catalogRepository.replaceCatalogsForProfile(activeProfileId, catalogs)
+        runCatching {
+            root.optJSONObject("catalogsByProfile")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
+                val type = TypeToken.getParameterized(Map::class.java, String::class.java, TypeToken.getParameterized(List::class.java, CatalogConfig::class.java).type).type
+                val map: Map<String, List<CatalogConfig>> = gson.fromJson(json, type) ?: emptyMap()
+                map.forEach { (profileId, catalogs) ->
+                    catalogRepository.replaceCatalogsForProfile(profileId, catalogs)
                 }
             }
-        }
+            root.optJSONArray("catalogs")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
+                if (!root.has("catalogsByProfile")) {
+                    val type = TypeToken.getParameterized(List::class.java, CatalogConfig::class.java).type
+                    val catalogs: List<CatalogConfig> = gson.fromJson(json, type) ?: emptyList()
+                    if (catalogs.isNotEmpty()) {
+                        catalogRepository.replaceCatalogsForProfile(activeProfileId, catalogs)
+                    }
+                }
+            }
+        }.onFailure { AppLogger.recordException(it, mapOf("error_area" to "CloudSync", "cloud_flow" to "apply_catalogs")) }
 
         // ── Hidden preinstalled catalogs ──
-        root.optJSONObject("hiddenPreinstalledByProfile")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
-            val type = TypeToken.getParameterized(Map::class.java, String::class.java, TypeToken.getParameterized(List::class.java, String::class.java).type).type
-            val map: Map<String, List<String>> = gson.fromJson(json, type) ?: emptyMap()
-            map.forEach { (profileId, hidden) ->
-                catalogRepository.setHiddenPreinstalledCatalogIdsForProfile(profileId, hidden)
-            }
-        }
-        root.optJSONArray("hiddenPreinstalledCatalogs")?.toString()?.let { json ->
-            if (!root.has("hiddenPreinstalledByProfile")) {
-                val hidden = if (json.isBlank()) {
-                    emptyList()
-                } else {
-                    val type = TypeToken.getParameterized(List::class.java, String::class.java).type
-                    gson.fromJson<List<String>>(json, type) ?: emptyList()
+        runCatching {
+            root.optJSONObject("hiddenPreinstalledByProfile")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
+                val type = TypeToken.getParameterized(Map::class.java, String::class.java, TypeToken.getParameterized(List::class.java, String::class.java).type).type
+                val map: Map<String, List<String>> = gson.fromJson(json, type) ?: emptyMap()
+                map.forEach { (profileId, hidden) ->
+                    catalogRepository.setHiddenPreinstalledCatalogIdsForProfile(profileId, hidden)
                 }
-                catalogRepository.setHiddenPreinstalledCatalogIdsForProfile(activeProfileId, hidden)
             }
-        }
+            root.optJSONArray("hiddenPreinstalledCatalogs")?.toString()?.let { json ->
+                if (!root.has("hiddenPreinstalledByProfile")) {
+                    val hidden = if (json.isBlank()) {
+                        emptyList()
+                    } else {
+                        val type = TypeToken.getParameterized(List::class.java, String::class.java).type
+                        gson.fromJson<List<String>>(json, type) ?: emptyList()
+                    }
+                    catalogRepository.setHiddenPreinstalledCatalogIdsForProfile(activeProfileId, hidden)
+                }
+            }
+        }.onFailure { AppLogger.recordException(it, mapOf("error_area" to "CloudSync", "cloud_flow" to "apply_hidden_preinstalled")) }
 
         // ── Hidden addon catalogs ──
-        root.optJSONObject("hiddenAddonByProfile")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
-            val type = TypeToken.getParameterized(Map::class.java, String::class.java, TypeToken.getParameterized(List::class.java, String::class.java).type).type
-            val map: Map<String, List<String>> = gson.fromJson(json, type) ?: emptyMap()
-            map.forEach { (profileId, hidden) ->
-                catalogRepository.setHiddenAddonCatalogIdsForProfile(profileId, hidden)
+        runCatching {
+            root.optJSONObject("hiddenAddonByProfile")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
+                val type = TypeToken.getParameterized(Map::class.java, String::class.java, TypeToken.getParameterized(List::class.java, String::class.java).type).type
+                val map: Map<String, List<String>> = gson.fromJson(json, type) ?: emptyMap()
+                map.forEach { (profileId, hidden) ->
+                    catalogRepository.setHiddenAddonCatalogIdsForProfile(profileId, hidden)
+                }
             }
-        }
+        }.onFailure { AppLogger.recordException(it, mapOf("error_area" to "CloudSync", "cloud_flow" to "apply_hidden_addons")) }
+
+        // ── Hidden Home Server catalogs ──
+        runCatching {
+            root.optJSONObject("hiddenHomeServerByProfile")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
+                val type = TypeToken.getParameterized(Map::class.java, String::class.java, TypeToken.getParameterized(List::class.java, String::class.java).type).type
+                val map: Map<String, List<String>> = gson.fromJson(json, type) ?: emptyMap()
+                map.forEach { (profileId, hidden) ->
+                    catalogRepository.setHiddenHomeServerCatalogIdsForProfile(profileId, hidden)
+                }
+            }
+        }.onFailure { AppLogger.recordException(it, mapOf("error_area" to "CloudSync", "cloud_flow" to "apply_hidden_home_server")) }
 
         // ── IPTV config + favorites ──
-        root.optJSONObject("hiddenHomeServerByProfile")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
-            val type = TypeToken.getParameterized(Map::class.java, String::class.java, TypeToken.getParameterized(List::class.java, String::class.java).type).type
-            val map: Map<String, List<String>> = gson.fromJson(json, type) ?: emptyMap()
-            map.forEach { (profileId, hidden) ->
-                catalogRepository.setHiddenHomeServerCatalogIdsForProfile(profileId, hidden)
-            }
-        }
-
-        var importedActiveProfileIptv = false
-        root.optJSONObject("iptvByProfile")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
-            val type = TypeToken.getParameterized(Map::class.java, String::class.java, IptvCloudProfileState::class.java).type
-            val map: Map<String, IptvCloudProfileState> = gson.fromJson(json, type) ?: emptyMap()
-            map.forEach { (profileId, state) ->
-                iptvRepository.importCloudConfigForProfile(profileId, state)
-                if (profileId == activeProfileId) {
-                    importedActiveProfileIptv = true
+        runCatching {
+            var importedActiveProfileIptv = false
+            root.optJSONObject("iptvByProfile")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
+                val type = TypeToken.getParameterized(Map::class.java, String::class.java, IptvCloudProfileState::class.java).type
+                val map: Map<String, IptvCloudProfileState> = gson.fromJson(json, type) ?: emptyMap()
+                map.forEach { (profileId, state) ->
+                    iptvRepository.importCloudConfigForProfile(profileId, state)
+                    if (profileId == activeProfileId) {
+                        importedActiveProfileIptv = true
+                    }
                 }
             }
-        }
 
-        // Legacy IPTV flat fields (only used if iptvByProfile is absent)
-        val cloudHasIptvKeys = root.has("iptvM3uUrl") || root.has("iptvEpgUrl") ||
-            root.has("iptvFavoriteGroups") || root.has("iptvFavoriteChannels")
-        val m3u = root.optString("iptvM3uUrl")
-        val epg = root.optString("iptvEpgUrl")
-        val favorites = root.optJSONArray("iptvFavoriteGroups")?.toString().orEmpty().let { j ->
-            if (j.isBlank()) emptyList() else {
-                val type = TypeToken.getParameterized(List::class.java, String::class.java).type
-                gson.fromJson<List<String>>(j, type) ?: emptyList()
+            // Legacy IPTV flat fields (only used if iptvByProfile is absent)
+            val cloudHasIptvKeys = root.has("iptvM3uUrl") || root.has("iptvEpgUrl") ||
+                root.has("iptvFavoriteGroups") || root.has("iptvFavoriteChannels")
+            val m3u = root.optString("iptvM3uUrl")
+            val epg = root.optString("iptvEpgUrl")
+            val favorites = root.optJSONArray("iptvFavoriteGroups")?.toString().orEmpty().let { j ->
+                if (j.isBlank()) emptyList() else {
+                    val type = TypeToken.getParameterized(List::class.java, String::class.java).type
+                    gson.fromJson<List<String>>(j, type) ?: emptyList()
+                }
             }
-        }
-        val favoriteChannels = root.optJSONArray("iptvFavoriteChannels")?.toString().orEmpty().let { j ->
-            if (j.isBlank()) emptyList() else {
-                val type = TypeToken.getParameterized(List::class.java, String::class.java).type
-                gson.fromJson<List<String>>(j, type) ?: emptyList()
+            val favoriteChannels = root.optJSONArray("iptvFavoriteChannels")?.toString().orEmpty().let { j ->
+                if (j.isBlank()) emptyList() else {
+                    val type = TypeToken.getParameterized(List::class.java, String::class.java).type
+                    gson.fromJson<List<String>>(j, type) ?: emptyList()
+                }
             }
-        }
-        val localIptv = iptvRepository.observeConfig().first()
-        val cloudHasIptvData = m3u.isNotBlank() || epg.isNotBlank() || favorites.isNotEmpty() || favoriteChannels.isNotEmpty()
-        val localHasIptvData = localIptv.m3uUrl.isNotBlank() || localIptv.epgUrl.isNotBlank()
-        var importedLegacyIptv = false
-        if (!root.has("iptvByProfile") && cloudHasIptvKeys && (cloudHasIptvData || !localHasIptvData)) {
-            iptvRepository.importCloudConfig(m3u, epg, favorites, favoriteChannels)
-            importedLegacyIptv = true
-        }
+            val localIptv = iptvRepository.observeConfig().first()
+            val cloudHasIptvData = m3u.isNotBlank() || epg.isNotBlank() || favorites.isNotEmpty() || favoriteChannels.isNotEmpty()
+            val localHasIptvData = localIptv.m3uUrl.isNotBlank() || localIptv.epgUrl.isNotBlank()
+            var importedLegacyIptv = false
+            if (!root.has("iptvByProfile") && cloudHasIptvKeys && (cloudHasIptvData || !localHasIptvData)) {
+                iptvRepository.importCloudConfig(m3u, epg, favorites, favoriteChannels)
+                importedLegacyIptv = true
+            }
 
-        if (importedActiveProfileIptv || importedLegacyIptv) {
-            runCatching {
-                iptvRepository.invalidateCache()
+            if (importedActiveProfileIptv || importedLegacyIptv) {
+                runCatching {
+                    iptvRepository.invalidateCache()
+                }
             }
-        }
+        }.onFailure { AppLogger.recordException(it, mapOf("error_area" to "CloudSync", "cloud_flow" to "apply_iptv")) }
 
         // ── Watchlist ──
-        root.optJSONObject("watchlistByProfile")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
-            val type = TypeToken.getParameterized(Map::class.java, String::class.java, TypeToken.getParameterized(List::class.java, LocalWatchlistItem::class.java).type).type
-            val map: Map<String, List<LocalWatchlistItem>> = gson.fromJson(json, type) ?: emptyMap()
-            map.forEach { (profileId, items) ->
-                // Restore the cloud mirror for every profile, including Trakt profiles.
-                // Trakt remains the source of truth after a successful live sync, but
-                // skipping this cache made fresh installs show an empty watchlist while
-                // auth/network refresh was still settling or failed.
-                watchlistRepository.importWatchlistForProfile(profileId, items)
+        runCatching {
+            root.optJSONObject("watchlistByProfile")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
+                val type = TypeToken.getParameterized(Map::class.java, String::class.java, TypeToken.getParameterized(List::class.java, LocalWatchlistItem::class.java).type).type
+                val map: Map<String, List<LocalWatchlistItem>> = gson.fromJson(json, type) ?: emptyMap()
+                map.forEach { (profileId, items) ->
+                    // Restore the cloud mirror for every profile, including Trakt profiles.
+                    // Trakt remains the source of truth after a successful live sync, but
+                    // skipping this cache made fresh installs show an empty watchlist while
+                    // auth/network refresh was still settling or failed.
+                    watchlistRepository.importWatchlistForProfile(profileId, items)
+                }
             }
-        }
+        }.onFailure { AppLogger.recordException(it, mapOf("error_area" to "CloudSync", "cloud_flow" to "apply_watchlist")) }
 
         // ── Dismissed Continue Watching ──
-        root.optJSONObject("dismissedContinueWatchingByProfile")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
-            val type = TypeToken.getParameterized(Map::class.java, String::class.java, String::class.java).type
-            val map: Map<String, String> = gson.fromJson(json, type) ?: emptyMap()
-            traktRepository.importDismissedContinueWatchingForProfiles(map)
-        }
+        runCatching {
+            root.optJSONObject("dismissedContinueWatchingByProfile")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
+                val type = TypeToken.getParameterized(Map::class.java, String::class.java, String::class.java).type
+                val map: Map<String, String> = gson.fromJson(json, type) ?: emptyMap()
+                traktRepository.importDismissedContinueWatchingForProfiles(map)
+            }
+        }.onFailure { AppLogger.recordException(it, mapOf("error_area" to "CloudSync", "cloud_flow" to "apply_dismissed_cw")) }
 
-        // Only import local CW for profiles that DON'T have Trakt connected.
-        // For Trakt profiles, CW is sourced exclusively from Trakt's progress API.
-        // The previous code imported local CW unconditionally, which meant every
-        // show ever partially watched in ARVIO (written to cloud by
-        // saveLocalContinueWatching during playback) got restored to local DataStore
-        // on cloud pull — polluting the CW row with non-Trakt items that persisted
-        // even after app reinstall.
-        // Only import local CW for profiles that DON'T have Trakt connected.
-        // For Trakt profiles, CW is sourced exclusively from Trakt's progress API.
-        // Only import local CW for profiles that DON'T have Trakt connected.
-        // For Trakt profiles, CW is sourced exclusively from Trakt's progress API.
-        root.optJSONObject("localContinueWatchingByProfile")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
-            val type = TypeToken.getParameterized(Map::class.java, String::class.java, TypeToken.getParameterized(List::class.java, ContinueWatchingItem::class.java).type).type
-            val map: Map<String, List<ContinueWatchingItem>> = gson.fromJson(json, type) ?: emptyMap()
-            val traktProfiles = mutableSetOf<String>()
+        // ── Local Continue Watching ──
+        runCatching {
+            // Only import local CW for profiles that DON'T have Trakt connected.
+            // For Trakt profiles, CW is sourced exclusively from Trakt's progress API.
+            root.optJSONObject("localContinueWatchingByProfile")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
+                val type = TypeToken.getParameterized(Map::class.java, String::class.java, TypeToken.getParameterized(List::class.java, ContinueWatchingItem::class.java).type).type
+                val map: Map<String, List<ContinueWatchingItem>> = gson.fromJson(json, type) ?: emptyMap()
+                val traktProfiles = mutableSetOf<String>()
 
-            val traktTokenType = TypeToken.getParameterized(Map::class.java, String::class.java, TraktRepository.CloudTraktToken::class.java).type
-            val traktTokens = root.optJSONObject("traktTokens")
-                ?.toString()
-                ?.takeIf { it.isNotBlank() }
-                ?.let { tokenJson ->
-                    runCatching {
-                        gson.fromJson<Map<String, TraktRepository.CloudTraktToken>>(tokenJson, traktTokenType)
-                    }.getOrNull()
+                val traktTokenType = TypeToken.getParameterized(Map::class.java, String::class.java, TraktRepository.CloudTraktToken::class.java).type
+                val traktTokens = root.optJSONObject("traktTokens")
+                    ?.toString()
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { tokenJson ->
+                        runCatching {
+                            gson.fromJson<Map<String, TraktRepository.CloudTraktToken>>(tokenJson, traktTokenType)
+                        }.getOrNull()
+                    }
+                    .orEmpty()
+
+                traktTokens.forEach { (profileId, token) ->
+                    if (profileId.isNotBlank() && token.accessToken.isNotBlank()) {
+                        traktProfiles.add(profileId)
+                    }
                 }
-                .orEmpty()
 
-            traktTokens.forEach { (profileId, token) ->
-                if (profileId.isNotBlank() && token.accessToken.isNotBlank()) {
-                    traktProfiles.add(profileId)
+                val isActiveProfileTrakt = runCatching { traktRepository.hasTrakt() }.getOrDefault(false)
+                val activeProfileIdLocal = profileManager.getProfileIdSync().ifBlank { null }
+                if (isActiveProfileTrakt && activeProfileIdLocal != null) {
+                    traktProfiles.add(activeProfileIdLocal)
+                }
+
+                val nonTraktOnly = map.filterKeys { it !in traktProfiles }
+                if (nonTraktOnly.isNotEmpty()) {
+                    traktRepository.importLocalContinueWatchingForProfiles(nonTraktOnly)
                 }
             }
+        }.onFailure { AppLogger.recordException(it, mapOf("error_area" to "CloudSync", "cloud_flow" to "apply_local_cw")) }
 
-            val isActiveProfileTrakt = runCatching { traktRepository.hasTrakt() }.getOrDefault(false)
-            val activeProfileId = profileManager.getProfileIdSync().ifBlank { null }
-            if (isActiveProfileTrakt && activeProfileId != null) {
-                traktProfiles.add(activeProfileId)
+        runCatching {
+            root.optJSONObject("localWatchedMoviesByProfile")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
+                val type = TypeToken.getParameterized(Map::class.java, String::class.java, TypeToken.getParameterized(List::class.java, Int::class.javaObjectType).type).type
+                val map: Map<String, List<Int>> = gson.fromJson(json, type) ?: emptyMap()
+                traktRepository.importLocalWatchedMoviesForProfiles(map)
             }
 
-            val nonTraktOnly = map.filterKeys { it !in traktProfiles }
-            if (nonTraktOnly.isNotEmpty()) {
-                traktRepository.importLocalContinueWatchingForProfiles(nonTraktOnly)
+            root.optJSONObject("localWatchedEpisodesByProfile")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
+                val type = TypeToken.getParameterized(Map::class.java, String::class.java, TypeToken.getParameterized(List::class.java, String::class.java).type).type
+                val map: Map<String, List<String>> = gson.fromJson(json, type) ?: emptyMap()
+                traktRepository.importLocalWatchedEpisodesForProfiles(map)
             }
-        }
-
-        root.optJSONObject("localWatchedMoviesByProfile")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
-            val type = TypeToken.getParameterized(Map::class.java, String::class.java, TypeToken.getParameterized(List::class.java, Int::class.javaObjectType).type).type
-            val map: Map<String, List<Int>> = gson.fromJson(json, type) ?: emptyMap()
-            traktRepository.importLocalWatchedMoviesForProfiles(map)
-        }
-
-        root.optJSONObject("localWatchedEpisodesByProfile")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
-            val type = TypeToken.getParameterized(Map::class.java, String::class.java, TypeToken.getParameterized(List::class.java, String::class.java).type).type
-            val map: Map<String, List<String>> = gson.fromJson(json, type) ?: emptyMap()
-            traktRepository.importLocalWatchedEpisodesForProfiles(map)
-        }
+        }.onFailure { AppLogger.recordException(it, mapOf("error_area" to "CloudSync", "cloud_flow" to "apply_local_watched")) }
 
         traktRepository.clearAllProfileCaches()
         watchHistoryRepository.clearProfileCaches()

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/WatchHistoryRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/WatchHistoryRepository.kt
@@ -125,9 +125,25 @@ class WatchHistoryRepository @Inject constructor(
         position: Long,
         streamKey: String? = null,
         streamAddonId: String? = null,
-        streamTitle: String? = null
+        streamTitle: String? = null,
+        sessionStartTime: Long = 0L
     ) {
         val userId = authRepositoryProvider.get().getCurrentUserId() ?: return
+
+        if (sessionStartTime > 0L) {
+            val existingProgress = getProgress(mediaType, tmdbId, season, episode)
+            if (existingProgress != null) {
+                val cloudUpdatedAt = parseEpoch(existingProgress.updated_at)
+                if (cloudUpdatedAt > sessionStartTime + 10_000L) {
+                    com.arflix.tv.util.AppLogger.breadcrumb(
+                        tag = "WatchHistory",
+                        message = "Rejected stale push for $tmdbId. Cloud updated $cloudUpdatedAt, session start $sessionStartTime",
+                        severity = "warning"
+                    )
+                    return
+                }
+            }
+        }
 
         val entry = WatchHistoryEntry(
                 user_id = userId,

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/WatchlistRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/WatchlistRepository.kt
@@ -331,9 +331,33 @@ class WatchlistRepository @Inject constructor(
         }
     }
 
-    suspend fun importWatchlistForProfile(profileId: String, items: List<LocalWatchlistItem>) {
+    suspend fun importWatchlistForProfile(profileId: String, cloudItems: List<LocalWatchlistItem>) {
         val safeProfileId = profileId.trim().ifBlank { "default" }
-        val json = runCatching { gson.toJson(items) }.getOrDefault("[]")
+
+        // Union merge local and cloud items to prevent offline additions from being wiped
+        val localJson = runCatching { context.traktDataStore.data.first()[watchlistKeyFor(safeProfileId)] }.getOrNull()
+        val type = TypeToken.getParameterized(MutableList::class.java, LocalWatchlistItem::class.java).type
+        val localItems: List<LocalWatchlistItem> = if (localJson != null) {
+            runCatching { gson.fromJson<List<LocalWatchlistItem>>(localJson, type) }.getOrDefault(emptyList()) ?: emptyList()
+        } else {
+            emptyList()
+        }
+
+        val combinedMap = mutableMapOf<String, LocalWatchlistItem>()
+        cloudItems.forEach { item ->
+            combinedMap["${item.mediaType}:${item.tmdbId}"] = item
+        }
+        localItems.forEach { item ->
+            val key = "${item.mediaType}:${item.tmdbId}"
+            val existing = combinedMap[key]
+            if (existing == null || item.addedAt > existing.addedAt) {
+                combinedMap[key] = item
+            }
+        }
+
+        val mergedList = combinedMap.values.sortedWith(compareBy<LocalWatchlistItem> { it.sourceOrder }.thenByDescending { it.addedAt })
+        val json = runCatching { gson.toJson(mergedList) }.getOrDefault("[]")
+
         context.traktDataStore.edit { prefs ->
             prefs[watchlistKeyFor(safeProfileId)] = json
         }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
@@ -174,6 +174,7 @@ class PlayerViewModel @Inject constructor(
     private var lastIsPlaying: Boolean = false
     private var hasMarkedWatched: Boolean = false
     private var hasManualSubtitleSelection: Boolean = false
+    private var playbackSessionStartTime: Long = 0L
 
     // AI subtitle settings (read once per video load)
     private var aiSubtitleEnabled = false
@@ -314,6 +315,7 @@ class PlayerViewModel @Inject constructor(
         currentPreferredAddonId = preferredAddonId?.trim()?.takeIf { it.isNotBlank() }
         currentPreferredSourceName = preferredSourceName?.trim()?.takeIf { it.isNotBlank() }
         currentPreferredBingeGroup = preferredBingeGroup?.trim()?.takeIf { it.isNotBlank() }
+        playbackSessionStartTime = System.currentTimeMillis()
         playbackDiag(
             "loadMedia type=$mediaType id=$mediaId season=$seasonNumber episode=$episodeNumber " +
                 "providedUrl=${!providedStreamUrl.isNullOrBlank()} preferredAddon=${currentPreferredAddonId.orEmpty()} " +
@@ -2533,7 +2535,8 @@ class PlayerViewModel @Inject constructor(
                     position = positionSeconds,
                     streamKey = streamKey,
                     streamAddonId = streamAddonId,
-                    streamTitle = streamTitle
+                    streamTitle = streamTitle,
+                    sessionStartTime = playbackSessionStartTime
                 )
 
                 // Also save to local Continue Watching (profile-scoped, for profiles without Trakt).


### PR DESCRIPTION
## Description
This PR implements **Phase 4: Cloud Sync Reliability & Conflict Resolution Audit**. It hardens the cloud sync system to prevent offline data overwrites, resolves watchlist data loss, adds fault tolerance to malformed payloads, and eliminates real-time sync storms.

## Key Changes
1. **Watch Progress Overwrite Protection (`WatchHistoryRepository.kt`)**
   - Added `playbackSessionStartTime` to track playback sessions.
   - Prevents stale local watch history updates from clobbering newer cloud progress by comparing the cloud's `updatedAt` against the local session's start time.

2. **Watchlist Union Merging (`WatchlistRepository.kt`)**
   - Changed watchlist sync from a clobbering strategy to a **Union Merge** strategy. 
   - When pulling the cloud watchlist, items are merged locally based on their `addedAt` timestamps. This guarantees that items added offline are no longer wiped out during a cloud sync.

3. **Granular Sync Resilience (`CloudSyncRepository.kt`)**
   - Hardened `applyCloudPayload` by isolating major sub-components (IPTV, Catalogs, Addons, Watchlist, Trakt tokens) inside independent `try/catch` blocks.
   - If a specific sub-component's JSON payload is malformed or throws an exception during restore, it will no longer crash the entire cloud restoration pipeline. 

4. **Real-Time Sync Deduplication (`CloudSyncRepository.kt`)**
   - Implemented a `lastAppliedHash` check on incoming `account_sync_state` payloads.
   - If multiple devices or tabs broadcast identical sync payloads, the app skips the redundant JSON parsing and DataStore writes, preventing I/O wear and circular sync storms.

## Verification
- [x] Tested against latest `main` (merges cleanly).
- [x] Code compiles with Kotlin/Android checks passing.
- [x] Passed `git diff --check` (no trailing whitespaces or formatting regressions introduced).