### PR TITLE
feat: add 15 secondary accent color options to theme palette

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -1186,11 +1186,16 @@ class SettingsViewModel @Inject constructor(
     }
 
     /**
-     * Cycle the accent color through the rainbow palette.
-     * Order: White → Red → Orange → Yellow → Green → Blue → Indigo → Violet → White
+     * Cycle the accent color through the full palette (primary + secondary).
+     * Order: neutrals → warms → cools → back to White
      */
     fun cycleAccentColor() {
-        val colors = listOf("White", "Red", "Orange", "Yellow", "Green", "Blue", "Indigo", "Violet")
+        val colors = listOf(
+            "White", "Silver", "Slate", "Charcoal", "Cream",
+            "Gold", "Bronze", "Amber", "Orange", "Red", "Maroon",
+            "Rose Gold", "Magenta", "Lavender", "Violet", "Indigo", "Navy",
+            "Blue", "Cyan", "Teal", "Green", "Olive", "Yellow"
+        )
         val current = _uiState.value.accentColor
         val nextIndex = (colors.indexOf(current) + 1) % colors.size
         val next = colors[nextIndex]

--- a/app/src/main/kotlin/com/arflix/tv/ui/skin/ArvioSkin.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/skin/ArvioSkin.kt
@@ -33,6 +33,7 @@ fun resolveAccentColor(fallback: Color): Color {
  * Used by the accent colour setting and the colour picker.
  */
 fun accentColorFromName(name: String): Color = when (name) {
+    // Primary palette (existing)
     "Red" -> Color(0xFFFF4444)
     "Orange" -> Color(0xFFFF8800)
     "Yellow" -> Color(0xFFFFDD44)
@@ -40,6 +41,22 @@ fun accentColorFromName(name: String): Color = when (name) {
     "Blue" -> Color(0xFF4488FF)
     "Indigo" -> Color(0xFF6644CC)
     "Violet" -> Color(0xFFBB44CC)
+    // Secondary palette (new)
+    "Gold" -> Color(0xFFFFD700)
+    "Silver" -> Color(0xFFC0C0C0)
+    "Rose Gold" -> Color(0xFFEAA6A0)
+    "Teal" -> Color(0xFF009688)
+    "Cyan" -> Color(0xFF00BCD4)
+    "Magenta" -> Color(0xFFE040FB)
+    "Charcoal" -> Color(0xFF5D6D7E)
+    "Slate" -> Color(0xFF8899AA)
+    "Cream" -> Color(0xFFFFFDD0)
+    "Olive" -> Color(0xFF8A9A5B)
+    "Navy" -> Color(0xFF4A6FA5)
+    "Amber" -> Color(0xFFFFC107)
+    "Maroon" -> Color(0xFFC62828)
+    "Lavender" -> Color(0xFFB39DDB)
+    "Bronze" -> Color(0xFFCD7F32)
     else -> Color(0xFFFFFFFF) // White (default)
 }
 

--- a/app/src/main/kotlin/com/arflix/tv/ui/skin/ArvioSkin.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/skin/ArvioSkin.kt
@@ -32,7 +32,8 @@ fun resolveAccentColor(fallback: Color): Color {
  * Maps a user-facing colour name to its [Color] value.
  * Used by the accent colour setting and the colour picker.
  */
-fun accentColorFromName(name: String): Color = when (name) {
+fun accentColorFromName(name: String): Color = when (name.trim()) {
+    "White" -> Color(0xFFFFFFFF)
     // Primary palette (existing)
     "Red" -> Color(0xFFFF4444)
     "Orange" -> Color(0xFFFF8800)


### PR DESCRIPTION
## feat: Add 15 secondary accent color options to theme palette

### Overview

Expands the accent colour picker from 8 primary rainbow colours to **23 total**, giving users significantly more control over their UI theme.

### New colours

| Category | Colours |
|----------|---------|
| 🪙 Metallics | Gold, Silver, Bronze, Rose Gold |
| ⚪ Neutrals | Charcoal, Slate, Cream |
| 🔴 Warms | Amber, Maroon |
| 🌸 Pinks/Purples | Magenta, Lavender |
| 🔵 Blues | Navy, Cyan, Teal |
| 🌿 Greens | Olive |

### Cycle order

```
White → Silver → Slate → Charcoal → Cream → Gold → Bronze → Amber → Orange → Red → Maroon → Rose Gold → Magenta → Lavender → Violet → Indigo → Navy → Blue → Cyan → Teal → Green → Olive → Yellow → (back to White)
```

The order flows naturally: neutrals → warm metallics → reds → pinks/purples → blues/cyans → greens → back to White.

### Files changed

| File | Change |
|------|--------|
| `app/src/main/kotlin/com/arflix/tv/ui/skin/ArvioSkin.kt` | Added 15 new colour hex mappings to `accentColorFromName()` |
| `app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt` | Updated the colour cycle list in `cycleAccentColor()` |

### Hex values

| Name | Hex |
|------|-----|
| Gold | `#FFD700` |
| Silver | `#C0C0C0` |
| Rose Gold | `#EAA6A0` |
| Teal | `#009688` |
| Cyan | `#00BCD4` |
| Magenta | `#E040FB` |
| Charcoal | `#5D6D7E` |
| Slate | `#8899AA` |
| Cream | `#FFFDD0` |
| Olive | `#8A9A5B` |
| Navy | `#4A6FA5` |
| Amber | `#FFC107` |
| Maroon | `#C62828` |
| Lavender | `#B39DDB` |
| Bronze | `#CD7F32` |

### Testing

1. Open **Settings → General → Accent Color**
2. Press D-pad right/cycle button repeatedly
3. Verify all 23 colours cycle through
4. Verify focus rings, buttons, and player chrome update with each selection
5. Verify the setting persists across app restarts
