### PR TITLE
feat: add loading screen customization (animation style, progress style background treatment

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -2644,7 +2644,7 @@ fun PlayerScreen(
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center
             ) {
-                if (uiState.backdropUrl != null) {
+                if (uiState.backdropUrl != null && uiState.loadingBackground == "Backdrop") {
                     AsyncImage(
                         model = uiState.backdropUrl,
                         contentDescription = null,
@@ -2662,7 +2662,10 @@ fun PlayerScreen(
                     logoUrl = uiState.logoUrl,
                     title = uiState.title,
                     progress = if (uiState.showLoadingStats) uiState.streamProgress else null,
-                    phaseLabel = if (uiState.showLoadingStats) uiState.streamLoadPhase else null
+                    phaseLabel = if (uiState.showLoadingStats) uiState.streamLoadPhase else null,
+                    animationStyle = uiState.loadingAnimationStyle,
+                    progressStyle = uiState.loadingProgressStyle,
+                    backgroundStyle = uiState.loadingBackground
                 )
             }
         }
@@ -2674,7 +2677,13 @@ fun PlayerScreen(
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center
             ) {
-                PulsingLogo(logoUrl = uiState.logoUrl, title = uiState.title)
+                PulsingLogo(
+                    logoUrl = uiState.logoUrl,
+                    title = uiState.title,
+                    animationStyle = uiState.loadingAnimationStyle,
+                    progressStyle = uiState.loadingProgressStyle,
+                    backgroundStyle = uiState.loadingBackground
+                )
             }
         }
 
@@ -3657,26 +3666,74 @@ private fun PulsingLogo(
     title: String,
     modifier: Modifier = Modifier,
     progress: Float? = null,
-    phaseLabel: String? = null
+    phaseLabel: String? = null,
+    animationStyle: String = "Heartbeat",
+    progressStyle: String = "Arc",
+    backgroundStyle: String = "Dark"
 ) {
-    val infiniteTransition = rememberInfiniteTransition(label = "heartbeat")
+    val accentColor = LocalAccentColorOverride.current ?: Color.White
+    val infiniteTransition = rememberInfiniteTransition(label = "pulsingLogo")
+
+    // --- Logo scale animation ---
     val scale by infiniteTransition.animateFloat(
         initialValue = 1.0f,
         targetValue = 1.0f,
         animationSpec = infiniteRepeatable(
             animation = keyframes {
-                durationMillis = 1500
-                // Two quick beats followed by a short rest (heartbeat).
-                1.0f at 0
-                1.08f at 160 using FastOutSlowInEasing
-                1.02f at 280 using FastOutSlowInEasing
-                1.12f at 420 using FastOutSlowInEasing
-                1.0f at 620 using FastOutSlowInEasing
-                1.0f at 1500
+                when (animationStyle) {
+                    "Heartbeat" -> {
+                        durationMillis = 1500
+                        1.0f at 0
+                        1.08f at 160 using FastOutSlowInEasing
+                        1.02f at 280 using FastOutSlowInEasing
+                        1.12f at 420 using FastOutSlowInEasing
+                        1.0f at 620 using FastOutSlowInEasing
+                        1.0f at 1500
+                    }
+                    "Breathe" -> {
+                        durationMillis = 3000
+                        1.0f at 0
+                        1.10f at 1500 using FastOutSlowInEasing
+                        1.0f at 3000 using FastOutSlowInEasing
+                    }
+                    "Glow" -> {
+                        // Scale remains steady; alpha pulses instead
+                        durationMillis = 1
+                        1.0f at 0
+                        1.0f at 1
+                    }
+                    else -> { // "Static" / fallback
+                        durationMillis = 1
+                        1.0f at 0
+                        1.0f at 1
+                    }
+                }
             },
             repeatMode = RepeatMode.Restart
         ),
-        label = "heartbeatScale"
+        label = "logoScale"
+    )
+
+    // --- Glow alpha animation (only active for "Glow" style) ---
+    val glowAlpha by infiniteTransition.animateFloat(
+        initialValue = 1.0f,
+        targetValue = 1.0f,
+        animationSpec = infiniteRepeatable(
+            animation = keyframes {
+                if (animationStyle == "Glow") {
+                    durationMillis = 2000
+                    0.55f at 0
+                    1.0f at 1000 using FastOutSlowInEasing
+                    0.55f at 2000 using FastOutSlowInEasing
+                } else {
+                    durationMillis = 1
+                    1.0f at 0
+                    1.0f at 1
+                }
+            },
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "glowAlpha"
     )
 
     // Smoothly interpolate discrete progress jumps from the ViewModel so the
@@ -3695,41 +3752,74 @@ private fun PulsingLogo(
             modifier = Modifier.size(196.dp),
             contentAlignment = Alignment.Center
         ) {
-            if (progress != null) {
-                // Track + arc progress ring — renders even at 0% so users see
-                // the loader frame immediately rather than a bare logo.
-                Canvas(modifier = Modifier.fillMaxSize()) {
-                    val strokeWidthPx = 4.dp.toPx()
-                    val diameter = size.minDimension - strokeWidthPx
-                    val topLeft = Offset(
-                        (size.width - diameter) / 2f,
-                        (size.height - diameter) / 2f
-                    )
-                    val arcSize = Size(diameter, diameter)
-                    // Track
-                    drawArc(
-                        color = Color.White.copy(alpha = 0.15f),
-                        startAngle = 0f,
-                        sweepAngle = 360f,
-                        useCenter = false,
-                        topLeft = topLeft,
-                        size = arcSize,
-                        style = Stroke(width = strokeWidthPx, cap = StrokeCap.Round)
-                    )
-                    // Filled arc
-                    drawArc(
-                        color = Color.White,
-                        startAngle = -90f,
-                        sweepAngle = 360f * animatedProgress,
-                        useCenter = false,
-                        topLeft = topLeft,
-                        size = arcSize,
-                        style = Stroke(width = strokeWidthPx, cap = StrokeCap.Round)
-                    )
+            // --- Progress ring / bar (accent-colored) ---
+            if (progress != null && progressStyle != "None") {
+                when (progressStyle) {
+                    "Arc" -> {
+                        Canvas(modifier = Modifier.fillMaxSize()) {
+                            val strokeWidthPx = 4.dp.toPx()
+                            val diameter = size.minDimension - strokeWidthPx
+                            val topLeft = Offset(
+                                (size.width - diameter) / 2f,
+                                (size.height - diameter) / 2f
+                            )
+                            val arcSize = Size(diameter, diameter)
+                            // Track
+                            drawArc(
+                                color = accentColor.copy(alpha = 0.15f),
+                                startAngle = 0f,
+                                sweepAngle = 360f,
+                                useCenter = false,
+                                topLeft = topLeft,
+                                size = arcSize,
+                                style = Stroke(width = strokeWidthPx, cap = StrokeCap.Round)
+                            )
+                            // Filled arc — accent-colored
+                            drawArc(
+                                color = accentColor,
+                                startAngle = -90f,
+                                sweepAngle = 360f * animatedProgress,
+                                useCenter = false,
+                                topLeft = topLeft,
+                                size = arcSize,
+                                style = Stroke(width = strokeWidthPx, cap = StrokeCap.Round)
+                            )
+                        }
+                    }
+                    "Linear" -> {
+                        // Horizontal progress bar positioned below the logo box
+                        // (rendered inside the Box so it overlays at the bottom)
+                        Box(
+                            modifier = Modifier
+                                .align(Alignment.BottomCenter)
+                                .padding(bottom = 8.dp)
+                                .width(152.dp)
+                                .height(4.dp)
+                                .clip(RoundedCornerShape(2.dp))
+                                .background(accentColor.copy(alpha = 0.15f))
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth(animatedProgress)
+                                    .fillMaxHeight()
+                                    .background(accentColor, RoundedCornerShape(2.dp))
+                            )
+                        }
+                    }
+                    "Percentage" -> {
+                        // No ring or bar — percentage text shown below
+                    }
                 }
             }
+
+            // --- Logo with animation ---
             Box(
-                modifier = Modifier.graphicsLayer { scaleX = scale; scaleY = scale },
+                modifier = Modifier
+                    .graphicsLayer {
+                        scaleX = scale
+                        scaleY = scale
+                        alpha = glowAlpha
+                    },
                 contentAlignment = Alignment.Center
             ) {
                 if (!logoUrl.isNullOrBlank()) {
@@ -3741,13 +3831,23 @@ private fun PulsingLogo(
             }
         }
 
-        if (progress != null) {
+        // --- Progress text / percentage below the logo ---
+        if (progress != null && progressStyle != "None") {
             Spacer(modifier = Modifier.height(16.dp))
-            Text(
-                text = "${(animatedProgress * 100f).toInt()}%",
-                style = ArflixTypography.sectionTitle.copy(fontSize = 22.sp, fontWeight = FontWeight.SemiBold),
-                color = Color.White
-            )
+            if (progressStyle == "Percentage" || progressStyle == "Arc") {
+                Text(
+                    text = "${(animatedProgress * 100f).toInt()}%",
+                    style = ArflixTypography.sectionTitle.copy(fontSize = 22.sp, fontWeight = FontWeight.SemiBold),
+                    color = accentColor
+                )
+            }
+            if (progressStyle == "Linear") {
+                Text(
+                    text = "${(animatedProgress * 100f).toInt()}%",
+                    style = ArflixTypography.sectionTitle.copy(fontSize = 22.sp, fontWeight = FontWeight.SemiBold),
+                    color = accentColor
+                )
+            }
             if (!phaseLabel.isNullOrBlank()) {
                 Spacer(modifier = Modifier.height(6.dp))
                 Text(

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
@@ -103,6 +103,12 @@ data class PlayerUiState(
     val volumeBoostDb: Int = 0,
     // Show loading progress during stream resolution
     val showLoadingStats: Boolean = true,
+    // Loading animation style: Heartbeat / Breathe / Glow / Static
+    val loadingAnimationStyle: String = "Heartbeat",
+    // Loading progress style: Arc / Linear / Percentage / None
+    val loadingProgressStyle: String = "Arc",
+    // Loading background treatment: Dark / Backdrop
+    val loadingBackground: String = "Dark",
     // Skip intro/recap
     val activeSkipInterval: SkipInterval? = null,
     val skipIntervalDismissed: Boolean = false,
@@ -257,6 +263,9 @@ class PlayerViewModel @Inject constructor(
     private fun frameRateMatchingModeKey() = profileManager.profileStringKey("frame_rate_matching_mode")
     private fun autoPlayNextKey() = profileManager.profileBooleanKey("auto_play_next")
     private fun showLoadingStatsKey() = profileManager.profileBooleanKey("show_loading_stats")
+    private fun loadingAnimationStyleKey() = profileManager.profileStringKey("loading_animation_style")
+    private fun loadingProgressStyleKey() = profileManager.profileStringKey("loading_progress_style")
+    private fun loadingBackgroundKey() = profileManager.profileStringKey("loading_background")
     private val gson = Gson()
     private val knownLanguageCodes = setOf(
         "en", "es", "fr", "de", "it", "pt", "nl", "ru", "zh", "ja", "ko",
@@ -387,6 +396,9 @@ class PlayerViewModel @Inject constructor(
             val subOffset = prefs[profileManager.profileStringKey("subtitle_offset")] ?: "Bottom"
             val autoPlayNext = prefs[autoPlayNextKey()] ?: true
             val showLoadingStats = prefs[showLoadingStatsKey()] ?: true
+            val loadingAnimationStyle = prefs[loadingAnimationStyleKey()] ?: "Heartbeat"
+            val loadingProgressStyle = prefs[loadingProgressStyleKey()] ?: "Arc"
+            val loadingBackground = prefs[loadingBackgroundKey()] ?: "Dark"
             val volumeBoostDb = prefs[profileManager.profileStringKey("volume_boost_db")]
                 ?.toIntOrNull()?.coerceIn(0, 15) ?: 0
             val orderedAddonIds = streamRepository.installedAddons.first()
@@ -430,6 +442,9 @@ class PlayerViewModel @Inject constructor(
                 subtitleOffset = subOffset,
                 autoPlayNext = autoPlayNext,
                 showLoadingStats = showLoadingStats,
+                loadingAnimationStyle = loadingAnimationStyle,
+                loadingProgressStyle = loadingProgressStyle,
+                loadingBackground = loadingBackground,
                 volumeBoostDb = volumeBoostDb
             )
 

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -219,7 +219,7 @@ private fun tvGeneralRowsForSection(section: String): List<Int> {
         "subtitles" -> listOf(1, 2, 4, 5, 6, 7, 8, 9)
         "ai_subtitles" -> listOf(28, 29, 30, 31, 32, 33)
         "playback" -> listOf(10, 11, 12, 13, 14, 37, 34, 16, 15, 27)
-        "appearance" -> listOf(17, 18, 20, 21, 24, 23, 22, 36)
+        "appearance" -> listOf(17, 18, 20, 21, 24, 23, 22, 36, 38, 39, 40)
         "profiles" -> listOf(19)
         "network" -> listOf(25, 26, 35)
         else -> emptyList()
@@ -1339,7 +1339,13 @@ fun SettingsScreen(
                             onSubtitleAiApiKeyClick = { showAiApiKeyDialog = true },
                             onSubtitleAiQrClick = { viewModel.startAiKeyServer() },
                             customUserAgent = uiState.customUserAgent,
-                            onCustomUserAgentClick = { showCustomUserAgentDialog = true }
+                            onCustomUserAgentClick = { showCustomUserAgentDialog = true },
+                            loadingAnimationStyle = uiState.loadingAnimationStyle,
+                            onLoadingAnimationStyleClick = { viewModel.cycleLoadingAnimationStyle() },
+                            loadingProgressStyle = uiState.loadingProgressStyle,
+                            onLoadingProgressStyleClick = { viewModel.cycleLoadingProgressStyle() },
+                            loadingBackground = uiState.loadingBackground,
+                            onLoadingBackgroundClick = { viewModel.cycleLoadingBackground() }
                         )
                         if (showAiModelDialog) {
                             AiModelDialog(
@@ -4746,7 +4752,13 @@ private fun TvGeneralSettingsRows(
     onSubtitleAiApiKeyClick: () -> Unit = {},
     onSubtitleAiQrClick: () -> Unit = {},
     customUserAgent: String = "",
-    onCustomUserAgentClick: () -> Unit = {}
+    onCustomUserAgentClick: () -> Unit = {},
+    loadingAnimationStyle: String = "Heartbeat",
+    onLoadingAnimationStyleClick: () -> Unit = {},
+    loadingProgressStyle: String = "Arc",
+    onLoadingProgressStyleClick: () -> Unit = {},
+    loadingBackground: String = "Dark",
+    onLoadingBackgroundClick: () -> Unit = {}
 ) {
     Column {
         tvGeneralRowsForSection(section).forEachIndexed { localIndex, rowId ->
@@ -4854,6 +4866,33 @@ private fun TvGeneralSettingsRows(
                 34 -> SettingsRow(Icons.Default.Schedule, stringResource(R.string.trailer_delay), stringResource(R.string.trailer_delay_desc), "${trailerDelaySeconds}s", focusedIndex == localIndex, onTrailerDelayClick, Modifier.settingsFocusSlot(localIndex))
                 35 -> SettingsRow(Icons.Default.Language, stringResource(R.string.custom_user_agent), stringResource(R.string.custom_user_agent_desc), formatUserAgentPreview(customUserAgent, 30), focusedIndex == localIndex, onCustomUserAgentClick, Modifier.settingsFocusSlot(localIndex))
                 37 -> SettingsToggleRow(stringResource(R.string.trailer_in_cards), stringResource(R.string.trailer_in_cards_desc), trailerInCards, focusedIndex == localIndex, onTrailerInCardsToggle, Modifier.settingsFocusSlot(localIndex))
+                38 -> SettingsRow(
+                    icon = Icons.Default.Palette,
+                    title = stringResource(R.string.loading_animation_style),
+                    subtitle = stringResource(R.string.loading_animation_style_desc),
+                    value = loadingAnimationStyle,
+                    isFocused = focusedIndex == localIndex,
+                    onClick = onLoadingAnimationStyleClick,
+                    modifier = Modifier.settingsFocusSlot(localIndex)
+                )
+                39 -> SettingsRow(
+                    icon = Icons.Default.Refresh,
+                    title = stringResource(R.string.loading_progress_style),
+                    subtitle = stringResource(R.string.loading_progress_style_desc),
+                    value = loadingProgressStyle,
+                    isFocused = focusedIndex == localIndex,
+                    onClick = onLoadingProgressStyleClick,
+                    modifier = Modifier.settingsFocusSlot(localIndex)
+                )
+                40 -> SettingsRow(
+                    icon = Icons.Default.Movie,
+                    title = stringResource(R.string.loading_background),
+                    subtitle = stringResource(R.string.loading_background_desc),
+                    value = loadingBackground,
+                    isFocused = focusedIndex == localIndex,
+                    onClick = onLoadingBackgroundClick,
+                    modifier = Modifier.settingsFocusSlot(localIndex)
+                )
             }
         }
     }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -201,7 +201,13 @@ data class SettingsUiState(
     val subtitleAiModel: SubtitleAiModel = SubtitleAiModel.GROQ_LLAMA_70B,
     val subtitleRemoveHearingImpaired: Boolean = true,
     val aiKeyServerState: AiKeyServerState = AiKeyServerState(),
-    val smoothScrolling: Boolean = true
+    val smoothScrolling: Boolean = true,
+    // Loading animation style: Heartbeat / Breathe / Glow / Static
+    val loadingAnimationStyle: String = "Heartbeat",
+    // Loading progress style: Arc / Linear / Percentage / None
+    val loadingProgressStyle: String = "Arc",
+    // Loading background treatment: Dark / Backdrop
+    val loadingBackground: String = "Dark"
 )
 
 @HiltViewModel
@@ -270,6 +276,9 @@ class SettingsViewModel @Inject constructor(
     // a handful of discrete dB values. Parsed back to Int on read.
     private fun volumeBoostDbKey() = profileManager.profileStringKey("volume_boost_db")
     private fun showLoadingStatsKey() = profileManager.profileBooleanKey("show_loading_stats")
+    private fun loadingAnimationStyleKey() = profileManager.profileStringKey("loading_animation_style")
+    private fun loadingProgressStyleKey() = profileManager.profileStringKey("loading_progress_style")
+    private fun loadingBackgroundKey() = profileManager.profileStringKey("loading_background")
 
     private fun subtitleSizeKey() = profileManager.profileStringKey("subtitle_size")
     private fun subtitleColorKey() = profileManager.profileStringKey("subtitle_color")
@@ -462,6 +471,9 @@ class SettingsViewModel @Inject constructor(
             val volumeBoostDb = prefs[volumeBoostDbKey()]?.toIntOrNull()?.coerceIn(0, 15) ?: 0
             val showLoadingStats = prefs[showLoadingStatsKey()] ?: true
             val smoothScrolling = prefs[smoothScrollingKey()] ?: true
+            val loadingAnimationStyle = prefs[loadingAnimationStyleKey()] ?: "Heartbeat"
+            val loadingProgressStyle = prefs[loadingProgressStyleKey()] ?: "Arc"
+            val loadingBackground = prefs[loadingBackgroundKey()] ?: "Dark"
 
             val subtitleSize = prefs[subtitleSizeKey()] ?: "Medium"
             val subtitleColor = prefs[subtitleColorKey()] ?: "White"
@@ -530,7 +542,9 @@ class SettingsViewModel @Inject constructor(
                 showBudget = showBudget,
                 volumeBoostDb = volumeBoostDb,
                 showLoadingStats = showLoadingStats,
-
+                loadingAnimationStyle = loadingAnimationStyle,
+                loadingProgressStyle = loadingProgressStyle,
+                loadingBackground = loadingBackground,
                 subtitleSize = subtitleSize,
                 subtitleColor = subtitleColor,
                 subtitleStyle = subtitleStyle,
@@ -1172,6 +1186,42 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             context.settingsDataStore.edit { it[showLoadingStatsKey()] = enabled }
             _uiState.value = _uiState.value.copy(showLoadingStats = enabled)
+            syncLocalStateToCloud(silent = true)
+        }
+    }
+
+    fun cycleLoadingAnimationStyle() {
+        val styles = listOf("Heartbeat", "Breathe", "Glow", "Static")
+        val current = _uiState.value.loadingAnimationStyle
+        val nextIndex = (styles.indexOf(current) + 1) % styles.size
+        val next = styles[nextIndex]
+        viewModelScope.launch {
+            context.settingsDataStore.edit { it[loadingAnimationStyleKey()] = next }
+            _uiState.value = _uiState.value.copy(loadingAnimationStyle = next)
+            syncLocalStateToCloud(silent = true)
+        }
+    }
+
+    fun cycleLoadingProgressStyle() {
+        val styles = listOf("Arc", "Linear", "Percentage", "None")
+        val current = _uiState.value.loadingProgressStyle
+        val nextIndex = (styles.indexOf(current) + 1) % styles.size
+        val next = styles[nextIndex]
+        viewModelScope.launch {
+            context.settingsDataStore.edit { it[loadingProgressStyleKey()] = next }
+            _uiState.value = _uiState.value.copy(loadingProgressStyle = next)
+            syncLocalStateToCloud(silent = true)
+        }
+    }
+
+    fun cycleLoadingBackground() {
+        val options = listOf("Dark", "Backdrop")
+        val current = _uiState.value.loadingBackground
+        val nextIndex = (options.indexOf(current) + 1) % options.size
+        val next = options[nextIndex]
+        viewModelScope.launch {
+            context.settingsDataStore.edit { it[loadingBackgroundKey()] = next }
+            _uiState.value = _uiState.value.copy(loadingBackground = next)
             syncLocalStateToCloud(silent = true)
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -188,6 +188,12 @@
     <string name="accent_color_desc">Choose the accent color for focus rings, buttons, and selected items</string>
     <string name="show_loading_stats_desc">Display stream resolution progress</string>
     <string name="volume_boost_desc">Amplify quiet sources (via system LoudnessEnhancer)</string>
+    <string name="loading_animation_style">Loading Animation</string>
+    <string name="loading_animation_style_desc">Choose how the clearlogo animates during loading</string>
+    <string name="loading_progress_style">Loading Progress</string>
+    <string name="loading_progress_style_desc">Choose the progress indicator style during loading</string>
+    <string name="loading_background">Loading Background</string>
+    <string name="loading_background_desc">Choose the background treatment during loading</string>
     <string name="dns_desc">Resolve API and stream requests</string>
     <string name="add_catalog_desc">Import a Trakt or MDBList catalog URL</string>
 


### PR DESCRIPTION
## ✨ Loading Screen Customization

Adds three new cycle settings to the **Appearance** section that give users full control over how the clearlogo loading screen looks during playback startup and mid-stream buffering.

### Settings Added (Appearance section)

| Setting | Cycle Order | Default |
|---|---|---|
| **Loading Animation** | Heartbeat → Breathe → Glow → Static | Heartbeat |
| **Loading Progress** | Arc → Linear → Percentage → None | Arc |
| **Loading Background** | Dark → Backdrop | Dark |

### Animation Styles

1. **Heartbeat** — Two quick beats followed by a rest (1.5s cycle). The original behavior, preserved as default.
2. **Breathe** — Slow, smooth scale from 1.0→1.1→1.0 (3s cycle). A calm, ambient pulse.
3. **Glow** — Alpha transparency pulses from 0.55→1.0→0.55 (2s cycle). The logo size stays steady while it fades in and out like a glowing ember.
4. **Static** — No animation at all. The logo renders at full size and opacity.

### Progress Styles

1. **Arc** — Accent-colored circular arc ring around the logo (existing visual, now respects the user's selected accent color).
2. **Linear** — Accent-colored horizontal progress bar below the logo box, with percentage text beneath.
3. **Percentage** — Just the percentage number text, no ring or bar overlay.
4. **None** — No progress indicator at all. Clean logo-only look.

### Background Treatment

1. **Dark** — Solid black background. Clean, minimal, OLED-friendly.
2. **Backdrop** — Show the content backdrop art behind the logo with a dark overlay (original behavior).

### Technical Details

- All progress arcs/bars and percentage text render in the user's selected **accent color** via `LocalAccentColorOverride.current`.
- The `PulsingLogo` composable was rewritten to accept three new parameters (`animationStyle`, `progressStyle`, `backgroundStyle`) that flow from `PlayerUiState` → `PlayerScreen`.
- Settings are persisted per-profile via DataStore string keys, matching the existing pattern used by `cycleAccentColor()`.
- The loading screen container conditionally shows/hides backdrop art based on `loadingBackground` ("Backdrop" shows art + overlay, "Dark" shows plain black).
- Both the initial loading screen and mid-stream buffering overlay respect all three settings.
- Row IDs 38/39/40 were used — no existing settings were shifted or renumbered. D-pad focus flows naturally: Smooth Scrolling → Loading Animation → Loading Progress → Loading Background.

### Files Modified

- `SettingsViewModel.kt` — Added 3 DataStore string keys, 3 state fields (`loadingAnimationStyle`, `loadingProgressStyle`, `loadingBackground`), 3 cycle functions
- `SettingsScreen.kt` — Added 3 new settings rows to the Appearance section with proper focus wiring
- `strings.xml` — Added 6 string resources for labels and descriptions
- `PlayerViewModel.kt` — Added 3 fields to `PlayerUiState` + DataStore reads in init block
- `PlayerScreen.kt` — Rewrote `PulsingLogo` composable (lines 3654→3761) with all animation/progress/background styles; updated loading screen container for backdrop toggle
