### PR TITLE
Fix plugin cloud sync: wire CloudSyncInvalidationBus to PluginManager

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncCoordinator.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncCoordinator.kt
@@ -98,6 +98,7 @@ class CloudSyncCoordinator @Inject constructor(
         return when (scope) {
             CloudSyncScope.LOCAL_HISTORY -> 2_000L
             CloudSyncScope.IPTV -> 750L
+            CloudSyncScope.PLUGINS -> 1_000L
             else -> 500L
         }
     }

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncInvalidationBus.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncInvalidationBus.kt
@@ -15,7 +15,8 @@ enum class CloudSyncScope {
     IPTV,
     WATCHLIST,
     LOCAL_HISTORY,
-    ACCOUNT
+    ACCOUNT,
+    PLUGINS
 }
 
 data class CloudSyncInvalidation(

--- a/app/src/sideload/kotlin/com/arflix/tv/core/plugin/PluginManager.kt
+++ b/app/src/sideload/kotlin/com/arflix/tv/core/plugin/PluginManager.kt
@@ -7,6 +7,8 @@ import com.arflix.tv.core.plugin.cloudstream.ExternalExtensionLoader
 import com.arflix.tv.core.plugin.cloudstream.ExternalExtensionRunner
 import com.arflix.tv.core.plugin.cloudstream.ExternalRepoParser
 import com.arflix.tv.data.local.PluginDataStore
+import com.arflix.tv.data.repository.CloudSyncInvalidationBus
+import com.arflix.tv.data.repository.CloudSyncScope
 import com.arflix.tv.domain.model.ExternalPluginEntry
 import com.arflix.tv.domain.model.LocalScraperResult
 import com.arflix.tv.domain.model.PluginManifest
@@ -65,7 +67,8 @@ class PluginManager @Inject constructor(
     private val runtime: PluginRuntime,
     private val externalRepoParser: ExternalRepoParser,
     private val externalExtensionLoader: ExternalExtensionLoader,
-    private val externalExtensionRunner: ExternalExtensionRunner
+    private val externalExtensionRunner: ExternalExtensionRunner,
+    private val invalidationBus: CloudSyncInvalidationBus
 ) {
     private val moshi = Moshi.Builder()
         .addLast(KotlinJsonAdapterFactory())
@@ -247,28 +250,21 @@ class PluginManager @Inject constructor(
     fun flushPendingSync() {
         if (pendingPushAfterSync) {
             pendingPushAfterSync = false
-            Log.d(TAG, "flushPendingSync: firing deferred push")
-            triggerRemoteSync()
+            Log.d(TAG, "flushPendingSync: firing deferred push after remote sync")
+            triggerRemoteSync("flush after remote sync")
         }
     }
 
     private var syncJob: kotlinx.coroutines.Job? = null
 
-    private fun triggerRemoteSync() {
+    private fun triggerRemoteSync(reason: String = "plugin change") {
         if (isSyncingFromRemote) {
-            Log.d(TAG, "triggerRemoteSync: skipped (syncing from remote), will push after sync")
+            Log.d(TAG, "triggerRemoteSync: deferred (syncing from remote)")
             pendingPushAfterSync = true
             return
         }
-        if (true /* !authManager.isAuthenticated */) {
-            Log.d(TAG, "triggerRemoteSync: skipped (not authenticated, simulated)")
-            return
-        }
-        Log.d(TAG, "triggerRemoteSync: scheduling push in 500ms")
-        syncJob?.cancel()
-        syncJob = syncScope.launch {
-            kotlinx.coroutines.delay(500)
-        }
+        Log.d(TAG, "triggerRemoteSync: marking dirty — $reason")
+        invalidationBus.markDirty(CloudSyncScope.PLUGINS, null, reason)
     }
 
     // Combined flow of enabled scrapers
@@ -399,7 +395,7 @@ class PluginManager @Inject constructor(
         downloadJsScrapers(repo.id, canonicalManifestUrl, manifest.getActiveScrapers())
 
         Log.d(TAG, "NuvioTV repository added: ${repo.name} with ${manifest.getActiveScrapers().size} scrapers")
-        triggerRemoteSync()
+        triggerRemoteSync("repo added: ${repo.name}")
         return Result.success(repo)
     }
 
@@ -430,7 +426,7 @@ class PluginManager @Inject constructor(
         downloadDexExtensions(repo.id, parseResult.plugins)
 
         Log.d(TAG, "External repository added: ${repo.name} with ${parseResult.plugins.size} extensions")
-        triggerRemoteSync()
+        triggerRemoteSync("repo added: ${repo.name}")
         return Result.success(repo)
     }
 
@@ -457,14 +453,7 @@ class PluginManager @Inject constructor(
         // Remove repository
         dataStore.removeRepository(repoId)
 
-        // Push synchronously when user-initiated (not during reconciliation)
-        // to prevent the next sync pull from re-adding the removed repo
-        if (!isSyncingFromRemote && false /* authManager.isAuthenticated */) {
-            Log.d(TAG, "removeRepository: pushing removal to remote synchronously")
-            // pluginSyncService.pushToRemote()
-        } else if (isSyncingFromRemote) {
-            pendingPushAfterSync = true
-        }
+        triggerRemoteSync("repo removed: $repoId")
     }
 
 
@@ -603,6 +592,7 @@ class PluginManager @Inject constructor(
             if (scraper.id == scraperId) scraper.copy(enabled = enabled) else scraper
         }
         dataStore.saveScrapers(updatedScrapers)
+        triggerRemoteSync("scraper toggled: $scraperId=$enabled")
     }
 
     /**
@@ -614,6 +604,7 @@ class PluginManager @Inject constructor(
             if (scraper.repositoryId == repoId) scraper.copy(enabled = enabled) else scraper
         }
         dataStore.saveScrapers(updatedScrapers)
+        triggerRemoteSync("all scrapers toggled for repo: $repoId=$enabled")
     }
 
     /**
@@ -621,6 +612,7 @@ class PluginManager @Inject constructor(
      */
     suspend fun setPluginsEnabled(enabled: Boolean) {
         dataStore.setPluginsEnabled(enabled)
+        triggerRemoteSync("plugins enabled=$enabled")
     }
 
     suspend fun setGroupStreamsByRepository(enabled: Boolean) {


### PR DESCRIPTION
## Bug

`PluginManager.triggerRemoteSync()` always returned early due to dead code left from the old Supabase auth system:

```kotlin
if (true /* !authManager.isAuthenticated */) {
    return  // ← always exits here, nothing is ever pushed
}
```

As a result, adding/removing plugin repositories was saved **locally only** and never triggered a cloud push.

## Fix

**3 files changed:**

### 1. `CloudSyncInvalidationBus.kt`
Add `PLUGINS` to the `CloudSyncScope` enum so the coordinator knows how to debounce plugin changes.

### 2. `CloudSyncCoordinator.kt`
Add 1000ms debounce for `PLUGINS` scope (between IPTV's 750ms and LOCAL_HISTORY's 2000ms).

### 3. `PluginManager.kt` (sideload)
- Inject `CloudSyncInvalidationBus`
- Replace dead `triggerRemoteSync()` implementation with `invalidationBus.markDirty(CloudSyncScope.PLUGINS, ...)`
- Wire `markDirty()` to: `addRepository`, `removeRepository`, `toggleScraper`, `toggleAllScrapersForRepo`, `setPluginsEnabled`, `flushPendingSync`

## Result

After this fix, any plugin change (add repo, remove repo, enable/disable scraper) will:
1. Save locally as before
2. Trigger `CloudSyncCoordinator` via the invalidation bus (1s debounce)
3. Push the full snapshot (including `pluginRepositories` + `pluginScrapers`) to cloud
4. Other devices sync down on next pull