### PR TITLE
fix: use per-episode overview in pause overlay instead of series synopsis

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
@@ -968,10 +968,16 @@ class PlayerViewModel @Inject constructor(
                 val season = currentSeason
                 val episode = currentEpisode
                 if (season != null && episode != null) {
-                    currentEpisodeTitle = runCatching {
+                    val matchedEpisode = runCatching {
                         val seasonDetails = tmdbApi.getTvSeason(mediaId, season, Constants.TMDB_API_KEY)
-                        seasonDetails.episodes.firstOrNull { it.episodeNumber == episode }?.name
+                        seasonDetails.episodes.firstOrNull { it.episodeNumber == episode }
                     }.getOrNull()
+                    currentEpisodeTitle = matchedEpisode?.name
+                    // Use per-episode overview in pause overlay instead of the series synopsis,
+                    // so each episode shows its unique description rather than the show's generic blurb.
+                    matchedEpisode?.overview?.takeIf { it.isNotBlank() }?.let { epOv ->
+                        overview = epOv
+                    }
                 }
             } else {
                 val movieDetails = details as com.arflix.tv.data.api.TmdbMovieDetails


### PR DESCRIPTION
File: [PlayerViewModel.kt:967-977](vscode-webview://0qb7dhfpkuiun8reev1g526mqkd0kif8ft1crq9qs0g93lorue7c/ArvioGitlab/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt:967)

Problem: The pause overlay showed the series synopsis for every episode instead of the episode-specific overview. E.g. every episode of "Breaking Bad" showed the show's general blurb.

Fix: The TMDB season details endpoint already returns per-episode objects with their own overview field. The existing code was only using the episode name. Now it also captures matchedEpisode.overview and overrides the series-level overview with it, so each episode shows its unique description.