### PR TITLE
fix: resolve profile deletion sync bug and homescreen snap-back

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncRepository.kt
@@ -140,19 +140,9 @@ class CloudSyncRepository @Inject constructor(
     private fun shouldRestoreRemoteBeforePush(localPayload: String, remotePayload: String): Boolean {
         val localRank = accountSyncPayloadRestoreRank(localPayload)
         val remoteRank = accountSyncPayloadRestoreRank(remotePayload)
-        val localProfileCount = cloudPayloadProfileCount(localPayload)
-        val remoteProfileCount = cloudPayloadProfileCount(remotePayload)
 
-        if (
-            localProfileCount != null &&
-            remoteProfileCount != null &&
-            remoteProfileCount > localProfileCount &&
-            remoteRank >= localRank
-        ) {
-            return true
-        }
-
-        return remoteRank >= 70 && localRank < 70
+        if (localRank >= 40) return false
+        return remoteRank >= 40 && localRank < 40
     }
 
     private fun mergeAddonsForSharedRestore(addonLists: Iterable<List<Addon>>): List<Addon> {
@@ -658,7 +648,7 @@ class CloudSyncRepository @Inject constructor(
     // ══════════════════════════════════════════════════════════
 
     suspend fun pushToCloud(force: Boolean = false): Result<Unit> = cloudSyncMutex.withLock {
-        pushToCloudLocked(force = force)
+        pushToCloudLocked(force = force, allowRemoteRestoreBeforePush = !force)
     }
 
     suspend fun pushLocalSnapshotToCloud(): Result<Unit> = cloudSyncMutex.withLock {

--- a/netlify-auth-site/netlify/functions/_backend.js
+++ b/netlify-auth-site/netlify/functions/_backend.js
@@ -1258,22 +1258,11 @@ function payloadMetrics(payload) {
 function isExistingSnapshotRicher(existing, incoming) {
   if (!existing) return false;
   const existingRank = Number(existing.restore_rank ?? existing.restoreRank ?? 0);
-  const existingProfilesRaw = existing.profile_count ?? existing.profileCount;
-  const existingCoverage = Number(existing.scoped_coverage ?? existing.scopedCoverage ?? 0);
+  const incomingRank = Number(incoming?.restoreRank ?? 0);
 
-  if (existingRank > incoming.restoreRank) return true;
-  if (existingRank < incoming.restoreRank) return false;
-
-  const existingProfiles = existingProfilesRaw === null || existingProfilesRaw === undefined
-    ? -1
-    : Number(existingProfilesRaw);
-  const incomingProfiles = incoming.profileCount === null || incoming.profileCount === undefined
-    ? -1
-    : Number(incoming.profileCount);
-  if (existingProfiles > incomingProfiles) return true;
-  if (existingProfiles < incomingProfiles) return false;
-
-  return existingCoverage > incoming.scopedCoverage;
+  if (incomingRank >= 40) return false;
+  if (existingRank >= 40 && incomingRank < 40) return true;
+  return existingRank > incomingRank;
 }
 
 function bearerToken(event) {

--- a/supabase/migrations/20260618_account_delta_sync.sql
+++ b/supabase/migrations/20260618_account_delta_sync.sql
@@ -418,11 +418,7 @@ begin
     v_existing_coverage := public.account_sync_scoped_coverage(v_existing_payload_json);
 
     v_keep_existing :=
-      v_existing_rank >= 70 and (
-        v_incoming_rank < v_existing_rank or
-        v_incoming_profile_count < v_existing_profile_count or
-        v_incoming_coverage < v_existing_coverage
-      );
+      v_incoming_rank < 40 and v_existing_rank >= 40;
   end if;
 
   if v_keep_existing then


### PR DESCRIPTION
### Summary
Fixes a critical profile sync bug where deleting a profile would cause the UI to snap back to the homescreen, and the deleted profile would reappear when re-opening switch profiles.

### Root Cause Analysis
During profile deletion, three mechanisms improperly blocked or reverted the local deletion:
1. **Server-Side Snapshot Rejection**: Both the Netlify cloud function (`account-sync-push.js`) and Supabase SQL function (`save_account_sync_payload`) evaluated incoming cloud snapshots against existing cloud storage using a heuristic that checked if `existing.profileCount > incoming.profileCount`. Because deleting a profile reduces the total profile count, legitimate deletions were rejected with `existing_snapshot_is_richer`.
2. **Client-Side Remote Restore**: When `pushToCloud(force = true)` ran after deletion, `CloudSyncRepository.shouldRestoreRemoteBeforePush()` evaluated the local snapshot against the un-updated remote payload. Seeing that the remote snapshot had more profiles, it blocked the push and applied the remote snapshot over local storage.
3. **Homescreen Snap-Back**: When `applyCloudPayload` restored the old cloud snapshot into `profilesDataStore`, `ProfileSelectionScreen` detected an unexpected change to `activeProfile` while `navigateTriggered` was active, instantly calling `onProfileSelected()` and navigating back to the homescreen.

### Changes Made
- **Android Client (`CloudSyncRepository.kt`)**:
  - Updated `shouldRestoreRemoteBeforePush` so configured local snapshots (`restoreRank >= 40`) are never overridden by remote cloud snapshots before a push.
  - Updated `pushToCloud(force = true)` to explicitly pass `allowRemoteRestoreBeforePush = false`.
- **Netlify Cloud Backend (`_backend.js`)**:
  - Updated `isExistingSnapshotRicher` so configured incoming payloads (`incomingRank >= 40`) are accepted even when profile count or coverage decreases due to legitimate deletion.
- **Supabase SQL Migration (`20260618_account_delta_sync.sql`)**:
  - Updated `save_account_sync_payload` to align with the improved heuristic (`v_incoming_rank < 40 and v_existing_rank >= 40`).