### PR TITLE
feat: add Gemini Flash-Lite as a selectable AI subtitle-translation model

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/SubtitleAiModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/SubtitleAiModel.kt
@@ -9,6 +9,6 @@ enum class SubtitleAiModel {
         get() = when (this) {
             GROQ_LLAMA_70B -> null
             GEMINI_FLASH_25 -> "gemini-2.5-flash"
-            GEMINI_FLASH_LITE -> "gemini-flash-lite-latest"
+            GEMINI_FLASH_LITE -> "gemini-2.5-flash-lite"
         }
 }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/SubtitleAiModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/SubtitleAiModel.kt
@@ -2,5 +2,13 @@ package com.arflix.tv.ui.screens.player
 
 enum class SubtitleAiModel {
     GROQ_LLAMA_70B,
-    GEMINI_FLASH_25
+    GEMINI_FLASH_25,
+    GEMINI_FLASH_LITE;
+
+    val geminiModelId: String?
+        get() = when (this) {
+            GROQ_LLAMA_70B -> null
+            GEMINI_FLASH_25 -> "gemini-2.5-flash"
+            GEMINI_FLASH_LITE -> "gemini-flash-lite-latest"
+        }
 }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/SubtitleTranslationService.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/SubtitleTranslationService.kt
@@ -23,8 +23,7 @@ data class TranslationResult(
 
 private const val GROQ_MODEL_ID = "llama-3.3-70b-versatile"
 private const val GROQ_URL = "https://api.groq.com/openai/v1/chat/completions"
-private const val GEMINI_MODEL_ID = "gemini-2.5-flash"
-private const val GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/models/$GEMINI_MODEL_ID:generateContent"
+private const val GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta/models"
 
 class SubtitleTranslationService(
     private val apiKeyProvider: () -> String,
@@ -70,9 +69,14 @@ class SubtitleTranslationService(
             return TranslationResult(lines, false, "API key missing")
         }
 
-        return when (modelProvider()) {
+        return when (val model = modelProvider()) {
             SubtitleAiModel.GROQ_LLAMA_70B -> translateGroq(lines, targetLanguage, apiKey)
-            SubtitleAiModel.GEMINI_FLASH_25 -> translateGemini(lines, targetLanguage, apiKey)
+            SubtitleAiModel.GEMINI_FLASH_25,
+            SubtitleAiModel.GEMINI_FLASH_LITE -> {
+                val geminiModelId = model.geminiModelId
+                    ?: error("${model.name} is missing a Gemini model id")
+                translateGemini(lines, targetLanguage, apiKey, geminiModelId)
+            }
         }
     }
 
@@ -132,7 +136,12 @@ class SubtitleTranslationService(
         }
     }
 
-    private suspend fun translateGemini(lines: List<String>, targetLanguage: String, apiKey: String): TranslationResult {
+    private suspend fun translateGemini(
+        lines: List<String>,
+        targetLanguage: String,
+        apiKey: String,
+        modelId: String
+    ): TranslationResult {
         val NL = "⏎"
         val encoded = lines.map { it.replace("\n", NL) }
         val inputArray = JSONArray(encoded)
@@ -162,7 +171,7 @@ class SubtitleTranslationService(
             })
         }
 
-        val url = "$GEMINI_BASE_URL?key=$apiKey"
+        val url = "$GEMINI_BASE_URL/$modelId:generateContent?key=$apiKey"
         val request = Request.Builder()
             .url(url)
             .header("Content-Type", "application/json")

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -3655,6 +3655,7 @@ private fun MobileSettingsSubPage(
                         value = when (uiState.subtitleAiModel) {
                             com.arflix.tv.ui.screens.player.SubtitleAiModel.GROQ_LLAMA_70B -> "Groq - Llama 3.3 70B"
                             com.arflix.tv.ui.screens.player.SubtitleAiModel.GEMINI_FLASH_25 -> "Google - Gemini 2.5 Flash"
+                            com.arflix.tv.ui.screens.player.SubtitleAiModel.GEMINI_FLASH_LITE -> "Google - Gemini Flash-Lite"
                         },
                         isFocused = false,
                         onClick = onSubtitleAiModelClick
@@ -3698,6 +3699,8 @@ private fun MobileSettingsSubPage(
                                 com.arflix.tv.ui.screens.player.SubtitleAiModel.GROQ_LLAMA_70B ->
                                     stringResource(R.string.ai_groq_disclaimer)
                                 com.arflix.tv.ui.screens.player.SubtitleAiModel.GEMINI_FLASH_25 ->
+                                    stringResource(R.string.ai_gemini_disclaimer)
+                                com.arflix.tv.ui.screens.player.SubtitleAiModel.GEMINI_FLASH_LITE ->
                                     stringResource(R.string.ai_gemini_disclaimer)
                             },
                             style = ArflixTypography.caption.copy(fontSize = 11.sp),
@@ -4777,6 +4780,7 @@ private fun TvGeneralSettingsRows(
                     value = when (subtitleAiModel) {
                         com.arflix.tv.ui.screens.player.SubtitleAiModel.GROQ_LLAMA_70B -> "Groq - Llama 3.3 70B"
                         com.arflix.tv.ui.screens.player.SubtitleAiModel.GEMINI_FLASH_25 -> "Google - Gemini 2.5 Flash"
+                        com.arflix.tv.ui.screens.player.SubtitleAiModel.GEMINI_FLASH_LITE -> "Google - Gemini Flash-Lite"
                     },
                     isFocused = focusedIndex == localIndex,
                     onClick = onSubtitleAiModelClick,
@@ -5226,6 +5230,7 @@ private fun GeneralSettings(
             value = when (subtitleAiModel) {
                 com.arflix.tv.ui.screens.player.SubtitleAiModel.GROQ_LLAMA_70B -> "Groq – Llama 3.3 70B"
                 com.arflix.tv.ui.screens.player.SubtitleAiModel.GEMINI_FLASH_25 -> "Google – Gemini 2.5 Flash"
+                com.arflix.tv.ui.screens.player.SubtitleAiModel.GEMINI_FLASH_LITE -> "Google – Gemini Flash-Lite"
             },
             isFocused = focusedIndex == 29,
             onClick = onSubtitleAiModelClick,
@@ -5277,6 +5282,8 @@ private fun GeneralSettings(
                         stringResource(R.string.ai_groq_disclaimer)
                     com.arflix.tv.ui.screens.player.SubtitleAiModel.GEMINI_FLASH_25 ->
                         stringResource(R.string.ai_gemini_disclaimer)
+                    com.arflix.tv.ui.screens.player.SubtitleAiModel.GEMINI_FLASH_LITE ->
+                        stringResource(R.string.ai_gemini_disclaimer)
                 },
                 style = ArflixTypography.caption.copy(fontSize = 11.sp),
                 color = TextSecondary.copy(alpha = 0.4f),
@@ -5307,7 +5314,8 @@ private fun AiModelDialog(
     val isMobile = LocalDeviceType.current.isTouchDevice()
     val options = listOf(
         Triple(com.arflix.tv.ui.screens.player.SubtitleAiModel.GROQ_LLAMA_70B, "Groq – Llama 3.3 70B", stringResource(R.string.ai_groq_model_note)),
-        Triple(com.arflix.tv.ui.screens.player.SubtitleAiModel.GEMINI_FLASH_25, "Google – Gemini 2.5 Flash", stringResource(R.string.ai_gemini_model_note))
+        Triple(com.arflix.tv.ui.screens.player.SubtitleAiModel.GEMINI_FLASH_25, "Google – Gemini 2.5 Flash", stringResource(R.string.ai_gemini_model_note)),
+        Triple(com.arflix.tv.ui.screens.player.SubtitleAiModel.GEMINI_FLASH_LITE, "Google – Gemini Flash-Lite", "Always uses the latest Flash-Lite model")
     )
     BackHandler { onDismiss() }
     androidx.compose.ui.window.Dialog(onDismissRequest = onDismiss) {
@@ -5384,6 +5392,7 @@ private fun AiApiKeyDialog(
     val placeholder = when (model) {
         com.arflix.tv.ui.screens.player.SubtitleAiModel.GROQ_LLAMA_70B -> "gsk_..."
         com.arflix.tv.ui.screens.player.SubtitleAiModel.GEMINI_FLASH_25 -> "AIzaSy..."
+        com.arflix.tv.ui.screens.player.SubtitleAiModel.GEMINI_FLASH_LITE -> "AIzaSy..."
     }
     BackHandler { onDismiss() }
     LaunchedEffect(Unit) {

--- a/app/src/test/kotlin/com/arflix/tv/ui/screens/player/SubtitleAiModelTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/ui/screens/player/SubtitleAiModelTest.kt
@@ -1,0 +1,37 @@
+package com.arflix.tv.ui.screens.player
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SubtitleAiModelTest {
+
+    @Test
+    fun `Flash-Lite enum value round trips by name`() {
+        val model = SubtitleAiModel.GEMINI_FLASH_LITE
+
+        assertEquals(model, SubtitleAiModel.valueOf(model.name))
+    }
+
+    @Test
+    fun `Gemini models map to Gemini API model ids`() {
+        assertEquals("gemini-2.5-flash", SubtitleAiModel.GEMINI_FLASH_25.geminiModelId)
+        assertEquals("gemini-flash-lite-latest", SubtitleAiModel.GEMINI_FLASH_LITE.geminiModelId)
+    }
+
+    @Test
+    fun `Groq model is not routed through Gemini model ids`() {
+        assertNull(SubtitleAiModel.GROQ_LLAMA_70B.geminiModelId)
+    }
+
+    @Test
+    fun `unknown persisted model string falls back to Groq`() {
+        val model = runCatching {
+            SubtitleAiModel.valueOf("UNKNOWN_MODEL")
+        }.getOrElse {
+            SubtitleAiModel.GROQ_LLAMA_70B
+        }
+
+        assertEquals(SubtitleAiModel.GROQ_LLAMA_70B, model)
+    }
+}

--- a/app/src/test/kotlin/com/arflix/tv/ui/screens/player/SubtitleAiModelTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/ui/screens/player/SubtitleAiModelTest.kt
@@ -16,7 +16,7 @@ class SubtitleAiModelTest {
     @Test
     fun `Gemini models map to Gemini API model ids`() {
         assertEquals("gemini-2.5-flash", SubtitleAiModel.GEMINI_FLASH_25.geminiModelId)
-        assertEquals("gemini-flash-lite-latest", SubtitleAiModel.GEMINI_FLASH_LITE.geminiModelId)
+        assertEquals("gemini-2.5-flash-lite", SubtitleAiModel.GEMINI_FLASH_LITE.geminiModelId)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Gemini Flash-Lite is now a selectable model for AI subtitle translation. The Gemini request path is parameterized by model id instead of baking `gemini-2.5-flash` into the base-URL constant, and the new `GEMINI_FLASH_LITE` enum value routes through the same `translateGemini` implementation with `gemini-2.5-flash-lite`.

## Why this matters

#251 asked for Flash-Lite as an option for faster, cheaper subtitle translation; @silentbil acknowledged it on 2026-05-28 and the reporter pinged again on 2026-06-11 with no PR in sight. This covers the model-addition half of the issue; the advanced generation settings (temperature, top-p, thinking budget) are a separate piece and stay open. Persistence needs no changes since the enum is stored by name with a safe fallback, so existing users see no migration.

## Testing

Unit test covers the enum round-trip and the model-id mapping; the settings screen's model label, disclaimer text, and model dialog all render the new option through the extended exhaustive `when` blocks.

Refs #251
