### PR TITLE
fix: harden settings screen values against NullPointerException (#413)

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/components/SettingsRows.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/SettingsRows.kt
@@ -40,7 +40,9 @@ import com.arflix.tv.ui.skin.resolveAccentColor
  *  The stored/compared value stays English; only the shown label is translated.
  *  Unknown values (720p, 4K, language/DNS names) pass through unchanged. */
 @Composable
-internal fun localizeSettingValue(value: String): String = when (value) {
+internal fun localizeSettingValue(value: String?): String {
+    val safeValue = value ?: return ""
+    return when (safeValue) {
     "Off" -> stringResource(R.string.off)
     "On" -> stringResource(R.string.on)
     "Auto" -> stringResource(R.string.auto)
@@ -74,7 +76,8 @@ internal fun localizeSettingValue(value: String): String = when (value) {
     "System DNS" -> stringResource(R.string.settings_dns_system)
     "12-hour" -> stringResource(R.string.settings_clock_12h)
     "24-hour" -> stringResource(R.string.settings_clock_24h)
-    else -> value
+    else -> safeValue
+    }
 }
 
 @OptIn(ExperimentalTvMaterial3Api::class)
@@ -83,7 +86,7 @@ fun SettingsRow(
     icon: ImageVector,
     title: String,
     subtitle: String = "",
-    value: String,
+    value: String?,
     isFocused: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
@@ -140,7 +143,8 @@ fun SettingsRow(
         }
         Spacer(modifier = Modifier.width(12.dp))
 
-        if (value.isNotBlank()) {
+        val safeValue = value.orEmpty()
+        if (safeValue.isNotBlank()) {
             Box(
                 modifier = Modifier
                     .background(Pink.copy(alpha = 0.15f), RoundedCornerShape(999.dp))
@@ -149,7 +153,7 @@ fun SettingsRow(
                 contentAlignment = Alignment.Center
             ) {
                 Text(
-                    text = localizeSettingValue(value).uppercase(),
+                    text = localizeSettingValue(safeValue).uppercase(),
                     style = ArflixTypography.label.copy(fontSize = 11.sp, letterSpacing = 0.5.sp),
                     color = Pink,
                     maxLines = 1,

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -248,8 +248,9 @@ private fun openExternalUrl(context: Context, url: String) {
 }
 
 @Composable
-private fun formatUserAgentPreview(value: String, maxLength: Int): String {
-    val displayValue = value.ifBlank { stringResource(R.string.settings_ua_default) }
+private fun formatUserAgentPreview(value: String?, maxLength: Int): String {
+    val safeValue = value.orEmpty()
+    val displayValue = safeValue.ifBlank { stringResource(R.string.settings_ua_default) }
     val preview = displayValue.take(maxLength)
     return if (displayValue.length > maxLength) "$preview..." else preview
 }
@@ -3980,7 +3981,7 @@ private fun MobileSettingsRow(
     icon: ImageVector,
     title: String,
     subtitle: String = "",
-    value: String,
+    value: String?,
     isFocused: Boolean = false,
     showDivider: Boolean = true,
     onClick: () -> Unit
@@ -4021,10 +4022,11 @@ private fun MobileSettingsRow(
                     }
                 }
             }
-            if (value.isNotEmpty()) {
+            val safeValue = value.orEmpty()
+            if (safeValue.isNotEmpty()) {
                 Spacer(modifier = Modifier.width(16.dp))
-                if (value == "On" || value == "Off") {
-                    val isChecked = value == "On"
+                if (safeValue == "On" || safeValue == "Off") {
+                    val isChecked = safeValue == "On"
                     Box(
                         modifier = Modifier
                             .width(44.dp)
@@ -4047,7 +4049,7 @@ private fun MobileSettingsRow(
                     }
                 } else {
                     Text(
-                        text = localizeSettingValue(value),
+                        text = localizeSettingValue(safeValue),
                         style = ArflixTypography.caption.copy(
                             fontSize = 13.sp,
                             fontWeight = androidx.compose.ui.text.font.FontWeight.Medium


### PR DESCRIPTION
### Summary
Fixes issue #413 where opening the Settings screen consistently crashes with a `NullPointerException: Attempt to invoke interface method 'int java.lang.CharSequence.length()' on a null object reference`.

### Root Cause
When opening the Settings screen or switching locales (such as `es-ES`), setting strings or preference values loaded from `DataStore`/`SharedPreferences` or resource lookups can pass `null` into UI row composables and formatters.
Previously, functions such as `SettingsRow`, `MobileSettingsRow`, `localizeSettingValue`, and `formatUserAgentPreview` expected non-null `String` parameters and invoked operations like `.isNotBlank()`, `.isNotEmpty()`, or `.ifBlank {}` on them directly, causing `CharSequence.length()` to be called on a null reference.

### Changes Made
- **`SettingsRows.kt`**:
  - Updated `localizeSettingValue(value: String?)` and `SettingsRow(..., value: String?)` to safely handle nullable string inputs, defaulting to empty strings before evaluating length/emptiness.
- **`SettingsScreen.kt`**:
  - Updated `formatUserAgentPreview(value: String?, maxLength: Int)` and `MobileSettingsRow(..., value: String?)` to accept nullable values and evaluate safe fallback strings via `.orEmpty()`.

Resolves #413.