### PR TITLE
feat(iptv): add support for MPEG-DASH DRM (Widevine and ClearKey) (#187)

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/model/IptvModels.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/model/IptvModels.kt
@@ -3,6 +3,22 @@ package com.arflix.tv.data.model
 import java.time.Instant
 
 /**
+ * DRM configuration parsed from `#KODIPROP` directives in an M3U playlist.
+ *
+ * @property scheme Canonical DRM scheme name: `"clearkey"`, `"widevine"`, `"playready"`,
+ *   or the raw value if unrecognised.
+ * @property licenseUrl For Widevine: the license server URL.
+ *   For ClearKey: the `kid:key` hex pair (e.g. `9eb4…:166…`).
+ * @property licenseData Optional PSSH override (base64). Most MPD manifests declare
+ *   PSSH inline or in the init segment; ExoPlayer handles both automatically.
+ */
+data class DrmInfo(
+    val scheme: String,
+    val licenseUrl: String? = null,
+    val licenseData: String? = null,
+)
+
+/**
  * IPTV channel parsed from an M3U playlist.
  */
 data class IptvChannel(
@@ -23,7 +39,8 @@ data class IptvChannel(
     val language: String? = null,
     val country: String? = null,
     val qualityLabel: String? = null,
-    val variantKey: String? = null
+    val variantKey: String? = null,
+    val drmInfo: DrmInfo? = null,
 )
 
 /**

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
@@ -7,6 +7,7 @@ import android.util.Base64
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import com.arflix.tv.data.model.IptvChannel
+import com.arflix.tv.data.model.DrmInfo
 import com.arflix.tv.data.model.IptvNowNext
 import com.arflix.tv.data.model.IptvProgram
 import com.arflix.tv.data.model.IptvSnapshot
@@ -6180,6 +6181,7 @@ class IptvRepository @Inject constructor(
         val seenChannelIds = HashSet<String>()
         var pendingMetadata: String? = null
         val pendingHeaders = linkedMapOf<String, String>()
+        val pendingDrmProps = linkedMapOf<String, String>()
         var parsedCount = 0
 
         BufferedReader(InputStreamReader(input, StandardCharsets.UTF_8), 256 * 1024).use { reader ->
@@ -6197,12 +6199,13 @@ class IptvRepository @Inject constructor(
                 if (line.startsWith("#EXTINF", ignoreCase = true)) {
                     pendingMetadata = line
                     pendingHeaders.clear()
-                    mergeM3uHeaderOptions(pendingHeaders, line)
+                    pendingDrmProps.clear()
+                    mergeM3uHeaderOptions(pendingHeaders, pendingDrmProps, line)
                     continue
                 }
 
                 if (line.startsWith("#EXTVLCOPT", ignoreCase = true) || line.startsWith("#KODIPROP", ignoreCase = true)) {
-                    mergeM3uHeaderOptions(pendingHeaders, line)
+                    mergeM3uHeaderOptions(pendingHeaders, pendingDrmProps, line)
                     continue
                 }
 
@@ -6269,9 +6272,11 @@ class IptvRepository @Inject constructor(
                     language = language,
                     country = country,
                     qualityLabel = qualityLabel,
-                    variantKey = buildChannelVariantKey(tvgName ?: channelName, groupTitle, epgId)
+                    variantKey = buildChannelVariantKey(tvgName ?: channelName, groupTitle, epgId),
+                    drmInfo = buildDrmInfo(pendingDrmProps)
                 )
                 pendingHeaders.clear()
+                pendingDrmProps.clear()
                 parsedCount++
                 if (parsedCount % 5000 == 0) {
                     onProgress(IptvLoadProgress("Parsing channels... $parsedCount found", 85))
@@ -6908,11 +6913,24 @@ class IptvRepository @Inject constructor(
         return null
     }
 
-    private fun mergeM3uHeaderOptions(target: MutableMap<String, String>, line: String) {
+    private fun mergeM3uHeaderOptions(
+        target: MutableMap<String, String>,
+        drmProps: MutableMap<String, String>,
+        line: String
+    ) {
         val value = line.substringAfter(':', missingDelimiterValue = "").trim()
         if (value.isBlank()) return
 
         when {
+            // ── DRM properties (routed to drmProps, not HTTP headers) ────
+            value.startsWith("inputstream.adaptive.license_type=", ignoreCase = true) ->
+                drmProps["license_type"] = value.substringAfter('=').trim()
+            value.startsWith("inputstream.adaptive.license_key=", ignoreCase = true) ->
+                drmProps["license_key"] = value.substringAfter('=').trim()
+            value.startsWith("inputstream.adaptive.license_data=", ignoreCase = true) ->
+                drmProps["license_data"] = value.substringAfter('=').trim()
+
+            // ── HTTP headers ────────────────────────────────────────────
             value.startsWith("http-user-agent=", ignoreCase = true) ->
                 target["User-Agent"] = value.substringAfter('=').trim()
             value.startsWith("user-agent=", ignoreCase = true) ->
@@ -6930,6 +6948,19 @@ class IptvRepository @Inject constructor(
             value.startsWith("inputstream.adaptive.manifest_headers=", ignoreCase = true) ->
                 target.putAll(parseHeaderPairs(value.substringAfter('=')))
         }
+    }
+
+    /**
+     * Builds a [DrmInfo] from accumulated `#KODIPROP` DRM properties, or returns
+     * `null` if no `license_type` was declared.
+     */
+    private fun buildDrmInfo(props: Map<String, String>): DrmInfo? {
+        val rawScheme = props["license_type"] ?: return null
+        return DrmInfo(
+            scheme = com.arflix.tv.util.ClearKeyUtil.normalizeScheme(rawScheme),
+            licenseUrl = props["license_key"],
+            licenseData = props["license_data"]
+        )
     }
 
     private fun extractInlineRequestHeaders(metadata: String?): Map<String, String> {

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/TvScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/TvScreen.kt
@@ -599,7 +599,7 @@ fun TvScreen(
     }
 
     // Helper: prepare ExoPlayer with a stream URL (shared by normal play + error retry)
-    fun prepareStream(stream: String) {
+    fun prepareStream(stream: String, drmInfo: com.arflix.tv.data.model.DrmInfo? = null) {
         val player = exoPlayer ?: return
         if (isPlayerReleased) return
         player.stop()
@@ -613,6 +613,20 @@ fun TvScreen(
                     .setTargetOffsetMs(4_000)
                     .build()
             )
+            .apply {
+                // DRM configuration from #KODIPROP directives
+                drmInfo?.let { drm ->
+                    val schemeUuid = com.arflix.tv.util.ClearKeyUtil.drmSchemeToUuid(drm.scheme)
+                    val drmBuilder = MediaItem.DrmConfiguration.Builder(schemeUuid)
+                    if (drm.scheme == "clearkey" && !drm.licenseUrl.isNullOrBlank()) {
+                        com.arflix.tv.util.ClearKeyUtil.buildClearKeyLicenseUri(drm.licenseUrl)
+                            ?.let { dataUri -> drmBuilder.setLicenseUri(dataUri) }
+                    } else if (!drm.licenseUrl.isNullOrBlank()) {
+                        drmBuilder.setLicenseUri(drm.licenseUrl.substringBefore("|"))
+                    }
+                    setDrmConfiguration(drmBuilder.build())
+                }
+            }
             .build()
         val streamLower = stream.lowercase()
         if (streamLower.contains(".m3u8") || streamLower.contains("/hls") || streamLower.contains("format=hls")) {
@@ -660,7 +674,7 @@ fun TvScreen(
         }
         lastPreparedStreamUrl = stream
         playerRetryCount = 0
-        prepareStream(stream)
+        prepareStream(stream, drmInfo = playingChannel?.drmInfo)
     }
 
     LaunchedEffect(isFullScreen, miniPlayerView, fullPlayerView, exoPlayer) {
@@ -714,6 +728,20 @@ fun TvScreen(
                             .setTargetOffsetMs(4_000)
                             .build()
                     )
+                    .apply {
+                        // Preserve DRM config on retry
+                        playingChannel?.drmInfo?.let { drm ->
+                            val schemeUuid = com.arflix.tv.util.ClearKeyUtil.drmSchemeToUuid(drm.scheme)
+                            val drmBuilder = MediaItem.DrmConfiguration.Builder(schemeUuid)
+                            if (drm.scheme == "clearkey" && !drm.licenseUrl.isNullOrBlank()) {
+                                com.arflix.tv.util.ClearKeyUtil.buildClearKeyLicenseUri(drm.licenseUrl)
+                                    ?.let { dataUri -> drmBuilder.setLicenseUri(dataUri) }
+                            } else if (!drm.licenseUrl.isNullOrBlank()) {
+                                drmBuilder.setLicenseUri(drm.licenseUrl.substringBefore("|"))
+                            }
+                            setDrmConfiguration(drmBuilder.build())
+                        }
+                    }
                     .build()
                 player.setMediaItem(mediaItem)
                 player.prepare()

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvScreen.kt
@@ -1330,6 +1330,7 @@ fun LiveTvScreen(
         headers: Map<String, String>,
         resetRetry: Boolean,
         initialPositionMs: Long = 0L,
+        drmInfo: com.arflix.tv.data.model.DrmInfo? = null,
     ) {
         val mergedHeaders = (baseRequestHeaders + headers).filterValues { it.isNotBlank() }
         iptvDataSourceFactory.setDefaultRequestProperties(mergedHeaders)
@@ -1347,6 +1348,20 @@ fun LiveTvScreen(
                             .setMinPlaybackSpeed(1.0f).setMaxPlaybackSpeed(1.0f)
                             .setTargetOffsetMs(8_000).build()
                     )
+                }
+                // DRM configuration from #KODIPROP directives
+                drmInfo?.let { drm ->
+                    val schemeUuid = com.arflix.tv.util.ClearKeyUtil.drmSchemeToUuid(drm.scheme)
+                    val drmBuilder = MediaItem.DrmConfiguration.Builder(schemeUuid)
+                    if (drm.scheme == "clearkey" && !drm.licenseUrl.isNullOrBlank()) {
+                        // ClearKey: build inline JWKS data URI from kid:key hex pair
+                        com.arflix.tv.util.ClearKeyUtil.buildClearKeyLicenseUri(drm.licenseUrl)
+                            ?.let { dataUri -> drmBuilder.setLicenseUri(dataUri) }
+                    } else if (!drm.licenseUrl.isNullOrBlank()) {
+                        // Widevine / PlayReady: strip Kodi pipe syntax, use clean URL
+                        drmBuilder.setLicenseUri(drm.licenseUrl.substringBefore("|"))
+                    }
+                    setDrmConfiguration(drmBuilder.build())
                 }
             }
             .build()
@@ -1492,6 +1507,7 @@ fun LiveTvScreen(
             headers = headers,
             resetRetry = true,
             initialPositionMs = if (playingCatchupProgram != null) catchupInSegmentSeekMs else 0L,
+            drmInfo = playingChannel?.source?.drmInfo,
         )
         // Persist "recent" as soon as playback starts.
         playingChannelId?.let { id ->
@@ -1598,6 +1614,7 @@ fun LiveTvScreen(
                         headers = retryHeaders,
                         resetRetry = false,
                         initialPositionMs = if (retryProgram != null) catchupInSegmentSeekMs else 0L,
+                        drmInfo = retryChannel?.drmInfo,
                     )
                 }
             }

--- a/app/src/main/kotlin/com/arflix/tv/util/ClearKeyUtil.kt
+++ b/app/src/main/kotlin/com/arflix/tv/util/ClearKeyUtil.kt
@@ -1,0 +1,88 @@
+package com.arflix.tv.util
+
+import androidx.media3.common.C
+import java.util.UUID
+
+/**
+ * Utility for DRM scheme resolution and ClearKey JWKS construction.
+ *
+ * ClearKey licenses are served inline as `data:` URIs containing a JSON Web
+ * Key Set (JWKS). This avoids the need for a custom [MediaDrmCallback] — ExoPlayer's
+ * [DataSchemeDataSource] reads the response directly from the URI.
+ */
+object ClearKeyUtil {
+
+    /**
+     * Maps a Kodi-style `inputstream.adaptive.license_type` value to the
+     * corresponding DRM scheme [UUID] used by Media3/ExoPlayer.
+     */
+    fun drmSchemeToUuid(scheme: String): UUID = when (scheme.lowercase().trim()) {
+        "clearkey", "org.w3.clearkey" -> C.CLEARKEY_UUID
+        "widevine", "com.widevine.alpha" -> C.WIDEVINE_UUID
+        "playready", "com.microsoft.playready" -> C.PLAYREADY_UUID
+        else -> try {
+            UUID.fromString(scheme)
+        } catch (_: IllegalArgumentException) {
+            C.WIDEVINE_UUID // safe default
+        }
+    }
+
+    /**
+     * Normalises a Kodi `license_type` string to a short canonical name.
+     */
+    fun normalizeScheme(raw: String): String = when (raw.lowercase().trim()) {
+        "org.w3.clearkey", "clearkey" -> "clearkey"
+        "com.widevine.alpha", "widevine" -> "widevine"
+        "com.microsoft.playready", "playready" -> "playready"
+        else -> raw.lowercase().trim()
+    }
+
+    /**
+     * Builds a `data:` URI containing a JSON Web Key Set (JWKS) suitable for
+     * ExoPlayer's ClearKey licence acquisition.
+     *
+     * @param kidKeyHex A colon-separated hex pair `kid:key`, for example
+     *   `9eb4050de44b4802932e27d75083e266:166634c675823c235a4a9446fad52e4d`.
+     * @return A `data:application/json;base64,...` URI, or `null` if parsing fails.
+     *
+     * Per the W3C ClearKey spec, the `kid` and `k` values inside the JWK must be
+     * Base64Url-encoded **without padding**.
+     */
+    fun buildClearKeyLicenseUri(kidKeyHex: String): String? {
+        val parts = kidKeyHex.split(':')
+        if (parts.size != 2) return null
+        val kidHex = parts[0].trim()
+        val keyHex = parts[1].trim()
+        if (kidHex.length != 32 || keyHex.length != 32) return null
+
+        val kidB64 = hexToBase64Url(kidHex) ?: return null
+        val keyB64 = hexToBase64Url(keyHex) ?: return null
+
+        // JSON Web Key Set per https://www.w3.org/TR/encrypted-media/#clear-key-license-format
+        val jwks = """{"keys":[{"kty":"oct","kid":"$kidB64","k":"$keyB64"}],"type":"temporary"}"""
+
+        val encoded = android.util.Base64.encodeToString(
+            jwks.toByteArray(Charsets.UTF_8),
+            android.util.Base64.NO_WRAP or android.util.Base64.NO_PADDING
+        )
+        return "data:application/json;base64,$encoded"
+    }
+
+    /**
+     * Converts a 32-char hex string (16 bytes) to a Base64Url string without padding.
+     */
+    private fun hexToBase64Url(hex: String): String? {
+        if (hex.length % 2 != 0) return null
+        val bytes = try {
+            ByteArray(hex.length / 2) { i ->
+                hex.substring(i * 2, i * 2 + 2).toInt(16).toByte()
+            }
+        } catch (_: NumberFormatException) {
+            return null
+        }
+        return android.util.Base64.encodeToString(
+            bytes,
+            android.util.Base64.URL_SAFE or android.util.Base64.NO_WRAP or android.util.Base64.NO_PADDING
+        )
+    }
+}


### PR DESCRIPTION
Resolves #187.

### Overview
This pull request adds native support for playing DRM-protected MPEG-DASH streams in IPTV playlists by parsing `#KODIPROP` directives (`license_type`, `license_key`, `license_data`) and setting the appropriate `DrmConfiguration` on the ExoPlayer `MediaItem` before playback.

### Test Download
A test build including these changes is available for download here:
https://mega.nz/file/5EFmEKRL#pbs-i5jE1UZxgtE4it2rZs_futVzg6Ss5tDUXI9EMVo

### Key Features
1. **DRM Scheme Parsing:** Automatically captures `#KODIPROP:inputstream.adaptive.license_type`, `license_key`, and `license_data` in `IptvRepository`.
2. **ClearKey Support:** Hex-encoded key pairs (e.g., `kid:key`) are parsed, structured into a JSON Web Key Set (JWKS), and encoded into a standard `data:` URI. This leverages ExoPlayer's `DataSchemeDataSource` to handle key validation locally without custom MediaDrmCallbacks.
3. **Widevine & PlayReady Support:** Standard license URLs are passed directly to the player, with the Kodi pipe-delimited suffix (`|`) stripped off to prevent `MalformedURLException` crashes.
4. **No PSSH Manual Extraction Needed:** The MPD extractor natively handles init segment PSSH parsing once the DRM configuration is supplied.

cc @rscm — please test these changes with your MPEG-DASH DRM channels!
