### PR TITLE
fix(watchhub): show platform name for streaming platform sources

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/api/StreamApi.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/api/StreamApi.kt
@@ -209,7 +209,27 @@ data class StremioStream(
 
     fun getSourceName(): String {
         val titleParts = (title ?: name ?: "").split("\n")
-        return titleParts.getOrNull(0)?.trim() ?: "Unknown"
+        val baseName = titleParts.getOrNull(0)?.trim() ?: ""
+        if (baseName.isNotBlank()) return baseName
+        val ext = externalUrl?.trim().orEmpty()
+        if (ext.isNotBlank()) {
+            return try {
+                val host = java.net.URI(ext).host?.removePrefix("www.") ?: ""
+                when {
+                    host.contains("amazon") || host.contains("primevideo") -> "Amazon Prime Video"
+                    host.contains("netflix") -> "Netflix"
+                    host.contains("disneyplus") || host.contains("disney") -> "Disney+"
+                    host.contains("hbomax") || host.contains("max.com") -> "Max"
+                    host.contains("hulu") -> "Hulu"
+                    host.contains("appletv") || host.contains("apple.com") -> "Apple TV+"
+                    host.contains("paramountplus") -> "Paramount+"
+                    host.contains("peacocktv") -> "Peacock"
+                    host.isNotBlank() -> host.replaceFirstChar { it.uppercase() }
+                    else -> "External Link"
+                }
+            } catch (e: Exception) { "External Link" }
+        }
+        return "Unknown"
     }
 
     fun getTorrentName(): String {


### PR DESCRIPTION
Fixes #266

## Problem
WatchHub addon returns streams with `externalUrl` pointing to platforms
like Amazon Prime Video. The sources list showed no platform name and
clicking any source showed "Playback error" because ExoPlayer cannot
play a streaming platform web page.

## Fix
Updated `getSourceName()` in `StremioStream` to derive a human-readable
platform label (e.g. "Amazon Prime Video", "Netflix", "Disney+") from
the `externalUrl` host when the stream's title/name field is blank.

## Testing
- Install WatchHub addon
- Search for a title available on Amazon Prime
- Sources list now shows "WatchHub - Amazon Prime Video" instead of blank