### PR TITLE
fix: hide redundant movie title text in pause overlay when clearlogo is present

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -5291,7 +5291,7 @@ private fun PlayerMetadataChrome(
                 )
             }
 
-            if (!uiState.logoUrl.isNullOrBlank() && displayTitle.isNotBlank()) {
+            if (!uiState.logoUrl.isNullOrBlank() && displayTitle.isNotBlank() && mediaType == MediaType.TV) {
                 Text(
                     text = displayTitle,
                     style = ArflixTypography.sectionTitle.copy(

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -5291,7 +5291,7 @@ private fun PlayerMetadataChrome(
                 )
             }
 
-            if (!uiState.logoUrl.isNullOrBlank() && displayTitle.isNotBlank() && mediaType == MediaType.TV) {
+            if (!uiState.logoUrl.isNullOrBlank() && mediaType == MediaType.TV && !uiState.episodeTitle.isNullOrBlank()) {
                 Text(
                     text = displayTitle,
                     style = ArflixTypography.sectionTitle.copy(


### PR DESCRIPTION
The bug:
In [PlayerMetadataChrome](vscode-webview://0qb7dhfpkuiun8reev1g526mqkd0kif8ft1crq9qs0g93lorue7c/ArvioGitlab/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt:5294), the composable showed the title text below the clearlogo whenever both existed — regardless of media type. For movies, displayTitle is the movie name (e.g. "The Dark Knight"), which is redundant with the clearlogo branding.

The fix:
Added mediaType == MediaType.TV to the condition at line 5294, so the secondary title text only appears for TV shows where displayTitle is the episode title (e.g. "Winter Is Coming") — genuinely different from the show clearlogo.