### PR TITLE
fix: enforce HTTPS and checksum validation for sideloaded plugins

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/domain/model/Plugin.kt
+++ b/app/src/main/kotlin/com/arflix/tv/domain/model/Plugin.kt
@@ -148,5 +148,6 @@ data class ExternalPluginEntry(
     val iconUrl: String? = null,
     val url: String,
     val fileSize: Long? = null,
-    val repositoryUrl: String? = null
+    val repositoryUrl: String? = null,
+    val checksum: String? = null
 )

--- a/app/src/sideload/kotlin/com/arflix/tv/core/plugin/PluginManager.kt
+++ b/app/src/sideload/kotlin/com/arflix/tv/core/plugin/PluginManager.kt
@@ -1061,7 +1061,7 @@ class PluginManager @Inject constructor(
                     try {
                         val scraperId = "$repoId:${plugin.internalName}"
 
-                        val file = externalExtensionLoader.downloadExtension(scraperId, plugin.url)
+                        val file = externalExtensionLoader.downloadExtension(scraperId, plugin.url, plugin.checksum)
                         if (file == null) {
                             Log.e(TAG, "Failed to download extension: ${plugin.name}")
                             return@withPermit

--- a/app/src/sideload/kotlin/com/arflix/tv/core/plugin/cloudstream/ExternalExtensionLoader.kt
+++ b/app/src/sideload/kotlin/com/arflix/tv/core/plugin/cloudstream/ExternalExtensionLoader.kt
@@ -200,7 +200,11 @@ class ExternalExtensionLoader @Inject constructor(
      * Download a .cs3 DEX file for the given scraper.
      * Returns the local file path, or null on failure.
      */
-    suspend fun downloadExtension(scraperId: String, downloadUrl: String): File? = withContext(Dispatchers.IO) {
+    suspend fun downloadExtension(scraperId: String, downloadUrl: String, expectedChecksum: String? = null): File? = withContext(Dispatchers.IO) {
+        if (downloadUrl.startsWith("http://", ignoreCase = true)) {
+            Log.e(TAG, "Insecure HTTP URLs are not allowed: $downloadUrl")
+            return@withContext null
+        }
         com.arflix.tv.core.runtime.PluginRuntimeHooks.ensureCloudstreamInitialized()
         try {
             val targetFile = File(extensionsDir, "${safeFileName(scraperId)}.cs3")
@@ -236,6 +240,17 @@ class ExternalExtensionLoader @Inject constructor(
                 }
 
                 targetFile.writeBytes(bytes)
+
+                if (expectedChecksum != null) {
+                    val digest = java.security.MessageDigest.getInstance("SHA-256")
+                    val hashBytes = digest.digest(bytes)
+                    val hexString = hashBytes.joinToString("") { "%02x".format(it) }
+                    if (!hexString.equals(expectedChecksum, ignoreCase = true)) {
+                        Log.e(TAG, "Checksum mismatch for $scraperId. Expected: $expectedChecksum, Actual: $hexString")
+                        targetFile.delete()
+                        return@withContext null
+                    }
+                }
 
                 // Fix for Android API 28+: DEX files must be read-only
                 // Writing writable DEX files is blocked on newer Android versions

--- a/app/src/sideload/kotlin/com/arflix/tv/core/plugin/cloudstream/ExternalRepoParser.kt
+++ b/app/src/sideload/kotlin/com/arflix/tv/core/plugin/cloudstream/ExternalRepoParser.kt
@@ -52,6 +52,10 @@ class ExternalRepoParser @Inject constructor(
      * Returns null if the content doesn't match any known external format.
      */
     suspend fun tryParse(url: String, fallbackName: String? = null): ExternalRepoParseResult? = withContext(Dispatchers.IO) {
+        if (url.startsWith("http://", ignoreCase = true)) {
+            Log.e(TAG, "Insecure HTTP URLs are not allowed: $url")
+            return@withContext null
+        }
         val body = fetchBody(url) ?: return@withContext null
         val trimmed = body.trim()
 
@@ -112,6 +116,10 @@ class ExternalRepoParser @Inject constructor(
     }
 
     private fun fetchBody(url: String): String? {
+        if (url.startsWith("http://", ignoreCase = true)) {
+            Log.e(TAG, "Insecure HTTP URLs are not allowed: $url")
+            return null
+        }
         return try {
             val request = Request.Builder()
                 .url(url)
@@ -131,7 +139,10 @@ class ExternalRepoParser @Inject constructor(
     }
 
     private fun resolveUrl(baseUrl: String, relativeUrl: String): String {
-        if (relativeUrl.startsWith("http://") || relativeUrl.startsWith("https://")) {
+        if (relativeUrl.startsWith("http://", ignoreCase = true)) {
+            throw IllegalArgumentException("Insecure HTTP URLs are not allowed: $relativeUrl")
+        }
+        if (relativeUrl.startsWith("https://", ignoreCase = true)) {
             return relativeUrl
         }
         val base = baseUrl.substringBeforeLast("/")


### PR DESCRIPTION
Fixes #380

## Description
To mitigate the RCE vector via sideloaded plugins:
* Added a \checksum\ field to \ExternalPluginEntry\.
* Enforced strict HTTPS for all external repository metadata and plugin downloads in \ExternalRepoParser\ and \ExternalExtensionLoader\.
* Implemented SHA-256 hash verification if the repository manifest provides a checksum, ensuring payload integrity.