### PR TITLE
fix(layout): adjust collection card sizing and disable pagination on constant home rows

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/model/Models.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/model/Models.kt
@@ -140,6 +140,15 @@ data class Category(
     val items: List<MediaItem>
 ) : Serializable
 
+fun Category.isPortrait(globalPosterMode: Boolean): Boolean {
+    val isCollectionRow = id.startsWith("collection_row_")
+    return if (isCollectionRow) {
+        items.firstOrNull()?.collectionTileShape == CollectionTileShape.POSTER
+    } else {
+        globalPosterMode
+    }
+}
+
 /**
  * Stream source from addons - enhanced with behavior hints.
  *

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
@@ -131,6 +131,7 @@ import com.arflix.tv.data.model.CatalogConfig
 import com.arflix.tv.data.model.CollectionTileShape
 import com.arflix.tv.data.model.MediaItem
 import com.arflix.tv.data.model.MediaType
+import com.arflix.tv.data.model.isPortrait
 import com.arflix.tv.network.OkHttpProvider
 import com.arflix.tv.ui.components.MediaCard as ArvioMediaCard
 import com.arflix.tv.ui.components.TrailerPlayer
@@ -2643,7 +2644,8 @@ private fun MobileHomeRowsLayer(
             val isCollectionRow = category.id.startsWith("collection_row_")
             val rowKey = remember(category.id) { "home:${category.id}" }
             val rowUsePosterCards = rememberCatalogueRowLayoutMode(rowKey) == CardLayoutMode.POSTER
-            val rowMobileItemWidth = if (rowUsePosterCards) 120.dp else 200.dp
+            val isPortrait = category.isPortrait(rowUsePosterCards)
+            val rowMobileItemWidth = if (isPortrait) 120.dp else 200.dp
             val rowState = rememberLazyListState()
 
             LaunchedEffect(rowState, category.id) {
@@ -2679,11 +2681,6 @@ private fun MobileHomeRowsLayer(
                 }
 
                 val rowHasMore = categoryHasMoreMap[category.id] == true
-                val isPortrait = if (isCollectionRow) {
-                    category.items.firstOrNull()?.collectionTileShape == CollectionTileShape.POSTER
-                } else {
-                    rowUsePosterCards
-                }
                 val skeletonCount = if (isPortrait) 12 else 7
                 val itemsToRender = remember(category.items, rowHasMore, isPortrait) {
                     if (rowHasMore) {
@@ -2745,11 +2742,10 @@ private fun MobileHomeRowsLayer(
                                 modifier = Modifier.width(rowMobileItemWidth)
                             ) {
                                 val cardLogoUrl = if (isCollectionRow) null else cardLogoUrls["${item.mediaType}_${item.id}"]
-                                val collectionLandscape = item.collectionTileShape != CollectionTileShape.POSTER
                                 ArvioMediaCard(
                                     item = item,
                                     width = rowMobileItemWidth,
-                                    isLandscape = if (isCollectionRow) collectionLandscape else !rowUsePosterCards,
+                                    isLandscape = !isPortrait,
                                     logoImageUrl = cardLogoUrl,
                                     showProgress = false,
                                     showTitle = !item.collectionHideTitle,
@@ -2771,11 +2767,10 @@ private fun MobileHomeRowsLayer(
                             }
                         } else {
                             val cardLogoUrl = if (isCollectionRow) null else cardLogoUrls["${item.mediaType}_${item.id}"]
-                            val collectionLandscape = item.collectionTileShape != CollectionTileShape.POSTER
                             ArvioMediaCard(
                                 item = item,
                                 width = rowMobileItemWidth,
-                                isLandscape = if (isCollectionRow) collectionLandscape else !rowUsePosterCards,
+                                isLandscape = !isPortrait,
                                 logoImageUrl = cardLogoUrl,
                                 showProgress = isContinueWatching,
                                 showTitle = !item.collectionHideTitle,

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
@@ -2680,7 +2680,7 @@ private fun MobileHomeRowsLayer(
                     )
                 }
 
-                val rowHasMore = categoryHasMoreMap[category.id] == true
+                val rowHasMore = !isCollectionRow && categoryHasMoreMap[category.id] == true
                 val skeletonCount = if (isPortrait) 12 else 7
                 val itemsToRender = remember(category.items, rowHasMore, isPortrait) {
                     if (rowHasMore) {
@@ -3220,6 +3220,7 @@ private fun ContentRow(
     onItemFocused: (MediaItem, Int) -> Unit
 ) {
     val isCollectionRow = category.id.startsWith("collection_row_")
+    val effectiveCategoryHasMore = !isCollectionRow && categoryHasMore
     val rowState = rememberLazyListState()
     val density = LocalDensity.current
     val isContinueWatching = category.id == "continue_watching"
@@ -3350,8 +3351,8 @@ private fun ContentRow(
         }
 
         val skeletonCount = if (effectivePosterMode) 12 else 7
-        val itemsToRender = remember(category.items, categoryHasMore, effectivePosterMode) {
-            if (categoryHasMore) {
+        val itemsToRender = remember(category.items, effectiveCategoryHasMore, effectivePosterMode) {
+            if (effectiveCategoryHasMore) {
                 category.items + List(skeletonCount) { idx ->
                     MediaItem(
                         id = -1000 - idx,
@@ -3403,7 +3404,7 @@ private fun ContentRow(
                     LaunchedEffect(item.id) {
                         onLoadMore()
                     }
-                } else if (categoryHasMore && index >= category.items.size - 5) {
+                } else if (effectiveCategoryHasMore && index >= category.items.size - 5) {
                     LaunchedEffect(category.items.size) {
                         onLoadMore()
                     }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/search/SearchScreen.kt
@@ -77,6 +77,7 @@ import androidx.tv.material3.Text
 import com.arflix.tv.data.model.MediaItem
 import com.arflix.tv.data.model.MediaType
 import com.arflix.tv.data.model.Category
+import com.arflix.tv.data.model.isPortrait
 import com.arflix.tv.ui.components.LoadingIndicator
 import com.arflix.tv.ui.components.CardLayoutMode
 import com.arflix.tv.ui.components.AppTopBar
@@ -910,14 +911,15 @@ private fun RowsLayer(
                 val isCurrentRow = isFocused && index == currentRowIndex
                 val rowKey = remember(category.id) { "search:${category.id}" }
                 val rowUsePosterCards = rememberCatalogueRowLayoutMode(rowKey) == CardLayoutMode.POSTER
+                val isPortrait = category.isPortrait(rowUsePosterCards)
                 val itemWidth = if (isTouchDevice) {
-                    if (rowUsePosterCards) 110.dp else 170.dp
+                    if (isPortrait) 110.dp else 170.dp
                 } else {
-                    if (rowUsePosterCards) 105.dp else 210.dp
+                    if (isPortrait) 105.dp else 210.dp
                 }
                 val baseRowHeight = if (isTouchDevice) {
-                    if (rowUsePosterCards) 260.dp else 190.dp
-                } else if (rowUsePosterCards) {
+                    if (isPortrait) 260.dp else 190.dp
+                } else if (isPortrait) {
                     // Poster cards (2:3) need extra vertical room for title + date below the image
                     if (screenHeight <= 640) 271.dp else 309.dp
                 } else {
@@ -1013,7 +1015,7 @@ private fun RowsLayer(
                                         year = ""
                                     ),
                                     width = itemWidth,
-                                    isLandscape = !rowUsePosterCards,
+                                    isLandscape = !isPortrait,
                                     logoImageUrl = cardLogoUrls["${item.mediaType}_${item.id}"],
                                     showProgress = false,
                                     titleMaxLines = 2,

--- a/app/src/test/kotlin/com/arflix/tv/data/model/CategoryModelTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/model/CategoryModelTest.kt
@@ -1,0 +1,69 @@
+package com.arflix.tv.data.model
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CategoryModelTest {
+
+    @Test
+    fun `isPortrait returns false when collection row has empty items list`() {
+        val category = Category(
+            id = "collection_row_service",
+            title = "Services",
+            items = emptyList()
+        )
+        assertFalse(category.isPortrait(globalPosterMode = true))
+        assertFalse(category.isPortrait(globalPosterMode = false))
+    }
+
+    @Test
+    fun `isPortrait returns true when collection row has poster items`() {
+        val category = Category(
+            id = "collection_row_franchise",
+            title = "Franchises",
+            items = listOf(
+                MediaItem(
+                    id = 1,
+                    title = "Marvel",
+                    collectionTileShape = CollectionTileShape.POSTER
+                )
+            )
+        )
+        assertTrue(category.isPortrait(globalPosterMode = true))
+        assertTrue(category.isPortrait(globalPosterMode = false))
+    }
+
+    @Test
+    fun `isPortrait returns false when collection row has landscape items`() {
+        val category = Category(
+            id = "collection_row_service",
+            title = "Services",
+            items = listOf(
+                MediaItem(
+                    id = 2,
+                    title = "Netflix",
+                    collectionTileShape = CollectionTileShape.LANDSCAPE
+                )
+            )
+        )
+        assertFalse(category.isPortrait(globalPosterMode = true))
+        assertFalse(category.isPortrait(globalPosterMode = false))
+    }
+
+    @Test
+    fun `isPortrait respects globalPosterMode for non-collection rows`() {
+        val category = Category(
+            id = "trending_movies",
+            title = "Trending Movies",
+            items = listOf(
+                MediaItem(
+                    id = 3,
+                    title = "Some Movie"
+                )
+            )
+        )
+        assertTrue(category.isPortrait(globalPosterMode = true))
+        assertFalse(category.isPortrait(globalPosterMode = false))
+    }
+}


### PR DESCRIPTION
### Summary
This PR addresses layout issues in portrait (poster) mode where landscape-oriented collection rows (like "Services") were rendering too small, and resolves a resource/network overhead where infinite scroll pagination (loading extra skeletons and triggering API calls) was active on constant/static collection rows.

### Key Changes
1. **Landscape Collection Card Sizing in Global Portrait Mode**:
   - Updated the item width computation in `MobileHomeRowsLayer` in `HomeScreen.kt` to dynamically respect the actual card layout mode of each row instead of using the global screen-level poster mode.
   - For collection rows, this checks the shape of the collection items (e.g., `CollectionTileShape.POSTER` vs `CollectionTileShape.LANDSCAPE`) to compute the correct width, preventing landscape-oriented cards (like streaming services) from shrinking.

2. **Disable Pagination & Extra Skeletons on Constant Rows**:
   - **Mobile Layout**: Disabled `rowHasMore` for collection rows (identified by category IDs starting with `collection_row_`), which prevents placeholder cards from being appended and disables the loading-more scroll trigger.
   - **TV Layout**: Updated `ContentRow` to ignore pagination if it is a collection row, preventing infinite scroll triggers and skeleton generation at the end of the row.