### PR TITLE
fix: add contentDescription to selection-state icons for screen readers

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -5884,7 +5884,7 @@ private fun IptvSettings(
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             if (selectionMode) {
-                                Icon(imageVector = if (isSelected) Icons.Default.CheckCircle else Icons.Default.RadioButtonUnchecked, contentDescription = null, tint = if (isSelected) Pink else TextSecondary, modifier = Modifier.size(24.dp))
+                                Icon(imageVector = if (isSelected) Icons.Default.CheckCircle else Icons.Default.RadioButtonUnchecked, contentDescription = stringResource(if (isSelected) R.string.item_selected else R.string.item_not_selected), tint = if (isSelected) Pink else TextSecondary, modifier = Modifier.size(24.dp))
                                 Spacer(modifier = Modifier.width(16.dp))
                             } else {
                                 Icon(imageVector = Icons.Default.LiveTv, contentDescription = null, tint = TextSecondary, modifier = Modifier.size(24.dp))
@@ -6919,7 +6919,7 @@ private fun CatalogsSettings(
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
                                 if (selectionMode) {
-                                    Icon(if (isSelected) Icons.Default.CheckCircle else Icons.Default.RadioButtonUnchecked, contentDescription = null, tint = if (isSelected) Pink else TextSecondary, modifier = Modifier.size(24.dp))
+                                    Icon(if (isSelected) Icons.Default.CheckCircle else Icons.Default.RadioButtonUnchecked, contentDescription = stringResource(if (isSelected) R.string.item_selected else R.string.item_not_selected), tint = if (isSelected) Pink else TextSecondary, modifier = Modifier.size(24.dp))
                                     Spacer(modifier = Modifier.width(16.dp))
                                 } else {
                                     Icon(Icons.Default.Widgets, contentDescription = null, tint = TextSecondary, modifier = Modifier.size(24.dp))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -92,6 +92,8 @@
     <string name="add">Add</string>
     <string name="refresh">Refresh</string>
     <string name="selected">selected</string>
+    <string name="item_selected">Selected</string>
+    <string name="item_not_selected">Not selected</string>
     <string name="sign_in">Sign In</string>
     <string name="log_out">Log Out</string>
     <string name="watched">Watched</string>


### PR DESCRIPTION
## What this fixes
Adds proper `contentDescription` values to selection-state icons (`CheckCircle`/`RadioButtonUnchecked`) in `SettingsScreen.kt` (IPTV playlist and catalog selection rows). Previously these used `contentDescription = null`, so TalkBack gave no audio feedback on whether an item was selected when navigating with a D-pad on Android TV.

## Changes
- Added `item_selected` / `item_not_selected` string resources in `strings.xml`
- Updated 2 icon usages in `IptvSettings()` and `CatalogsSettings()` composables to use `stringResource()` reflecting current selection state

## Testing
- Verified the project builds successfully (`./gradlew :app:assemblePlayDebug` — BUILD SUCCESSFUL)
- Scope limited to 2 files for this initial PR per discussion in #399; happy to follow up with remaining occurrences in a separate PR if this looks good

Closes #399

---
🙏 First-time contributor here for GSSoC — would appreciate a review and the `gssoc:approved` + difficulty label if this looks good. Thanks!