### PR TITLE
fix(tv): trailer close button and IPTV settings redirection

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/arflix/tv/navigation/AppNavigation.kt
@@ -54,7 +54,15 @@ sealed class Screen(val route: String) {
             return if (streamEnc != null) "tv?channelId=$enc&streamUrl=$streamEnc" else "tv?channelId=$enc"
         }
     }
-    object Settings : Screen("settings")
+    object Settings : Screen("settings") {
+        fun createRoute(autoCloudAuth: Boolean = false, initialSection: String? = null): String {
+            val base = "settings"
+            val params = mutableListOf<String>()
+            if (autoCloudAuth) params.add("autoCloudAuth=true")
+            initialSection?.let { params.add("initialSection=$it") }
+            return if (params.isNotEmpty()) "$base?${params.joinToString("&")}" else base
+        }
+    }
     object TelegramSettings : Screen("telegram_settings")
     object ProfileSelection : Screen("profile_selection")
 
@@ -258,6 +266,7 @@ fun AppNavigation(
                 onNavigateToSearch = { navigateTopLevel(Screen.Search.route) },
                 onNavigateToWatchlist = { navigateTopLevel(Screen.Watchlist.route) },
                 onNavigateToSettings = { navigateTopLevel(Screen.Settings.route) },
+                onNavigateToIptvSettings = { navigateTopLevel(Screen.Settings.createRoute(initialSection = "iptv")) },
                 onSwitchProfile = {
                     onSwitchProfile()
                     navController.navigate(Screen.ProfileSelection.route) {
@@ -270,18 +279,25 @@ fun AppNavigation(
 
         // Settings screen
         composable(
-            route = "settings?autoCloudAuth={autoCloudAuth}",
+            route = "settings?autoCloudAuth={autoCloudAuth}&initialSection={initialSection}",
             arguments = listOf(
                 navArgument("autoCloudAuth") {
                     type = NavType.BoolType
                     defaultValue = false
+                },
+                navArgument("initialSection") {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
                 }
             )
         ) { backStackEntry ->
             val autoCloudAuth = backStackEntry.arguments?.getBoolean("autoCloudAuth") ?: false
+            val initialSection = backStackEntry.arguments?.getString("initialSection")
             SettingsScreen(
                 currentProfile = currentProfile,
                 autoStartCloudAuth = autoCloudAuth,
+                initialSection = initialSection,
                 onNavigateToHome = { navigateHome() },
                 onNavigateToSearch = { navigateTopLevel(Screen.Search.route) },
                 onNavigateToTv = { navigateTopLevel(Screen.Tv.createRoute()) },

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
@@ -913,22 +913,24 @@ fun DetailsScreen(
                     volume = 1f
                 )
                 // Close button for touch devices
-                Box(
-                    modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .padding(top = 48.dp, end = 16.dp)
-                        .size(40.dp)
-                        .clip(CircleShape)
-                        .background(Color.Black.copy(alpha = 0.6f))
-                        .clickable { showTrailerPlayer = false },
-                    contentAlignment = Alignment.Center
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Close,
-                        contentDescription = stringResource(R.string.close),
-                        tint = Color.White,
-                        modifier = Modifier.size(24.dp)
-                    )
+                if (isMobile) {
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .padding(top = 48.dp, end = 16.dp)
+                            .size(40.dp)
+                            .clip(CircleShape)
+                            .background(Color.Black.copy(alpha = 0.6f))
+                            .clickable { showTrailerPlayer = false },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Close,
+                            contentDescription = stringResource(R.string.close),
+                            tint = Color.White,
+                            modifier = Modifier.size(24.dp)
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -282,6 +282,7 @@ fun SettingsScreen(
     viewModel: SettingsViewModel = hiltViewModel(),
     currentProfile: com.arflix.tv.data.model.Profile? = null,
     autoStartCloudAuth: Boolean = false,
+    initialSection: String? = null,
     onNavigateToHome: () -> Unit = {},
     onNavigateToSearch: () -> Unit = {},
     onNavigateToTv: () -> Unit = {},
@@ -294,6 +295,30 @@ fun SettingsScreen(
     val isTouchDevice = LocalDeviceType.current.isTouchDevice()
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
+
+    val sections = remember {
+        buildList {
+            add("accounts")
+            add("profiles")
+            add("playback")
+            add("language")
+            add("subtitles")
+            add("ai_subtitles")
+            add("iptv")
+            add("stremio")
+            add("catalogs")
+            add("home_server")
+            if (BuildConfig.FEATURE_PLUGINS_ENABLED) {
+                add("plugins")
+            }
+            add("appearance")
+            add("network")
+        }
+    }
+
+    val initialSectionIdx = remember(initialSection, sections) {
+        initialSection?.let { sections.indexOf(it) }?.takeIf { it >= 0 }
+    }
 
     // Auto-start cloud auth if requested (e.g. from profile selection page)
     LaunchedEffect(autoStartCloudAuth) {
@@ -310,8 +335,12 @@ fun SettingsScreen(
     val hasProfile = currentProfile != null
     val maxSidebarIndex = topBarMaxIndex(hasProfile)
     var sidebarFocusIndex by remember { mutableIntStateOf(if (hasProfile) 5 else 4) } // SETTINGS
-    var sectionIndex by remember { mutableIntStateOf(0) }
-    var mobilePage by remember { mutableStateOf("MAIN") }
+    var sectionIndex by remember { mutableIntStateOf(initialSectionIdx ?: 0) }
+    var mobilePage by remember {
+        mutableStateOf(
+            if (initialSection == "iptv") "TV" else "MAIN"
+        )
+    }
     var contentFocusIndex by remember { mutableIntStateOf(0) }
     var activeZone by remember { mutableStateOf(Zone.CONTENT) }
     var suppressSelectUntilMs by remember { mutableLongStateOf(0L) }
@@ -373,25 +402,6 @@ fun SettingsScreen(
 
     val stremioAddons = remember(uiState.addons) {
         uiState.addons.filter { it.runtimeKind == RuntimeKind.STREMIO }
-    }
-    val sections = remember {
-        buildList {
-            add("accounts")
-            add("profiles")
-            add("playback")
-            add("language")
-            add("subtitles")
-            add("ai_subtitles")
-            add("iptv")
-            add("stremio")
-            add("catalogs")
-            add("home_server")
-            if (BuildConfig.FEATURE_PLUGINS_ENABLED) {
-                add("plugins")
-            }
-            add("appearance")
-            add("network")
-        }
     }
     val sectionMaxIndex: (String) -> Int = { section ->
         when (section) {

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LivePanes.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LivePanes.kt
@@ -1,6 +1,7 @@
 package com.arflix.tv.ui.screens.tv.live
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -19,6 +20,17 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.Text
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.tv.material3.Button
+import androidx.tv.material3.ButtonDefaults
+import androidx.compose.ui.graphics.Color
+import com.arflix.tv.util.LocalDeviceType
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
@@ -47,22 +59,90 @@ fun LoadingPane(message: String?, percent: Int) {
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
-fun EmptyStatePane(message: String, actionLabel: String, onAction: () -> Unit) {
+fun EmptyStatePane(
+    message: String,
+    actionLabel: String,
+    onAction: () -> Unit,
+    modifier: Modifier = Modifier,
+    isFocused: Boolean = true,
+    onMoveUp: (() -> Unit)? = null,
+    focusRequester: FocusRequester? = null
+) {
+    val isTouchDevice = LocalDeviceType.current.isTouchDevice()
     Column(
-        modifier = Modifier.fillMaxSize(),
+        modifier = modifier.fillMaxSize(),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(message, style = LiveType.ProgramTitle.copy(color = LiveColors.FgDim))
-        Box(
-            modifier = Modifier
-                .padding(top = 18.dp)
-                .clip(RoundedCornerShape(8.dp))
-                .background(LiveColors.Accent)
-                .clickable { onAction() }
-                .padding(horizontal = 18.dp, vertical = 10.dp),
-        ) {
-            Text(actionLabel, style = LiveType.CatLabel.copy(color = LiveColors.Bg))
+        if (isTouchDevice) {
+            Box(
+                modifier = Modifier
+                    .padding(top = 18.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(Color.Black)
+                    .border(
+                        width = 1.dp,
+                        color = Color.White.copy(alpha = 0.15f),
+                        shape = RoundedCornerShape(8.dp)
+                    )
+                    .clickable { onAction() }
+                    .padding(horizontal = 18.dp, vertical = 10.dp),
+            ) {
+                Text(actionLabel, style = LiveType.CatLabel.copy(color = Color.White))
+            }
+        } else {
+            val focusModifier = if (focusRequester != null) {
+                Modifier.focusRequester(focusRequester)
+            } else {
+                Modifier
+            }
+            val background = if (isFocused) Color.White else Color.Black
+            val contentColor = if (isFocused) Color.Black else Color.White
+            val borderModifier = if (isFocused) {
+                Modifier
+            } else {
+                Modifier.border(
+                    width = 1.dp,
+                    color = Color.White.copy(alpha = 0.15f),
+                    shape = RoundedCornerShape(8.dp)
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .padding(top = 18.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(background)
+                    .then(borderModifier),
+                contentAlignment = Alignment.Center
+            ) {
+                Button(
+                    onClick = onAction,
+                    modifier = Modifier
+                        .then(focusModifier)
+                        .onPreviewKeyEvent { event ->
+                            if (event.type == KeyEventType.KeyDown && event.key == Key.DirectionUp) {
+                                onMoveUp?.invoke()
+                                true
+                            } else {
+                                false
+                            }
+                        },
+                    colors = ButtonDefaults.colors(
+                        containerColor = Color.Transparent,
+                        focusedContainerColor = Color.Transparent,
+                        contentColor = contentColor,
+                        focusedContentColor = contentColor
+                    ),
+                    scale = ButtonDefaults.scale(1f, 1f, 1f, 1f, 1f),
+                    shape = ButtonDefaults.shape(RoundedCornerShape(8.dp))
+                ) {
+                    Text(
+                        text = actionLabel,
+                        style = LiveType.CatLabel.copy(color = contentColor)
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvScreen.kt
@@ -358,6 +358,7 @@ fun LiveTvScreen(
     onNavigateToSearch: () -> Unit = {},
     onNavigateToWatchlist: () -> Unit = {},
     onNavigateToSettings: () -> Unit = {},
+    onNavigateToIptvSettings: (() -> Unit)? = null,
     onSwitchProfile: () -> Unit = {},
     onBack: () -> Unit = {},
 ) {
@@ -923,6 +924,7 @@ fun LiveTvScreen(
     val providerFocus = remember { FocusRequester() }
     val epgFocus = remember { FocusRequester() }
     val fsFocus = remember { FocusRequester() }
+    val emptyStateButtonFocus = remember { FocusRequester() }
 
     // Monotonic counter bumped on every DPAD key while in fullscreen —
     // the HUD observes this to re-show and reset its auto-hide timer.
@@ -1568,6 +1570,13 @@ fun LiveTvScreen(
         }
     }
 
+    LaunchedEffect(state.isConfigured, visibleEnrichedState.value) {
+        if (!isTouchDevice && !state.isConfigured && visibleEnrichedState.value === EnrichedChannels.Empty) {
+            delay(100L)
+            runCatching { emptyStateButtonFocus.requestFocus() }
+        }
+    }
+
     BackHandler(enabled = searchOpen) { searchOpen = false }
     BackHandler(enabled = !searchOpen && variantPickerChannel != null) { variantPickerChannel = null }
     BackHandler(enabled = !searchOpen && isFullScreen && fullscreenGuideOpen) {
@@ -1627,7 +1636,12 @@ fun LiveTvScreen(
                                         true
                                     }
                                     Key.DirectionDown -> {
-                                        focusProviderSwitcher()
+                                        if (!state.isConfigured && state.snapshot.channels.isEmpty()) {
+                                            focusZone = LiveTvFocusZone.CATEGORY_LIST
+                                            runCatching { emptyStateButtonFocus.requestFocus() }
+                                        } else {
+                                            focusProviderSwitcher()
+                                        }
                                         true
                                     }
                                     Key.DirectionCenter, Key.Enter -> {
@@ -1668,7 +1682,13 @@ fun LiveTvScreen(
             EmptyStatePane(
                 message = "No IPTV playlist configured.",
                 actionLabel = "Open settings",
-                onAction = onNavigateToSettings,
+                onAction = onNavigateToIptvSettings ?: onNavigateToSettings,
+                isFocused = focusZone != LiveTvFocusZone.TOPBAR,
+                focusRequester = emptyStateButtonFocus,
+                onMoveUp = {
+                    focusZone = LiveTvFocusZone.TOPBAR
+                    topBarFocusIndex = topBarSelectedIndex(SidebarItem.TV, hasProfile).coerceIn(0, maxTopBarIndex)
+                }
             )
         } else {
             // Content starts right under the pill row — 52 dp puts the first


### PR DESCRIPTION
Hides the close button in trailer player under TV mode, and adds D-pad focus and settings navigation redirection for the empty IPTV settings state.