### PR TITLE
play trailers in card mode

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncRepository.kt
@@ -221,6 +221,7 @@ class CloudSyncRepository @Inject constructor(
         val trailerAutoPlay: Boolean = false,
         val trailerSoundEnabled: Boolean = false,
         val trailerDelaySeconds: Int = 2,
+        val trailerInCards: Boolean = true,
         val clockFormat: String = "24h",
         val showBudget: Boolean = true,
         val showLoadingStats: Boolean? = null,
@@ -245,6 +246,8 @@ class CloudSyncRepository @Inject constructor(
         profileManager.profileBooleanKeyFor(profileId, "trailer_auto_play")
     private fun trailerSoundEnabledKeyFor(profileId: String) =
         profileManager.profileBooleanKeyFor(profileId, "trailer_sound_enabled")
+    private fun trailerInCardsKeyFor(profileId: String) =
+        profileManager.profileBooleanKeyFor(profileId, "trailer_in_cards")
     private fun trailerDelayKeyFor(profileId: String) =
         profileManager.profileStringKeyFor(profileId, "trailer_delay_seconds")
     private fun clockFormatKeyFor(profileId: String) =
@@ -382,6 +385,7 @@ class CloudSyncRepository @Inject constructor(
                         trailerAutoPlay = prefs[trailerAutoPlayKeyFor(profile.id)] ?: false,
                         trailerSoundEnabled = prefs[trailerSoundEnabledKeyFor(profile.id)] ?: false,
                         trailerDelaySeconds = prefs[trailerDelayKeyFor(profile.id)]?.toIntOrNull() ?: 2,
+                        trailerInCards = prefs[trailerInCardsKeyFor(profile.id)] ?: true,
                         clockFormat = prefs[clockFormatKeyFor(profile.id)] ?: "24h",
                         showBudget = prefs[showBudgetKeyFor(profile.id)] ?: true,
                         showLoadingStats = prefs[showLoadingStatsKeyFor(profile.id)] ?: true,
@@ -893,6 +897,7 @@ class CloudSyncRepository @Inject constructor(
                         prefs[trailerAutoPlayKeyFor(profileId)] = state.trailerAutoPlay
                         prefs[trailerSoundEnabledKeyFor(profileId)] = state.trailerSoundEnabled
                         prefs[trailerDelayKeyFor(profileId)] = state.trailerDelaySeconds.toString()
+                        prefs[trailerInCardsKeyFor(profileId)] = state.trailerInCards
                         prefs[clockFormatKeyFor(profileId)] = state.clockFormat
                         prefs[showBudgetKeyFor(profileId)] = state.showBudget
                         state.showLoadingStats?.let { prefs[showLoadingStatsKeyFor(profileId)] = it }

--- a/app/src/main/kotlin/com/arflix/tv/ui/components/MediaCard.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/MediaCard.kt
@@ -637,3 +637,78 @@ fun PosterCard(
         }
     }
 }
+
+/**
+ * Wide focused card that shows backdrop art and plays the trailer inline.
+ * Used in TV card rows: the focused item expands to this wider landscape format
+ * while other items in the row keep their normal width. The trailer starts
+ * after [trailerDelayMs] (same setting as the hero backdrop trailer).
+ */
+@androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+fun FeaturedMediaCard(
+    item: MediaItem,
+    width: Dp,
+    height: Dp,
+    trailerKey: String?,
+    trailerDelayMs: Long,
+    trailerVolume: Float,
+    onClick: () -> Unit,
+) {
+    val shape = rememberArvioCardShape(ArvioSkin.radius.md)
+    val imageUrl = (item.backdrop ?: item.image).takeIf { it.isNotBlank() }
+
+    ArvioFocusableSurface(
+        modifier = Modifier.size(width, height),
+        shape = shape,
+        backgroundColor = Color(0xFF1A1A1A),
+        outlineColor = ArvioSkin.colors.focusOutline,
+        outlineWidth = 2.5.dp,
+        focusedScale = 1f,
+        pressedScale = 0.97f,
+        animateFocus = false,
+        enableSystemFocus = false,
+        isFocusedOverride = true,
+        onClick = onClick,
+    ) { _ ->
+        if (imageUrl != null) {
+            AsyncImage(
+                model = imageUrl,
+                contentDescription = item.title,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize()
+            )
+        }
+        if (trailerKey != null) {
+            TrailerPlayer(
+                youtubeKey = trailerKey,
+                delayMs = trailerDelayMs,
+                volume = trailerVolume,
+                modifier = Modifier.fillMaxSize()
+            )
+        }
+        // Bottom gradient so title text is readable over the backdrop/trailer
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.verticalGradient(
+                        0f to Color.Transparent,
+                        0.55f to Color.Transparent,
+                        1f to Color.Black.copy(alpha = 0.85f)
+                    )
+                )
+        )
+        Text(
+            text = item.title,
+            style = ArvioSkin.typography.cardTitle,
+            color = Color.White,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(horizontal = 10.dp, vertical = 8.dp)
+        )
+    }
+}

--- a/app/src/main/kotlin/com/arflix/tv/ui/components/TrailerPlayer.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/TrailerPlayer.kt
@@ -1,6 +1,8 @@
 package com.arflix.tv.ui.components
 
+import android.view.LayoutInflater
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.fillMaxSize
@@ -10,8 +12,10 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
@@ -19,12 +23,12 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
-import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.source.MergingMediaSource
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
+import com.arflix.tv.R
 import com.arflix.tv.data.api.InAppYouTubeExtractor
 import com.arflix.tv.data.api.YoutubeChunkedDataSourceFactory
 import dagger.hilt.EntryPoint
@@ -38,7 +42,8 @@ import kotlinx.coroutines.withContext
 /**
  * Muted YouTube trailer player using ExoPlayer with direct YouTube stream extraction.
  * Waits [delayMs] before resolving and playing (shows static backdrop first).
- * Uses InAppYouTubeExtractor to get direct googlevideo.com CDN URLs.
+ * Uses TextureView (via layout XML) so AnimatedVisibility's fadeIn works without a black flash —
+ * the view is transparent during the fade while ExoPlayer buffers in the background.
  */
 @EntryPoint
 @InstallIn(SingletonComponent::class)
@@ -56,16 +61,14 @@ fun TrailerPlayer(
     onPlayingChanged: (Boolean) -> Unit = {}
 ) {
     val context = LocalContext.current
+    val currentOnPlayingChanged by rememberUpdatedState(onPlayingChanged)
+
     var shouldPlay by remember { mutableStateOf(false) }
     var videoUrl by remember { mutableStateOf<String?>(null) }
     var audioUrl by remember { mutableStateOf<String?>(null) }
 
-    // Get singleton extractor from DI
     val entryPoint = remember {
-        EntryPointAccessors.fromApplication(
-            context,
-            TrailerPlayerEntryPoint::class.java
-        )
+        EntryPointAccessors.fromApplication(context, TrailerPlayerEntryPoint::class.java)
     }
     val extractor = remember { entryPoint.inAppYouTubeExtractor() }
 
@@ -85,15 +88,17 @@ fun TrailerPlayer(
         }
         if (videoUrl != null) {
             shouldPlay = true
-            onPlayingChanged(true)
+            currentOnPlayingChanged(true)
         } else {
-            onPlayingChanged(false)
+            currentOnPlayingChanged(false)
         }
     }
 
+    // TextureView (set via XML) means the view is transparent during the fade-in,
+    // so the backdrop image shows through while ExoPlayer buffers. No black flash.
     AnimatedVisibility(
         visible = shouldPlay && videoUrl != null,
-        enter = fadeIn(animationSpec = androidx.compose.animation.core.tween(1000)),
+        enter = fadeIn(animationSpec = tween(800)),
         exit = fadeOut(),
         modifier = modifier
     ) {
@@ -101,21 +106,9 @@ fun TrailerPlayer(
             ExoPlayer.Builder(context).build().apply {
                 repeatMode = Player.REPEAT_MODE_OFF
                 playWhenReady = true
-                addListener(object : Player.Listener {
-                    override fun onPlayerError(error: androidx.media3.common.PlaybackException) {
-                        extractor.evictCache(youtubeKey)
-                    }
-                    override fun onPlaybackStateChanged(playbackState: Int) {
-                        if (playbackState == Player.STATE_ENDED) {
-                            shouldPlay = false
-                            onPlayingChanged(false)
-                        }
-                    }
-                })
             }
         }
 
-        // Reactively update volume when the setting changes (trailer sound toggle)
         LaunchedEffect(volume) {
             player.volume = volume.coerceIn(0f, 1f)
         }
@@ -123,13 +116,11 @@ fun TrailerPlayer(
         LaunchedEffect(videoUrl, audioUrl, youtubeKey) {
             val vUrl = videoUrl ?: return@LaunchedEffect
             if (!audioUrl.isNullOrBlank()) {
-                // Adaptive: separate video + audio streams
                 val factory = DefaultMediaSourceFactory(YoutubeChunkedDataSourceFactory())
                 val videoSource = factory.createMediaSource(MediaItem.fromUri(vUrl))
                 val audioSource = factory.createMediaSource(MediaItem.fromUri(audioUrl!!))
                 player.setMediaSource(MergingMediaSource(videoSource, audioSource))
             } else {
-                // Progressive: combined video+audio
                 player.setMediaItem(MediaItem.fromUri(vUrl))
             }
             player.prepare()
@@ -137,6 +128,17 @@ fun TrailerPlayer(
 
         val lifecycleOwner = LocalLifecycleOwner.current
         DisposableEffect(lifecycleOwner, player) {
+            val listener = object : Player.Listener {
+                override fun onPlayerError(error: androidx.media3.common.PlaybackException) {
+                    extractor.evictCache(youtubeKey)
+                }
+                override fun onPlaybackStateChanged(playbackState: Int) {
+                    if (playbackState == Player.STATE_ENDED) {
+                        shouldPlay = false
+                        currentOnPlayingChanged(false)
+                    }
+                }
+            }
             val observer = LifecycleEventObserver { _, event ->
                 when (event) {
                     Lifecycle.Event.ON_PAUSE -> player.pause()
@@ -144,14 +146,15 @@ fun TrailerPlayer(
                     else -> {}
                 }
             }
+            player.addListener(listener)
             lifecycleOwner.lifecycle.addObserver(observer)
-            // If already backgrounded when composable enters (e.g. URL resolved while paused)
             if (!lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
                 player.pause()
             }
             onDispose {
                 lifecycleOwner.lifecycle.removeObserver(observer)
-                onPlayingChanged(false)
+                player.removeListener(listener)
+                currentOnPlayingChanged(false)
                 player.stop()
                 player.release()
             }
@@ -159,15 +162,16 @@ fun TrailerPlayer(
 
         AndroidView(
             factory = { ctx ->
-                PlayerView(ctx).apply {
+                (LayoutInflater.from(ctx).inflate(R.layout.trailer_player_view, null) as PlayerView).apply {
                     this.player = player
-                    useController = false
                     resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM
-                    setShutterBackgroundColor(android.graphics.Color.TRANSPARENT)
-                    setKeepContentOnPlayerReset(true)
+                    keepScreenOn = true
                 }
             },
-            modifier = Modifier.fillMaxSize()
+            update = { view ->
+                if (view.player !== player) view.player = player
+            },
+            modifier = Modifier.fillMaxSize().clipToBounds()
         )
     }
 }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
@@ -8,11 +8,13 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animate
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.snap
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
@@ -132,6 +134,7 @@ import com.arflix.tv.data.model.CollectionTileShape
 import com.arflix.tv.data.model.MediaItem
 import com.arflix.tv.data.model.MediaType
 import com.arflix.tv.network.OkHttpProvider
+import com.arflix.tv.ui.components.FeaturedMediaCard
 import com.arflix.tv.ui.components.MediaCard as ArvioMediaCard
 import com.arflix.tv.ui.components.TrailerPlayer
 import com.arflix.tv.ui.components.CardLayoutMode
@@ -181,9 +184,13 @@ import androidx.media3.ui.PlayerView
 import okhttp3.ConnectionPool
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.withContext
+import dagger.hilt.android.EntryPointAccessors
+import com.arflix.tv.ui.components.TrailerPlayerEntryPoint
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.abs
@@ -1000,8 +1007,8 @@ fun HomeScreen(
                     )
                 }
 
-                // YouTube trailer auto-play (sound controlled by trailerSoundEnabled setting)
-                if (heroVideoUrl == null && uiState.trailerAutoPlay && uiState.heroTrailerKey != null && !trailerSuppressed && !heroRowIsContinueWatching) {
+                // YouTube trailer auto-play — on TV, trailer plays inside the focused card instead
+                if ((isMobile || !uiState.trailerInCards) && heroVideoUrl == null && uiState.trailerAutoPlay && uiState.heroTrailerKey != null && !trailerSuppressed && !heroRowIsContinueWatching) {
                     TrailerPlayer(
                         youtubeKey = uiState.heroTrailerKey!!,
                         delayMs = uiState.trailerDelaySeconds * 1000L,
@@ -1132,6 +1139,9 @@ fun HomeScreen(
             onNavigateToSettings = onNavigateToSettings,
             onSwitchProfile = onSwitchProfile,
             onExitApp = onExitApp,
+            featuredTrailerKey = if (!isMobile && uiState.trailerInCards && uiState.trailerAutoPlay && !trailerSuppressed && !heroRowIsContinueWatching) uiState.heroTrailerKey else null,
+            featuredTrailerDelayMs = uiState.trailerDelaySeconds * 1000L,
+            featuredTrailerVolume = if (uiState.trailerSoundEnabled) 1f else 0f,
             onOpenContextMenu = { item, isContinue ->
                 contextMenuItem = item
                 contextMenuIsContinueWatching = isContinue
@@ -2157,6 +2167,9 @@ private fun HomeInputLayer(
     onNavigateToSettings: () -> Unit,
     onSwitchProfile: () -> Unit,
     onExitApp: () -> Unit,
+    featuredTrailerKey: String? = null,
+    featuredTrailerDelayMs: Long = 0L,
+    featuredTrailerVolume: Float = 0f,
     onOpenContextMenu: (MediaItem, Boolean) -> Unit,
 ) {
     val focusRequester = remember { FocusRequester() }
@@ -2510,6 +2523,9 @@ private fun HomeInputLayer(
             onSwitchProfile = onSwitchProfile,
             onNavigateToDetails = onNavigateToDetails,
             onMobileCategoryVisiblePosition = onMobileCategoryVisiblePosition,
+            featuredTrailerKey = featuredTrailerKey,
+            featuredTrailerDelayMs = featuredTrailerDelayMs,
+            featuredTrailerVolume = featuredTrailerVolume,
             onItemClick = { item ->
                 if (!isActionableHomeItem(item)) {
                     return@HomeRowsLayer
@@ -2552,6 +2568,9 @@ private fun HomeRowsLayer(
     onSwitchProfile: () -> Unit = {},
     onNavigateToDetails: (MediaType, Int, Int?, Int?) -> Unit = { _, _, _, _ -> },
     onMobileCategoryVisiblePosition: (String, Int) -> Unit = { _, _ -> },
+    featuredTrailerKey: String? = null,
+    featuredTrailerDelayMs: Long = 0L,
+    featuredTrailerVolume: Float = 0f,
     onItemClick: (MediaItem) -> Unit,
     onItemLongClick: ((MediaItem, Boolean) -> Unit)? = null
 ) {
@@ -2592,6 +2611,9 @@ private fun HomeRowsLayer(
             smoothScrolling = smoothScrolling,
             onLoadMoreCategory = onLoadMoreCategory,
             onItemFocusedPrefetch = onItemFocusedPrefetch,
+            featuredTrailerKey = featuredTrailerKey,
+            featuredTrailerDelayMs = featuredTrailerDelayMs,
+            featuredTrailerVolume = featuredTrailerVolume,
             onItemClick = onItemClick
         )
     }
@@ -2807,6 +2829,9 @@ private fun TvHomeRowsLayer(
     smoothScrolling: Boolean = true,
     onLoadMoreCategory: (String) -> Unit = {},
     onItemFocusedPrefetch: (MediaItem) -> Unit = {},
+    featuredTrailerKey: String? = null,
+    featuredTrailerDelayMs: Long = 0L,
+    featuredTrailerVolume: Float = 0f,
     onItemClick: (MediaItem) -> Unit
 ) {
     // ── Focus-row stabilizer ──
@@ -3008,6 +3033,9 @@ private fun TvHomeRowsLayer(
                             onLoadMore = onRowLoadMore,
                             focusedItemIndex = if (rowIsFocused) focusState.currentItemIndex else -1,
                             isFastScrolling = rowIsFocused && isFastScrolling,
+                            featuredTrailerKey = if (rowIsFocused) featuredTrailerKey else null,
+                            featuredTrailerDelayMs = featuredTrailerDelayMs,
+                            featuredTrailerVolume = featuredTrailerVolume,
                             onItemClick = onItemClick,
                             onItemFocused = onRowItemFocused
                         )
@@ -3221,6 +3249,9 @@ private fun ContentRow(
     onLoadMore: () -> Unit = {},
     focusedItemIndex: Int,
     isFastScrolling: Boolean,
+    featuredTrailerKey: String? = null,
+    featuredTrailerDelayMs: Long = 0L,
+    featuredTrailerVolume: Float = 0f,
     onItemClick: (MediaItem) -> Unit,
     onItemFocused: (MediaItem, Int) -> Unit
 ) {
@@ -3248,7 +3279,43 @@ private fun ContentRow(
     val itemSpanPx = remember(density, itemWidth, itemSpacing) {
         with(density) { (itemWidth + itemSpacing).toPx().coerceAtLeast(1f) }
     }
+    val hasFeaturedCard = !effectivePosterMode && featuredTrailerKey != null
+    // Tracks which item index has held focus long enough to expand.
+    // Using an index (not a boolean) means the derived `featuredExpanded`
+    // evaluates to false immediately in the same composition frame when
+    // focusedItemIndex changes — no async LaunchedEffect reset needed.
+    // Without this, the new card briefly saw featuredExpanded=true
+    // (stale from the previous card) and rendered at 380dp, causing a
+    // layout overshoot in the LazyRow before snapping back.
+    var featuredExpandedForIndex by remember { mutableIntStateOf(-1) }
+    val featuredExpanded = hasFeaturedCard && isCurrentRow &&
+        featuredExpandedForIndex == focusedItemIndex && focusedItemIndex >= 0
+    val context = LocalContext.current
+    val trailerExtractor = remember {
+        EntryPointAccessors.fromApplication(
+            context.applicationContext,
+            TrailerPlayerEntryPoint::class.java
+        ).inAppYouTubeExtractor()
+    }
+    // Pre-warm the URL cache the moment a card gets focus — races ahead of the
+    // expansion delay so the cache is populated by the time the card expands.
+    LaunchedEffect(focusedItemIndex, featuredTrailerKey) {
+        val key = featuredTrailerKey ?: return@LaunchedEffect
+        if (!hasFeaturedCard || !isCurrentRow || focusedItemIndex < 0) return@LaunchedEffect
+        withContext(Dispatchers.IO) {
+            try { trailerExtractor.extractPlaybackSource("https://www.youtube.com/watch?v=$key") }
+            catch (_: Exception) {}
+        }
+    }
+    LaunchedEffect(focusedItemIndex, hasFeaturedCard) {
+        featuredExpandedForIndex = -1
+        if (hasFeaturedCard && isCurrentRow && focusedItemIndex >= 0) {
+            delay(featuredTrailerDelayMs.coerceAtLeast(500L))
+            featuredExpandedForIndex = focusedItemIndex
+        }
+    }
     val railFocusOverlayActive = isCurrentRow && isScrollable && focusedItemIndex >= 0 && totalItems > 0 &&
+        !hasFeaturedCard &&
         focusedItemIndex <= maxFirstIndex &&
         focusedItemIndex == rowState.firstVisibleItemIndex &&
         rowState.firstVisibleItemScrollOffset == 0
@@ -3422,15 +3489,90 @@ private fun ContentRow(
                     { latestOnItemClick.value(currentItem.value) }
                 }
                 if (isRanked && index < 10) {
-                    // Top 10 rows should use the SAME card sizing as every other row.
-                    // The previous layout used giant background numerals and a smaller
-                    // embedded card, which made the row feel cramped and inconsistent.
-                    // Use a normal card and place a premium gold rank badge in the
-                    // top-right corner instead.
                     val cardLogoUrl = if (isCollectionRow) null else cardLogoUrls["${item.mediaType}_${item.id}"]
-                    Box(
-                        modifier = Modifier.width(itemWidth)
-                    ) {
+                    val rankedExpanded = hasFeaturedCard && itemIsFocused && featuredExpanded
+                    if (rankedExpanded) {
+                        // Expanded: fresh Animatable starting at itemWidth so the expansion
+                        // animates in from the card's resting size. This branch is only entered
+                        // after the 500ms focus-settle delay, so the Animatable is always new.
+                        val expandAnim = remember { Animatable(itemWidth.value) }
+                        LaunchedEffect(Unit) {
+                            expandAnim.animateTo(380f, spring())
+                        }
+                        val expandedWidth = expandAnim.value.dp
+                        Box(modifier = Modifier.width(expandedWidth)) {
+                            FeaturedMediaCard(
+                                item = item,
+                                width = expandedWidth,
+                                height = 146.dp,
+                                trailerKey = featuredTrailerKey,
+                                trailerDelayMs = 0L,
+                                trailerVolume = featuredTrailerVolume,
+                                onClick = onCardClick,
+                            )
+                            TopRankRibbon(
+                                rank = index + 1,
+                                isFocused = itemIsFocused,
+                                compact = !effectivePosterMode,
+                                modifier = Modifier
+                                    .align(Alignment.TopStart)
+                                    .zIndex(2f)
+                                    .padding(start = 8.dp)
+                            )
+                        }
+                    } else {
+                        // Collapsed: plain constant width — no animation state, no frame delay.
+                        // The LazyRow item is immediately itemWidth, same as non-ranked cards,
+                        // so the scroll delta is always computed against the correct layout.
+                        Box(modifier = Modifier.width(itemWidth)) {
+                            ArvioMediaCard(
+                                item = item,
+                                width = itemWidth,
+                                isLandscape = !effectivePosterMode,
+                                logoImageUrl = cardLogoUrl,
+                                showLogoImage = true,
+                                raiseOnFocus = !isFastScrolling,
+                                showProgress = false,
+                                showTitle = isCollectionRow && !item.collectionHideTitle,
+                                isFocusedOverride = itemIsFocused && !railFocusOverlayActive,
+                                focusedScale = 1f,
+                                enableFocusedImageSwap = !isCollectionRow && !isFastScrolling,
+                                animateFocus = false,
+                                enableSystemFocus = false,
+                                onFocused = onCardFocused,
+                                onClick = onCardClick,
+                            )
+                            TopRankRibbon(
+                                rank = index + 1,
+                                isFocused = itemIsFocused,
+                                compact = !effectivePosterMode,
+                                modifier = Modifier
+                                    .align(Alignment.TopStart)
+                                    .zIndex(2f)
+                                    .padding(start = 8.dp)
+                            )
+                        }
+                    }
+                } else {
+                    val cardLogoUrl = if (isCollectionRow) null else cardLogoUrls["${item.mediaType}_${item.id}"]
+                    val cardExpanded = hasFeaturedCard && itemIsFocused && featuredExpanded
+                    val animatedCardWidth by animateDpAsState(
+                        targetValue = if (cardExpanded) 380.dp else itemWidth,
+                        animationSpec = if (cardExpanded) spring() else snap(),
+                        label = "featuredCardWidth"
+                    )
+                    if (cardExpanded) {
+                        FeaturedMediaCard(
+                            item = item,
+                            width = animatedCardWidth,
+                            height = 146.dp,
+                            trailerKey = featuredTrailerKey,
+                            trailerDelayMs = 0L,
+                            trailerVolume = featuredTrailerVolume,
+                            onClick = onCardClick,
+                        )
+                    } else {
+                        // Normal card — not focused, not yet expanded, or hasFeaturedCard off
                         ArvioMediaCard(
                             item = item,
                             width = itemWidth,
@@ -3438,7 +3580,7 @@ private fun ContentRow(
                             logoImageUrl = cardLogoUrl,
                             showLogoImage = true,
                             raiseOnFocus = !isFastScrolling,
-                            showProgress = false,
+                            showProgress = isContinueWatching,
                             showTitle = isCollectionRow && !item.collectionHideTitle,
                             isFocusedOverride = itemIsFocused && !railFocusOverlayActive,
                             focusedScale = 1f,
@@ -3448,37 +3590,7 @@ private fun ContentRow(
                             onFocused = onCardFocused,
                             onClick = onCardClick,
                         )
-
-                        TopRankRibbon(
-                            rank = index + 1,
-                            isFocused = itemIsFocused,
-                            compact = !effectivePosterMode,
-                            modifier = Modifier
-                                .align(Alignment.TopStart)
-                                .zIndex(2f)
-                                .padding(start = 8.dp)
-                        )
                     }
-                } else {
-                    // Standard Card - keep width aligned with scroll math
-                    val cardLogoUrl = if (isCollectionRow) null else cardLogoUrls["${item.mediaType}_${item.id}"]
-                    ArvioMediaCard(
-                        item = item,
-                        width = itemWidth,
-                        isLandscape = !effectivePosterMode,
-                        logoImageUrl = cardLogoUrl,
-                        showLogoImage = true,
-                        raiseOnFocus = !isFastScrolling,
-                        showProgress = isContinueWatching,
-                        showTitle = isCollectionRow && !item.collectionHideTitle,
-                        isFocusedOverride = itemIsFocused && !railFocusOverlayActive,
-                        focusedScale = 1f,
-                        enableFocusedImageSwap = !isCollectionRow && !isFastScrolling,
-                        animateFocus = false,
-                        enableSystemFocus = false,
-                        onFocused = onCardFocused,
-                        onClick = onCardClick,
-                    )
                 }
                 }
             }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
@@ -80,6 +80,7 @@ data class HomeUiState(
     val trailerAutoPlay: Boolean = false,
     val trailerSoundEnabled: Boolean = false,
     val trailerDelaySeconds: Int = 2,
+    val trailerInCards: Boolean = true,
     // Home hero metadata visibility toggles (issue #72)
     val showBudget: Boolean = true,
     val heroOverviewOverride: String? = null,
@@ -1285,6 +1286,9 @@ class HomeViewModel @Inject constructor(
                 val trailerDelaySeconds = (prefs.asMap().entries
                     .firstOrNull { (key, _) -> key.name.endsWith("_trailer_delay_seconds") }
                     ?.value as? String)?.toIntOrNull() ?: 2
+                val trailerInCards = prefs.asMap().entries
+                    .firstOrNull { (key, _) -> key.name.endsWith("_trailer_in_cards") }
+                    ?.value as? Boolean ?: true
                 val smoothScrollingExplicit = prefs.asMap().entries
                     .firstOrNull { (key, _) -> key.name.endsWith("_smooth_scrolling") }
                     ?.value as? Boolean
@@ -1293,6 +1297,7 @@ class HomeViewModel @Inject constructor(
                     trailerAutoPlay = trailerEnabled,
                     trailerSoundEnabled = trailerSoundEnabled,
                     trailerDelaySeconds = trailerDelaySeconds,
+                    trailerInCards = trailerInCards,
                     showBudget = showBudget,
                     clockFormat = clockFormat,
                     smoothScrolling = smoothScrolling

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -214,7 +214,7 @@ private fun tvGeneralRowsForSection(section: String): List<Int> {
         "language" -> listOf(0, 3)
         "subtitles" -> listOf(1, 2, 4, 5, 6, 7, 8, 9)
         "ai_subtitles" -> listOf(28, 29, 30, 31, 32, 33)
-        "playback" -> listOf(10, 11, 12, 13, 14, 34, 16, 15, 27)
+        "playback" -> listOf(10, 11, 12, 13, 14, 37, 34, 16, 15, 27)
         "appearance" -> listOf(17, 18, 20, 21, 24, 23, 22, 36)
         "profiles" -> listOf(19)
         "network" -> listOf(25, 26, 35)
@@ -869,6 +869,7 @@ fun SettingsScreen(
                                                 32 -> showAiApiKeyDialog = true
                                                 33 -> viewModel.startAiKeyServer()
                                                 34 -> viewModel.cycleTrailerDelay()
+                                                37 -> viewModel.setTrailerInCards(!uiState.trailerInCards)
                                             }
                                         }
                                         "iptv" -> {
@@ -1255,6 +1256,8 @@ fun SettingsScreen(
                             onTrailerAutoPlayToggle = { viewModel.setTrailerAutoPlay(it) },
                             trailerSoundEnabled = uiState.trailerSoundEnabled,
                             onTrailerSoundEnabledToggle = { viewModel.setTrailerSoundEnabled(it) },
+                            trailerInCards = uiState.trailerInCards,
+                            onTrailerInCardsToggle = { viewModel.setTrailerInCards(it) },
                             trailerDelaySeconds = uiState.trailerDelaySeconds,
                             onTrailerDelayClick = { viewModel.cycleTrailerDelay() },
                             onDeviceModeClick = openUiModeWarningDialog,
@@ -3505,6 +3508,13 @@ private fun MobileSettingsSubPage(
                         onClick = { viewModel.cycleTrailerDelay() }
                     )
                     MobileSettingsRow(
+                        icon = Icons.Default.Movie,
+                        title = stringResource(R.string.trailer_in_cards),
+                        value = if (uiState.trailerInCards) "On" else "Off",
+                        isFocused = false,
+                        onClick = { viewModel.setTrailerInCards(!uiState.trailerInCards) }
+                    )
+                    MobileSettingsRow(
                         icon = Icons.Default.Settings,
                         title = stringResource(R.string.frame_rate),
                         value = uiState.frameRateMatchingMode,
@@ -4615,6 +4625,8 @@ private fun TvGeneralSettingsRows(
     onFilterSubtitlesByLanguageToggle: (Boolean) -> Unit = {},
     onTrailerAutoPlayToggle: (Boolean) -> Unit = {},
     onTrailerSoundEnabledToggle: (Boolean) -> Unit = {},
+    trailerInCards: Boolean = true,
+    onTrailerInCardsToggle: (Boolean) -> Unit = {},
     trailerDelaySeconds: Int = 1,
     onTrailerDelayClick: () -> Unit = {},
     qualityFilterValue: String = "OFF",
@@ -4738,6 +4750,7 @@ private fun TvGeneralSettingsRows(
                 33 -> SettingsRow(Icons.Default.QrCode, stringResource(R.string.ai_scan_qr_title), stringResource(R.string.ai_scan_qr_desc), "", focusedIndex == localIndex, onSubtitleAiQrClick, Modifier.settingsFocusSlot(localIndex).alpha(if (subtitleAiEnabled) 1f else 0.4f))
                 34 -> SettingsRow(Icons.Default.Schedule, stringResource(R.string.trailer_delay), stringResource(R.string.trailer_delay_desc), "${trailerDelaySeconds}s", focusedIndex == localIndex, onTrailerDelayClick, Modifier.settingsFocusSlot(localIndex))
                 35 -> SettingsRow(Icons.Default.Language, stringResource(R.string.custom_user_agent), stringResource(R.string.custom_user_agent_desc), formatUserAgentPreview(customUserAgent, 30), focusedIndex == localIndex, onCustomUserAgentClick, Modifier.settingsFocusSlot(localIndex))
+                37 -> SettingsToggleRow(stringResource(R.string.trailer_in_cards), stringResource(R.string.trailer_in_cards_desc), trailerInCards, focusedIndex == localIndex, onTrailerInCardsToggle, Modifier.settingsFocusSlot(localIndex))
             }
         }
     }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -110,6 +110,7 @@ data class SettingsUiState(
     val trailerAutoPlay: Boolean = false,
     val trailerSoundEnabled: Boolean = false,
     val trailerDelaySeconds: Int = 2,
+    val trailerInCards: Boolean = true,
     val showBudget: Boolean = true,
     // Volume boost in decibels (0 = off, up to 15 dB). Applied via system LoudnessEnhancer
     // attached to the ExoPlayer audio session. Issue #88.
@@ -258,6 +259,7 @@ class SettingsViewModel @Inject constructor(
     private fun trailerAutoPlayKey() = profileManager.profileBooleanKey("trailer_auto_play")
     private fun trailerSoundEnabledKey() = profileManager.profileBooleanKey("trailer_sound_enabled")
     private fun trailerDelayKey() = profileManager.profileStringKey("trailer_delay_seconds")
+    private fun trailerInCardsKey() = profileManager.profileBooleanKey("trailer_in_cards")
     private fun showBudgetKey() = profileManager.profileBooleanKey("show_budget_on_home")
     private fun clockFormatKey() = profileManager.profileStringKey("clock_format")
     private fun smoothScrollingKey() = profileManager.profileBooleanKey("smooth_scrolling")
@@ -437,6 +439,7 @@ class SettingsViewModel @Inject constructor(
             val trailerAutoPlay = prefs[trailerAutoPlayKey()] ?: false
             val trailerSoundEnabled = prefs[trailerSoundEnabledKey()] ?: false
             val trailerDelaySeconds = prefs[trailerDelayKey()]?.toIntOrNull() ?: 2
+            val trailerInCards = prefs[trailerInCardsKey()] ?: true
             val spoilerBlurEnabled = prefs[spoilerBlurKey()] ?: false
             val showBudget = prefs[showBudgetKey()] ?: true
             val clockFormat = prefs[clockFormatKey()] ?: "24h"
@@ -521,6 +524,7 @@ class SettingsViewModel @Inject constructor(
                 trailerAutoPlay = trailerAutoPlay,
                 trailerSoundEnabled = trailerSoundEnabled,
                 trailerDelaySeconds = trailerDelaySeconds,
+                trailerInCards = trailerInCards,
                 showBudget = showBudget,
                 volumeBoostDb = volumeBoostDb,
                 showLoadingStats = showLoadingStats,
@@ -1125,6 +1129,10 @@ class SettingsViewModel @Inject constructor(
 
     fun setTrailerSoundEnabled(enabled: Boolean) {
         viewModelScope.launch { context.settingsDataStore.edit { it[trailerSoundEnabledKey()] = enabled }; _uiState.value = _uiState.value.copy(trailerSoundEnabled = enabled); syncLocalStateToCloud(silent = true) }
+    }
+
+    fun setTrailerInCards(enabled: Boolean) {
+        viewModelScope.launch { context.settingsDataStore.edit { it[trailerInCardsKey()] = enabled }; _uiState.value = _uiState.value.copy(trailerInCards = enabled); syncLocalStateToCloud(silent = true) }
     }
 
     fun cycleTrailerDelay() {

--- a/app/src/main/res/layout/trailer_player_view.xml
+++ b/app/src/main/res/layout/trailer_player_view.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.media3.ui.PlayerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/trailer_player_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:surface_type="texture_view"
+    app:use_controller="false"
+    app:show_buffering="never"
+    app:shutter_background_color="@android:color/transparent" />

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -115,6 +115,8 @@
     <string name="trailer_sound_desc">הפעל שמע טריילר בבאנר הראשי</string>
     <string name="trailer_delay">השהיית טריילר</string>
     <string name="trailer_delay_desc">שניות לפני שהטריילר מתחיל לנגן</string>
+    <string name="trailer_in_cards">טריילרים בכרטיסים</string>
+    <string name="trailer_in_cards_desc">הפעל טריילרים בתוך הכרטיס הממוקד במקום במסך מלא</string>
     <string name="frame_rate_desc">כבוי, חלק, או תמיד</string>
     <string name="quality_filters_desc">הוצא רמות איכות במכשיר זה</string>
     <string name="card_layout_desc">כרטיסים לרוחב או לגובה</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -172,6 +172,8 @@
     <string name="trailer_sound_desc">Play trailer audio in hero banner</string>
     <string name="trailer_delay">Trailer Delay</string>
     <string name="trailer_delay_desc">Seconds before trailer starts playing</string>
+    <string name="trailer_in_cards">Trailers In Cards</string>
+    <string name="trailer_in_cards_desc">TV: play trailers inside the focused card instead of full screen</string>
     <string name="frame_rate_desc">Off, Seamless, or Always</string>
     <string name="quality_filters_desc">Exclude quality tiers on this device</string>
     <string name="card_layout_desc">Landscape or poster cards</string>


### PR DESCRIPTION
  Inline card trailers (TV)

  On TV, the focused card in any home row now expands and plays the YouTube trailer directly inside the card after the user's configured delay. The card widens smoothly from its resting size, shows the backdrop, and fades in the video once it buffers. The title is overlaid at the bottom with a gradient so
  it stays readable. Other cards in the row stay at their normal width — only the focused one expands.

  Previously, trailer autoplay always played in the full-screen hero backdrop regardless of which card was focused. On TV the new behaviour is now the default.

  New setting: Trailers In Cards
  Added a toggle under Settings → Playback. When off, behaviour reverts to the original full-screen hero trailer. The setting is per-profile and synced to cloud like other playback prefs.