### PR TITLE
fix(watchlist): center loading and empty state info in mobile and tv

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/watchlist/WatchlistScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/watchlist/WatchlistScreen.kt
@@ -50,6 +50,7 @@ import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.Text
 import androidx.compose.foundation.layout.Row
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.sp
 import com.arflix.tv.R
 import com.arflix.tv.data.model.MediaItem
@@ -274,13 +275,13 @@ fun WatchlistScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(top = if (isMobile) 0.dp else AppTopBarContentTopInset)
-                .padding(start = 24.dp, top = 4.dp, end = 48.dp)
+                .padding(top = 4.dp)
         ) {
             if (isMobile) {
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(vertical = 16.dp),
+                        .padding(start = 24.dp, end = 48.dp, top = 16.dp, bottom = 16.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
@@ -316,13 +317,15 @@ fun WatchlistScreen(
                             Text(
                                 text = tr("Your watchlist is empty"),
                                 style = ArflixTypography.body,
-                                color = Color.White.copy(alpha = 0.5f)
+                                color = Color.White.copy(alpha = 0.5f),
+                                textAlign = TextAlign.Center
                             )
                             Spacer(modifier = Modifier.height(8.dp))
                             Text(
                                 text = tr("Add movies and shows for later"),
                                 style = ArflixTypography.caption,
-                                color = Color.White.copy(alpha = 0.3f)
+                                color = Color.White.copy(alpha = 0.3f),
+                                textAlign = TextAlign.Center
                             )
                         }
                     }
@@ -330,7 +333,11 @@ fun WatchlistScreen(
                 else -> {
                     LazyColumn(
                         state = lazyColumnState,
-                        modifier = Modifier.weight(1f).fillMaxWidth().focusable(false),
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxWidth()
+                            .padding(start = 24.dp, end = 48.dp)
+                            .focusable(false),
                         contentPadding = PaddingValues(top = if (isMobile) 8.dp else 0.dp, bottom = 16.dp),
                         verticalArrangement = Arrangement.spacedBy(if (isMobile) 24.dp else 16.dp),
                         userScrollEnabled = isMobile


### PR DESCRIPTION
> [!NOTE]
> This PR is stacked on top of the changes in the mobile watchlist header PR (#337). It should be merged after PR #337 is integrated.

### Summary
This PR resolves an issue where the empty state information and loading indicators on the Watchlist screen were not centered horizontally on both mobile and TV layouts.

### Key Changes
1. **Separated Content Margins**:
   - Removed the asymmetrical horizontal padding (`start = 24.dp, end = 48.dp`) from the parent `Column` in `WatchlistScreen.kt`.
   - Applied the margins (`start = 24.dp, end = 48.dp`) directly to the mobile header `Row` and the list `LazyColumn`.
   - This allows the empty state `Box` and loading indicator `Box` (which use `.fillMaxWidth()`) to span the full screen width and center their content perfectly on both TV and mobile devices.
2. **Centered Text Alignment**:
   - Added `textAlign = TextAlign.Center` to the "watchlist is empty" title and subtitle texts to ensure they are centered.