### PR TITLE
feat: per-profile catalog artwork editor with automatic cloud sync

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/CatalogRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/CatalogRepository.kt
@@ -793,6 +793,25 @@ class CatalogRepository @Inject constructor(
         return true
     }
 
+    suspend fun updateCatalogArtwork(
+        catalogId: String,
+        coverImageUrl: String?,
+        heroImageUrl: String?,
+        focusGifUrl: String?,
+        clearLogoUrl: String?
+    ): Boolean {
+        val current = getCatalogs().toMutableList()
+        val index = current.indexOfFirst { it.id == catalogId }
+        if (index < 0) return false
+        current[index] = current[index].copy(
+            collectionCoverImageUrl = coverImageUrl?.trim()?.takeIf { it.isNotBlank() },
+            collectionHeroImageUrl = heroImageUrl?.trim()?.takeIf { it.isNotBlank() },
+            collectionFocusGifUrl = focusGifUrl?.trim()?.takeIf { it.isNotBlank() },
+            collectionClearLogoUrl = clearLogoUrl?.trim()?.takeIf { it.isNotBlank() }
+        )
+        saveCatalogs(current)
+        return true
+    }
     suspend fun moveCatalogUp(catalogId: String): Boolean {
         val current = getCatalogs().toMutableList()
         val visible = current.filter { isVisibleCatalogInSettings(it) }

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncRepository.kt
@@ -91,7 +91,8 @@ class CloudSyncRepository @Inject constructor(
     private val watchHistoryRepository: WatchHistoryRepository,
     private val watchlistRepository: WatchlistRepository,
     private val profileAvatarImageManager: ProfileAvatarImageManager,
-    private val invalidationBus: CloudSyncInvalidationBus
+    private val invalidationBus: CloudSyncInvalidationBus,
+    private val pluginDataStore: com.arflix.tv.data.local.PluginDataStore
 ) {
     private val TAG = "CloudSync"
     private val gson = Gson()
@@ -623,6 +624,16 @@ class CloudSyncRepository @Inject constructor(
         root.put("iptvEpgUrl", iptvConfig.epgUrl)
         root.put("iptvFavoriteGroups", JSONArray(gson.toJson(iptvRepository.observeFavoriteGroups().first())))
         root.put("iptvFavoriteChannels", JSONArray(gson.toJson(iptvRepository.observeFavoriteChannels().first())))
+
+        // Plugin repositories and scrapers (sideload flavor)
+        runCatching {
+            val pluginRepos = pluginDataStore.repositories.first()
+            val pluginScrapers = pluginDataStore.scrapers.first()
+            val pluginsEnabled = pluginDataStore.pluginsEnabled.first()
+            root.put("pluginRepositories", JSONArray(gson.toJson(pluginRepos)))
+            root.put("pluginScrapers", JSONArray(gson.toJson(pluginScrapers)))
+            root.put("pluginsEnabled", pluginsEnabled)
+        }
 
         // Informational
         val isTraktLinked = traktRepository.hasTrakt()
@@ -1442,6 +1453,21 @@ class CloudSyncRepository @Inject constructor(
 
         traktRepository.clearAllProfileCaches()
         watchHistoryRepository.clearProfileCaches()
+
+        // Restore plugin repositories and scrapers
+        runCatching {
+            root.optJSONArray("pluginRepositories")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
+                val type = com.google.gson.reflect.TypeToken.getParameterized(List::class.java, com.arflix.tv.domain.model.PluginRepository::class.java).type
+                val repos: List<com.arflix.tv.domain.model.PluginRepository> = gson.fromJson(json, type) ?: emptyList()
+                if (repos.isNotEmpty()) pluginDataStore.saveRepositories(repos)
+            }
+            root.optJSONArray("pluginScrapers")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
+                val type = com.google.gson.reflect.TypeToken.getParameterized(List::class.java, com.arflix.tv.domain.model.ScraperInfo::class.java).type
+                val scrapers: List<com.arflix.tv.domain.model.ScraperInfo> = gson.fromJson(json, type) ?: emptyList()
+                if (scrapers.isNotEmpty()) pluginDataStore.saveScrapers(scrapers)
+            }
+            if (root.has("pluginsEnabled")) pluginDataStore.setPluginsEnabled(root.optBoolean("pluginsEnabled", false))
+        }.onFailure { AppLogger.recordException(it, mapOf("error_area" to "CloudSync", "cloud_flow" to "apply_plugins")) }
 
         System.err.println("[CLOUD-SYNC] Full cloud restore applied successfully")
     }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -355,6 +355,11 @@ fun SettingsScreen(
     var iptvActionIndex by remember { mutableIntStateOf(0) }
     var showIptvCategoriesSettings by remember { mutableStateOf(false) }
     // Rename dialog state
+    // Artwork edit state
+    var editCatalogCoverUrl by remember { mutableStateOf("") }
+    var editCatalogHeroUrl by remember { mutableStateOf("") }
+    var editCatalogFocusGifUrl by remember { mutableStateOf("") }
+    var editCatalogClearLogoUrl by remember { mutableStateOf("") }
     var showCatalogRename by remember { mutableStateOf(false) }
     var renameCatalogId by remember { mutableStateOf("") }
     var renameCatalogTitle by remember { mutableStateOf("") }
@@ -1010,6 +1015,10 @@ fun SettingsScreen(
                                                         0 -> {
                                                             renameCatalogId = catalog.id
                                                             renameCatalogTitle = catalog.title
+                                                            editCatalogCoverUrl = catalog.collectionCoverImageUrl.orEmpty()
+                                                            editCatalogHeroUrl = catalog.collectionHeroImageUrl.orEmpty()
+                                                            editCatalogFocusGifUrl = catalog.collectionFocusGifUrl.orEmpty()
+                                                            editCatalogClearLogoUrl = catalog.collectionClearLogoUrl.orEmpty()
                                                             showCatalogRename = true
                                                         }
                                                         1 -> viewModel.moveCatalogUp(catalog.id)
@@ -1113,6 +1122,10 @@ fun SettingsScreen(
                 onRenameCatalogClick = { catalog ->
                     renameCatalogId = catalog.id
                     renameCatalogTitle = catalog.title
+                    editCatalogCoverUrl = catalog.collectionCoverImageUrl.orEmpty()
+                    editCatalogHeroUrl = catalog.collectionHeroImageUrl.orEmpty()
+                    editCatalogFocusGifUrl = catalog.collectionFocusGifUrl.orEmpty()
+                    editCatalogClearLogoUrl = catalog.collectionClearLogoUrl.orEmpty()
                     showCatalogRename = true
                 },
                 onConnectHomeServerClick = {
@@ -1507,6 +1520,10 @@ fun SettingsScreen(
                             onRenameCatalog = { catalog ->
                                 renameCatalogId = catalog.id
                                 renameCatalogTitle = catalog.title
+                                editCatalogCoverUrl = catalog.collectionCoverImageUrl.orEmpty()
+                                editCatalogHeroUrl = catalog.collectionHeroImageUrl.orEmpty()
+                                editCatalogFocusGifUrl = catalog.collectionFocusGifUrl.orEmpty()
+                                editCatalogClearLogoUrl = catalog.collectionClearLogoUrl.orEmpty()
                                 showCatalogRename = true
                             },
                             onMoveCatalogUp = { catalog -> viewModel.moveCatalogUp(catalog.id) },
@@ -1777,15 +1794,50 @@ fun SettingsScreen(
             InputModal(
                 title = stringResource(R.string.rename_catalog),
                 fields = listOf(
-                    InputField(label = "Title", value = renameCatalogTitle, onValueChange = { renameCatalogTitle = it })
+                    InputField(label = "Title", value = renameCatalogTitle, onValueChange = { renameCatalogTitle = it }),
+                    InputField(
+                        label = "Cover image URL",
+                        placeholder = "https://... direct image link",
+                        value = editCatalogCoverUrl,
+                        onValueChange = { editCatalogCoverUrl = it }
+                    ),
+                    InputField(
+                        label = "Hero image URL (optional)",
+                        placeholder = "Background shown when row is focused",
+                        value = editCatalogHeroUrl,
+                        onValueChange = { editCatalogHeroUrl = it }
+                    ),
+                    InputField(
+                        label = "Animated GIF URL (optional)",
+                        placeholder = "Replaces cover on focus",
+                        value = editCatalogFocusGifUrl,
+                        onValueChange = { editCatalogFocusGifUrl = it }
+                    ),
+                    InputField(
+                        label = "Clear logo URL (optional)",
+                        placeholder = "Transparent title logo",
+                        value = editCatalogClearLogoUrl,
+                        onValueChange = { editCatalogClearLogoUrl = it }
+                    )
                 ),
                 onConfirm = {
                     if (renameCatalogTitle.isNotBlank()) {
                         viewModel.renameCatalog(renameCatalogId, renameCatalogTitle)
+                        viewModel.updateCatalogArtwork(
+                            catalogId = renameCatalogId,
+                            coverImageUrl = editCatalogCoverUrl.takeIf { it.isNotBlank() },
+                            heroImageUrl = editCatalogHeroUrl.takeIf { it.isNotBlank() },
+                            focusGifUrl = editCatalogFocusGifUrl.takeIf { it.isNotBlank() },
+                            clearLogoUrl = editCatalogClearLogoUrl.takeIf { it.isNotBlank() }
+                        )
                         showCatalogRename = false
                     }
                 },
                 onDismiss = {
+                    editCatalogCoverUrl = ""
+                    editCatalogHeroUrl = ""
+                    editCatalogFocusGifUrl = ""
+                    editCatalogClearLogoUrl = ""
                     showCatalogRename = false
                 }
             )

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -1844,6 +1844,23 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
+    fun updateCatalogArtwork(
+        catalogId: String,
+        coverImageUrl: String?,
+        heroImageUrl: String?,
+        focusGifUrl: String?,
+        clearLogoUrl: String?
+    ) {
+        viewModelScope.launch {
+            val success = catalogRepository.updateCatalogArtwork(
+                catalogId, coverImageUrl, heroImageUrl, focusGifUrl, clearLogoUrl
+            )
+            if (success) {
+                syncLocalStateToCloud(silent = true)
+            }
+        }
+    }
+
     fun moveCatalogUp(catalogId: String) {
         viewModelScope.launch {
             catalogRepository.moveCatalogUp(catalogId)

--- a/netlify-arvio-tv-site/companion/app.js
+++ b/netlify-arvio-tv-site/companion/app.js
@@ -73,6 +73,8 @@ const sections = {
   dashboard: renderDashboard,
   profiles: renderProfiles,
   addons: renderAddons,
+  iptv: renderIPTV,
+  plugins: renderPlugins,
   history: renderHistory,
   watchlist: renderWatchlist,
   ai: renderAI,
@@ -273,6 +275,148 @@ async function renderAddons() {
     ${renderAddonList(byType.TELEGRAM, `Telegram מקורות (${byType.TELEGRAM.length})`)}
     <div class="card" style="margin-top:16px">
       <div style="font-size:13px;color:var(--text-muted)">💡 להוספה/הסרה של הרחבות — גש להגדרות ב-ARVIO. הנתונים מסונכרנים אוטומטית.</div>
+    </div>
+  `;
+}
+
+// ── IPTV ──────────────────────────────────────────────────────────────────
+async function renderIPTV() {
+  const main = document.getElementById('main-content');
+  const payload = state.syncPayload;
+  const profiles = payload?.profiles ?? [];
+  const activeId = payload?.activeProfileId;
+  const iptvByProfile = payload?.iptvByProfile ?? {};
+
+  // Collect all playlists across profiles
+  const allPlaylists = [];
+  const seenUrls = new Set();
+  for (const [profileId, iptvState] of Object.entries(iptvByProfile)) {
+    const profile = profiles.find(p => p.id === profileId);
+    const pName = profile?.name ?? profileId.slice(0, 8);
+    (iptvState.playlists ?? []).forEach(pl => {
+      if (!seenUrls.has(pl.m3uUrl)) {
+        seenUrls.add(pl.m3uUrl);
+        allPlaylists.push({ ...pl, _profileName: pName, _profileId: profileId });
+      }
+    });
+    // Legacy single M3U
+    if (iptvState.m3uUrl && !seenUrls.has(iptvState.m3uUrl)) {
+      seenUrls.add(iptvState.m3uUrl);
+      allPlaylists.push({ id: 'legacy', name: 'M3U', m3uUrl: iptvState.m3uUrl, epgUrl: iptvState.epgUrl, enabled: true, _profileName: pName, _profileId: profileId });
+    }
+  }
+
+  // Collect favourite channels/groups from active profile
+  const activeIPTV = iptvByProfile[activeId] ?? Object.values(iptvByProfile)[0] ?? {};
+  const favGroups = activeIPTV.favoriteGroups ?? [];
+  const favChannels = activeIPTV.favoriteChannels ?? [];
+
+  main.innerHTML = `
+    <div class="section-header">
+      <div><div class="section-title">IPTV</div><div class="section-sub">${allPlaylists.length} רשימות פעילות</div></div>
+    </div>
+
+    ${allPlaylists.length === 0 ? emptyState('אין רשימות IPTV מוגדרות — הגדר ב-ARVIO ← הגדרות ← IPTV') : `
+    <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin-bottom:12px">רשימות M3U</div>
+    <div class="card" style="padding:0 20px">
+      ${allPlaylists.map(pl => `
+        <div class="list-item">
+          <div class="item-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"/><path d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+          </div>
+          <div class="item-info">
+            <div class="item-title">${pl.name || 'M3U Playlist'}</div>
+            <div class="item-sub" style="font-family:monospace;font-size:11px;max-width:380px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${pl.m3uUrl}</div>
+            ${pl.epgUrl ? `<div class="item-sub" style="font-size:11px">EPG: ${pl.epgUrl}</div>` : ''}
+          </div>
+          <div style="display:flex;flex-direction:column;align-items:flex-end;gap:6px">
+            <span class="badge ${pl.enabled !== false ? 'badge-green' : 'badge-red'}">${pl.enabled !== false ? 'פעיל' : 'כבוי'}</span>
+            <span class="badge badge-gray">${pl._profileName}</span>
+          </div>
+        </div>
+      `).join('')}
+    </div>`}
+
+    ${favGroups.length > 0 ? `
+    <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin:24px 0 12px">קבוצות מועדפות (${favGroups.length})</div>
+    <div class="card" style="padding:14px 20px;display:flex;flex-wrap:wrap;gap:8px">
+      ${favGroups.map(g => `<span class="badge badge-gold">⭐ ${g}</span>`).join('')}
+    </div>` : ''}
+
+    ${favChannels.length > 0 ? `
+    <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin:24px 0 12px">ערוצים מועדפים (${favChannels.length})</div>
+    <div class="card" style="padding:14px 20px;display:flex;flex-wrap:wrap;gap:8px">
+      ${favChannels.slice(0, 50).map(c => `<span class="badge badge-blue">📺 ${c}</span>`).join('')}
+      ${favChannels.length > 50 ? `<span class="badge badge-gray">+${favChannels.length - 50} נוספים</span>` : ''}
+    </div>` : ''}
+
+    <div class="card" style="margin-top:16px">
+      <div style="font-size:13px;color:var(--text-muted)">💡 להוספת רשימות M3U ולניהול ערוצים — גש להגדרות IPTV ב-ARVIO. השינויים מסונכרנים אוטומטית לענן.</div>
+    </div>
+  `;
+}
+
+// ── Plugins ───────────────────────────────────────────────────────────────
+async function renderPlugins() {
+  const main = document.getElementById('main-content');
+  const payload = state.syncPayload;
+  const repos = payload?.pluginRepositories ?? [];
+  const scrapers = payload?.pluginScrapers ?? [];
+  const pluginsEnabled = payload?.pluginsEnabled ?? false;
+
+  main.innerHTML = `
+    <div class="section-header">
+      <div><div class="section-title">פלאגינים (Sideload)</div><div class="section-sub">${repos.length} מאגרים · ${scrapers.length} scrapers</div></div>
+      <div style="display:flex;align-items:center;gap:10px">
+        <span style="font-size:13px;color:var(--text-muted)">פלאגינים ${pluginsEnabled ? 'פעילים' : 'כבויים'}</span>
+        <label class="toggle">
+          <input type="checkbox" ${pluginsEnabled ? 'checked' : ''} onchange="updateSetting('pluginsEnabled',this.checked)">
+          <span class="toggle-slider"></span>
+        </label>
+      </div>
+    </div>
+
+    ${repos.length === 0 ? emptyState('אין מאגרי פלאגינים — הוסף ב-ARVIO ← הגדרות ← פלאגינים') : `
+    <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin-bottom:12px">מאגרים (${repos.length})</div>
+    <div class="card" style="padding:0 20px">
+      ${repos.map(r => `
+        <div class="list-item">
+          <div class="item-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 7h18M3 12h18M3 17h18"/></svg>
+          </div>
+          <div class="item-info">
+            <div class="item-title">${r.name}</div>
+            <div class="item-sub" style="font-family:monospace;font-size:11px">${r.url}</div>
+            <div class="item-sub">${r.scraperCount ?? 0} scrapers · עודכן ${r.lastUpdated ? timeAgo(new Date(r.lastUpdated).toISOString()) : 'אף פעם'}</div>
+          </div>
+          <span class="badge ${r.enabled ? 'badge-green' : 'badge-red'}">${r.enabled ? 'פעיל' : 'כבוי'}</span>
+        </div>
+      `).join('')}
+    </div>`}
+
+    ${scrapers.length > 0 ? `
+    <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin:24px 0 12px">Scrapers (${scrapers.length})</div>
+    <div class="card" style="padding:0 20px">
+      ${scrapers.map(s => `
+        <div class="list-item">
+          <div class="item-icon">
+            ${s.logo ? `<img src="${s.logo}" alt="" onerror="this.style.display='none'">` : `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>`}
+          </div>
+          <div class="item-info">
+            <div class="item-title">${s.name}</div>
+            <div class="item-sub">${s.description || ''} · v${s.version}</div>
+            <div style="display:flex;gap:6px;margin-top:4px;flex-wrap:wrap">
+              ${(s.supportedTypes ?? []).map(t => `<span class="badge badge-gray">${t}</span>`).join('')}
+              ${(s.contentLanguage ?? []).map(l => `<span class="badge badge-blue">${l}</span>`).join('')}
+            </div>
+          </div>
+          <span class="badge ${s.enabled && s.manifestEnabled ? 'badge-green' : 'badge-red'}">${s.enabled && s.manifestEnabled ? 'פעיל' : 'כבוי'}</span>
+        </div>
+      `).join('')}
+    </div>` : ''}
+
+    <div class="card" style="margin-top:16px">
+      <div style="font-size:13px;color:var(--text-muted)">💡 הפלאגינים מסונכרנים לענן אוטומטית. קוד ה-JS של כל scraper נשמר מקומית בטלוויזיה בלבד ולא עולה לענן.</div>
     </div>
   `;
 }
@@ -658,6 +802,8 @@ function buildShell(user) {
     { id: 'dashboard', label: 'Dashboard', icon: '<path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/>' },
     { id: 'profiles', label: 'פרופילים', icon: '<path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/>' },
     { id: 'addons', label: 'הרחבות', icon: '<rect x="3" y="3" width="18" height="18" rx="3"/><path d="M9 9h6M9 12h6M9 15h4"/>' },
+    { id: 'iptv', label: 'IPTV', icon: '<path d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"/><path d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>' },
+    { id: 'plugins', label: 'פלאגינים', icon: '<path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/>' },
     { id: 'history', label: 'היסטוריה', icon: '<circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>' },
     { id: 'watchlist', label: 'רשימת צפייה', icon: '<path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z"/>' },
     { id: 'ai', label: 'תרגום AI', icon: '<path d="M12 2a3 3 0 013 3v7a3 3 0 01-6 0V5a3 3 0 013-3z"/><path d="M19 10v2a7 7 0 01-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/>' },

--- a/netlify-arvio-tv-site/companion/app.js
+++ b/netlify-arvio-tv-site/companion/app.js
@@ -91,7 +91,7 @@ function navigate(id) {
 
 async function renderSection() {
   const main = document.getElementById('main-content');
-  main.innerHTML = `<div class="loading"><div class="spinner"></div> טוען...</div>`;
+  main.innerHTML = `<div class="loading"><div class="spinner"></div> Loading...</div>`;
   await sections[state.activeSection]?.();
 }
 
@@ -114,17 +114,17 @@ async function renderDashboard() {
     <div class="section-header">
       <div>
         <div class="section-title">Dashboard</div>
-        <div class="section-sub">סקירה מהירה של חשבון ה-ARVIO שלך</div>
+        <div class="section-sub">A quick overview of your ARVIO account</div>
       </div>
     </div>
     <div class="card-grid">
-      <div class="stat-card"><div class="stat-label">פרופילים</div><div class="stat-value gold">${profiles.length || 1}</div></div>
-      <div class="stat-card"><div class="stat-label">הרחבות</div><div class="stat-value">${addons.filter(a => a.isEnabled).length}</div></div>
-      <div class="stat-card"><div class="stat-label">היסטוריית צפייה</div><div class="stat-value">${histRes.count ?? '—'}</div></div>
-      <div class="stat-card"><div class="stat-label">רשימת צפייה</div><div class="stat-value">${wlRes.count ?? '—'}</div></div>
+      <div class="stat-card"><div class="stat-label">Profiles</div><div class="stat-value gold">${profiles.length || 1}</div></div>
+      <div class="stat-card"><div class="stat-label">Add-ons</div><div class="stat-value">${addons.filter(a => a.isEnabled).length}</div></div>
+      <div class="stat-card"><div class="stat-label">Watch History</div><div class="stat-value">${histRes.count ?? '—'}</div></div>
+      <div class="stat-card"><div class="stat-label">Watchlist</div><div class="stat-value">${wlRes.count ?? '—'}</div></div>
     </div>
     <div class="card">
-      <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin-bottom:14px">פעילות אחרונה</div>
+      <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin-bottom:14px">Recent Activity</div>
       <div id="recent-activity"><div class="loading"><div class="spinner"></div></div></div>
     </div>
   `;
@@ -137,7 +137,7 @@ async function renderDashboard() {
 
   const ra = document.getElementById('recent-activity');
   if (!recent?.length) {
-    ra.innerHTML = emptyState('אין פעילות אחרונה');
+    ra.innerHTML = emptyState('No recent activity');
     return;
   }
   ra.innerHTML = recent.map(r => `
@@ -145,7 +145,7 @@ async function renderDashboard() {
       <img class="history-poster" src="${r.poster_path ? TMDB_IMG + r.poster_path : ''}" onerror="this.style.background='var(--bg-card2)';this.src=''" alt="">
       <div class="item-info">
         <div class="item-title">${r.title || '—'}</div>
-        <div class="item-sub">${r.media_type === 'movie' ? '🎬 סרט' : '📺 סדרה'} · ${timeAgo(r.updated_at)}</div>
+        <div class="item-sub">${r.media_type === 'movie' ? '🎬 Movie' : '📺 Series'} · ${timeAgo(r.updated_at)}</div>
         <div class="progress-bar"><div class="progress-fill" style="width:${Math.round((r.progress||0)*100)}%"></div></div>
       </div>
       <span class="badge badge-gray">${Math.round((r.progress||0)*100)}%</span>
@@ -172,14 +172,14 @@ async function renderProfiles() {
 
   if (!profiles.length) {
     main.innerHTML = `
-      <div class="section-header"><div class="section-title">פרופילים</div></div>
-      ${emptyState('אין פרופילים — פתח את ARVIO בטלוויזיה ליצירת פרופיל')}`;
+      <div class="section-header"><div class="section-title">Profiles</div></div>
+      ${emptyState('No profiles found — open ARVIO on your TV to create one')}`;
     return;
   }
 
   main.innerHTML = `
     <div class="section-header">
-      <div><div class="section-title">פרופילים</div><div class="section-sub">${profiles.length} פרופילים בחשבון</div></div>
+      <div><div class="section-title">Profiles</div><div class="section-sub">${profiles.length} profile${profiles.length !== 1 ? 's' : ''} in account</div></div>
     </div>
     <div class="profiles-grid">
       ${profiles.map(p => `
@@ -187,15 +187,15 @@ async function renderProfiles() {
           ${renderProfileAvatar(p)}
           <div class="profile-name">${p.name}</div>
           <div style="display:flex;gap:6px;flex-wrap:wrap;justify-content:center">
-            ${p.id === activeId ? '<span class="badge badge-gold">פעיל</span>' : ''}
-            ${p.isKidsProfile ? '<span class="badge badge-blue">ילדים</span>' : ''}
-            ${p.pin ? '<span class="badge badge-gray">🔒 נעול</span>' : ''}
+            ${p.id === activeId ? '<span class="badge badge-gold">Active</span>' : ''}
+            ${p.isKidsProfile ? '<span class="badge badge-blue">Kids</span>' : ''}
+            ${p.pin ? '<span class="badge badge-gray">🔒 Locked</span>' : ''}
           </div>
         </div>
       `).join('')}
     </div>
     <div class="card">
-      <div style="font-size:13px;color:var(--text-muted)">💡 ניהול פרופילים (יצירה, מחיקה, שינוי שם) זמין ב-ARVIO על הטלוויזיה.<br>שינויים מסונכרנים אוטומטית עם הענן.</div>
+      <div style="font-size:13px;color:var(--text-muted)">💡 Profile management (create, delete, rename) is available in ARVIO on your TV.<br>Changes sync automatically to the cloud.</div>
     </div>
   `;
 }
@@ -219,8 +219,8 @@ async function renderAddons() {
 
   if (!addons.length) {
     main.innerHTML = `
-      <div class="section-header"><div class="section-title">הרחבות</div></div>
-      ${emptyState('אין הרחבות מותקנות')}`;
+      <div class="section-header"><div class="section-title">Add-ons</div></div>
+      ${emptyState('No add-ons installed')}`;
     return;
   }
 
@@ -238,11 +238,11 @@ async function renderAddons() {
 
   function addonTypeBadge(a) {
     const t = a.type || 'COMMUNITY';
-    if (t === 'OFFICIAL') return '<span class="badge badge-gold">רשמי</span>';
-    if (t === 'SUBTITLE') return '<span class="badge badge-blue">כתוביות</span>';
-    if (t === 'METADATA') return '<span class="badge badge-gray">מטאדאטה</span>';
+    if (t === 'OFFICIAL') return '<span class="badge badge-gold">Official</span>';
+    if (t === 'SUBTITLE') return '<span class="badge badge-blue">Subtitles</span>';
+    if (t === 'METADATA') return '<span class="badge badge-gray">Metadata</span>';
     if (a.runtimeKind === 'TELEGRAM') return '<span class="badge badge-blue">Telegram</span>';
-    return '<span class="badge badge-gray">קהילה</span>';
+    return '<span class="badge badge-gray">Community</span>';
   }
 
   function renderAddonList(list, label) {
@@ -259,7 +259,7 @@ async function renderAddons() {
             </div>
             <div style="display:flex;gap:8px;align-items:center">
               ${addonTypeBadge(a)}
-              <span class="badge ${a.isEnabled ? 'badge-green' : 'badge-red'}">${a.isEnabled ? 'פעיל' : 'כבוי'}</span>
+              <span class="badge ${a.isEnabled ? 'badge-green' : 'badge-red'}">${a.isEnabled ? 'Enabled' : 'Disabled'}</span>
             </div>
           </div>
         `).join('')}
@@ -269,12 +269,12 @@ async function renderAddons() {
 
   main.innerHTML = `
     <div class="section-header">
-      <div><div class="section-title">הרחבות</div><div class="section-sub">${addons.filter(a=>a.isEnabled).length} פעילות מתוך ${addons.length}</div></div>
+      <div><div class="section-title">Add-ons</div><div class="section-sub">${addons.filter(a=>a.isEnabled).length} active of ${addons.length}</div></div>
     </div>
-    ${renderAddonList(byType.STREMIO, `Stremio הרחבות (${byType.STREMIO.length})`)}
-    ${renderAddonList(byType.TELEGRAM, `Telegram מקורות (${byType.TELEGRAM.length})`)}
+    ${renderAddonList(byType.STREMIO, `Stremio Add-ons (${byType.STREMIO.length})`)}
+    ${renderAddonList(byType.TELEGRAM, `Telegram Sources (${byType.TELEGRAM.length})`)}
     <div class="card" style="margin-top:16px">
-      <div style="font-size:13px;color:var(--text-muted)">💡 להוספה/הסרה של הרחבות — גש להגדרות ב-ARVIO. הנתונים מסונכרנים אוטומטית.</div>
+      <div style="font-size:13px;color:var(--text-muted)">💡 To add or remove add-ons, go to Settings in ARVIO on your TV. Data syncs automatically.</div>
     </div>
   `;
 }
@@ -313,11 +313,11 @@ async function renderIPTV() {
 
   main.innerHTML = `
     <div class="section-header">
-      <div><div class="section-title">IPTV</div><div class="section-sub">${allPlaylists.length} רשימות פעילות</div></div>
+      <div><div class="section-title">IPTV</div><div class="section-sub">${allPlaylists.length} active playlist${allPlaylists.length !== 1 ? 's' : ''}</div></div>
     </div>
 
-    ${allPlaylists.length === 0 ? emptyState('אין רשימות IPTV מוגדרות — הגדר ב-ARVIO ← הגדרות ← IPTV') : `
-    <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin-bottom:12px">רשימות M3U</div>
+    ${allPlaylists.length === 0 ? emptyState('No IPTV playlists configured — go to ARVIO → Settings → IPTV') : `
+    <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin-bottom:12px">M3U Playlists</div>
     <div class="card" style="padding:0 20px">
       ${allPlaylists.map(pl => `
         <div class="list-item">
@@ -330,7 +330,7 @@ async function renderIPTV() {
             ${pl.epgUrl ? `<div class="item-sub" style="font-size:11px">EPG: ${pl.epgUrl}</div>` : ''}
           </div>
           <div style="display:flex;flex-direction:column;align-items:flex-end;gap:6px">
-            <span class="badge ${pl.enabled !== false ? 'badge-green' : 'badge-red'}">${pl.enabled !== false ? 'פעיל' : 'כבוי'}</span>
+            <span class="badge ${pl.enabled !== false ? 'badge-green' : 'badge-red'}">${pl.enabled !== false ? 'Active' : 'Disabled'}</span>
             <span class="badge badge-gray">${pl._profileName}</span>
           </div>
         </div>
@@ -338,16 +338,16 @@ async function renderIPTV() {
     </div>`}
 
     ${favGroups.length > 0 ? `
-    <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin:24px 0 12px">קבוצות מועדפות (${favGroups.length})</div>
+    <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin:24px 0 12px">Favourite Groups (${favGroups.length})</div>
     <div class="card" style="padding:14px 20px;display:flex;flex-wrap:wrap;gap:8px">
       ${favGroups.map(g => `<span class="badge badge-gold">⭐ ${g}</span>`).join('')}
     </div>` : ''}
 
     ${favChannels.length > 0 ? `
-    <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin:24px 0 12px">ערוצים מועדפים (${favChannels.length})</div>
+    <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin:24px 0 12px">Favourite Channels (${favChannels.length})</div>
     <div class="card" style="padding:14px 20px;display:flex;flex-wrap:wrap;gap:8px">
       ${favChannels.slice(0, 50).map(c => `<span class="badge badge-blue">📺 ${c}</span>`).join('')}
-      ${favChannels.length > 50 ? `<span class="badge badge-gray">+${favChannels.length - 50} נוספים</span>` : ''}
+      ${favChannels.length > 50 ? `<span class="badge badge-gray">+${favChannels.length - 50} more</span>` : ''}
     </div>` : ''}
 
     <div class="card" style="margin-top:16px">
@@ -366,9 +366,9 @@ async function renderPlugins() {
 
   main.innerHTML = `
     <div class="section-header">
-      <div><div class="section-title">פלאגינים (Sideload)</div><div class="section-sub">${repos.length} מאגרים · ${scrapers.length} scrapers</div></div>
+      <div><div class="section-title">Plugins (Sideload)</div><div class="section-sub">${repos.length} repositor${repos.length !== 1 ? 'ies' : 'y'} · ${scrapers.length} scrapers</div></div>
       <div style="display:flex;align-items:center;gap:10px">
-        <span style="font-size:13px;color:var(--text-muted)">פלאגינים ${pluginsEnabled ? 'פעילים' : 'כבויים'}</span>
+        <span style="font-size:13px;color:var(--text-muted)">Plugins ${pluginsEnabled ? 'enabled' : 'disabled'}</span>
         <label class="toggle">
           <input type="checkbox" ${pluginsEnabled ? 'checked' : ''} onchange="updateSetting('pluginsEnabled',this.checked)">
           <span class="toggle-slider"></span>
@@ -376,8 +376,8 @@ async function renderPlugins() {
       </div>
     </div>
 
-    ${repos.length === 0 ? emptyState('אין מאגרי פלאגינים — הוסף ב-ARVIO ← הגדרות ← פלאגינים') : `
-    <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin-bottom:12px">מאגרים (${repos.length})</div>
+    ${repos.length === 0 ? emptyState('No plugin repositories — add one in ARVIO → Settings → Plugins') : `
+    <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin-bottom:12px">Repositories (${repos.length})</div>
     <div class="card" style="padding:0 20px">
       ${repos.map(r => `
         <div class="list-item">
@@ -387,9 +387,9 @@ async function renderPlugins() {
           <div class="item-info">
             <div class="item-title">${r.name}</div>
             <div class="item-sub" style="font-family:monospace;font-size:11px">${r.url}</div>
-            <div class="item-sub">${r.scraperCount ?? 0} scrapers · עודכן ${r.lastUpdated ? timeAgo(new Date(r.lastUpdated).toISOString()) : 'אף פעם'}</div>
+            <div class="item-sub">${r.scraperCount ?? 0} scrapers · updated ${r.lastUpdated ? timeAgo(new Date(r.lastUpdated).toISOString()) : 'never'}</div>
           </div>
-          <span class="badge ${r.enabled ? 'badge-green' : 'badge-red'}">${r.enabled ? 'פעיל' : 'כבוי'}</span>
+          <span class="badge ${r.enabled ? 'badge-green' : 'badge-red'}">${r.enabled ? 'Active' : 'Disabled'}</span>
         </div>
       `).join('')}
     </div>`}
@@ -410,13 +410,13 @@ async function renderPlugins() {
               ${(s.contentLanguage ?? []).map(l => `<span class="badge badge-blue">${l}</span>`).join('')}
             </div>
           </div>
-          <span class="badge ${s.enabled && s.manifestEnabled ? 'badge-green' : 'badge-red'}">${s.enabled && s.manifestEnabled ? 'פעיל' : 'כבוי'}</span>
+          <span class="badge ${s.enabled && s.manifestEnabled ? 'badge-green' : 'badge-red'}">${s.enabled && s.manifestEnabled ? 'Active' : 'Disabled'}</span>
         </div>
       `).join('')}
     </div>` : ''}
 
     <div class="card" style="margin-top:16px">
-      <div style="font-size:13px;color:var(--text-muted)">💡 הפלאגינים מסונכרנים לענן אוטומטית. קוד ה-JS של כל scraper נשמר מקומית בטלוויזיה בלבד ולא עולה לענן.</div>
+      <div style="font-size:13px;color:var(--text-muted)">💡 Plugins sync to the cloud automatically. Each scraper's JS code stays local on your TV only and is never uploaded to the cloud.</div>
     </div>
   `;
 }
@@ -430,9 +430,9 @@ async function renderHistory() {
       <div><div class="section-title">היסטוריית צפייה</div></div>
     </div>
     <div class="tabs">
-      <button class="tab ${state.historyTab==='movies'?'active':''}" onclick="state.historyTab='movies';renderHistoryContent()">סרטים</button>
-      <button class="tab ${state.historyTab==='tv'?'active':''}" onclick="state.historyTab='tv';renderHistoryContent()">סדרות</button>
-      <button class="tab ${state.historyTab==='all'?'active':''}" onclick="state.historyTab='all';renderHistoryContent()">הכל</button>
+      <button class="tab ${state.historyTab==='movies'?'active':''}" onclick="state.historyTab='movies';renderHistoryContent()">Movies</button>
+      <button class="tab ${state.historyTab==='tv'?'active':''}" onclick="state.historyTab='tv';renderHistoryContent()">TV Shows</button>
+      <button class="tab ${state.historyTab==='all'?'active':''}" onclick="state.historyTab='all';renderHistoryContent()">All</button>
     </div>
     <div id="history-content"><div class="loading"><div class="spinner"></div></div></div>
   `;
@@ -441,7 +441,7 @@ async function renderHistory() {
 
 async function renderHistoryContent() {
   document.querySelectorAll('.tab').forEach(t => {
-    const map = { movies: 'סרטים', tv: 'סדרות', all: 'הכל' };
+    const map = { movies: 'Movies', tv: 'TV Shows', all: 'All' };
     t.classList.toggle('active', t.textContent.trim() === map[state.historyTab]);
   });
 
@@ -459,8 +459,8 @@ async function renderHistoryContent() {
   if (state.historyTab === 'tv') q = q.eq('media_type', 'tv');
 
   const { data, error } = await q;
-  if (error) { el.innerHTML = `<div class="empty"><div class="empty-title">שגיאה בטעינה</div></div>`; return; }
-  if (!data?.length) { el.innerHTML = emptyState('אין היסטוריית צפייה'); return; }
+  if (error) { el.innerHTML = `<div class="empty"><div class="empty-title">Failed to load</div></div>`; return; }
+  if (!data?.length) { el.innerHTML = emptyState('No watch history'); return; }
 
   el.innerHTML = `<div class="card" style="padding:0 20px">
     ${data.map(r => `
@@ -485,15 +485,15 @@ async function renderHistoryContent() {
 async function deleteHistory(id, btn) {
   btn.disabled = true;
   const { error } = await db.from('watch_history').delete().eq('id', id).eq('user_id', state.userId);
-  if (error) { toast('שגיאה במחיקה', 'err'); btn.disabled = false; return; }
-  toast('הוסר מההיסטוריה ✓');
+  if (error) { toast('Failed to delete', 'err'); btn.disabled = false; return; }
+  toast('Removed from history ✓');
   btn.closest('.list-item').remove();
 }
 
 // ── Watchlist ─────────────────────────────────────────────────────────────
 async function renderWatchlist() {
   const main = document.getElementById('main-content');
-  main.innerHTML = `<div class="section-header"><div class="section-title">רשימת צפייה</div></div><div class="loading"><div class="spinner"></div></div>`;
+  main.innerHTML = `<div class="section-header"><div class="section-title">Watchlist</div></div><div class="loading"><div class="spinner"></div></div>`;
 
   const { data, error } = await db.from('watchlist')
     .select('*')
@@ -501,7 +501,7 @@ async function renderWatchlist() {
     .order('added_at', { ascending: false });
 
   if (error || !data?.length) {
-    main.innerHTML = `<div class="section-header"><div class="section-title">רשימת צפייה</div></div>${emptyState('רשימת הצפייה ריקה')}`;
+    main.innerHTML = `<div class="section-header"><div class="section-title">Watchlist</div></div>${emptyState('Your watchlist is empty')}`;
     return;
   }
 
@@ -523,7 +523,7 @@ async function renderWatchlist() {
               <div class="item-title">TMDB #${i.tmdb_id}</div>
               <div class="item-sub">נוסף ${timeAgo(i.added_at)}</div>
             </div>
-            <button class="btn btn-danger" style="padding:6px 10px" onclick="removeWatchlist(${i.tmdb_id},'${i.media_type}',this)">הסר</button>
+            <button class="btn btn-danger" style="padding:6px 10px" onclick="removeWatchlist(${i.tmdb_id},'${i.media_type}',this)">Remove</button>
           </div>
         `).join('')}
       </div>`;
@@ -531,10 +531,10 @@ async function renderWatchlist() {
 
   main.innerHTML = `
     <div class="section-header">
-      <div><div class="section-title">רשימת צפייה</div><div class="section-sub">${data.length} פריטים</div></div>
+      <div><div class="section-title">Watchlist</div><div class="section-sub">${data.length} item${data.length !== 1 ? 's' : ''}</div></div>
     </div>
-    ${renderWLSection(movies, '🎬 סרטים')}
-    ${renderWLSection(shows, '📺 סדרות')}
+    ${renderWLSection(movies, '🎬 Movies')}
+    ${renderWLSection(shows, '📺 TV Shows')}
   `;
 }
 
@@ -542,8 +542,8 @@ async function removeWatchlist(tmdbId, mediaType, btn) {
   btn.disabled = true;
   const { error } = await db.from('watchlist').delete()
     .eq('user_id', state.userId).eq('tmdb_id', tmdbId).eq('media_type', mediaType);
-  if (error) { toast('שגיאה במחיקה', 'err'); btn.disabled = false; return; }
-  toast('הוסר מהרשימה ✓');
+  if (error) { toast('Failed to remove', 'err'); btn.disabled = false; return; }
+  toast('Removed from watchlist ✓');
   document.getElementById(`wl-${tmdbId}-${mediaType}`)?.remove();
 }
 
@@ -558,7 +558,7 @@ async function renderAI() {
 
   main.innerHTML = `
     <div class="section-header">
-      <div><div class="section-title">תרגום כתוביות AI</div><div class="section-sub">הגדר תרגום כתוביות בזמן אמת על ידי AI</div></div>
+      <div><div class="section-title">AI Subtitle Translation</div><div class="section-sub">Configure real-time AI subtitle translation</div></div>
     </div>
 
     <div class="tv-banner">
@@ -567,19 +567,19 @@ async function renderAI() {
         <path d="M8 21h8M12 17v4"/>
       </svg>
       <div>
-        <div class="tv-banner-title">🔑 מפתח API — הגדר ישירות בטלוויזיה</div>
-        <div class="tv-banner-sub">מטעמי אבטחה, מפתח ה-API נשמר רק מקומית בטלוויזיה.<br>פתח את ARVIO ← הגדרות ← כתוביות ← תרגום AI</div>
+        <div class="tv-banner-title">🔑 API Key — set directly on your TV</div>
+        <div class="tv-banner-sub">For security, your API key is stored locally on your TV only.<br>Open ARVIO → Settings → Subtitles → AI Translation</div>
       </div>
     </div>
 
     <div class="card">
-      <div style="font-size:16px;font-weight:700;margin-bottom:16px">הגדרות תרגום</div>
+      <div style="font-size:16px;font-weight:700;margin-bottom:16px">Translation Settings</div>
 
       <div class="form-group">
         <div style="display:flex;align-items:center;justify-content:space-between">
           <div>
-            <div style="font-weight:600">הפעל תרגום AI</div>
-            <div style="font-size:12px;color:var(--text-muted);margin-top:2px">תרגם כתוביות אוטומטית בזמן צפייה</div>
+            <div style="font-weight:600">Enable AI Translation</div>
+            <div style="font-size:12px;color:var(--text-muted);margin-top:2px">Automatically translate subtitles while watching</div>
           </div>
           <label class="toggle">
             <input type="checkbox" id="ai-enabled" ${enabled ? 'checked' : ''} onchange="updateAISetting('subtitleAiEnabled', this.checked)">
@@ -591,8 +591,8 @@ async function renderAI() {
       <div class="form-group">
         <div style="display:flex;align-items:center;justify-content:space-between">
           <div>
-            <div style="font-weight:600">בחירה אוטומטית</div>
-            <div style="font-size:12px;color:var(--text-muted);margin-top:2px">בחר אוטומטית כתוביות לתרגום</div>
+            <div style="font-weight:600">Auto-select</div>
+            <div style="font-size:12px;color:var(--text-muted);margin-top:2px">Automatically pick subtitles for translation</div>
           </div>
           <label class="toggle">
             <input type="checkbox" id="ai-auto" ${autoSelect ? 'checked' : ''} onchange="updateAISetting('subtitleAiAutoSelect', this.checked)">
@@ -604,8 +604,8 @@ async function renderAI() {
       <div class="form-group">
         <div style="display:flex;align-items:center;justify-content:space-between">
           <div>
-            <div style="font-weight:600">הסר כתוביות לכבדי שמיעה</div>
-            <div style="font-size:12px;color:var(--text-muted);margin-top:2px">הסר תיאורי קול מהכתוביות [SDH]</div>
+            <div style="font-weight:600">Remove Hearing Impaired (HI)</div>
+            <div style="font-size:12px;color:var(--text-muted);margin-top:2px">Strip audio descriptions from subtitles [SDH]</div>
           </div>
           <label class="toggle">
             <input type="checkbox" id="ai-hi" ${removeHI ? 'checked' : ''} onchange="updateAISetting('subtitleRemoveHearingImpaired', this.checked)">
@@ -616,29 +616,29 @@ async function renderAI() {
     </div>
 
     <div class="card">
-      <div style="font-size:16px;font-weight:700;margin-bottom:16px">בחר מודל AI</div>
+      <div style="font-size:16px;font-weight:700;margin-bottom:16px">Select AI Model</div>
       <div class="models-grid">
         <label class="model-card ${model==='GROQ_LLAMA_70B'?'selected':''}">
           <input type="radio" name="ai-model" value="GROQ_LLAMA_70B" ${model==='GROQ_LLAMA_70B'?'checked':''} onchange="updateAISetting('subtitleAiModel',this.value)">
           <div>
             <div class="model-name">⚡ Groq Llama 70B</div>
-            <div class="model-desc">מהיר ביותר, חינמי, מומלץ לתרגום כתוביות</div>
+            <div class="model-desc">Fastest, free, recommended for subtitle translation</div>
           </div>
         </label>
         <label class="model-card ${model==='GEMINI_FLASH_25'?'selected':''}">
           <input type="radio" name="ai-model" value="GEMINI_FLASH_25" ${model==='GEMINI_FLASH_25'?'checked':''} onchange="updateAISetting('subtitleAiModel',this.value)">
           <div>
             <div class="model-name">🤖 Gemini Flash 2.5</div>
-            <div class="model-desc">Google Gemini, איכות גבוהה, מהיר מאוד</div>
+            <div class="model-desc">Google Gemini, high quality, very fast</div>
           </div>
         </label>
       </div>
 
       <div style="background:var(--bg-card2);border-radius:8px;padding:14px 16px;margin-top:8px">
-        <div style="font-size:13px;font-weight:600;margin-bottom:8px">איך לקבל מפתח API חינמי?</div>
+        <div style="font-size:13px;font-weight:600;margin-bottom:8px">How to get a free API key?</div>
         <div style="font-size:12px;color:var(--text-muted);line-height:1.7">
-          🔹 <b>Groq (מומלץ)</b>: גש ל-<code style="background:var(--bg);padding:1px 5px;border-radius:4px">console.groq.com</code> ← צור חשבון ← API Keys ← Create Key<br>
-          🔹 <b>Gemini</b>: גש ל-<code style="background:var(--bg);padding:1px 5px;border-radius:4px">aistudio.google.com</code> ← Get API Key
+          🔹 <b>Groq (recommended)</b>: go to <code style="background:var(--bg);padding:1px 5px;border-radius:4px">console.groq.com</code> → Create account → API Keys → Create Key<br>
+          🔹 <b>Gemini</b>: go to <code style="background:var(--bg);padding:1px 5px;border-radius:4px">aistudio.google.com</code> → Get API Key
         </div>
       </div>
     </div>
@@ -646,11 +646,11 @@ async function renderAI() {
 }
 
 async function updateAISetting(key, value) {
-  if (!state.syncPayload) { toast('אין נתוני סנכרון', 'err'); return; }
+  if (!state.syncPayload) { toast('No sync data', 'err'); return; }
   state.syncPayload[key] = value;
   try {
     await saveSyncPayload(state.syncPayload);
-    toast('נשמר ✓');
+    toast('Saved ✓');
     // Update model card UI
     if (key === 'subtitleAiModel') {
       document.querySelectorAll('.model-card').forEach(card => {
@@ -659,7 +659,7 @@ async function updateAISetting(key, value) {
       });
     }
   } catch (e) {
-    toast('שגיאה בשמירה', 'err');
+    toast('Failed to save', 'err');
   }
 }
 
@@ -676,17 +676,17 @@ async function renderSettings() {
 
   main.innerHTML = `
     <div class="section-header">
-      <div><div class="section-title">הגדרות</div><div class="section-sub">הגדרות כלליות לחשבון</div></div>
+      <div><div class="section-title">Settings</div><div class="section-sub">General account settings</div></div>
     </div>
 
     <div class="card">
-      <div style="font-size:16px;font-weight:700;margin-bottom:16px">מראה</div>
+      <div style="font-size:16px;font-weight:700;margin-bottom:16px">Appearance</div>
 
       <div class="form-group">
         <div style="display:flex;align-items:center;justify-content:space-between">
           <div>
-            <div style="font-weight:600">רקע OLED שחור</div>
-            <div style="font-size:12px;color:var(--text-muted);margin-top:2px">רקע שחור לחלוטין לחיסכון בסוללה</div>
+            <div style="font-weight:600">OLED Black Background</div>
+            <div style="font-size:12px;color:var(--text-muted);margin-top:2px">Pure black background to save battery on OLED screens</div>
           </div>
           <label class="toggle">
             <input type="checkbox" ${oled?'checked':''} onchange="updateSetting('oledBlackBackground',this.checked)">
@@ -696,15 +696,15 @@ async function renderSettings() {
       </div>
 
       <div class="form-group">
-        <label class="form-label">פריסת כרטיסי מדיה</label>
+        <label class="form-label">Media Card Layout</label>
         <select class="form-select" onchange="updateSetting('cardLayoutMode',this.value)">
-          <option value="landscape" ${cardLayout==='landscape'?'selected':''}>Landscape (רוחב)</option>
-          <option value="portrait" ${cardLayout==='portrait'?'selected':''}>Portrait (אנכי)</option>
+          <option value="landscape" ${cardLayout==='landscape'?'selected':''}>Landscape</option>
+          <option value="portrait" ${cardLayout==='portrait'?'selected':''}>Portrait</option>
         </select>
       </div>
 
       <div class="form-group">
-        <label class="form-label">שפת ממשק</label>
+        <label class="form-label">App Language</label>
         <select class="form-select" onchange="updateSetting('lastAppLanguage',this.value)">
           <option value="en" ${lang==='en'?'selected':''}>English</option>
           <option value="he" ${lang==='he'?'selected':''}>עברית</option>
@@ -719,12 +719,12 @@ async function renderSettings() {
     </div>
 
     <div class="card">
-      <div style="font-size:16px;font-weight:700;margin-bottom:16px">פרופיל</div>
+      <div style="font-size:16px;font-weight:700;margin-bottom:16px">Profile</div>
       <div class="form-group">
         <div style="display:flex;align-items:center;justify-content:space-between">
           <div>
-            <div style="font-weight:600">דלג על בחירת פרופיל</div>
-            <div style="font-size:12px;color:var(--text-muted);margin-top:2px">עבור ישירות לאפליקציה עם הפרופיל הפעיל</div>
+            <div style="font-weight:600">Skip Profile Selection</div>
+            <div style="font-size:12px;color:var(--text-muted);margin-top:2px">Launch directly into the app with the active profile</div>
           </div>
           <label class="toggle">
             <input type="checkbox" ${skipProfile?'checked':''} onchange="updateSetting('skipProfileSelection',this.checked)">
@@ -735,29 +735,29 @@ async function renderSettings() {
     </div>
 
     <div class="card">
-      <div style="font-size:16px;font-weight:700;margin-bottom:16px">חשבון</div>
+      <div style="font-size:16px;font-weight:700;margin-bottom:16px">Account</div>
       <div class="list-item" style="padding:10px 0;border:none">
         <div class="item-info">
-          <div class="item-title">מזהה משתמש</div>
+          <div class="item-title">User ID</div>
           <div class="item-sub" style="font-family:monospace;font-size:11px">${state.userId}</div>
         </div>
       </div>
       <button class="btn btn-danger" onclick="signOut()" style="margin-top:8px">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
-        התנתק
+        Sign out
       </button>
     </div>
   `;
 }
 
 async function updateSetting(key, value) {
-  if (!state.syncPayload) { toast('אין נתוני סנכרון', 'err'); return; }
+  if (!state.syncPayload) { toast('No sync data', 'err'); return; }
   state.syncPayload[key] = value;
   try {
     await saveSyncPayload(state.syncPayload);
-    toast('נשמר ✓');
+    toast('Saved ✓');
   } catch (e) {
-    toast('שגיאה בשמירה', 'err');
+    toast('Failed to save', 'err');
   }
 }
 
@@ -766,13 +766,13 @@ function timeAgo(iso) {
   if (!iso) return '';
   const d = Date.now() - new Date(iso).getTime();
   const m = Math.floor(d / 60000);
-  if (m < 1) return 'עכשיו';
-  if (m < 60) return `לפני ${m} דק׳`;
+  if (m < 1) return 'just now';
+  if (m < 60) return `${m}m ago`;
   const h = Math.floor(m / 60);
-  if (h < 24) return `לפני ${h} שע׳`;
+  if (h < 24) return `${h}h ago`;
   const days = Math.floor(h / 24);
-  if (days < 30) return `לפני ${days} ימים`;
-  return new Date(iso).toLocaleDateString('he-IL');
+  if (days < 30) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString('en-US');
 }
 
 function formatDuration(secs) {
@@ -793,21 +793,21 @@ function emptyState(msg) {
 
 // ── Shell ─────────────────────────────────────────────────────────────────
 function buildShell(user) {
-  const name = user.user_metadata?.full_name || user.email || 'משתמש';
+  const name = user.user_metadata?.full_name || user.email || 'User';
   const avatar = user.user_metadata?.avatar_url || '';
   const email = user.email || '';
   const initial = name[0].toUpperCase();
 
   const navItems = [
     { id: 'dashboard', label: 'Dashboard', icon: '<path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/>' },
-    { id: 'profiles', label: 'פרופילים', icon: '<path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/>' },
-    { id: 'addons', label: 'הרחבות', icon: '<rect x="3" y="3" width="18" height="18" rx="3"/><path d="M9 9h6M9 12h6M9 15h4"/>' },
+    { id: 'profiles', label: 'Profiles', icon: '<path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/>' },
+    { id: 'addons', label: 'Add-ons', icon: '<rect x="3" y="3" width="18" height="18" rx="3"/><path d="M9 9h6M9 12h6M9 15h4"/>' },
     { id: 'iptv', label: 'IPTV', icon: '<path d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"/><path d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>' },
-    { id: 'plugins', label: 'פלאגינים', icon: '<path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/>' },
-    { id: 'history', label: 'היסטוריה', icon: '<circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>' },
-    { id: 'watchlist', label: 'רשימת צפייה', icon: '<path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z"/>' },
-    { id: 'ai', label: 'תרגום AI', icon: '<path d="M12 2a3 3 0 013 3v7a3 3 0 01-6 0V5a3 3 0 013-3z"/><path d="M19 10v2a7 7 0 01-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/>' },
-    { id: 'settings', label: 'הגדרות', icon: '<circle cx="12" cy="12" r="3"/><path d="M19.07 4.93l-1.41 1.41M4.93 4.93l1.41 1.41M19.07 19.07l-1.41-1.41M4.93 19.07l1.41-1.41M1 12h2M21 12h2M12 1v2M12 21v2"/>' },
+    { id: 'plugins', label: 'Plugins', icon: '<path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/>' },
+    { id: 'history', label: 'History', icon: '<circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>' },
+    { id: 'watchlist', label: 'Watchlist', icon: '<path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z"/>' },
+    { id: 'ai', label: 'AI Subtitles', icon: '<path d="M12 2a3 3 0 013 3v7a3 3 0 01-6 0V5a3 3 0 013-3z"/><path d="M19 10v2a7 7 0 01-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/>' },
+    { id: 'settings', label: 'Settings', icon: '<circle cx="12" cy="12" r="3"/><path d="M19.07 4.93l-1.41 1.41M4.93 4.93l1.41 1.41M19.07 19.07l-1.41-1.41M4.93 19.07l1.41-1.41M1 12h2M21 12h2M12 1v2M12 21v2"/>' },
   ];
 
   document.getElementById('app-screen').innerHTML = `
@@ -832,7 +832,7 @@ function buildShell(user) {
           <div class="user-name">${name}</div>
           <div class="user-email">${email}</div>
         </div>
-        <button class="btn-logout" onclick="signOut()" title="התנתק">
+        <button class="btn-logout" onclick="signOut()" title="Sign out">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
         </button>
       </div>

--- a/netlify-arvio-tv-site/companion/app.js
+++ b/netlify-arvio-tv-site/companion/app.js
@@ -261,13 +261,15 @@ async function loadSyncPayload() {
 
 async function saveSyncPayload(payload) {
   const raw = JSON.stringify(payload);
-  const wrapper = JSON.stringify({
-    __arvioAccountSyncPayload: raw,
-    __arvioAccountSyncUpdatedAt: new Date().toISOString(),
-  });
+  // Read existing wrapper so we only overwrite our two keys and preserve any others
+  const { data: existing } = await db.from('profiles').select('addons').eq('id', state.userId).single();
+  let wrapper = {};
+  try { wrapper = JSON.parse(existing?.addons ?? '{}'); } catch {}
+  wrapper.__arvioAccountSyncPayload = raw;
+  wrapper.__arvioAccountSyncUpdatedAt = new Date().toISOString();
   const { error } = await db
     .from('profiles')
-    .update({ addons: wrapper })
+    .update({ addons: JSON.stringify(wrapper) })
     .eq('id', state.userId);
   if (error) throw error;
   state.syncPayload = payload;
@@ -347,9 +349,9 @@ async function renderDashboard() {
   }
   ra.innerHTML = recent.map(r => `
     <div class="list-item">
-      <img class="history-poster" src="${r.poster_path ? TMDB_IMG + r.poster_path : ''}" onerror="this.style.background='var(--bg-card2)';this.src=''" alt="">
+      <img class="history-poster" src="${r.poster_path ? escapeHtml(TMDB_IMG + r.poster_path) : ''}" onerror="this.style.background='var(--bg-card2)';this.src=''" alt="">
       <div class="item-info">
-        <div class="item-title">${r.title || '—'}</div>
+        <div class="item-title">${escapeHtml(r.title) || '—'}</div>
         <div class="item-sub">${r.media_type === 'movie' ? t('type_movie') : t('type_series')} · ${timeAgo(r.updated_at)}</div>
         <div class="progress-bar"><div class="progress-fill" style="width:${Math.round((r.progress||0)*100)}%"></div></div>
       </div>
@@ -364,8 +366,10 @@ function getProfileColors() {
 }
 
 function renderProfileAvatar(profile) {
-  const color = '#' + (profile.avatarColor?.toString(16).padStart(8,'0').slice(2) || 'F5C442');
-  const letter = (profile.name || '?')[0].toUpperCase();
+  const color = /^[0-9a-fA-F]{6}$/.test((profile.avatarColor?.toString(16).padStart(8,'0').slice(2) || ''))
+    ? '#' + profile.avatarColor.toString(16).padStart(8,'0').slice(2)
+    : '#F5C442';
+  const letter = escapeHtml((profile.name || '?')[0].toUpperCase());
   return `<div class="profile-avatar-big" style="background:${color}22;color:${color}">${letter}</div>`;
 }
 
@@ -390,7 +394,7 @@ async function renderProfiles() {
       ${profiles.map(p => `
         <div class="profile-card ${p.id === activeId ? 'active-profile' : ''}">
           ${renderProfileAvatar(p)}
-          <div class="profile-name">${p.name}</div>
+          <div class="profile-name">${escapeHtml(p.name)}</div>
           <div style="display:flex;gap:6px;flex-wrap:wrap;justify-content:center">
             ${p.id === activeId ? `<span class="badge badge-gold">${t('badge_active')}</span>` : ''}
             ${p.isKidsProfile ? `<span class="badge badge-blue">${t('badge_kids')}</span>` : ''}
@@ -435,9 +439,8 @@ async function renderAddons() {
   };
 
   function addonIcon(a) {
-    if (a.manifest?.logo || a.logo) {
-      return `<img src="${a.manifest?.logo || a.logo}" alt="" onerror="this.style.display='none'">`;
-    }
+    const logo = safeUrl(a.manifest?.logo || a.logo);
+    if (logo) return `<img src="${logo}" alt="" onerror="this.style.display='none'">`;
     return `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="3" width="18" height="18" rx="3"/><path d="M9 9h6M9 12h6M9 15h4"/></svg>`;
   }
 
@@ -459,8 +462,8 @@ async function renderAddons() {
           <div class="list-item">
             <div class="item-icon">${addonIcon(a)}</div>
             <div class="item-info">
-              <div class="item-title">${a.name || a.id}</div>
-              <div class="item-sub">${a.manifest?.description || a.description || a.id}</div>
+              <div class="item-title">${escapeHtml(a.name || a.id)}</div>
+              <div class="item-sub">${escapeHtml(a.manifest?.description || a.description || a.id)}</div>
             </div>
             <div style="display:flex;gap:8px;align-items:center">
               ${addonTypeBadge(a)}
@@ -530,13 +533,13 @@ async function renderIPTV() {
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"/><path d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
           </div>
           <div class="item-info">
-            <div class="item-title">${pl.name || 'M3U Playlist'}</div>
-            <div class="item-sub" style="font-family:monospace;font-size:11px;max-width:380px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${pl.m3uUrl}</div>
-            ${pl.epgUrl ? `<div class="item-sub" style="font-size:11px">EPG: ${pl.epgUrl}</div>` : ''}
+            <div class="item-title">${escapeHtml(pl.name) || 'M3U Playlist'}</div>
+            <div class="item-sub" style="font-family:monospace;font-size:11px;max-width:380px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${escapeHtml(pl.m3uUrl)}</div>
+            ${pl.epgUrl ? `<div class="item-sub" style="font-size:11px">EPG: ${escapeHtml(pl.epgUrl)}</div>` : ''}
           </div>
           <div style="display:flex;flex-direction:column;align-items:flex-end;gap:6px">
             <span class="badge ${pl.enabled !== false ? 'badge-green' : 'badge-red'}">${pl.enabled !== false ? t('iptv_active') : t('iptv_disabled')}</span>
-            <span class="badge badge-gray">${pl._profileName}</span>
+            <span class="badge badge-gray">${escapeHtml(pl._profileName)}</span>
           </div>
         </div>
       `).join('')}
@@ -545,13 +548,13 @@ async function renderIPTV() {
     ${favGroups.length > 0 ? `
     <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin:24px 0 12px">${t('fav_groups', favGroups.length)}</div>
     <div class="card" style="padding:14px 20px;display:flex;flex-wrap:wrap;gap:8px">
-      ${favGroups.map(g => `<span class="badge badge-gold">⭐ ${g}</span>`).join('')}
+      ${favGroups.map(g => `<span class="badge badge-gold">⭐ ${escapeHtml(g)}</span>`).join('')}
     </div>` : ''}
 
     ${favChannels.length > 0 ? `
     <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin:24px 0 12px">${t('fav_channels', favChannels.length)}</div>
     <div class="card" style="padding:14px 20px;display:flex;flex-wrap:wrap;gap:8px">
-      ${favChannels.slice(0, 50).map(c => `<span class="badge badge-blue">📺 ${c}</span>`).join('')}
+      ${favChannels.slice(0, 50).map(c => `<span class="badge badge-blue">📺 ${escapeHtml(c)}</span>`).join('')}
       ${favChannels.length > 50 ? `<span class="badge badge-gray">${t('iptv_more', favChannels.length - 50)}</span>` : ''}
     </div>` : ''}
 
@@ -590,8 +593,8 @@ async function renderPlugins() {
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M3 7h18M3 12h18M3 17h18"/></svg>
           </div>
           <div class="item-info">
-            <div class="item-title">${r.name}</div>
-            <div class="item-sub" style="font-family:monospace;font-size:11px">${r.url}</div>
+            <div class="item-title">${escapeHtml(r.name)}</div>
+            <div class="item-sub" style="font-family:monospace;font-size:11px">${escapeHtml(r.url)}</div>
             <div class="item-sub">${r.scraperCount ?? 0} scrapers · ${t('repo_updated')} ${r.lastUpdated ? timeAgo(new Date(r.lastUpdated).toISOString()) : t('repo_never')}</div>
           </div>
           <span class="badge ${r.enabled ? 'badge-green' : 'badge-red'}">${r.enabled ? t('plugin_active') : t('plugin_disabled')}</span>
@@ -605,14 +608,14 @@ async function renderPlugins() {
       ${scrapers.map(s => `
         <div class="list-item">
           <div class="item-icon">
-            ${s.logo ? `<img src="${s.logo}" alt="" onerror="this.style.display='none'">` : `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>`}
+            ${safeUrl(s.logo) ? `<img src="${safeUrl(s.logo)}" alt="" onerror="this.style.display='none'">` : `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>`}
           </div>
           <div class="item-info">
-            <div class="item-title">${s.name}</div>
-            <div class="item-sub">${s.description || ''} · v${s.version}</div>
+            <div class="item-title">${escapeHtml(s.name)}</div>
+            <div class="item-sub">${escapeHtml(s.description)} · v${escapeHtml(s.version)}</div>
             <div style="display:flex;gap:6px;margin-top:4px;flex-wrap:wrap">
-              ${(s.supportedTypes ?? []).map(st => `<span class="badge badge-gray">${st}</span>`).join('')}
-              ${(s.contentLanguage ?? []).map(l => `<span class="badge badge-blue">${l}</span>`).join('')}
+              ${(s.supportedTypes ?? []).map(st => `<span class="badge badge-gray">${escapeHtml(st)}</span>`).join('')}
+              ${(s.contentLanguage ?? []).map(l => `<span class="badge badge-blue">${escapeHtml(l)}</span>`).join('')}
             </div>
           </div>
           <span class="badge ${s.enabled && s.manifestEnabled ? 'badge-green' : 'badge-red'}">${s.enabled && s.manifestEnabled ? t('plugin_active') : t('plugin_disabled')}</span>
@@ -670,9 +673,9 @@ async function renderHistoryContent() {
   el.innerHTML = `<div class="card" style="padding:0 20px">
     ${data.map(r => `
       <div class="list-item">
-        <img class="history-poster" src="${r.poster_path ? TMDB_IMG+r.poster_path : ''}" onerror="this.style.background='var(--bg-card2)';this.src=''" alt="">
+        <img class="history-poster" src="${r.poster_path ? escapeHtml(TMDB_IMG+r.poster_path) : ''}" onerror="this.style.background='var(--bg-card2)';this.src=''" alt="">
         <div class="item-info">
-          <div class="item-title">${r.title || '—'}${r.season ? ` S${String(r.season).padStart(2,'0')}E${String(r.episode||0).padStart(2,'0')}` : ''}</div>
+          <div class="item-title">${escapeHtml(r.title) || '—'}${r.season ? ` S${String(Number(r.season)||0).padStart(2,'0')}E${String(Number(r.episode)||0).padStart(2,'0')}` : ''}</div>
           <div class="item-sub">${timeAgo(r.updated_at)} · ${formatDuration(r.position_seconds)} / ${formatDuration(r.duration_seconds)}</div>
           <div class="progress-bar"><div class="progress-fill" style="width:${Math.round((r.progress||0)*100)}%"></div></div>
         </div>
@@ -940,7 +943,7 @@ async function renderSettings() {
       <div class="list-item" style="padding:10px 0;border:none">
         <div class="item-info">
           <div class="item-title">${t('user_id_label')}</div>
-          <div class="item-sub" style="font-family:monospace;font-size:11px">${state.userId}</div>
+          <div class="item-sub" style="font-family:monospace;font-size:11px">${escapeHtml(state.userId)}</div>
         </div>
       </div>
       <button class="btn btn-danger" onclick="signOut()" style="margin-top:8px">
@@ -963,6 +966,24 @@ async function updateSetting(key, value) {
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────
+function escapeHtml(str) {
+  if (str == null) return '';
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+function safeUrl(url) {
+  if (!url) return '';
+  try {
+    const u = new URL(url);
+    return (u.protocol === 'https:' || u.protocol === 'http:') ? url : '';
+  } catch { return ''; }
+}
+
 function timeAgo(iso) {
   if (!iso) return '';
   const d = Date.now() - new Date(iso).getTime();
@@ -995,9 +1016,9 @@ function emptyState(msg) {
 // ── Shell ─────────────────────────────────────────────────────────────────
 function buildShell(user) {
   const name = user.user_metadata?.full_name || user.email || t('user_fallback');
-  const avatar = user.user_metadata?.avatar_url || '';
+  const avatar = safeUrl(user.user_metadata?.avatar_url || '');
   const email = user.email || '';
-  const initial = name[0].toUpperCase();
+  const initial = escapeHtml(name[0].toUpperCase());
 
   const navItems = [
     { id: 'dashboard', label: t('nav_dashboard'), icon: '<path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/>' },
@@ -1030,8 +1051,8 @@ function buildShell(user) {
           ${avatar ? `<img src="${avatar}" alt="">` : initial}
         </div>
         <div class="user-info">
-          <div class="user-name">${name}</div>
-          <div class="user-email">${email}</div>
+          <div class="user-name">${escapeHtml(name)}</div>
+          <div class="user-email">${escapeHtml(email)}</div>
         </div>
         <button class="btn-lang" onclick="setLang(currentLang==='en'?'he':'en')" title="Switch language" style="background:none;border:1px solid var(--border);border-radius:6px;color:var(--text-muted);cursor:pointer;padding:4px 8px;font-size:12px;font-weight:600;margin-left:4px">
           ${currentLang === 'en' ? 'עב' : 'EN'}

--- a/netlify-arvio-tv-site/companion/app.js
+++ b/netlify-arvio-tv-site/companion/app.js
@@ -6,6 +6,211 @@ const TMDB_IMG = 'https://image.tmdb.org/t/p/w92';
 const { createClient } = supabase;
 const db = createClient(SUPABASE_URL, SUPABASE_ANON);
 
+// ── i18n ──────────────────────────────────────────────────────────────────
+const STRINGS = {
+  en: {
+    nav_dashboard: 'Dashboard', nav_profiles: 'Profiles', nav_addons: 'Add-ons',
+    nav_iptv: 'IPTV', nav_plugins: 'Plugins', nav_history: 'History',
+    nav_watchlist: 'Watchlist', nav_ai: 'AI Subtitles', nav_settings: 'Settings',
+    sign_out: 'Sign out', user_fallback: 'User', loading: 'Loading...',
+    saved: 'Saved ✓', save_err: 'Failed to save', no_sync: 'No sync data',
+    // auth
+    auth_sub: 'Manage your ARVIO account — profiles, add-ons, history & AI subtitles',
+    auth_google: 'Continue with Google',
+    // dashboard
+    dash_sub: 'A quick overview of your ARVIO account',
+    stat_profiles: 'Profiles', stat_addons: 'Add-ons',
+    stat_history: 'Watch History', stat_watchlist: 'Watchlist',
+    recent_activity: 'Recent Activity', no_activity: 'No recent activity',
+    type_movie: '🎬 Movie', type_series: '📺 Series',
+    // profiles
+    profiles_title: 'Profiles',
+    profiles_sub: (n) => `${n} profile${n !== 1 ? 's' : ''} in account`,
+    profiles_empty: 'No profiles found — open ARVIO on your TV to create one',
+    profiles_tip: '💡 Profile management (create, delete, rename) is available in ARVIO on your TV.<br>Changes sync automatically to the cloud.',
+    badge_active: 'Active', badge_kids: 'Kids', badge_locked: '🔒 Locked',
+    // addons
+    addons_title: 'Add-ons',
+    addons_sub: (a, t) => `${a} active of ${t}`,
+    addons_empty: 'No add-ons installed',
+    addons_tip: '💡 To add or remove add-ons, go to Settings in ARVIO on your TV. Data syncs automatically.',
+    badge_official: 'Official', badge_subtitles: 'Subtitles',
+    badge_metadata: 'Metadata', badge_community: 'Community',
+    badge_telegram: 'Telegram', badge_enabled: 'Enabled', badge_disabled: 'Disabled',
+    stremio_label: (n) => `Stremio Add-ons (${n})`,
+    telegram_label: (n) => `Telegram Sources (${n})`,
+    // iptv
+    iptv_sub: (n) => `${n} active playlist${n !== 1 ? 's' : ''}`,
+    iptv_empty: 'No IPTV playlists configured — go to ARVIO → Settings → IPTV',
+    iptv_m3u: 'M3U Playlists', iptv_active: 'Active', iptv_disabled: 'Disabled',
+    fav_groups: (n) => `Favourite Groups (${n})`,
+    fav_channels: (n) => `Favourite Channels (${n})`,
+    iptv_more: (n) => `+${n} more`,
+    iptv_tip: '💡 To add M3U playlists and manage channels — go to IPTV Settings in ARVIO. Changes sync automatically to the cloud.',
+    // plugins
+    plugins_title: 'Plugins (Sideload)',
+    plugins_sub: (r, s) => `${r} repositor${r !== 1 ? 'ies' : 'y'} · ${s} scrapers`,
+    plugins_status_on: 'Plugins enabled', plugins_status_off: 'Plugins disabled',
+    plugins_empty: 'No plugin repositories — add one in ARVIO → Settings → Plugins',
+    repos_label: (n) => `Repositories (${n})`,
+    repo_updated: 'updated', repo_never: 'never',
+    scrapers_label: (n) => `Scrapers (${n})`,
+    plugin_active: 'Active', plugin_disabled: 'Disabled',
+    plugins_tip: '💡 Plugins sync to the cloud automatically. Each scraper\'s JS code stays local on your TV only and is never uploaded to the cloud.',
+    // history
+    history_title: 'Watch History',
+    tab_movies: 'Movies', tab_tv: 'TV Shows', tab_all: 'All',
+    history_empty: 'No watch history', history_err: 'Failed to load',
+    delete_err: 'Failed to delete', deleted_history: 'Removed from history ✓',
+    // watchlist
+    watchlist_title: 'Watchlist',
+    watchlist_sub: (n) => `${n} item${n !== 1 ? 's' : ''}`,
+    watchlist_empty: 'Your watchlist is empty',
+    wl_movies: '🎬 Movies', wl_tv: '📺 TV Shows',
+    wl_remove: 'Remove', wl_remove_err: 'Failed to remove',
+    wl_removed: 'Removed from watchlist ✓',
+    // ai
+    ai_title: 'AI Subtitle Translation',
+    ai_sub: 'Configure real-time AI subtitle translation',
+    ai_banner_title: '🔑 API Key — set directly on your TV',
+    ai_banner_sub: 'For security, your API key is stored locally on your TV only.<br>Open ARVIO → Settings → Subtitles → AI Translation',
+    ai_settings_title: 'Translation Settings',
+    ai_enable: 'Enable AI Translation', ai_enable_desc: 'Automatically translate subtitles while watching',
+    ai_auto: 'Auto-select', ai_auto_desc: 'Automatically pick subtitles for translation',
+    ai_hi: 'Remove Hearing Impaired (HI)', ai_hi_desc: 'Strip audio descriptions from subtitles [SDH]',
+    ai_model_title: 'Select AI Model',
+    ai_groq_desc: 'Fastest · Free · Great quality for subtitles',
+    ai_gemini_desc: 'Google Gemini, high quality, very fast',
+    ai_key_title: 'How to get a free API key?',
+    ai_key_desc: '🔹 <b>Groq (recommended)</b>: go to <code>console.groq.com</code> → Create account → API Keys → Create Key<br>🔹 <b>Gemini</b>: go to <code>aistudio.google.com</code> → Get API Key',
+    ai_recommended: 'Recommended',
+    // settings
+    settings_title: 'Settings', settings_sub: 'General account settings',
+    appearance: 'Appearance',
+    oled_label: 'OLED Black Background', oled_desc: 'Pure black background to save battery on OLED screens',
+    layout_label: 'Media Card Layout', layout_landscape: 'Landscape', layout_portrait: 'Portrait',
+    lang_label: 'App Language',
+    profile_section: 'Profile',
+    skip_label: 'Skip Profile Selection', skip_desc: 'Launch directly into the app with the active profile',
+    account_section: 'Account', user_id_label: 'User ID',
+    // time
+    just_now: 'just now', m_ago: (m) => `${m}m ago`, h_ago: (h) => `${h}h ago`, d_ago: (d) => `${d}d ago`,
+  },
+  he: {
+    nav_dashboard: 'דשבורד', nav_profiles: 'פרופילים', nav_addons: 'הרחבות',
+    nav_iptv: 'IPTV', nav_plugins: 'פלאגינים', nav_history: 'היסטוריה',
+    nav_watchlist: 'רשימת צפייה', nav_ai: 'כתוביות AI', nav_settings: 'הגדרות',
+    sign_out: 'התנתק', user_fallback: 'משתמש', loading: 'טוען...',
+    saved: 'נשמר ✓', save_err: 'שגיאה בשמירה', no_sync: 'אין נתוני סנכרון',
+    // auth
+    auth_sub: 'נהל את חשבון ה-ARVIO שלך — פרופילים, הרחבות, היסטוריה ותרגום AI',
+    auth_google: 'המשך עם Google',
+    // dashboard
+    dash_sub: 'סקירה מהירה של חשבון ה-ARVIO שלך',
+    stat_profiles: 'פרופילים', stat_addons: 'הרחבות',
+    stat_history: 'היסטוריית צפייה', stat_watchlist: 'רשימת צפייה',
+    recent_activity: 'פעילות אחרונה', no_activity: 'אין פעילות אחרונה',
+    type_movie: '🎬 סרט', type_series: '📺 סדרה',
+    // profiles
+    profiles_title: 'פרופילים',
+    profiles_sub: (n) => `${n} פרופילים בחשבון`,
+    profiles_empty: 'אין פרופילים — פתח את ARVIO בטלוויזיה ליצירת פרופיל',
+    profiles_tip: '💡 ניהול פרופילים (יצירה, מחיקה, שינוי שם) זמין ב-ARVIO על הטלוויזיה.<br>שינויים מסונכרנים אוטומטית עם הענן.',
+    badge_active: 'פעיל', badge_kids: 'ילדים', badge_locked: '🔒 נעול',
+    // addons
+    addons_title: 'הרחבות',
+    addons_sub: (a, total) => `${a} פעילות מתוך ${total}`,
+    addons_empty: 'אין הרחבות מותקנות',
+    addons_tip: '💡 להוספה/הסרה של הרחבות — גש להגדרות ב-ARVIO. הנתונים מסונכרנים אוטומטית.',
+    badge_official: 'רשמי', badge_subtitles: 'כתוביות',
+    badge_metadata: 'מטאדאטה', badge_community: 'קהילה',
+    badge_telegram: 'Telegram', badge_enabled: 'פעיל', badge_disabled: 'כבוי',
+    stremio_label: (n) => `הרחבות Stremio (${n})`,
+    telegram_label: (n) => `מקורות Telegram (${n})`,
+    // iptv
+    iptv_sub: (n) => `${n} רשימות פעילות`,
+    iptv_empty: 'אין רשימות IPTV מוגדרות — הגדר ב-ARVIO ← הגדרות ← IPTV',
+    iptv_m3u: 'רשימות M3U', iptv_active: 'פעיל', iptv_disabled: 'כבוי',
+    fav_groups: (n) => `קבוצות מועדפות (${n})`,
+    fav_channels: (n) => `ערוצים מועדפים (${n})`,
+    iptv_more: (n) => `+${n} נוספים`,
+    iptv_tip: '💡 להוספת רשימות M3U ולניהול ערוצים — גש להגדרות IPTV ב-ARVIO. השינויים מסונכרנים אוטומטית לענן.',
+    // plugins
+    plugins_title: 'פלאגינים (Sideload)',
+    plugins_sub: (r, s) => `${r} מאגרים · ${s} scrapers`,
+    plugins_status_on: 'פלאגינים פעילים', plugins_status_off: 'פלאגינים כבויים',
+    plugins_empty: 'אין מאגרי פלאגינים — הוסף ב-ARVIO ← הגדרות ← פלאגינים',
+    repos_label: (n) => `מאגרים (${n})`,
+    repo_updated: 'עודכן', repo_never: 'אף פעם',
+    scrapers_label: (n) => `Scrapers (${n})`,
+    plugin_active: 'פעיל', plugin_disabled: 'כבוי',
+    plugins_tip: '💡 הפלאגינים מסונכרנים לענן אוטומטית. קוד ה-JS של כל scraper נשמר מקומית בטלוויזיה בלבד ולא עולה לענן.',
+    // history
+    history_title: 'היסטוריית צפייה',
+    tab_movies: 'סרטים', tab_tv: 'סדרות', tab_all: 'הכל',
+    history_empty: 'אין היסטוריית צפייה', history_err: 'שגיאה בטעינה',
+    delete_err: 'שגיאה במחיקה', deleted_history: 'הוסר מההיסטוריה ✓',
+    // watchlist
+    watchlist_title: 'רשימת צפייה',
+    watchlist_sub: (n) => `${n} פריטים`,
+    watchlist_empty: 'רשימת הצפייה ריקה',
+    wl_movies: '🎬 סרטים', wl_tv: '📺 סדרות',
+    wl_remove: 'הסר', wl_remove_err: 'שגיאה במחיקה',
+    wl_removed: 'הוסר מהרשימה ✓',
+    // ai
+    ai_title: 'תרגום כתוביות AI',
+    ai_sub: 'הגדר תרגום כתוביות בזמן אמת על ידי AI',
+    ai_banner_title: '🔑 מפתח API — הגדר ישירות בטלוויזיה',
+    ai_banner_sub: 'מטעמי אבטחה, מפתח ה-API נשמר רק מקומית בטלוויזיה.<br>פתח את ARVIO ← הגדרות ← כתוביות ← תרגום AI',
+    ai_settings_title: 'הגדרות תרגום',
+    ai_enable: 'הפעל תרגום AI', ai_enable_desc: 'תרגם כתוביות אוטומטית בזמן צפייה',
+    ai_auto: 'בחירה אוטומטית', ai_auto_desc: 'בחר אוטומטית כתוביות לתרגום',
+    ai_hi: 'הסר כתוביות לכבדי שמיעה', ai_hi_desc: 'הסר תיאורי קול מהכתוביות [SDH]',
+    ai_model_title: 'בחר מודל AI',
+    ai_groq_desc: 'מהיר ביותר, חינמי, מומלץ לתרגום כתוביות',
+    ai_gemini_desc: 'Google Gemini, איכות גבוהה, מהיר מאוד',
+    ai_key_title: 'איך לקבל מפתח API חינמי?',
+    ai_key_desc: '🔹 <b>Groq (מומלץ)</b>: גש ל-<code>console.groq.com</code> ← צור חשבון ← API Keys ← Create Key<br>🔹 <b>Gemini</b>: גש ל-<code>aistudio.google.com</code> ← Get API Key',
+    ai_recommended: 'מומלץ',
+    // settings
+    settings_title: 'הגדרות', settings_sub: 'הגדרות כלליות לחשבון',
+    appearance: 'מראה',
+    oled_label: 'רקע OLED שחור', oled_desc: 'רקע שחור לחלוטין לחיסכון בסוללה',
+    layout_label: 'פריסת כרטיסי מדיה', layout_landscape: 'Landscape (רוחב)', layout_portrait: 'Portrait (אנכי)',
+    lang_label: 'שפת ממשק',
+    profile_section: 'פרופיל',
+    skip_label: 'דלג על בחירת פרופיל', skip_desc: 'עבור ישירות לאפליקציה עם הפרופיל הפעיל',
+    account_section: 'חשבון', user_id_label: 'מזהה משתמש',
+    // time
+    just_now: 'עכשיו', m_ago: (m) => `לפני ${m} דק׳`, h_ago: (h) => `לפני ${h} שע׳`, d_ago: (d) => `לפני ${d} ימים`,
+  },
+};
+
+let currentLang = localStorage.getItem('arvio_lang') || 'en';
+
+function t(key, ...args) {
+  const s = STRINGS[currentLang][key];
+  return typeof s === 'function' ? s(...args) : (s ?? key);
+}
+
+function setLang(lang) {
+  currentLang = lang;
+  localStorage.setItem('arvio_lang', lang);
+  const isRTL = lang === 'he';
+  document.documentElement.lang = lang;
+  document.documentElement.dir = isRTL ? 'rtl' : 'ltr';
+  // Re-render auth text if on auth screen
+  const authSub = document.querySelector('.auth-sub');
+  if (authSub) authSub.textContent = t('auth_sub');
+  const authBtn = document.querySelector('.btn-google');
+  if (authBtn) authBtn.childNodes[authBtn.childNodes.length - 1].textContent = ' ' + t('auth_google');
+  // Re-render app if logged in
+  if (state.session) {
+    buildShell(state.session.user);
+    renderSection();
+  }
+}
+
 // ── State ─────────────────────────────────────────────────────────────────
 let state = {
   session: null,
@@ -91,7 +296,7 @@ function navigate(id) {
 
 async function renderSection() {
   const main = document.getElementById('main-content');
-  main.innerHTML = `<div class="loading"><div class="spinner"></div> Loading...</div>`;
+  main.innerHTML = `<div class="loading"><div class="spinner"></div> ${t('loading')}</div>`;
   await sections[state.activeSection]?.();
 }
 
@@ -113,18 +318,18 @@ async function renderDashboard() {
   main.innerHTML = `
     <div class="section-header">
       <div>
-        <div class="section-title">Dashboard</div>
-        <div class="section-sub">A quick overview of your ARVIO account</div>
+        <div class="section-title">${t('nav_dashboard')}</div>
+        <div class="section-sub">${t('dash_sub')}</div>
       </div>
     </div>
     <div class="card-grid">
-      <div class="stat-card"><div class="stat-label">Profiles</div><div class="stat-value gold">${profiles.length || 1}</div></div>
-      <div class="stat-card"><div class="stat-label">Add-ons</div><div class="stat-value">${addons.filter(a => a.isEnabled).length}</div></div>
-      <div class="stat-card"><div class="stat-label">Watch History</div><div class="stat-value">${histRes.count ?? '—'}</div></div>
-      <div class="stat-card"><div class="stat-label">Watchlist</div><div class="stat-value">${wlRes.count ?? '—'}</div></div>
+      <div class="stat-card"><div class="stat-label">${t('stat_profiles')}</div><div class="stat-value gold">${profiles.length || 1}</div></div>
+      <div class="stat-card"><div class="stat-label">${t('stat_addons')}</div><div class="stat-value">${addons.filter(a => a.isEnabled).length}</div></div>
+      <div class="stat-card"><div class="stat-label">${t('stat_history')}</div><div class="stat-value">${histRes.count ?? '—'}</div></div>
+      <div class="stat-card"><div class="stat-label">${t('stat_watchlist')}</div><div class="stat-value">${wlRes.count ?? '—'}</div></div>
     </div>
     <div class="card">
-      <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin-bottom:14px">Recent Activity</div>
+      <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin-bottom:14px">${t('recent_activity')}</div>
       <div id="recent-activity"><div class="loading"><div class="spinner"></div></div></div>
     </div>
   `;
@@ -137,7 +342,7 @@ async function renderDashboard() {
 
   const ra = document.getElementById('recent-activity');
   if (!recent?.length) {
-    ra.innerHTML = emptyState('No recent activity');
+    ra.innerHTML = emptyState(t('no_activity'));
     return;
   }
   ra.innerHTML = recent.map(r => `
@@ -145,7 +350,7 @@ async function renderDashboard() {
       <img class="history-poster" src="${r.poster_path ? TMDB_IMG + r.poster_path : ''}" onerror="this.style.background='var(--bg-card2)';this.src=''" alt="">
       <div class="item-info">
         <div class="item-title">${r.title || '—'}</div>
-        <div class="item-sub">${r.media_type === 'movie' ? '🎬 Movie' : '📺 Series'} · ${timeAgo(r.updated_at)}</div>
+        <div class="item-sub">${r.media_type === 'movie' ? t('type_movie') : t('type_series')} · ${timeAgo(r.updated_at)}</div>
         <div class="progress-bar"><div class="progress-fill" style="width:${Math.round((r.progress||0)*100)}%"></div></div>
       </div>
       <span class="badge badge-gray">${Math.round((r.progress||0)*100)}%</span>
@@ -172,14 +377,14 @@ async function renderProfiles() {
 
   if (!profiles.length) {
     main.innerHTML = `
-      <div class="section-header"><div class="section-title">Profiles</div></div>
-      ${emptyState('No profiles found — open ARVIO on your TV to create one')}`;
+      <div class="section-header"><div class="section-title">${t('profiles_title')}</div></div>
+      ${emptyState(t('profiles_empty'))}`;
     return;
   }
 
   main.innerHTML = `
     <div class="section-header">
-      <div><div class="section-title">Profiles</div><div class="section-sub">${profiles.length} profile${profiles.length !== 1 ? 's' : ''} in account</div></div>
+      <div><div class="section-title">${t('profiles_title')}</div><div class="section-sub">${t('profiles_sub', profiles.length)}</div></div>
     </div>
     <div class="profiles-grid">
       ${profiles.map(p => `
@@ -187,15 +392,15 @@ async function renderProfiles() {
           ${renderProfileAvatar(p)}
           <div class="profile-name">${p.name}</div>
           <div style="display:flex;gap:6px;flex-wrap:wrap;justify-content:center">
-            ${p.id === activeId ? '<span class="badge badge-gold">Active</span>' : ''}
-            ${p.isKidsProfile ? '<span class="badge badge-blue">Kids</span>' : ''}
-            ${p.pin ? '<span class="badge badge-gray">🔒 Locked</span>' : ''}
+            ${p.id === activeId ? `<span class="badge badge-gold">${t('badge_active')}</span>` : ''}
+            ${p.isKidsProfile ? `<span class="badge badge-blue">${t('badge_kids')}</span>` : ''}
+            ${p.pin ? `<span class="badge badge-gray">${t('badge_locked')}</span>` : ''}
           </div>
         </div>
       `).join('')}
     </div>
     <div class="card">
-      <div style="font-size:13px;color:var(--text-muted)">💡 Profile management (create, delete, rename) is available in ARVIO on your TV.<br>Changes sync automatically to the cloud.</div>
+      <div style="font-size:13px;color:var(--text-muted)">${t('profiles_tip')}</div>
     </div>
   `;
 }
@@ -219,8 +424,8 @@ async function renderAddons() {
 
   if (!addons.length) {
     main.innerHTML = `
-      <div class="section-header"><div class="section-title">Add-ons</div></div>
-      ${emptyState('No add-ons installed')}`;
+      <div class="section-header"><div class="section-title">${t('addons_title')}</div></div>
+      ${emptyState(t('addons_empty'))}`;
     return;
   }
 
@@ -238,11 +443,11 @@ async function renderAddons() {
 
   function addonTypeBadge(a) {
     const t = a.type || 'COMMUNITY';
-    if (t === 'OFFICIAL') return '<span class="badge badge-gold">Official</span>';
-    if (t === 'SUBTITLE') return '<span class="badge badge-blue">Subtitles</span>';
-    if (t === 'METADATA') return '<span class="badge badge-gray">Metadata</span>';
-    if (a.runtimeKind === 'TELEGRAM') return '<span class="badge badge-blue">Telegram</span>';
-    return '<span class="badge badge-gray">Community</span>';
+    if (t === 'OFFICIAL') return `<span class="badge badge-gold">${STRINGS[currentLang].badge_official}</span>`;
+    if (t === 'SUBTITLE') return `<span class="badge badge-blue">${STRINGS[currentLang].badge_subtitles}</span>`;
+    if (t === 'METADATA') return `<span class="badge badge-gray">${STRINGS[currentLang].badge_metadata}</span>`;
+    if (a.runtimeKind === 'TELEGRAM') return `<span class="badge badge-blue">${STRINGS[currentLang].badge_telegram}</span>`;
+    return `<span class="badge badge-gray">${STRINGS[currentLang].badge_community}</span>`;
   }
 
   function renderAddonList(list, label) {
@@ -259,7 +464,7 @@ async function renderAddons() {
             </div>
             <div style="display:flex;gap:8px;align-items:center">
               ${addonTypeBadge(a)}
-              <span class="badge ${a.isEnabled ? 'badge-green' : 'badge-red'}">${a.isEnabled ? 'Enabled' : 'Disabled'}</span>
+              <span class="badge ${a.isEnabled ? 'badge-green' : 'badge-red'}">${a.isEnabled ? t('badge_enabled') : t('badge_disabled')}</span>
             </div>
           </div>
         `).join('')}
@@ -269,12 +474,12 @@ async function renderAddons() {
 
   main.innerHTML = `
     <div class="section-header">
-      <div><div class="section-title">Add-ons</div><div class="section-sub">${addons.filter(a=>a.isEnabled).length} active of ${addons.length}</div></div>
+      <div><div class="section-title">${t('addons_title')}</div><div class="section-sub">${t('addons_sub', addons.filter(a=>a.isEnabled).length, addons.length)}</div></div>
     </div>
-    ${renderAddonList(byType.STREMIO, `Stremio Add-ons (${byType.STREMIO.length})`)}
-    ${renderAddonList(byType.TELEGRAM, `Telegram Sources (${byType.TELEGRAM.length})`)}
+    ${renderAddonList(byType.STREMIO, t('stremio_label', byType.STREMIO.length))}
+    ${renderAddonList(byType.TELEGRAM, t('telegram_label', byType.TELEGRAM.length))}
     <div class="card" style="margin-top:16px">
-      <div style="font-size:13px;color:var(--text-muted)">💡 To add or remove add-ons, go to Settings in ARVIO on your TV. Data syncs automatically.</div>
+      <div style="font-size:13px;color:var(--text-muted)">${t('addons_tip')}</div>
     </div>
   `;
 }
@@ -313,11 +518,11 @@ async function renderIPTV() {
 
   main.innerHTML = `
     <div class="section-header">
-      <div><div class="section-title">IPTV</div><div class="section-sub">${allPlaylists.length} active playlist${allPlaylists.length !== 1 ? 's' : ''}</div></div>
+      <div><div class="section-title">IPTV</div><div class="section-sub">${t('iptv_sub', allPlaylists.length)}</div></div>
     </div>
 
-    ${allPlaylists.length === 0 ? emptyState('No IPTV playlists configured — go to ARVIO → Settings → IPTV') : `
-    <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin-bottom:12px">M3U Playlists</div>
+    ${allPlaylists.length === 0 ? emptyState(t('iptv_empty')) : `
+    <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin-bottom:12px">${t('iptv_m3u')}</div>
     <div class="card" style="padding:0 20px">
       ${allPlaylists.map(pl => `
         <div class="list-item">
@@ -330,7 +535,7 @@ async function renderIPTV() {
             ${pl.epgUrl ? `<div class="item-sub" style="font-size:11px">EPG: ${pl.epgUrl}</div>` : ''}
           </div>
           <div style="display:flex;flex-direction:column;align-items:flex-end;gap:6px">
-            <span class="badge ${pl.enabled !== false ? 'badge-green' : 'badge-red'}">${pl.enabled !== false ? 'Active' : 'Disabled'}</span>
+            <span class="badge ${pl.enabled !== false ? 'badge-green' : 'badge-red'}">${pl.enabled !== false ? t('iptv_active') : t('iptv_disabled')}</span>
             <span class="badge badge-gray">${pl._profileName}</span>
           </div>
         </div>
@@ -338,20 +543,20 @@ async function renderIPTV() {
     </div>`}
 
     ${favGroups.length > 0 ? `
-    <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin:24px 0 12px">Favourite Groups (${favGroups.length})</div>
+    <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin:24px 0 12px">${t('fav_groups', favGroups.length)}</div>
     <div class="card" style="padding:14px 20px;display:flex;flex-wrap:wrap;gap:8px">
       ${favGroups.map(g => `<span class="badge badge-gold">⭐ ${g}</span>`).join('')}
     </div>` : ''}
 
     ${favChannels.length > 0 ? `
-    <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin:24px 0 12px">Favourite Channels (${favChannels.length})</div>
+    <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin:24px 0 12px">${t('fav_channels', favChannels.length)}</div>
     <div class="card" style="padding:14px 20px;display:flex;flex-wrap:wrap;gap:8px">
       ${favChannels.slice(0, 50).map(c => `<span class="badge badge-blue">📺 ${c}</span>`).join('')}
-      ${favChannels.length > 50 ? `<span class="badge badge-gray">+${favChannels.length - 50} more</span>` : ''}
+      ${favChannels.length > 50 ? `<span class="badge badge-gray">${t('iptv_more', favChannels.length - 50)}</span>` : ''}
     </div>` : ''}
 
     <div class="card" style="margin-top:16px">
-      <div style="font-size:13px;color:var(--text-muted)">💡 להוספת רשימות M3U ולניהול ערוצים — גש להגדרות IPTV ב-ARVIO. השינויים מסונכרנים אוטומטית לענן.</div>
+      <div style="font-size:13px;color:var(--text-muted)">${t('iptv_tip')}</div>
     </div>
   `;
 }
@@ -366,9 +571,9 @@ async function renderPlugins() {
 
   main.innerHTML = `
     <div class="section-header">
-      <div><div class="section-title">Plugins (Sideload)</div><div class="section-sub">${repos.length} repositor${repos.length !== 1 ? 'ies' : 'y'} · ${scrapers.length} scrapers</div></div>
+      <div><div class="section-title">${t('plugins_title')}</div><div class="section-sub">${t('plugins_sub', repos.length, scrapers.length)}</div></div>
       <div style="display:flex;align-items:center;gap:10px">
-        <span style="font-size:13px;color:var(--text-muted)">Plugins ${pluginsEnabled ? 'enabled' : 'disabled'}</span>
+        <span style="font-size:13px;color:var(--text-muted)">${pluginsEnabled ? t('plugins_status_on') : t('plugins_status_off')}</span>
         <label class="toggle">
           <input type="checkbox" ${pluginsEnabled ? 'checked' : ''} onchange="updateSetting('pluginsEnabled',this.checked)">
           <span class="toggle-slider"></span>
@@ -376,8 +581,8 @@ async function renderPlugins() {
       </div>
     </div>
 
-    ${repos.length === 0 ? emptyState('No plugin repositories — add one in ARVIO → Settings → Plugins') : `
-    <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin-bottom:12px">Repositories (${repos.length})</div>
+    ${repos.length === 0 ? emptyState(t('plugins_empty')) : `
+    <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin-bottom:12px">${t('repos_label', repos.length)}</div>
     <div class="card" style="padding:0 20px">
       ${repos.map(r => `
         <div class="list-item">
@@ -387,15 +592,15 @@ async function renderPlugins() {
           <div class="item-info">
             <div class="item-title">${r.name}</div>
             <div class="item-sub" style="font-family:monospace;font-size:11px">${r.url}</div>
-            <div class="item-sub">${r.scraperCount ?? 0} scrapers · updated ${r.lastUpdated ? timeAgo(new Date(r.lastUpdated).toISOString()) : 'never'}</div>
+            <div class="item-sub">${r.scraperCount ?? 0} scrapers · ${t('repo_updated')} ${r.lastUpdated ? timeAgo(new Date(r.lastUpdated).toISOString()) : t('repo_never')}</div>
           </div>
-          <span class="badge ${r.enabled ? 'badge-green' : 'badge-red'}">${r.enabled ? 'Active' : 'Disabled'}</span>
+          <span class="badge ${r.enabled ? 'badge-green' : 'badge-red'}">${r.enabled ? t('plugin_active') : t('plugin_disabled')}</span>
         </div>
       `).join('')}
     </div>`}
 
     ${scrapers.length > 0 ? `
-    <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin:24px 0 12px">Scrapers (${scrapers.length})</div>
+    <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin:24px 0 12px">${t('scrapers_label', scrapers.length)}</div>
     <div class="card" style="padding:0 20px">
       ${scrapers.map(s => `
         <div class="list-item">
@@ -406,17 +611,17 @@ async function renderPlugins() {
             <div class="item-title">${s.name}</div>
             <div class="item-sub">${s.description || ''} · v${s.version}</div>
             <div style="display:flex;gap:6px;margin-top:4px;flex-wrap:wrap">
-              ${(s.supportedTypes ?? []).map(t => `<span class="badge badge-gray">${t}</span>`).join('')}
+              ${(s.supportedTypes ?? []).map(st => `<span class="badge badge-gray">${st}</span>`).join('')}
               ${(s.contentLanguage ?? []).map(l => `<span class="badge badge-blue">${l}</span>`).join('')}
             </div>
           </div>
-          <span class="badge ${s.enabled && s.manifestEnabled ? 'badge-green' : 'badge-red'}">${s.enabled && s.manifestEnabled ? 'Active' : 'Disabled'}</span>
+          <span class="badge ${s.enabled && s.manifestEnabled ? 'badge-green' : 'badge-red'}">${s.enabled && s.manifestEnabled ? t('plugin_active') : t('plugin_disabled')}</span>
         </div>
       `).join('')}
     </div>` : ''}
 
     <div class="card" style="margin-top:16px">
-      <div style="font-size:13px;color:var(--text-muted)">💡 Plugins sync to the cloud automatically. Each scraper's JS code stays local on your TV only and is never uploaded to the cloud.</div>
+      <div style="font-size:13px;color:var(--text-muted)">${t('plugins_tip')}</div>
     </div>
   `;
 }
@@ -427,12 +632,12 @@ async function renderHistory() {
 
   main.innerHTML = `
     <div class="section-header">
-      <div><div class="section-title">היסטוריית צפייה</div></div>
+      <div><div class="section-title">${t('history_title')}</div></div>
     </div>
     <div class="tabs">
-      <button class="tab ${state.historyTab==='movies'?'active':''}" onclick="state.historyTab='movies';renderHistoryContent()">Movies</button>
-      <button class="tab ${state.historyTab==='tv'?'active':''}" onclick="state.historyTab='tv';renderHistoryContent()">TV Shows</button>
-      <button class="tab ${state.historyTab==='all'?'active':''}" onclick="state.historyTab='all';renderHistoryContent()">All</button>
+      <button class="tab ${state.historyTab==='movies'?'active':''}" onclick="state.historyTab='movies';renderHistoryContent()">${t('tab_movies')}</button>
+      <button class="tab ${state.historyTab==='tv'?'active':''}" onclick="state.historyTab='tv';renderHistoryContent()">${t('tab_tv')}</button>
+      <button class="tab ${state.historyTab==='all'?'active':''}" onclick="state.historyTab='all';renderHistoryContent()">${t('tab_all')}</button>
     </div>
     <div id="history-content"><div class="loading"><div class="spinner"></div></div></div>
   `;
@@ -440,9 +645,9 @@ async function renderHistory() {
 }
 
 async function renderHistoryContent() {
-  document.querySelectorAll('.tab').forEach(t => {
-    const map = { movies: 'Movies', tv: 'TV Shows', all: 'All' };
-    t.classList.toggle('active', t.textContent.trim() === map[state.historyTab]);
+  document.querySelectorAll('.tab').forEach(tab => {
+    const map = { movies: t('tab_movies'), tv: t('tab_tv'), all: t('tab_all') };
+    tab.classList.toggle('active', tab.textContent.trim() === map[state.historyTab]);
   });
 
   const el = document.getElementById('history-content');
@@ -459,8 +664,8 @@ async function renderHistoryContent() {
   if (state.historyTab === 'tv') q = q.eq('media_type', 'tv');
 
   const { data, error } = await q;
-  if (error) { el.innerHTML = `<div class="empty"><div class="empty-title">Failed to load</div></div>`; return; }
-  if (!data?.length) { el.innerHTML = emptyState('No watch history'); return; }
+  if (error) { el.innerHTML = `<div class="empty"><div class="empty-title">${t('history_err')}</div></div>`; return; }
+  if (!data?.length) { el.innerHTML = emptyState(t('history_empty')); return; }
 
   el.innerHTML = `<div class="card" style="padding:0 20px">
     ${data.map(r => `
@@ -485,15 +690,15 @@ async function renderHistoryContent() {
 async function deleteHistory(id, btn) {
   btn.disabled = true;
   const { error } = await db.from('watch_history').delete().eq('id', id).eq('user_id', state.userId);
-  if (error) { toast('Failed to delete', 'err'); btn.disabled = false; return; }
-  toast('Removed from history ✓');
+  if (error) { toast(t('delete_err'), 'err'); btn.disabled = false; return; }
+  toast(t('deleted_history'));
   btn.closest('.list-item').remove();
 }
 
 // ── Watchlist ─────────────────────────────────────────────────────────────
 async function renderWatchlist() {
   const main = document.getElementById('main-content');
-  main.innerHTML = `<div class="section-header"><div class="section-title">Watchlist</div></div><div class="loading"><div class="spinner"></div></div>`;
+  main.innerHTML = `<div class="section-header"><div class="section-title">${t('watchlist_title')}</div></div><div class="loading"><div class="spinner"></div></div>`;
 
   const { data, error } = await db.from('watchlist')
     .select('*')
@@ -501,7 +706,7 @@ async function renderWatchlist() {
     .order('added_at', { ascending: false });
 
   if (error || !data?.length) {
-    main.innerHTML = `<div class="section-header"><div class="section-title">Watchlist</div></div>${emptyState('Your watchlist is empty')}`;
+    main.innerHTML = `<div class="section-header"><div class="section-title">${t('watchlist_title')}</div></div>${emptyState(t('watchlist_empty'))}`;
     return;
   }
 
@@ -521,9 +726,9 @@ async function renderWatchlist() {
             </div>
             <div class="item-info">
               <div class="item-title">TMDB #${i.tmdb_id}</div>
-              <div class="item-sub">נוסף ${timeAgo(i.added_at)}</div>
+              <div class="item-sub">${timeAgo(i.added_at)}</div>
             </div>
-            <button class="btn btn-danger" style="padding:6px 10px" onclick="removeWatchlist(${i.tmdb_id},'${i.media_type}',this)">Remove</button>
+            <button class="btn btn-danger" style="padding:6px 10px" onclick="removeWatchlist(${i.tmdb_id},'${i.media_type}',this)">${t('wl_remove')}</button>
           </div>
         `).join('')}
       </div>`;
@@ -531,10 +736,10 @@ async function renderWatchlist() {
 
   main.innerHTML = `
     <div class="section-header">
-      <div><div class="section-title">Watchlist</div><div class="section-sub">${data.length} item${data.length !== 1 ? 's' : ''}</div></div>
+      <div><div class="section-title">${t('watchlist_title')}</div><div class="section-sub">${t('watchlist_sub', data.length)}</div></div>
     </div>
-    ${renderWLSection(movies, '🎬 Movies')}
-    ${renderWLSection(shows, '📺 TV Shows')}
+    ${renderWLSection(movies, t('wl_movies'))}
+    ${renderWLSection(shows, t('wl_tv'))}
   `;
 }
 
@@ -542,8 +747,8 @@ async function removeWatchlist(tmdbId, mediaType, btn) {
   btn.disabled = true;
   const { error } = await db.from('watchlist').delete()
     .eq('user_id', state.userId).eq('tmdb_id', tmdbId).eq('media_type', mediaType);
-  if (error) { toast('Failed to remove', 'err'); btn.disabled = false; return; }
-  toast('Removed from watchlist ✓');
+  if (error) { toast(t('wl_remove_err'), 'err'); btn.disabled = false; return; }
+  toast(t('wl_removed'));
   document.getElementById(`wl-${tmdbId}-${mediaType}`)?.remove();
 }
 
@@ -558,7 +763,7 @@ async function renderAI() {
 
   main.innerHTML = `
     <div class="section-header">
-      <div><div class="section-title">AI Subtitle Translation</div><div class="section-sub">Configure real-time AI subtitle translation</div></div>
+      <div><div class="section-title">${t('ai_title')}</div><div class="section-sub">${t('ai_sub')}</div></div>
     </div>
 
     <div class="tv-banner">
@@ -567,19 +772,19 @@ async function renderAI() {
         <path d="M8 21h8M12 17v4"/>
       </svg>
       <div>
-        <div class="tv-banner-title">🔑 API Key — set directly on your TV</div>
-        <div class="tv-banner-sub">For security, your API key is stored locally on your TV only.<br>Open ARVIO → Settings → Subtitles → AI Translation</div>
+        <div class="tv-banner-title">${t('ai_banner_title')}</div>
+        <div class="tv-banner-sub">${t('ai_banner_sub')}</div>
       </div>
     </div>
 
     <div class="card">
-      <div style="font-size:16px;font-weight:700;margin-bottom:16px">Translation Settings</div>
+      <div style="font-size:16px;font-weight:700;margin-bottom:16px">${t('ai_settings_title')}</div>
 
       <div class="form-group">
         <div style="display:flex;align-items:center;justify-content:space-between">
           <div>
-            <div style="font-weight:600">Enable AI Translation</div>
-            <div style="font-size:12px;color:var(--text-muted);margin-top:2px">Automatically translate subtitles while watching</div>
+            <div style="font-weight:600">${t('ai_enable')}</div>
+            <div style="font-size:12px;color:var(--text-muted);margin-top:2px">${t('ai_enable_desc')}</div>
           </div>
           <label class="toggle">
             <input type="checkbox" id="ai-enabled" ${enabled ? 'checked' : ''} onchange="updateAISetting('subtitleAiEnabled', this.checked)">
@@ -591,8 +796,8 @@ async function renderAI() {
       <div class="form-group">
         <div style="display:flex;align-items:center;justify-content:space-between">
           <div>
-            <div style="font-weight:600">Auto-select</div>
-            <div style="font-size:12px;color:var(--text-muted);margin-top:2px">Automatically pick subtitles for translation</div>
+            <div style="font-weight:600">${t('ai_auto')}</div>
+            <div style="font-size:12px;color:var(--text-muted);margin-top:2px">${t('ai_auto_desc')}</div>
           </div>
           <label class="toggle">
             <input type="checkbox" id="ai-auto" ${autoSelect ? 'checked' : ''} onchange="updateAISetting('subtitleAiAutoSelect', this.checked)">
@@ -604,8 +809,8 @@ async function renderAI() {
       <div class="form-group">
         <div style="display:flex;align-items:center;justify-content:space-between">
           <div>
-            <div style="font-weight:600">Remove Hearing Impaired (HI)</div>
-            <div style="font-size:12px;color:var(--text-muted);margin-top:2px">Strip audio descriptions from subtitles [SDH]</div>
+            <div style="font-weight:600">${t('ai_hi')}</div>
+            <div style="font-size:12px;color:var(--text-muted);margin-top:2px">${t('ai_hi_desc')}</div>
           </div>
           <label class="toggle">
             <input type="checkbox" id="ai-hi" ${removeHI ? 'checked' : ''} onchange="updateAISetting('subtitleRemoveHearingImpaired', this.checked)">
@@ -616,42 +821,38 @@ async function renderAI() {
     </div>
 
     <div class="card">
-      <div style="font-size:16px;font-weight:700;margin-bottom:16px">Select AI Model</div>
+      <div style="font-size:16px;font-weight:700;margin-bottom:16px">${t('ai_model_title')}</div>
       <div class="models-grid">
         <label class="model-card ${model==='GROQ_LLAMA_70B'?'selected':''}">
           <input type="radio" name="ai-model" value="GROQ_LLAMA_70B" ${model==='GROQ_LLAMA_70B'?'checked':''} onchange="updateAISetting('subtitleAiModel',this.value)">
           <div>
-            <div class="model-name">⚡ Groq Llama 70B</div>
-            <div class="model-desc">Fastest, free, recommended for subtitle translation</div>
+            <div class="model-name">⚡ Groq Llama 70B <span class="badge badge-gold" style="font-size:10px">${t('ai_recommended')}</span></div>
+            <div class="model-desc">${t('ai_groq_desc')}</div>
           </div>
         </label>
         <label class="model-card ${model==='GEMINI_FLASH_25'?'selected':''}">
           <input type="radio" name="ai-model" value="GEMINI_FLASH_25" ${model==='GEMINI_FLASH_25'?'checked':''} onchange="updateAISetting('subtitleAiModel',this.value)">
           <div>
             <div class="model-name">🤖 Gemini Flash 2.5</div>
-            <div class="model-desc">Google Gemini, high quality, very fast</div>
+            <div class="model-desc">${t('ai_gemini_desc')}</div>
           </div>
         </label>
       </div>
 
       <div style="background:var(--bg-card2);border-radius:8px;padding:14px 16px;margin-top:8px">
-        <div style="font-size:13px;font-weight:600;margin-bottom:8px">How to get a free API key?</div>
-        <div style="font-size:12px;color:var(--text-muted);line-height:1.7">
-          🔹 <b>Groq (recommended)</b>: go to <code style="background:var(--bg);padding:1px 5px;border-radius:4px">console.groq.com</code> → Create account → API Keys → Create Key<br>
-          🔹 <b>Gemini</b>: go to <code style="background:var(--bg);padding:1px 5px;border-radius:4px">aistudio.google.com</code> → Get API Key
-        </div>
+        <div style="font-size:13px;font-weight:600;margin-bottom:8px">${t('ai_key_title')}</div>
+        <div style="font-size:12px;color:var(--text-muted);line-height:1.7">${t('ai_key_desc')}</div>
       </div>
     </div>
   `;
 }
 
 async function updateAISetting(key, value) {
-  if (!state.syncPayload) { toast('No sync data', 'err'); return; }
+  if (!state.syncPayload) { toast(t('no_sync'), 'err'); return; }
   state.syncPayload[key] = value;
   try {
     await saveSyncPayload(state.syncPayload);
-    toast('Saved ✓');
-    // Update model card UI
+    toast(t('saved'));
     if (key === 'subtitleAiModel') {
       document.querySelectorAll('.model-card').forEach(card => {
         const inp = card.querySelector('input');
@@ -659,7 +860,7 @@ async function updateAISetting(key, value) {
       });
     }
   } catch (e) {
-    toast('Failed to save', 'err');
+    toast(t('save_err'), 'err');
   }
 }
 
@@ -676,17 +877,17 @@ async function renderSettings() {
 
   main.innerHTML = `
     <div class="section-header">
-      <div><div class="section-title">Settings</div><div class="section-sub">General account settings</div></div>
+      <div><div class="section-title">${t('settings_title')}</div><div class="section-sub">${t('settings_sub')}</div></div>
     </div>
 
     <div class="card">
-      <div style="font-size:16px;font-weight:700;margin-bottom:16px">Appearance</div>
+      <div style="font-size:16px;font-weight:700;margin-bottom:16px">${t('appearance')}</div>
 
       <div class="form-group">
         <div style="display:flex;align-items:center;justify-content:space-between">
           <div>
-            <div style="font-weight:600">OLED Black Background</div>
-            <div style="font-size:12px;color:var(--text-muted);margin-top:2px">Pure black background to save battery on OLED screens</div>
+            <div style="font-weight:600">${t('oled_label')}</div>
+            <div style="font-size:12px;color:var(--text-muted);margin-top:2px">${t('oled_desc')}</div>
           </div>
           <label class="toggle">
             <input type="checkbox" ${oled?'checked':''} onchange="updateSetting('oledBlackBackground',this.checked)">
@@ -696,15 +897,15 @@ async function renderSettings() {
       </div>
 
       <div class="form-group">
-        <label class="form-label">Media Card Layout</label>
+        <label class="form-label">${t('layout_label')}</label>
         <select class="form-select" onchange="updateSetting('cardLayoutMode',this.value)">
-          <option value="landscape" ${cardLayout==='landscape'?'selected':''}>Landscape</option>
-          <option value="portrait" ${cardLayout==='portrait'?'selected':''}>Portrait</option>
+          <option value="landscape" ${cardLayout==='landscape'?'selected':''}>${t('layout_landscape')}</option>
+          <option value="portrait" ${cardLayout==='portrait'?'selected':''}>${t('layout_portrait')}</option>
         </select>
       </div>
 
       <div class="form-group">
-        <label class="form-label">App Language</label>
+        <label class="form-label">${t('lang_label')}</label>
         <select class="form-select" onchange="updateSetting('lastAppLanguage',this.value)">
           <option value="en" ${lang==='en'?'selected':''}>English</option>
           <option value="he" ${lang==='he'?'selected':''}>עברית</option>
@@ -719,12 +920,12 @@ async function renderSettings() {
     </div>
 
     <div class="card">
-      <div style="font-size:16px;font-weight:700;margin-bottom:16px">Profile</div>
+      <div style="font-size:16px;font-weight:700;margin-bottom:16px">${t('profile_section')}</div>
       <div class="form-group">
         <div style="display:flex;align-items:center;justify-content:space-between">
           <div>
-            <div style="font-weight:600">Skip Profile Selection</div>
-            <div style="font-size:12px;color:var(--text-muted);margin-top:2px">Launch directly into the app with the active profile</div>
+            <div style="font-weight:600">${t('skip_label')}</div>
+            <div style="font-size:12px;color:var(--text-muted);margin-top:2px">${t('skip_desc')}</div>
           </div>
           <label class="toggle">
             <input type="checkbox" ${skipProfile?'checked':''} onchange="updateSetting('skipProfileSelection',this.checked)">
@@ -735,29 +936,29 @@ async function renderSettings() {
     </div>
 
     <div class="card">
-      <div style="font-size:16px;font-weight:700;margin-bottom:16px">Account</div>
+      <div style="font-size:16px;font-weight:700;margin-bottom:16px">${t('account_section')}</div>
       <div class="list-item" style="padding:10px 0;border:none">
         <div class="item-info">
-          <div class="item-title">User ID</div>
+          <div class="item-title">${t('user_id_label')}</div>
           <div class="item-sub" style="font-family:monospace;font-size:11px">${state.userId}</div>
         </div>
       </div>
       <button class="btn btn-danger" onclick="signOut()" style="margin-top:8px">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
-        Sign out
+        ${t('sign_out')}
       </button>
     </div>
   `;
 }
 
 async function updateSetting(key, value) {
-  if (!state.syncPayload) { toast('No sync data', 'err'); return; }
+  if (!state.syncPayload) { toast(t('no_sync'), 'err'); return; }
   state.syncPayload[key] = value;
   try {
     await saveSyncPayload(state.syncPayload);
-    toast('Saved ✓');
+    toast(t('saved'));
   } catch (e) {
-    toast('Failed to save', 'err');
+    toast(t('save_err'), 'err');
   }
 }
 
@@ -766,13 +967,13 @@ function timeAgo(iso) {
   if (!iso) return '';
   const d = Date.now() - new Date(iso).getTime();
   const m = Math.floor(d / 60000);
-  if (m < 1) return 'just now';
-  if (m < 60) return `${m}m ago`;
+  if (m < 1) return t('just_now');
+  if (m < 60) return t('m_ago', m);
   const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h ago`;
+  if (h < 24) return t('h_ago', h);
   const days = Math.floor(h / 24);
-  if (days < 30) return `${days}d ago`;
-  return new Date(iso).toLocaleDateString('en-US');
+  if (days < 30) return t('d_ago', days);
+  return new Date(iso).toLocaleDateString(currentLang === 'he' ? 'he-IL' : 'en-US');
 }
 
 function formatDuration(secs) {
@@ -793,21 +994,21 @@ function emptyState(msg) {
 
 // ── Shell ─────────────────────────────────────────────────────────────────
 function buildShell(user) {
-  const name = user.user_metadata?.full_name || user.email || 'User';
+  const name = user.user_metadata?.full_name || user.email || t('user_fallback');
   const avatar = user.user_metadata?.avatar_url || '';
   const email = user.email || '';
   const initial = name[0].toUpperCase();
 
   const navItems = [
-    { id: 'dashboard', label: 'Dashboard', icon: '<path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/>' },
-    { id: 'profiles', label: 'Profiles', icon: '<path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/>' },
-    { id: 'addons', label: 'Add-ons', icon: '<rect x="3" y="3" width="18" height="18" rx="3"/><path d="M9 9h6M9 12h6M9 15h4"/>' },
+    { id: 'dashboard', label: t('nav_dashboard'), icon: '<path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/>' },
+    { id: 'profiles', label: t('nav_profiles'), icon: '<path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/>' },
+    { id: 'addons', label: t('nav_addons'), icon: '<rect x="3" y="3" width="18" height="18" rx="3"/><path d="M9 9h6M9 12h6M9 15h4"/>' },
     { id: 'iptv', label: 'IPTV', icon: '<path d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"/><path d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>' },
-    { id: 'plugins', label: 'Plugins', icon: '<path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/>' },
-    { id: 'history', label: 'History', icon: '<circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>' },
-    { id: 'watchlist', label: 'Watchlist', icon: '<path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z"/>' },
-    { id: 'ai', label: 'AI Subtitles', icon: '<path d="M12 2a3 3 0 013 3v7a3 3 0 01-6 0V5a3 3 0 013-3z"/><path d="M19 10v2a7 7 0 01-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/>' },
-    { id: 'settings', label: 'Settings', icon: '<circle cx="12" cy="12" r="3"/><path d="M19.07 4.93l-1.41 1.41M4.93 4.93l1.41 1.41M19.07 19.07l-1.41-1.41M4.93 19.07l1.41-1.41M1 12h2M21 12h2M12 1v2M12 21v2"/>' },
+    { id: 'plugins', label: t('nav_plugins'), icon: '<path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/>' },
+    { id: 'history', label: t('nav_history'), icon: '<circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>' },
+    { id: 'watchlist', label: t('nav_watchlist'), icon: '<path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z"/>' },
+    { id: 'ai', label: t('nav_ai'), icon: '<path d="M12 2a3 3 0 013 3v7a3 3 0 01-6 0V5a3 3 0 013-3z"/><path d="M19 10v2a7 7 0 01-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/>' },
+    { id: 'settings', label: t('nav_settings'), icon: '<circle cx="12" cy="12" r="3"/><path d="M19.07 4.93l-1.41 1.41M4.93 4.93l1.41 1.41M19.07 19.07l-1.41-1.41M4.93 19.07l1.41-1.41M1 12h2M21 12h2M12 1v2M12 21v2"/>' },
   ];
 
   document.getElementById('app-screen').innerHTML = `
@@ -832,7 +1033,10 @@ function buildShell(user) {
           <div class="user-name">${name}</div>
           <div class="user-email">${email}</div>
         </div>
-        <button class="btn-logout" onclick="signOut()" title="Sign out">
+        <button class="btn-lang" onclick="setLang(currentLang==='en'?'he':'en')" title="Switch language" style="background:none;border:1px solid var(--border);border-radius:6px;color:var(--text-muted);cursor:pointer;padding:4px 8px;font-size:12px;font-weight:600;margin-left:4px">
+          ${currentLang === 'en' ? 'עב' : 'EN'}
+        </button>
+        <button class="btn-logout" onclick="signOut()" title="${t('sign_out')}">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
         </button>
       </div>

--- a/netlify-arvio-tv-site/companion/app.js
+++ b/netlify-arvio-tv-site/companion/app.js
@@ -1,0 +1,725 @@
+// ── Supabase Config ───────────────────────────────────────────────────────
+const SUPABASE_URL = 'https://zrdwvortcfnoykltzuqf.supabase.co';
+const SUPABASE_ANON = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InpyZHd2b3J0Y2Zub3lrbHR6dXFmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjY3NDU4NzMsImV4cCI6MjA4MjMyMTg3M30.YfKZbSwxGs6_xMd6jkDtn1PKkfuyOHo9qVhUvFRddGU';
+const TMDB_IMG = 'https://image.tmdb.org/t/p/w92';
+
+const { createClient } = supabase;
+const db = createClient(SUPABASE_URL, SUPABASE_ANON);
+
+// ── State ─────────────────────────────────────────────────────────────────
+let state = {
+  session: null,
+  userId: null,
+  syncPayload: null,
+  activeSection: 'dashboard',
+  historyTab: 'movies',
+};
+
+// ── Toast ─────────────────────────────────────────────────────────────────
+function toast(msg, type = 'ok') {
+  const el = document.getElementById('toast');
+  el.textContent = msg;
+  el.className = `show toast-${type}`;
+  clearTimeout(el._t);
+  el._t = setTimeout(() => { el.className = ''; }, 3000);
+}
+
+// ── Auth ──────────────────────────────────────────────────────────────────
+async function signInGoogle() {
+  const { error } = await db.auth.signInWithOAuth({
+    provider: 'google',
+    options: { redirectTo: window.location.href },
+  });
+  if (error) toast(error.message, 'err');
+}
+
+async function signOut() {
+  await db.auth.signOut();
+  location.reload();
+}
+
+// ── Cloud Sync Payload ────────────────────────────────────────────────────
+async function loadSyncPayload() {
+  try {
+    const { data, error } = await db
+      .from('profiles')
+      .select('addons')
+      .eq('id', state.userId)
+      .single();
+    if (error || !data?.addons) return null;
+    const wrapper = JSON.parse(data.addons);
+    const raw = wrapper['__arvioAccountSyncPayload'];
+    if (!raw) return null;
+    return JSON.parse(raw);
+  } catch { return null; }
+}
+
+async function saveSyncPayload(payload) {
+  const raw = JSON.stringify(payload);
+  const wrapper = JSON.stringify({
+    __arvioAccountSyncPayload: raw,
+    __arvioAccountSyncUpdatedAt: new Date().toISOString(),
+  });
+  const { error } = await db
+    .from('profiles')
+    .update({ addons: wrapper })
+    .eq('id', state.userId);
+  if (error) throw error;
+  state.syncPayload = payload;
+}
+
+// ── Sections ──────────────────────────────────────────────────────────────
+const sections = {
+  dashboard: renderDashboard,
+  profiles: renderProfiles,
+  addons: renderAddons,
+  history: renderHistory,
+  watchlist: renderWatchlist,
+  ai: renderAI,
+  settings: renderSettings,
+};
+
+function navigate(id) {
+  state.activeSection = id;
+  document.querySelectorAll('.nav-item').forEach(el => {
+    el.classList.toggle('active', el.dataset.section === id);
+  });
+  renderSection();
+}
+
+async function renderSection() {
+  const main = document.getElementById('main-content');
+  main.innerHTML = `<div class="loading"><div class="spinner"></div> טוען...</div>`;
+  await sections[state.activeSection]?.();
+}
+
+// ── Dashboard ─────────────────────────────────────────────────────────────
+async function renderDashboard() {
+  const main = document.getElementById('main-content');
+
+  const [histRes, wlRes] = await Promise.all([
+    db.from('watch_history').select('id, media_type', { count: 'exact', head: false })
+      .eq('user_id', state.userId).limit(1),
+    db.from('watchlist').select('tmdb_id', { count: 'exact', head: false })
+      .eq('user_id', state.userId).limit(1),
+  ]);
+
+  const payload = state.syncPayload;
+  const profiles = payload?.profiles ?? [];
+  const addons = getAddons(payload);
+
+  main.innerHTML = `
+    <div class="section-header">
+      <div>
+        <div class="section-title">Dashboard</div>
+        <div class="section-sub">סקירה מהירה של חשבון ה-ARVIO שלך</div>
+      </div>
+    </div>
+    <div class="card-grid">
+      <div class="stat-card"><div class="stat-label">פרופילים</div><div class="stat-value gold">${profiles.length || 1}</div></div>
+      <div class="stat-card"><div class="stat-label">הרחבות</div><div class="stat-value">${addons.filter(a => a.isEnabled).length}</div></div>
+      <div class="stat-card"><div class="stat-label">היסטוריית צפייה</div><div class="stat-value">${histRes.count ?? '—'}</div></div>
+      <div class="stat-card"><div class="stat-label">רשימת צפייה</div><div class="stat-value">${wlRes.count ?? '—'}</div></div>
+    </div>
+    <div class="card">
+      <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin-bottom:14px">פעילות אחרונה</div>
+      <div id="recent-activity"><div class="loading"><div class="spinner"></div></div></div>
+    </div>
+  `;
+
+  const { data: recent } = await db.from('watch_history')
+    .select('title, media_type, progress, updated_at, poster_path, backdrop_path')
+    .eq('user_id', state.userId)
+    .order('updated_at', { ascending: false })
+    .limit(6);
+
+  const ra = document.getElementById('recent-activity');
+  if (!recent?.length) {
+    ra.innerHTML = emptyState('אין פעילות אחרונה');
+    return;
+  }
+  ra.innerHTML = recent.map(r => `
+    <div class="list-item">
+      <img class="history-poster" src="${r.poster_path ? TMDB_IMG + r.poster_path : ''}" onerror="this.style.background='var(--bg-card2)';this.src=''" alt="">
+      <div class="item-info">
+        <div class="item-title">${r.title || '—'}</div>
+        <div class="item-sub">${r.media_type === 'movie' ? '🎬 סרט' : '📺 סדרה'} · ${timeAgo(r.updated_at)}</div>
+        <div class="progress-bar"><div class="progress-fill" style="width:${Math.round((r.progress||0)*100)}%"></div></div>
+      </div>
+      <span class="badge badge-gray">${Math.round((r.progress||0)*100)}%</span>
+    </div>
+  `).join('');
+}
+
+// ── Profiles ──────────────────────────────────────────────────────────────
+function getProfileColors() {
+  return ['#E53935','#8E24AA','#1E88E5','#00897B','#F4511E','#6D4C41','#3949AB','#039BE5'];
+}
+
+function renderProfileAvatar(profile) {
+  const color = '#' + (profile.avatarColor?.toString(16).padStart(8,'0').slice(2) || 'F5C442');
+  const letter = (profile.name || '?')[0].toUpperCase();
+  return `<div class="profile-avatar-big" style="background:${color}22;color:${color}">${letter}</div>`;
+}
+
+async function renderProfiles() {
+  const main = document.getElementById('main-content');
+  const payload = state.syncPayload;
+  const profiles = payload?.profiles ?? [];
+  const activeId = payload?.activeProfileId;
+
+  if (!profiles.length) {
+    main.innerHTML = `
+      <div class="section-header"><div class="section-title">פרופילים</div></div>
+      ${emptyState('אין פרופילים — פתח את ARVIO בטלוויזיה ליצירת פרופיל')}`;
+    return;
+  }
+
+  main.innerHTML = `
+    <div class="section-header">
+      <div><div class="section-title">פרופילים</div><div class="section-sub">${profiles.length} פרופילים בחשבון</div></div>
+    </div>
+    <div class="profiles-grid">
+      ${profiles.map(p => `
+        <div class="profile-card ${p.id === activeId ? 'active-profile' : ''}">
+          ${renderProfileAvatar(p)}
+          <div class="profile-name">${p.name}</div>
+          <div style="display:flex;gap:6px;flex-wrap:wrap;justify-content:center">
+            ${p.id === activeId ? '<span class="badge badge-gold">פעיל</span>' : ''}
+            ${p.isKidsProfile ? '<span class="badge badge-blue">ילדים</span>' : ''}
+            ${p.pin ? '<span class="badge badge-gray">🔒 נעול</span>' : ''}
+          </div>
+        </div>
+      `).join('')}
+    </div>
+    <div class="card">
+      <div style="font-size:13px;color:var(--text-muted)">💡 ניהול פרופילים (יצירה, מחיקה, שינוי שם) זמין ב-ARVIO על הטלוויזיה.<br>שינויים מסונכרנים אוטומטית עם הענן.</div>
+    </div>
+  `;
+}
+
+// ── Addons ────────────────────────────────────────────────────────────────
+function getAddons(payload) {
+  if (!payload) return [];
+  const shared = payload.addons ?? [];
+  const byProfile = payload.addonsByProfile ?? {};
+  const allIds = new Set();
+  const all = [...shared];
+  Object.values(byProfile).forEach(arr => {
+    (arr || []).forEach(a => { if (!allIds.has(a.id)) { allIds.add(a.id); all.push(a); } });
+  });
+  return all;
+}
+
+async function renderAddons() {
+  const main = document.getElementById('main-content');
+  const addons = getAddons(state.syncPayload);
+
+  if (!addons.length) {
+    main.innerHTML = `
+      <div class="section-header"><div class="section-title">הרחבות</div></div>
+      ${emptyState('אין הרחבות מותקנות')}`;
+    return;
+  }
+
+  const byType = {
+    STREMIO: addons.filter(a => a.runtimeKind !== 'TELEGRAM'),
+    TELEGRAM: addons.filter(a => a.runtimeKind === 'TELEGRAM'),
+  };
+
+  function addonIcon(a) {
+    if (a.manifest?.logo || a.logo) {
+      return `<img src="${a.manifest?.logo || a.logo}" alt="" onerror="this.style.display='none'">`;
+    }
+    return `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="3" width="18" height="18" rx="3"/><path d="M9 9h6M9 12h6M9 15h4"/></svg>`;
+  }
+
+  function addonTypeBadge(a) {
+    const t = a.type || 'COMMUNITY';
+    if (t === 'OFFICIAL') return '<span class="badge badge-gold">רשמי</span>';
+    if (t === 'SUBTITLE') return '<span class="badge badge-blue">כתוביות</span>';
+    if (t === 'METADATA') return '<span class="badge badge-gray">מטאדאטה</span>';
+    if (a.runtimeKind === 'TELEGRAM') return '<span class="badge badge-blue">Telegram</span>';
+    return '<span class="badge badge-gray">קהילה</span>';
+  }
+
+  function renderAddonList(list, label) {
+    if (!list.length) return '';
+    return `
+      <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin:20px 0 12px">${label}</div>
+      <div class="card" style="padding:0 20px">
+        ${list.map(a => `
+          <div class="list-item">
+            <div class="item-icon">${addonIcon(a)}</div>
+            <div class="item-info">
+              <div class="item-title">${a.name || a.id}</div>
+              <div class="item-sub">${a.manifest?.description || a.description || a.id}</div>
+            </div>
+            <div style="display:flex;gap:8px;align-items:center">
+              ${addonTypeBadge(a)}
+              <span class="badge ${a.isEnabled ? 'badge-green' : 'badge-red'}">${a.isEnabled ? 'פעיל' : 'כבוי'}</span>
+            </div>
+          </div>
+        `).join('')}
+      </div>
+    `;
+  }
+
+  main.innerHTML = `
+    <div class="section-header">
+      <div><div class="section-title">הרחבות</div><div class="section-sub">${addons.filter(a=>a.isEnabled).length} פעילות מתוך ${addons.length}</div></div>
+    </div>
+    ${renderAddonList(byType.STREMIO, `Stremio הרחבות (${byType.STREMIO.length})`)}
+    ${renderAddonList(byType.TELEGRAM, `Telegram מקורות (${byType.TELEGRAM.length})`)}
+    <div class="card" style="margin-top:16px">
+      <div style="font-size:13px;color:var(--text-muted)">💡 להוספה/הסרה של הרחבות — גש להגדרות ב-ARVIO. הנתונים מסונכרנים אוטומטית.</div>
+    </div>
+  `;
+}
+
+// ── Watch History ─────────────────────────────────────────────────────────
+async function renderHistory() {
+  const main = document.getElementById('main-content');
+
+  main.innerHTML = `
+    <div class="section-header">
+      <div><div class="section-title">היסטוריית צפייה</div></div>
+    </div>
+    <div class="tabs">
+      <button class="tab ${state.historyTab==='movies'?'active':''}" onclick="state.historyTab='movies';renderHistoryContent()">סרטים</button>
+      <button class="tab ${state.historyTab==='tv'?'active':''}" onclick="state.historyTab='tv';renderHistoryContent()">סדרות</button>
+      <button class="tab ${state.historyTab==='all'?'active':''}" onclick="state.historyTab='all';renderHistoryContent()">הכל</button>
+    </div>
+    <div id="history-content"><div class="loading"><div class="spinner"></div></div></div>
+  `;
+  await renderHistoryContent();
+}
+
+async function renderHistoryContent() {
+  document.querySelectorAll('.tab').forEach(t => {
+    const map = { movies: 'סרטים', tv: 'סדרות', all: 'הכל' };
+    t.classList.toggle('active', t.textContent.trim() === map[state.historyTab]);
+  });
+
+  const el = document.getElementById('history-content');
+  if (!el) return;
+  el.innerHTML = `<div class="loading"><div class="spinner"></div></div>`;
+
+  let q = db.from('watch_history')
+    .select('*')
+    .eq('user_id', state.userId)
+    .order('updated_at', { ascending: false })
+    .limit(50);
+
+  if (state.historyTab === 'movies') q = q.eq('media_type', 'movie');
+  if (state.historyTab === 'tv') q = q.eq('media_type', 'tv');
+
+  const { data, error } = await q;
+  if (error) { el.innerHTML = `<div class="empty"><div class="empty-title">שגיאה בטעינה</div></div>`; return; }
+  if (!data?.length) { el.innerHTML = emptyState('אין היסטוריית צפייה'); return; }
+
+  el.innerHTML = `<div class="card" style="padding:0 20px">
+    ${data.map(r => `
+      <div class="list-item">
+        <img class="history-poster" src="${r.poster_path ? TMDB_IMG+r.poster_path : ''}" onerror="this.style.background='var(--bg-card2)';this.src=''" alt="">
+        <div class="item-info">
+          <div class="item-title">${r.title || '—'}${r.season ? ` S${String(r.season).padStart(2,'0')}E${String(r.episode||0).padStart(2,'0')}` : ''}</div>
+          <div class="item-sub">${timeAgo(r.updated_at)} · ${formatDuration(r.position_seconds)} / ${formatDuration(r.duration_seconds)}</div>
+          <div class="progress-bar"><div class="progress-fill" style="width:${Math.round((r.progress||0)*100)}%"></div></div>
+        </div>
+        <div style="display:flex;flex-direction:column;align-items:flex-end;gap:6px">
+          <span class="badge badge-gray">${Math.round((r.progress||0)*100)}%</span>
+          <button class="btn btn-danger" style="padding:4px 10px;font-size:11px" onclick="deleteHistory('${r.id}',this)">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v6M14 11v6"/></svg>
+          </button>
+        </div>
+      </div>
+    `).join('')}
+  </div>`;
+}
+
+async function deleteHistory(id, btn) {
+  btn.disabled = true;
+  const { error } = await db.from('watch_history').delete().eq('id', id).eq('user_id', state.userId);
+  if (error) { toast('שגיאה במחיקה', 'err'); btn.disabled = false; return; }
+  toast('הוסר מההיסטוריה ✓');
+  btn.closest('.list-item').remove();
+}
+
+// ── Watchlist ─────────────────────────────────────────────────────────────
+async function renderWatchlist() {
+  const main = document.getElementById('main-content');
+  main.innerHTML = `<div class="section-header"><div class="section-title">רשימת צפייה</div></div><div class="loading"><div class="spinner"></div></div>`;
+
+  const { data, error } = await db.from('watchlist')
+    .select('*')
+    .eq('user_id', state.userId)
+    .order('added_at', { ascending: false });
+
+  if (error || !data?.length) {
+    main.innerHTML = `<div class="section-header"><div class="section-title">רשימת צפייה</div></div>${emptyState('רשימת הצפייה ריקה')}`;
+    return;
+  }
+
+  const movies = data.filter(i => i.media_type === 'movie');
+  const shows = data.filter(i => i.media_type === 'tv');
+
+  function renderWLSection(items, label) {
+    if (!items.length) return '';
+    return `
+      <div style="font-size:13px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.5px;margin:20px 0 12px">${label} (${items.length})</div>
+      <div class="card" style="padding:0 20px">
+        ${items.map(i => `
+          <div class="list-item" id="wl-${i.tmdb_id}-${i.media_type}">
+            <div class="item-icon">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">${i.media_type==='movie'?'<path d="M15 10l4.553-2.069A1 1 0 0121 8.882v6.236a1 1 0 01-1.447.894L15 14M3 8a2 2 0 012-2h10a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V8z"/>':'<rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/>'}
+              </svg>
+            </div>
+            <div class="item-info">
+              <div class="item-title">TMDB #${i.tmdb_id}</div>
+              <div class="item-sub">נוסף ${timeAgo(i.added_at)}</div>
+            </div>
+            <button class="btn btn-danger" style="padding:6px 10px" onclick="removeWatchlist(${i.tmdb_id},'${i.media_type}',this)">הסר</button>
+          </div>
+        `).join('')}
+      </div>`;
+  }
+
+  main.innerHTML = `
+    <div class="section-header">
+      <div><div class="section-title">רשימת צפייה</div><div class="section-sub">${data.length} פריטים</div></div>
+    </div>
+    ${renderWLSection(movies, '🎬 סרטים')}
+    ${renderWLSection(shows, '📺 סדרות')}
+  `;
+}
+
+async function removeWatchlist(tmdbId, mediaType, btn) {
+  btn.disabled = true;
+  const { error } = await db.from('watchlist').delete()
+    .eq('user_id', state.userId).eq('tmdb_id', tmdbId).eq('media_type', mediaType);
+  if (error) { toast('שגיאה במחיקה', 'err'); btn.disabled = false; return; }
+  toast('הוסר מהרשימה ✓');
+  document.getElementById(`wl-${tmdbId}-${mediaType}`)?.remove();
+}
+
+// ── AI Subtitle Translation ────────────────────────────────────────────────
+async function renderAI() {
+  const main = document.getElementById('main-content');
+  const payload = state.syncPayload;
+  const enabled = payload?.subtitleAiEnabled ?? false;
+  const autoSelect = payload?.subtitleAiAutoSelect ?? false;
+  const model = payload?.subtitleAiModel ?? 'GROQ_LLAMA_70B';
+  const removeHI = payload?.subtitleRemoveHearingImpaired ?? false;
+
+  main.innerHTML = `
+    <div class="section-header">
+      <div><div class="section-title">תרגום כתוביות AI</div><div class="section-sub">הגדר תרגום כתוביות בזמן אמת על ידי AI</div></div>
+    </div>
+
+    <div class="tv-banner">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+        <rect x="2" y="3" width="20" height="14" rx="2"/>
+        <path d="M8 21h8M12 17v4"/>
+      </svg>
+      <div>
+        <div class="tv-banner-title">🔑 מפתח API — הגדר ישירות בטלוויזיה</div>
+        <div class="tv-banner-sub">מטעמי אבטחה, מפתח ה-API נשמר רק מקומית בטלוויזיה.<br>פתח את ARVIO ← הגדרות ← כתוביות ← תרגום AI</div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div style="font-size:16px;font-weight:700;margin-bottom:16px">הגדרות תרגום</div>
+
+      <div class="form-group">
+        <div style="display:flex;align-items:center;justify-content:space-between">
+          <div>
+            <div style="font-weight:600">הפעל תרגום AI</div>
+            <div style="font-size:12px;color:var(--text-muted);margin-top:2px">תרגם כתוביות אוטומטית בזמן צפייה</div>
+          </div>
+          <label class="toggle">
+            <input type="checkbox" id="ai-enabled" ${enabled ? 'checked' : ''} onchange="updateAISetting('subtitleAiEnabled', this.checked)">
+            <span class="toggle-slider"></span>
+          </label>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <div style="display:flex;align-items:center;justify-content:space-between">
+          <div>
+            <div style="font-weight:600">בחירה אוטומטית</div>
+            <div style="font-size:12px;color:var(--text-muted);margin-top:2px">בחר אוטומטית כתוביות לתרגום</div>
+          </div>
+          <label class="toggle">
+            <input type="checkbox" id="ai-auto" ${autoSelect ? 'checked' : ''} onchange="updateAISetting('subtitleAiAutoSelect', this.checked)">
+            <span class="toggle-slider"></span>
+          </label>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <div style="display:flex;align-items:center;justify-content:space-between">
+          <div>
+            <div style="font-weight:600">הסר כתוביות לכבדי שמיעה</div>
+            <div style="font-size:12px;color:var(--text-muted);margin-top:2px">הסר תיאורי קול מהכתוביות [SDH]</div>
+          </div>
+          <label class="toggle">
+            <input type="checkbox" id="ai-hi" ${removeHI ? 'checked' : ''} onchange="updateAISetting('subtitleRemoveHearingImpaired', this.checked)">
+            <span class="toggle-slider"></span>
+          </label>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div style="font-size:16px;font-weight:700;margin-bottom:16px">בחר מודל AI</div>
+      <div class="models-grid">
+        <label class="model-card ${model==='GROQ_LLAMA_70B'?'selected':''}">
+          <input type="radio" name="ai-model" value="GROQ_LLAMA_70B" ${model==='GROQ_LLAMA_70B'?'checked':''} onchange="updateAISetting('subtitleAiModel',this.value)">
+          <div>
+            <div class="model-name">⚡ Groq Llama 70B</div>
+            <div class="model-desc">מהיר ביותר, חינמי, מומלץ לתרגום כתוביות</div>
+          </div>
+        </label>
+        <label class="model-card ${model==='GEMINI_FLASH_25'?'selected':''}">
+          <input type="radio" name="ai-model" value="GEMINI_FLASH_25" ${model==='GEMINI_FLASH_25'?'checked':''} onchange="updateAISetting('subtitleAiModel',this.value)">
+          <div>
+            <div class="model-name">🤖 Gemini Flash 2.5</div>
+            <div class="model-desc">Google Gemini, איכות גבוהה, מהיר מאוד</div>
+          </div>
+        </label>
+      </div>
+
+      <div style="background:var(--bg-card2);border-radius:8px;padding:14px 16px;margin-top:8px">
+        <div style="font-size:13px;font-weight:600;margin-bottom:8px">איך לקבל מפתח API חינמי?</div>
+        <div style="font-size:12px;color:var(--text-muted);line-height:1.7">
+          🔹 <b>Groq (מומלץ)</b>: גש ל-<code style="background:var(--bg);padding:1px 5px;border-radius:4px">console.groq.com</code> ← צור חשבון ← API Keys ← Create Key<br>
+          🔹 <b>Gemini</b>: גש ל-<code style="background:var(--bg);padding:1px 5px;border-radius:4px">aistudio.google.com</code> ← Get API Key
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+async function updateAISetting(key, value) {
+  if (!state.syncPayload) { toast('אין נתוני סנכרון', 'err'); return; }
+  state.syncPayload[key] = value;
+  try {
+    await saveSyncPayload(state.syncPayload);
+    toast('נשמר ✓');
+    // Update model card UI
+    if (key === 'subtitleAiModel') {
+      document.querySelectorAll('.model-card').forEach(card => {
+        const inp = card.querySelector('input');
+        card.classList.toggle('selected', inp?.value === value);
+      });
+    }
+  } catch (e) {
+    toast('שגיאה בשמירה', 'err');
+  }
+}
+
+// ── Settings ──────────────────────────────────────────────────────────────
+async function renderSettings() {
+  const main = document.getElementById('main-content');
+  const p = state.syncPayload;
+
+  const cardLayout = p?.cardLayoutMode ?? 'landscape';
+  const accentColor = p?.accentColor ?? '#F5C442';
+  const oled = p?.oledBlackBackground ?? true;
+  const skipProfile = p?.skipProfileSelection ?? false;
+  const lang = p?.lastAppLanguage ?? 'en';
+
+  main.innerHTML = `
+    <div class="section-header">
+      <div><div class="section-title">הגדרות</div><div class="section-sub">הגדרות כלליות לחשבון</div></div>
+    </div>
+
+    <div class="card">
+      <div style="font-size:16px;font-weight:700;margin-bottom:16px">מראה</div>
+
+      <div class="form-group">
+        <div style="display:flex;align-items:center;justify-content:space-between">
+          <div>
+            <div style="font-weight:600">רקע OLED שחור</div>
+            <div style="font-size:12px;color:var(--text-muted);margin-top:2px">רקע שחור לחלוטין לחיסכון בסוללה</div>
+          </div>
+          <label class="toggle">
+            <input type="checkbox" ${oled?'checked':''} onchange="updateSetting('oledBlackBackground',this.checked)">
+            <span class="toggle-slider"></span>
+          </label>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <label class="form-label">פריסת כרטיסי מדיה</label>
+        <select class="form-select" onchange="updateSetting('cardLayoutMode',this.value)">
+          <option value="landscape" ${cardLayout==='landscape'?'selected':''}>Landscape (רוחב)</option>
+          <option value="portrait" ${cardLayout==='portrait'?'selected':''}>Portrait (אנכי)</option>
+        </select>
+      </div>
+
+      <div class="form-group">
+        <label class="form-label">שפת ממשק</label>
+        <select class="form-select" onchange="updateSetting('lastAppLanguage',this.value)">
+          <option value="en" ${lang==='en'?'selected':''}>English</option>
+          <option value="he" ${lang==='he'?'selected':''}>עברית</option>
+          <option value="ar" ${lang==='ar'?'selected':''}>العربية</option>
+          <option value="fr" ${lang==='fr'?'selected':''}>Français</option>
+          <option value="de" ${lang==='de'?'selected':''}>Deutsch</option>
+          <option value="es" ${lang==='es'?'selected':''}>Español</option>
+          <option value="ru" ${lang==='ru'?'selected':''}>Русский</option>
+          <option value="tr" ${lang==='tr'?'selected':''}>Türkçe</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="card">
+      <div style="font-size:16px;font-weight:700;margin-bottom:16px">פרופיל</div>
+      <div class="form-group">
+        <div style="display:flex;align-items:center;justify-content:space-between">
+          <div>
+            <div style="font-weight:600">דלג על בחירת פרופיל</div>
+            <div style="font-size:12px;color:var(--text-muted);margin-top:2px">עבור ישירות לאפליקציה עם הפרופיל הפעיל</div>
+          </div>
+          <label class="toggle">
+            <input type="checkbox" ${skipProfile?'checked':''} onchange="updateSetting('skipProfileSelection',this.checked)">
+            <span class="toggle-slider"></span>
+          </label>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div style="font-size:16px;font-weight:700;margin-bottom:16px">חשבון</div>
+      <div class="list-item" style="padding:10px 0;border:none">
+        <div class="item-info">
+          <div class="item-title">מזהה משתמש</div>
+          <div class="item-sub" style="font-family:monospace;font-size:11px">${state.userId}</div>
+        </div>
+      </div>
+      <button class="btn btn-danger" onclick="signOut()" style="margin-top:8px">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+        התנתק
+      </button>
+    </div>
+  `;
+}
+
+async function updateSetting(key, value) {
+  if (!state.syncPayload) { toast('אין נתוני סנכרון', 'err'); return; }
+  state.syncPayload[key] = value;
+  try {
+    await saveSyncPayload(state.syncPayload);
+    toast('נשמר ✓');
+  } catch (e) {
+    toast('שגיאה בשמירה', 'err');
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+function timeAgo(iso) {
+  if (!iso) return '';
+  const d = Date.now() - new Date(iso).getTime();
+  const m = Math.floor(d / 60000);
+  if (m < 1) return 'עכשיו';
+  if (m < 60) return `לפני ${m} דק׳`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `לפני ${h} שע׳`;
+  const days = Math.floor(h / 24);
+  if (days < 30) return `לפני ${days} ימים`;
+  return new Date(iso).toLocaleDateString('he-IL');
+}
+
+function formatDuration(secs) {
+  if (!secs) return '0:00';
+  const h = Math.floor(secs / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  const s = Math.floor(secs % 60);
+  if (h) return `${h}:${String(m).padStart(2,'0')}:${String(s).padStart(2,'0')}`;
+  return `${m}:${String(s).padStart(2,'0')}`;
+}
+
+function emptyState(msg) {
+  return `<div class="empty">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="10"/><path d="M8 12h8M12 8v8"/></svg>
+    <div class="empty-title">${msg}</div>
+  </div>`;
+}
+
+// ── Shell ─────────────────────────────────────────────────────────────────
+function buildShell(user) {
+  const name = user.user_metadata?.full_name || user.email || 'משתמש';
+  const avatar = user.user_metadata?.avatar_url || '';
+  const email = user.email || '';
+  const initial = name[0].toUpperCase();
+
+  const navItems = [
+    { id: 'dashboard', label: 'Dashboard', icon: '<path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/>' },
+    { id: 'profiles', label: 'פרופילים', icon: '<path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/>' },
+    { id: 'addons', label: 'הרחבות', icon: '<rect x="3" y="3" width="18" height="18" rx="3"/><path d="M9 9h6M9 12h6M9 15h4"/>' },
+    { id: 'history', label: 'היסטוריה', icon: '<circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>' },
+    { id: 'watchlist', label: 'רשימת צפייה', icon: '<path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z"/>' },
+    { id: 'ai', label: 'תרגום AI', icon: '<path d="M12 2a3 3 0 013 3v7a3 3 0 01-6 0V5a3 3 0 013-3z"/><path d="M19 10v2a7 7 0 01-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/>' },
+    { id: 'settings', label: 'הגדרות', icon: '<circle cx="12" cy="12" r="3"/><path d="M19.07 4.93l-1.41 1.41M4.93 4.93l1.41 1.41M19.07 19.07l-1.41-1.41M4.93 19.07l1.41-1.41M1 12h2M21 12h2M12 1v2M12 21v2"/>' },
+  ];
+
+  document.getElementById('app-screen').innerHTML = `
+    <aside class="sidebar">
+      <div class="sidebar-logo">
+        <img src="../assets/arvio-icon-512.png" class="auth-logo" style="width:32px;height:32px" onerror="this.style.display='none'" alt="ARVIO">
+        <span>ARVIO</span>
+      </div>
+      <nav>
+        ${navItems.map(n => `
+          <button class="nav-item ${n.id === state.activeSection ? 'active' : ''}" data-section="${n.id}" onclick="navigate('${n.id}')">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">${n.icon}</svg>
+            ${n.label}
+          </button>
+        `).join('')}
+      </nav>
+      <div class="sidebar-user">
+        <div class="user-avatar">
+          ${avatar ? `<img src="${avatar}" alt="">` : initial}
+        </div>
+        <div class="user-info">
+          <div class="user-name">${name}</div>
+          <div class="user-email">${email}</div>
+        </div>
+        <button class="btn-logout" onclick="signOut()" title="התנתק">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+        </button>
+      </div>
+    </aside>
+    <main class="main" id="main-content"></main>
+  `;
+}
+
+// ── Boot ──────────────────────────────────────────────────────────────────
+async function boot() {
+  const { data: { session } } = await db.auth.getSession();
+
+  if (!session) {
+    document.getElementById('auth-screen').style.display = 'flex';
+    document.getElementById('app-screen').style.display = 'none';
+    return;
+  }
+
+  state.session = session;
+  state.userId = session.user.id;
+
+  document.getElementById('auth-screen').style.display = 'none';
+  document.getElementById('app-screen').style.display = 'flex';
+
+  buildShell(session.user);
+
+  state.syncPayload = await loadSyncPayload();
+
+  await renderSection();
+
+  db.auth.onAuthStateChange((_e, s) => {
+    if (!s) location.reload();
+  });
+}
+
+boot();

--- a/netlify-arvio-tv-site/companion/app.js
+++ b/netlify-arvio-tv-site/companion/app.js
@@ -980,7 +980,7 @@ function safeUrl(url) {
   if (!url) return '';
   try {
     const u = new URL(url);
-    return (u.protocol === 'https:' || u.protocol === 'http:') ? url : '';
+    return (u.protocol === 'https:' || u.protocol === 'http:') ? escapeHtml(u.href) : '';
   } catch { return ''; }
 }
 

--- a/netlify-arvio-tv-site/companion/index.html
+++ b/netlify-arvio-tv-site/companion/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>ARVIO Companion</title>
+  <meta name="description" content="ניהול חשבון ARVIO — פרופילים, הרחבות, היסטוריה, תרגום AI">
+  <link rel="icon" href="../assets/arvio-icon-512.png" type="image/png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- Auth Screen -->
+  <div id="auth-screen" style="display:none">
+    <img src="../assets/arvio-icon-512.png" class="auth-logo" onerror="this.style.display='none'" alt="ARVIO">
+    <div class="auth-title">ARVIO Companion</div>
+    <div class="auth-sub">נהל את חשבון ה-ARVIO שלך — פרופילים, הרחבות, היסטוריה ותרגום AI</div>
+    <button class="btn-google" onclick="signInGoogle()">
+      <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
+        <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+        <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
+        <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+      </svg>
+      המשך עם Google
+    </button>
+  </div>
+
+  <!-- App Screen -->
+  <div id="app-screen" style="display:none"></div>
+
+  <!-- Toast -->
+  <div id="toast"></div>
+
+  <!-- Supabase CDN -->
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.min.js"></script>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/netlify-arvio-tv-site/companion/index.html
+++ b/netlify-arvio-tv-site/companion/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
-<html lang="he" dir="rtl">
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ARVIO Companion</title>
-  <meta name="description" content="ניהול חשבון ARVIO — פרופילים, הרחבות, היסטוריה, תרגום AI">
+  <meta name="description" content="Manage your ARVIO account — profiles, add-ons, history, AI subtitles">
   <link rel="icon" href="../assets/arvio-icon-512.png" type="image/png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap">
@@ -16,7 +16,7 @@
   <div id="auth-screen" style="display:none">
     <img src="../assets/arvio-icon-512.png" class="auth-logo" onerror="this.style.display='none'" alt="ARVIO">
     <div class="auth-title">ARVIO Companion</div>
-    <div class="auth-sub">נהל את חשבון ה-ARVIO שלך — פרופילים, הרחבות, היסטוריה ותרגום AI</div>
+    <div class="auth-sub">Manage your ARVIO account — profiles, add-ons, history &amp; AI subtitles</div>
     <button class="btn-google" onclick="signInGoogle()">
       <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
@@ -24,7 +24,7 @@
         <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
         <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
       </svg>
-      המשך עם Google
+      Continue with Google
     </button>
   </div>
 

--- a/netlify-arvio-tv-site/companion/mock-preview.html
+++ b/netlify-arvio-tv-site/companion/mock-preview.html
@@ -1,0 +1,485 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>ARVIO Companion — Preview</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap">
+<style>
+:root{--bg:#000;--bg-card:#111;--bg-card2:#1a1a1a;--bg-hover:#222;--border:#2a2a2a;--gold:#f5c442;--gold-dim:rgba(245,196,66,0.12);--text:#f0f0f0;--text-muted:#888;--text-dim:#555;--green:#4ade80;--red:#f87171;--blue:#60a5fa;--radius:12px;--sidebar-w:220px}
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:'Inter',-apple-system,sans-serif;background:var(--bg);color:var(--text);font-size:14px;line-height:1.5}
+.page{padding:32px 32px 32px calc(var(--sidebar-w)+32px)}
+.sidebar{width:var(--sidebar-w);background:var(--bg-card);border-right:1px solid var(--border);display:flex;flex-direction:column;position:fixed;top:0;left:0;bottom:0;z-index:10}
+.sidebar-logo{display:flex;align-items:center;gap:10px;padding:20px 16px;border-bottom:1px solid var(--border);font-weight:700;font-size:16px}
+.sidebar-logo img{width:28px;height:28px}
+.nav-item{display:flex;align-items:center;gap:10px;padding:10px 16px;color:var(--text-muted);cursor:pointer;border-radius:8px;margin:2px 8px;transition:.15s}
+.nav-item svg{width:18px;height:18px;flex-shrink:0;stroke:currentColor;fill:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round}
+.nav-item.active{background:var(--gold-dim);color:var(--gold)}
+.sidebar-user{margin-top:auto;padding:16px;border-top:1px solid var(--border);display:flex;align-items:center;gap:10px}
+.avatar{width:36px;height:36px;border-radius:50%;background:var(--gold);color:#000;display:flex;align-items:center;justify-content:center;font-weight:700;font-size:14px;flex-shrink:0}
+.user-name{font-size:13px;font-weight:600}
+.user-email{font-size:11px;color:var(--text-muted)}
+
+/* Section title */
+.section-title{font-size:22px;font-weight:700;margin-bottom:24px;display:flex;align-items:center;gap:10px}
+.section-sep{height:1px;background:var(--border);margin:40px 0}
+
+/* Stat cards */
+.stats{display:grid;grid-template-columns:repeat(4,1fr);gap:16px;margin-bottom:32px}
+.stat-card{background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius);padding:20px}
+.stat-icon{width:40px;height:40px;border-radius:10px;display:flex;align-items:center;justify-content:center;margin-bottom:12px;font-size:20px}
+.stat-icon.gold{background:var(--gold-dim)}
+.stat-icon.green{background:rgba(74,222,128,.1)}
+.stat-icon.blue{background:rgba(96,165,250,.1)}
+.stat-icon.purple{background:rgba(167,139,250,.1)}
+.stat-val{font-size:28px;font-weight:700;margin-bottom:4px}
+.stat-lbl{color:var(--text-muted);font-size:13px}
+
+/* Cards grid */
+.cards{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:16px;margin-bottom:32px}
+.card{background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius);padding:20px}
+.card-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:16px}
+.card-title{font-weight:600;font-size:15px}
+
+/* Badges */
+.badge{display:inline-flex;align-items:center;padding:3px 8px;border-radius:20px;font-size:11px;font-weight:600;gap:4px}
+.badge.green{background:rgba(74,222,128,.15);color:var(--green)}
+.badge.red{background:rgba(248,113,113,.15);color:var(--red)}
+.badge.gold{background:var(--gold-dim);color:var(--gold)}
+.badge.blue{background:rgba(96,165,250,.15);color:var(--blue)}
+.badge.muted{background:#222;color:var(--text-muted)}
+
+/* Toggle */
+.toggle{position:relative;width:44px;height:24px;flex-shrink:0}
+.toggle input{opacity:0;width:0;height:0;position:absolute}
+.toggle-track{position:absolute;inset:0;border-radius:12px;background:#333;cursor:pointer;transition:.2s}
+.toggle input:checked + .toggle-track{background:var(--gold)}
+.toggle-track::after{content:'';position:absolute;width:18px;height:18px;border-radius:50%;background:#fff;top:3px;left:3px;transition:.2s}
+.toggle input:checked + .toggle-track::after{left:23px}
+
+/* Row item */
+.row-item{display:flex;align-items:center;gap:12px;padding:12px 0;border-bottom:1px solid var(--border)}
+.row-item:last-child{border-bottom:none}
+.row-icon{width:36px;height:36px;border-radius:8px;background:var(--bg-card2);display:flex;align-items:center;justify-content:center;font-size:16px;flex-shrink:0}
+.row-main{flex:1;min-width:0}
+.row-title{font-weight:500;font-size:14px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.row-sub{font-size:12px;color:var(--text-muted);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+
+/* Profile cards */
+.profile-grid{display:flex;flex-wrap:wrap;gap:16px;margin-bottom:32px}
+.profile-card{background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius);padding:24px;text-align:center;width:180px;position:relative}
+.profile-card.active{border-color:var(--gold)}
+.profile-avatar{width:64px;height:64px;border-radius:50%;background:var(--gold);color:#000;font-size:24px;font-weight:700;display:flex;align-items:center;justify-content:center;margin:0 auto 12px}
+.profile-name{font-weight:600;font-size:15px;margin-bottom:8px}
+.profile-badges{display:flex;flex-wrap:wrap;gap:4px;justify-content:center}
+.profile-active-dot{width:8px;height:8px;border-radius:50%;background:var(--green);position:absolute;top:12px;left:12px}
+
+/* IPTV */
+.playlist-card{background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius);padding:20px;margin-bottom:12px}
+.playlist-name{font-weight:600;font-size:15px;margin-bottom:4px}
+.playlist-url{font-size:12px;color:var(--text-muted);font-family:monospace;margin-bottom:12px;word-break:break-all}
+.channel-count{font-size:22px;font-weight:700;color:var(--gold)}
+
+/* Chip list */
+.chip-list{display:flex;flex-wrap:wrap;gap:8px;margin-top:12px}
+.chip{padding:5px 12px;border-radius:20px;background:var(--bg-card2);border:1px solid var(--border);font-size:12px;color:var(--text-muted)}
+
+/* Plugin */
+.scraper-card{background:var(--bg-card);border:1px solid var(--border);border-radius:var(--radius);padding:16px;display:flex;align-items:center;gap:14px;margin-bottom:10px}
+.scraper-dot{width:10px;height:10px;border-radius:50%;flex-shrink:0}
+.scraper-dot.on{background:var(--green)}
+.scraper-dot.off{background:#333}
+.scraper-info{flex:1}
+.scraper-name{font-weight:600}
+.scraper-meta{font-size:12px;color:var(--text-muted);margin-top:3px}
+
+/* History */
+.history-item{display:flex;align-items:center;gap:14px;padding:12px 0;border-bottom:1px solid var(--border)}
+.history-poster{width:42px;height:58px;border-radius:6px;background:var(--bg-card2);display:flex;align-items:center;justify-content:center;font-size:18px;flex-shrink:0}
+.history-title{font-weight:500;margin-bottom:4px}
+.history-meta{font-size:12px;color:var(--text-muted)}
+.progress-bar{height:3px;background:#222;border-radius:2px;margin-top:6px;overflow:hidden}
+.progress-fill{height:100%;background:var(--gold);border-radius:2px}
+
+/* AI section */
+.model-option{border:2px solid var(--border);border-radius:var(--radius);padding:16px;cursor:pointer;margin-bottom:10px}
+.model-option.selected{border-color:var(--gold);background:var(--gold-dim)}
+.model-name{font-weight:600;margin-bottom:4px}
+.model-desc{font-size:12px;color:var(--text-muted)}
+
+/* Settings rows */
+.settings-row{display:flex;align-items:center;justify-content:space-between;padding:16px 0;border-bottom:1px solid var(--border)}
+.settings-label{font-weight:500}
+.settings-desc{font-size:12px;color:var(--text-muted);margin-top:2px}
+
+.section{margin-bottom:0}
+h2.sub{font-size:16px;font-weight:600;margin:24px 0 14px;color:var(--text-muted)}
+</style>
+</head>
+<body>
+
+<!-- Sidebar -->
+<div class="sidebar">
+  <div class="sidebar-logo">
+    <img src="../assets/arvio-icon-512.png" onerror="this.style.display='none'" alt="">
+    ARVIO
+  </div>
+  <div style="padding:8px 0;flex:1">
+    <div class="nav-item active">
+      <svg viewBox="0 0 24 24"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+      Dashboard
+    </div>
+    <div class="nav-item">
+      <svg viewBox="0 0 24 24"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>
+      Profiles
+    </div>
+    <div class="nav-item">
+      <svg viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="3"/><path d="M9 9h6M9 12h6M9 15h4"/></svg>
+      Add-ons
+    </div>
+    <div class="nav-item">
+      <svg viewBox="0 0 24 24"><path d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"/><path d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+      IPTV
+    </div>
+    <div class="nav-item">
+      <svg viewBox="0 0 24 24"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      Plugins
+    </div>
+    <div class="nav-item">
+      <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+      History
+    </div>
+    <div class="nav-item">
+      <svg viewBox="0 0 24 24"><path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z"/></svg>
+      Watchlist
+    </div>
+    <div class="nav-item">
+      <svg viewBox="0 0 24 24"><path d="M12 2a3 3 0 013 3v7a3 3 0 01-6 0V5a3 3 0 013-3z"/><path d="M19 10v2a7 7 0 01-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg>
+      AI Subtitles
+    </div>
+    <div class="nav-item">
+      <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M19.07 4.93a10 10 0 010 14.14"/><path d="M4.93 4.93a10 10 0 000 14.14"/></svg>
+      Settings
+    </div>
+  </div>
+  <div class="sidebar-user">
+    <div class="avatar">A</div>
+    <div>
+      <div class="user-name">ARVIO User</div>
+      <div class="user-email">user@example.com</div>
+    </div>
+  </div>
+</div>
+
+<!-- Main Content -->
+<div class="page">
+
+  <!-- ═══ DASHBOARD ═══ -->
+  <div class="section">
+    <div class="section-title">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="var(--gold)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/></svg>
+      Dashboard
+    </div>
+
+    <div class="stats">
+      <div class="stat-card">
+        <div class="stat-icon gold">🎬</div>
+        <div class="stat-val">47</div>
+        <div class="stat-lbl">Movies watched</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-icon green">📺</div>
+        <div class="stat-val">312</div>
+        <div class="stat-lbl">Episodes watched</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-icon blue">🔖</div>
+        <div class="stat-val">8</div>
+        <div class="stat-lbl">Watchlist</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-icon purple">🧩</div>
+        <div class="stat-val">5</div>
+        <div class="stat-lbl">Active add-ons</div>
+      </div>
+    </div>
+
+    <h2 class="sub">Recent Activity</h2>
+    <div class="cards">
+      <div class="history-item" style="border:1px solid var(--border);border-radius:var(--radius);padding:14px;background:var(--bg-card)">
+        <div class="history-poster">🎬</div>
+        <div style="flex:1">
+          <div class="history-title">Inception</div>
+          <div class="history-meta">Movie · 1d ago</div>
+          <div class="progress-bar"><div class="progress-fill" style="width:100%"></div></div>
+        </div>
+        <span class="badge green">Completed</span>
+      </div>
+      <div class="history-item" style="border:1px solid var(--border);border-radius:var(--radius);padding:14px;background:var(--bg-card)">
+        <div class="history-poster">📺</div>
+        <div style="flex:1">
+          <div class="history-title">Breaking Bad</div>
+          <div class="history-meta">S05E14 · 2d ago</div>
+          <div class="progress-bar"><div class="progress-fill" style="width:72%"></div></div>
+        </div>
+        <span class="badge gold">72%</span>
+      </div>
+      <div class="history-item" style="border:1px solid var(--border);border-radius:var(--radius);padding:14px;background:var(--bg-card)">
+        <div class="history-poster">🎬</div>
+        <div style="flex:1">
+          <div class="history-title">Oppenheimer</div>
+          <div class="history-meta">Movie · 4d ago</div>
+          <div class="progress-bar"><div class="progress-fill" style="width:55%"></div></div>
+        </div>
+        <span class="badge muted">55%</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="section-sep"></div>
+
+  <!-- ═══ PROFILES ═══ -->
+  <div class="section">
+    <div class="section-title">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="var(--gold)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/></svg>
+      Profiles
+    </div>
+    <div class="profile-grid">
+      <div class="profile-card active">
+        <div class="profile-active-dot"></div>
+        <div class="profile-avatar">A</div>
+        <div class="profile-name">Alex</div>
+        <div class="profile-badges"><span class="badge green">● Active</span></div>
+      </div>
+      <div class="profile-card">
+        <div class="profile-avatar" style="background:#60a5fa">S</div>
+        <div class="profile-name">Sarah</div>
+        <div class="profile-badges"><span class="badge muted">🔒 Locked</span></div>
+      </div>
+      <div class="profile-card">
+        <div class="profile-avatar" style="background:#4ade80">K</div>
+        <div class="profile-name">Kids</div>
+        <div class="profile-badges"><span class="badge blue">👶 Kids</span></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="section-sep"></div>
+
+  <!-- ═══ ADDONS ═══ -->
+  <div class="section">
+    <div class="section-title">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="var(--gold)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="3"/><path d="M9 9h6M9 12h6M9 15h4"/></svg>
+      Stremio Add-ons
+    </div>
+    <div class="cards">
+      <div class="card">
+        <div class="card-header">
+          <span class="card-title">Torrentio</span>
+          <label class="toggle"><input type="checkbox" checked><div class="toggle-track"></div></label>
+        </div>
+        <div style="font-size:12px;color:var(--text-muted);font-family:monospace;word-break:break-all">torrentio.strem.fun/manifest.json</div>
+      </div>
+      <div class="card">
+        <div class="card-header">
+          <span class="card-title">Cinemeta</span>
+          <label class="toggle"><input type="checkbox" checked><div class="toggle-track"></div></label>
+        </div>
+        <div style="font-size:12px;color:var(--text-muted);font-family:monospace;word-break:break-all">v3-cinemeta.strem.io/manifest.json</div>
+      </div>
+      <div class="card">
+        <div class="card-header">
+          <span class="card-title">OpenSubtitles</span>
+          <label class="toggle"><input type="checkbox"><div class="toggle-track"></div></label>
+        </div>
+        <div style="font-size:12px;color:var(--text-muted);font-family:monospace;word-break:break-all">opensubtitles-v3.strem.io/manifest.json</div>
+      </div>
+    </div>
+    <h2 class="sub">Telegram</h2>
+    <div class="card" style="max-width:400px">
+      <div class="card-header">
+        <span class="card-title">ARVIO Bot</span>
+        <span class="badge green">● Active</span>
+      </div>
+      <div style="font-size:13px;color:var(--text-muted)">@arvio_updates</div>
+    </div>
+  </div>
+
+  <div class="section-sep"></div>
+
+  <!-- ═══ IPTV ═══ -->
+  <div class="section">
+    <div class="section-title">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="var(--gold)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"/><path d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+      IPTV — Alex
+    </div>
+    <div class="playlist-card">
+      <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:16px">
+        <div>
+          <div class="playlist-name">ישראל HD</div>
+          <div class="playlist-url">https://example.m3u</div>
+          <div style="font-size:12px;color:var(--text-muted)">EPG: https://example.com/epg.xml</div>
+        </div>
+        <div style="text-align:center">
+          <div class="channel-count">142</div>
+          <div style="font-size:11px;color:var(--text-muted)">ערוצים</div>
+        </div>
+      </div>
+    </div>
+    <div class="playlist-card">
+      <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:16px">
+        <div>
+          <div class="playlist-name">Sports Pack</div>
+          <div class="playlist-url">https://sports.m3u</div>
+          <div style="font-size:12px;color:var(--text-dim)">ללא EPG</div>
+        </div>
+        <div style="text-align:center">
+          <div class="channel-count">38</div>
+          <div style="font-size:11px;color:var(--text-muted)">ערוצים</div>
+        </div>
+      </div>
+    </div>
+    <h2 class="sub">Favourite Groups</h2>
+    <div class="chip-list">
+      <div class="chip">Israel</div>
+      <div class="chip">Sports</div>
+      <div class="chip">Movies</div>
+    </div>
+    <h2 class="sub">Favourite Channels</h2>
+    <div class="chip-list">
+      <div class="chip">Channel 12</div>
+      <div class="chip">Channel 13</div>
+      <div class="chip">HOT Sport 1</div>
+      <div class="chip">Sport 5</div>
+    </div>
+  </div>
+
+  <div class="section-sep"></div>
+
+  <!-- ═══ PLUGINS ═══ -->
+  <div class="section">
+    <div class="section-title">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="var(--gold)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      Plugins
+    </div>
+    <div class="card" style="margin-bottom:24px">
+      <div class="settings-row" style="padding:0">
+        <div>
+          <div class="settings-label">Plugins enabled</div>
+          <div class="settings-desc">Enable or disable the scraper engine</div>
+        </div>
+        <label class="toggle"><input type="checkbox" checked><div class="toggle-track"></div></label>
+      </div>
+    </div>
+    <h2 class="sub">Repositories</h2>
+    <div class="card" style="margin-bottom:24px">
+      <div class="row-item">
+        <div class="row-icon">📦</div>
+        <div class="row-main">
+          <div class="row-title">ARVIO Plugins</div>
+          <div class="row-sub" style="font-family:monospace">raw.githubusercontent.com/arvio/plugins/main/repo.json</div>
+        </div>
+        <span class="badge gold">12 scrapers</span>
+      </div>
+      <div class="row-item">
+        <div class="row-icon">📦</div>
+        <div class="row-main">
+          <div class="row-title">Community Repo</div>
+          <div class="row-sub" style="font-family:monospace">community.arvio.tv/repo.json</div>
+        </div>
+        <span class="badge muted">7 scrapers</span>
+      </div>
+    </div>
+    <h2 class="sub">Scrapers</h2>
+    <div class="scraper-card">
+      <div class="scraper-dot on"></div>
+      <div class="scraper-info">
+        <div class="scraper-name">YesMovies <span style="color:var(--text-muted);font-weight:400;font-size:12px">v2.1.0</span></div>
+        <div class="scraper-meta">Movies · Series · Hebrew · English</div>
+      </div>
+      <span class="badge green">Active</span>
+    </div>
+    <div class="scraper-card">
+      <div class="scraper-dot on"></div>
+      <div class="scraper-info">
+        <div class="scraper-name">PrimeWire <span style="color:var(--text-muted);font-weight:400;font-size:12px">v1.4.2</span></div>
+        <div class="scraper-meta">Movies · English</div>
+      </div>
+      <span class="badge green">Active</span>
+    </div>
+    <div class="scraper-card">
+      <div class="scraper-dot off"></div>
+      <div class="scraper-info">
+        <div class="scraper-name">SolarMovie <span style="color:var(--text-muted);font-weight:400;font-size:12px">v1.0.1</span></div>
+        <div class="scraper-meta">Movies · Series · English</div>
+      </div>
+      <span class="badge muted">Disabled</span>
+    </div>
+  </div>
+
+  <div class="section-sep"></div>
+
+  <!-- ═══ AI SUBTITLE ═══ -->
+  <div class="section">
+    <div class="section-title">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="var(--gold)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a3 3 0 013 3v7a3 3 0 01-6 0V5a3 3 0 013-3z"/><path d="M19 10v2a7 7 0 01-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg>
+      AI Subtitle Translation
+    </div>
+    <div class="card" style="max-width:560px;margin-bottom:24px">
+      <div class="settings-row">
+        <div><div class="settings-label">Enable AI Translation</div><div class="settings-desc">Automatically translate subtitles while watching</div></div>
+        <label class="toggle"><input type="checkbox" checked><div class="toggle-track"></div></label>
+      </div>
+      <div class="settings-row">
+        <div><div class="settings-label">Auto-select</div><div class="settings-desc">Automatically pick subtitles for translation</div></div>
+        <label class="toggle"><input type="checkbox" checked><div class="toggle-track"></div></label>
+      </div>
+      <div class="settings-row" style="border-bottom:none">
+        <div><div class="settings-label">Remove HI</div><div class="settings-desc">Strip hearing-impaired audio descriptions [SDH]</div></div>
+        <label class="toggle"><input type="checkbox" checked><div class="toggle-track"></div></label>
+      </div>
+    </div>
+    <h2 class="sub">Select AI Model</h2>
+    <div style="max-width:560px">
+      <div class="model-option selected">
+        <div class="model-name">Groq — Llama 3.3 70B <span class="badge green" style="margin-right:8px">Recommended</span></div>
+        <div class="model-desc">Fastest · Free · Great quality for subtitles</div>
+      </div>
+      <div class="model-option">
+        <div class="model-name">Google — Gemini Flash 2.5</div>
+        <div class="model-desc">Fast · Free · Excellent multilingual support</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="section-sep"></div>
+
+  <!-- ═══ SETTINGS ═══ -->
+  <div class="section">
+    <div class="section-title">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="var(--gold)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.07 4.93a10 10 0 010 14.14"/><path d="M4.93 4.93a10 10 0 000 14.14"/></svg>
+      Settings
+    </div>
+    <div class="card" style="max-width:500px">
+      <div class="settings-row">
+        <div><div class="settings-label">App Language</div></div>
+        <span class="badge gold">English</span>
+      </div>
+      <div class="settings-row">
+        <div><div class="settings-label">OLED Mode</div><div class="settings-desc">Pure black background to save battery</div></div>
+        <label class="toggle"><input type="checkbox" checked><div class="toggle-track"></div></label>
+      </div>
+      <div class="settings-row" style="border-bottom:none">
+        <div><div class="settings-label">Skip Profile Selection</div><div class="settings-desc">Launch directly with the active profile</div></div>
+        <label class="toggle"><input type="checkbox"><div class="toggle-track"></div></label>
+      </div>
+    </div>
+  </div>
+
+  <div style="height:60px"></div>
+</div>
+
+</body>
+</html>

--- a/netlify-arvio-tv-site/companion/style.css
+++ b/netlify-arvio-tv-site/companion/style.css
@@ -1,0 +1,464 @@
+:root {
+  --bg: #000;
+  --bg-card: #111;
+  --bg-card2: #1a1a1a;
+  --bg-hover: #222;
+  --border: #2a2a2a;
+  --gold: #f5c442;
+  --gold-dim: rgba(245,196,66,0.12);
+  --text: #f0f0f0;
+  --text-muted: #888;
+  --text-dim: #555;
+  --green: #4ade80;
+  --red: #f87171;
+  --blue: #60a5fa;
+  --radius: 12px;
+  --sidebar-w: 220px;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+/* ── Auth Screen ─────────────────────────────── */
+#auth-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  gap: 32px;
+  padding: 24px;
+}
+
+.auth-logo { width: 56px; height: 56px; }
+.auth-title { font-size: 28px; font-weight: 700; letter-spacing: -0.5px; }
+.auth-sub { color: var(--text-muted); font-size: 15px; text-align: center; max-width: 320px; }
+
+.btn-google {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: #fff;
+  color: #111;
+  border: none;
+  border-radius: 10px;
+  padding: 14px 28px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity .15s;
+}
+.btn-google:hover { opacity: .85; }
+.btn-google svg { width: 20px; height: 20px; }
+
+/* ── App Shell ───────────────────────────────── */
+#app-screen { display: flex; min-height: 100vh; }
+
+/* Sidebar */
+.sidebar {
+  width: var(--sidebar-w);
+  flex-shrink: 0;
+  background: var(--bg-card);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  position: fixed;
+  top: 0; left: 0; bottom: 0;
+  z-index: 10;
+  overflow-y: auto;
+}
+
+.sidebar-logo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 20px 18px 16px;
+  border-bottom: 1px solid var(--border);
+}
+.sidebar-logo img { width: 32px; height: 32px; }
+.sidebar-logo span { font-size: 18px; font-weight: 700; letter-spacing: -0.3px; }
+
+nav { flex: 1; padding: 12px 8px; }
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 14px;
+  font-weight: 500;
+  transition: all .15s;
+  border: none;
+  background: none;
+  width: 100%;
+  text-align: left;
+}
+.nav-item:hover { background: var(--bg-hover); color: var(--text); }
+.nav-item.active { background: var(--gold-dim); color: var(--gold); }
+.nav-item svg { width: 18px; height: 18px; flex-shrink: 0; }
+
+.sidebar-user {
+  padding: 14px 18px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.user-avatar {
+  width: 32px; height: 32px;
+  border-radius: 50%;
+  background: var(--gold-dim);
+  border: 1px solid var(--gold);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 13px; font-weight: 600; color: var(--gold);
+  flex-shrink: 0;
+  overflow: hidden;
+}
+.user-avatar img { width: 100%; height: 100%; object-fit: cover; }
+.user-info { flex: 1; min-width: 0; }
+.user-name { font-size: 13px; font-weight: 600; truncate: clip; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.user-email { font-size: 11px; color: var(--text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+.btn-logout {
+  background: none; border: none; color: var(--text-dim);
+  cursor: pointer; padding: 4px;
+  display: flex; align-items: center;
+  border-radius: 6px;
+  transition: color .15s;
+}
+.btn-logout:hover { color: var(--red); }
+.btn-logout svg { width: 16px; height: 16px; }
+
+/* Main Content */
+.main {
+  margin-left: var(--sidebar-w);
+  flex: 1;
+  padding: 32px;
+  max-width: 960px;
+}
+
+/* ── Section Header ──────────────────────────── */
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 24px;
+}
+.section-title { font-size: 22px; font-weight: 700; letter-spacing: -0.3px; }
+.section-sub { font-size: 14px; color: var(--text-muted); margin-top: 2px; }
+
+/* ── Cards ───────────────────────────────────── */
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+  margin-bottom: 16px;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 14px;
+  margin-bottom: 24px;
+}
+
+.stat-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+}
+.stat-label { font-size: 12px; color: var(--text-muted); text-transform: uppercase; letter-spacing: .5px; margin-bottom: 6px; }
+.stat-value { font-size: 28px; font-weight: 700; color: var(--text); }
+.stat-value.gold { color: var(--gold); }
+
+/* ── Profile Cards ───────────────────────────── */
+.profiles-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 14px;
+}
+
+.profile-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  cursor: default;
+  transition: border-color .15s;
+}
+.profile-card.active-profile { border-color: var(--gold); }
+.profile-avatar-big {
+  width: 56px; height: 56px;
+  border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 22px; font-weight: 700;
+  flex-shrink: 0;
+}
+.profile-name { font-size: 14px; font-weight: 600; text-align: center; }
+.profile-badge {
+  font-size: 10px; padding: 2px 8px; border-radius: 20px;
+  background: var(--gold-dim); color: var(--gold); font-weight: 600;
+}
+.profile-badge.active-badge { background: var(--gold); color: #000; }
+.kids-badge { background: rgba(96,165,250,0.15); color: var(--blue); }
+
+/* ── List Items ──────────────────────────────── */
+.list-item {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--border);
+}
+.list-item:last-child { border-bottom: none; }
+
+.item-icon {
+  width: 40px; height: 40px;
+  border-radius: 8px;
+  background: var(--bg-card2);
+  display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+.item-icon img { width: 100%; height: 100%; object-fit: cover; border-radius: 8px; }
+.item-icon svg { width: 20px; height: 20px; color: var(--text-muted); }
+
+.item-info { flex: 1; min-width: 0; }
+.item-title { font-size: 14px; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.item-sub { font-size: 12px; color: var(--text-muted); margin-top: 2px; }
+
+.item-actions { display: flex; gap: 8px; flex-shrink: 0; }
+
+/* ── Toggle Switch ───────────────────────────── */
+.toggle {
+  position: relative;
+  width: 38px; height: 22px;
+  flex-shrink: 0;
+}
+.toggle input { opacity: 0; width: 0; height: 0; }
+.toggle-slider {
+  position: absolute;
+  inset: 0;
+  background: var(--bg-card2);
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  cursor: pointer;
+  transition: background .2s, border-color .2s;
+}
+.toggle-slider::before {
+  content: '';
+  position: absolute;
+  width: 16px; height: 16px;
+  left: 2px; top: 2px;
+  background: var(--text-muted);
+  border-radius: 50%;
+  transition: transform .2s, background .2s;
+}
+.toggle input:checked + .toggle-slider { background: var(--gold-dim); border-color: var(--gold); }
+.toggle input:checked + .toggle-slider::before { transform: translateX(16px); background: var(--gold); }
+
+/* ── Badges ──────────────────────────────────── */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 20px;
+  font-size: 11px;
+  font-weight: 600;
+}
+.badge-gold { background: var(--gold-dim); color: var(--gold); }
+.badge-green { background: rgba(74,222,128,.12); color: var(--green); }
+.badge-red { background: rgba(248,113,113,.12); color: var(--red); }
+.badge-blue { background: rgba(96,165,250,.12); color: var(--blue); }
+.badge-gray { background: var(--bg-card2); color: var(--text-muted); }
+
+/* ── Progress Bar ────────────────────────────── */
+.progress-bar {
+  height: 3px;
+  background: var(--border);
+  border-radius: 2px;
+  margin-top: 6px;
+  overflow: hidden;
+}
+.progress-fill {
+  height: 100%;
+  background: var(--gold);
+  border-radius: 2px;
+  transition: width .3s;
+}
+
+/* ── Buttons ─────────────────────────────────── */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  border-radius: 8px;
+  border: none;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity .15s;
+}
+.btn:hover { opacity: .8; }
+.btn-primary { background: var(--gold); color: #000; }
+.btn-ghost { background: var(--bg-card2); color: var(--text); border: 1px solid var(--border); }
+.btn-danger { background: rgba(248,113,113,.12); color: var(--red); border: 1px solid rgba(248,113,113,.2); }
+.btn svg { width: 14px; height: 14px; }
+.btn:disabled { opacity: .4; cursor: not-allowed; }
+
+/* ── Form Elements ───────────────────────────── */
+.form-group { margin-bottom: 20px; }
+.form-label { display: block; font-size: 13px; font-weight: 600; color: var(--text-muted); margin-bottom: 8px; text-transform: uppercase; letter-spacing: .4px; }
+.form-input, .form-select {
+  width: 100%;
+  background: var(--bg-card2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  padding: 10px 14px;
+  font-size: 14px;
+  outline: none;
+  transition: border-color .15s;
+  font-family: inherit;
+}
+.form-input:focus, .form-select:focus { border-color: var(--gold); }
+.form-input::placeholder { color: var(--text-dim); }
+.form-hint { font-size: 12px; color: var(--text-muted); margin-top: 6px; }
+
+/* ── AI Config Special ───────────────────────── */
+.model-card {
+  background: var(--bg-card2);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px;
+  cursor: pointer;
+  transition: border-color .15s;
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+.model-card.selected { border-color: var(--gold); background: var(--gold-dim); }
+.model-card input[type=radio] { margin-top: 3px; accent-color: var(--gold); flex-shrink: 0; }
+.model-name { font-size: 14px; font-weight: 600; }
+.model-desc { font-size: 12px; color: var(--text-muted); margin-top: 3px; }
+.models-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-bottom: 20px; }
+
+/* ── Watch History ───────────────────────────── */
+.history-poster {
+  width: 42px; height: 60px;
+  border-radius: 6px;
+  object-fit: cover;
+  background: var(--bg-card2);
+  flex-shrink: 0;
+}
+
+/* ── Empty State ─────────────────────────────── */
+.empty {
+  text-align: center;
+  padding: 48px 24px;
+  color: var(--text-muted);
+}
+.empty svg { width: 48px; height: 48px; margin: 0 auto 16px; display: block; opacity: .3; }
+.empty-title { font-size: 16px; font-weight: 600; color: var(--text); margin-bottom: 6px; }
+
+/* ── Loading ─────────────────────────────────── */
+.loading {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--text-muted);
+  padding: 32px;
+  justify-content: center;
+}
+.spinner {
+  width: 20px; height: 20px;
+  border: 2px solid var(--border);
+  border-top-color: var(--gold);
+  border-radius: 50%;
+  animation: spin .7s linear infinite;
+  flex-shrink: 0;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* ── Toast ───────────────────────────────────── */
+#toast {
+  position: fixed;
+  bottom: 24px; right: 24px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px 20px;
+  font-size: 14px;
+  font-weight: 500;
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity .2s, transform .2s;
+  z-index: 100;
+  max-width: 320px;
+}
+#toast.show { opacity: 1; transform: translateY(0); }
+#toast.toast-ok { border-color: rgba(74,222,128,.3); color: var(--green); }
+#toast.toast-err { border-color: rgba(248,113,113,.3); color: var(--red); }
+
+/* ── Tabs ────────────────────────────────────── */
+.tabs { display: flex; gap: 4px; margin-bottom: 20px; }
+.tab {
+  padding: 8px 16px;
+  border-radius: 8px;
+  cursor: pointer;
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 500;
+  transition: all .15s;
+}
+.tab.active { background: var(--gold-dim); color: var(--gold); }
+.tab:hover:not(.active) { background: var(--bg-card2); color: var(--text); }
+
+/* ── TV Connect Banner ───────────────────────── */
+.tv-banner {
+  background: var(--gold-dim);
+  border: 1px solid rgba(245,196,66,.25);
+  border-radius: var(--radius);
+  padding: 16px 20px;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 24px;
+}
+.tv-banner svg { width: 28px; height: 28px; color: var(--gold); flex-shrink: 0; }
+.tv-banner-title { font-size: 14px; font-weight: 600; color: var(--gold); }
+.tv-banner-sub { font-size: 12px; color: var(--text-muted); margin-top: 2px; }
+
+/* ── Scrollbar ───────────────────────────────── */
+::-webkit-scrollbar { width: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+
+/* ── Responsive ──────────────────────────────── */
+@media (max-width: 700px) {
+  :root { --sidebar-w: 0px; }
+  .sidebar { display: none; }
+  .main { margin-left: 0; padding: 20px 16px; }
+  .card-grid { grid-template-columns: 1fr 1fr; }
+  .models-grid { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
## What this adds

The catalog edit dialog (pencil icon in **Settings → Catalogs**) now exposes all four artwork URL fields for every catalog row, editable per-profile and automatically synced to ARVIO Cloud.

### Fields added to the edit dialog

| Field | What it controls |
|---|---|
| **Cover image URL** | The card face image shown in the catalog row |
| **Hero image URL** | Full-width background when the row is focused |
| **Animated GIF URL** | Replaces the cover image on card focus/hover |
| **Clear logo URL** | Transparent title-logo overlay on the hero |

All fields are pre-populated with the current values each time you open the pencil dialog, so you can see and edit what's already set.

### How to use

1. Go to **Settings → Catalogs**
2. Navigate to any row (genres like Action/Comedy, or custom catalogs)
3. Press the **pencil (edit) icon**
4. The dialog now shows **Title** + the four artwork URL fields
5. Paste any direct image URL (TMDB, TMDB image CDN, or any other host)
6. Press confirm → image updates immediately and syncs to cloud

## Implementation

**3 files changed, 89 insertions(+), 1 deletion(−)**

### `CatalogRepository.kt`
New `updateCatalogArtwork()` function that patches `collectionCoverImageUrl`, `collectionHeroImageUrl`, `collectionFocusGifUrl`, and `collectionClearLogoUrl` on the matching `CatalogConfig` entry and saves via the existing `saveCatalogs()` path. No new DataStore key needed.

### `SettingsViewModel.kt`
New `updateCatalogArtwork()` wrapper that calls the repository and triggers `syncLocalStateToCloud(silent = true)`, exactly matching the `renameCatalog()` pattern.

### `SettingsScreen.kt`
- Added four `mutableStateOf("")` variables for the artwork URLs
- Widened the rename `InputModal` to a five-field edit dialog
- All three places that open the dialog now pre-populate the URL state from `catalog.collectionCoverImageUrl` etc. before `showCatalogRename = true`

## Why no new cloud sync code

`catalogsByProfile` already serialises the **full** `CatalogConfig` JSON — including all `collectionCover/Hero/Gif/ClearLogo` fields. An artwork change therefore piggybacks on the existing `CATALOGS` invalidation scope and is pushed to cloud on the next debounced flush, exactly like a rename or reorder.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)