### PR TITLE
feat: extend accent colour to profile selection screen focus borders

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/profile/ProfileSelectionScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/profile/ProfileSelectionScreen.kt
@@ -1,5 +1,7 @@
 package com.arflix.tv.ui.screens.profile
 
+import com.arflix.tv.ui.skin.resolveAccentColor
+
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import kotlinx.coroutines.delay
@@ -390,6 +392,7 @@ private fun ProfileAvatar(
     onDelete: () -> Unit
 ) {
     var isFocused by remember { mutableIntStateOf(0) }
+    val accentColor = resolveAccentColor(fallback = Color.White)
     val scale by animateFloatAsState(
         targetValue = if (isFocused > 0) 1.1f else 1f,
         animationSpec = tween(150),
@@ -438,7 +441,7 @@ private fun ProfileAvatar(
                     ),
                     border = ClickableSurfaceDefaults.border(
                         focusedBorder = androidx.tv.material3.Border(
-                            border = androidx.compose.foundation.BorderStroke(3.dp, Color.White),
+                            border = androidx.compose.foundation.BorderStroke(3.dp, accentColor),
                             shape = RoundedCornerShape(8.dp)
                         )
                     )
@@ -486,6 +489,7 @@ private fun AddProfileButton(
     onClick: () -> Unit
 ) {
     var isFocused by remember { mutableIntStateOf(0) }
+    val accentColor = resolveAccentColor(fallback = Color.White)
     val scale by animateFloatAsState(
         targetValue = if (isFocused > 0) 1.1f else 1f,
         animationSpec = tween(150),
@@ -530,7 +534,7 @@ private fun AddProfileButton(
                         shape = RoundedCornerShape(8.dp)
                     ),
                     focusedBorder = androidx.tv.material3.Border(
-                        border = androidx.compose.foundation.BorderStroke(3.dp, Color.White),
+                        border = androidx.compose.foundation.BorderStroke(3.dp, accentColor),
                         shape = RoundedCornerShape(8.dp)
                     )
                 )
@@ -556,6 +560,7 @@ private fun ManageProfilesButton(
     onClick: () -> Unit
 ) {
     var isFocused by remember { mutableIntStateOf(0) }
+    val accentColor = resolveAccentColor(fallback = Color.White)
 
     val isTouchDevice = LocalDeviceType.current.isTouchDevice()
     Surface(
@@ -576,7 +581,7 @@ private fun ManageProfilesButton(
                 shape = RoundedCornerShape(4.dp)
             ),
             focusedBorder = androidx.tv.material3.Border(
-                border = androidx.compose.foundation.BorderStroke(2.dp, Color.White),
+                border = androidx.compose.foundation.BorderStroke(2.dp, accentColor),
                 shape = RoundedCornerShape(4.dp)
             )
         )
@@ -598,6 +603,7 @@ private fun CloudConnectButton(
 ) {
     val isTouchDevice = LocalDeviceType.current.isTouchDevice()
     var isFocused by remember { mutableIntStateOf(0) }
+    val accentColor = resolveAccentColor(fallback = Color.White)
 
     if (isTouchDevice) {
         Row(
@@ -645,7 +651,7 @@ private fun CloudConnectButton(
                     shape = RoundedCornerShape(24.dp)
                 ),
                 focusedBorder = androidx.tv.material3.Border(
-                    border = androidx.compose.foundation.BorderStroke(2.dp, Color.White.copy(alpha = 0.6f)),
+                    border = androidx.compose.foundation.BorderStroke(2.dp, accentColor.copy(alpha = 0.6f)),
                     shape = RoundedCornerShape(24.dp)
                 )
             )


### PR DESCRIPTION
## feat: Extend accent colour to profile selection screen focus borders

### Overview

Replaces hardcoded `Color.White` focus borders with the user's selected accent colour across all four TV-composable elements on the profile selection screen. Previously the accent colour setting was ignored on this screen despite being respected everywhere else (settings, player chrome, details, search, etc.).

### Changes

**File:** `app/src/main/kotlin/com/arflix/tv/ui/screens/profile/ProfileSelectionScreen.kt`

Added `resolveAccentColor(fallback = Color.White)` to each composable and replaced the hardcoded `Color.White` in the `focusedBorder` parameter:

| Composable | Before | After |
|------------|--------|-------|
| `ProfileAvatar` | `Color.White` 3dp focus ring | `accentColor` 3dp focus ring |
| `AddProfileButton` | `Color.White` 3dp focus ring | `accentColor` 3dp focus ring |
| `ManageProfilesButton` | `Color.White` 2dp focus ring | `accentColor` 2dp focus ring |
| `CloudConnectButton` | `Color.White.copy(alpha=0.6f)` 2dp focus ring | `accentColor.copy(alpha=0.6f)` 2dp focus ring |

This means D-pad navigation focus rings on the profile picker now respond to the user's **Settings → General → Accent Color** selection, providing a consistent themed experience across the entire app.

### Testing

1. Open Settings → General → Accent Color and select a non-white colour (e.g. Red, Blue, Gold)
2. Navigate to the profile selection screen (switch profile)
3. D-pad through each profile avatar — verify the focus ring matches the selected accent colour
4. Focus the **Add Profile** button — verify the ring uses the accent colour
5. Focus the **Manage Profiles / Done** button — verify the ring uses the accent colour
6. Focus the **Connect to Cloud** button — verify the ring uses the accent colour
7. Reset accent colour to White — verify all rings return to white as expected
