### PR TITLE
fix: disable global cleartext traffic to prevent MITM

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,8 +29,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:localeConfig="@xml/locale_config"
-        android:theme="@style/Theme.ArflixTV"
-        android:usesCleartextTraffic="true">
+        android:theme="@style/Theme.ArflixTV">
 
         <profileable
             android:shell="true"


### PR DESCRIPTION
Fixes #379

## Description
Removed \usesCleartextTraffic=true\ from \AndroidManifest.xml\ to restore the Android 9+ default of rejecting plain HTTP connections. This mitigates the Man-in-the-Middle (MITM) vulnerability reported in Issue #379.