### PR TITLE
fix(home): restore poster and catalog skeletons with correct TV/mobile title visibility

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/components/MediaCard.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/MediaCard.kt
@@ -98,6 +98,7 @@ fun MediaCard(
         PlaceholderCard(
             width = width,
             isLandscape = isLandscape,
+            showTitle = showTitle,
             modifier = modifier
         )
         return
@@ -522,6 +523,7 @@ fun MediaCard(
 private fun PlaceholderCard(
     width: Dp,
     isLandscape: Boolean,
+    showTitle: Boolean = true,
     modifier: Modifier = Modifier
 ) {
     val aspectRatio = if (isLandscape) 16f / 9f else 2f / 3f
@@ -542,25 +544,27 @@ private fun PlaceholderCard(
             )
         }
 
-        Spacer(modifier = Modifier.height(ArvioSkin.spacing.x2))
+        if (showTitle) {
+            Spacer(modifier = Modifier.height(ArvioSkin.spacing.x2))
 
-        // Title skeleton
-        SkeletonBox(
-            modifier = Modifier
-                .fillMaxWidth(0.7f)
-                .height(14.dp)
-                .clip(rememberArvioCardShape(ArvioSkin.radius.sm))
-        )
+            // Title skeleton
+            SkeletonBox(
+                modifier = Modifier
+                    .fillMaxWidth(0.7f)
+                    .height(14.dp)
+                    .clip(rememberArvioCardShape(ArvioSkin.radius.sm))
+            )
 
-        Spacer(modifier = Modifier.height(4.dp))
+            Spacer(modifier = Modifier.height(4.dp))
 
-        // Subtitle skeleton
-        SkeletonBox(
-            modifier = Modifier
-                .fillMaxWidth(0.5f)
-                .height(12.dp)
-                .clip(rememberArvioCardShape(ArvioSkin.radius.sm))
-        )
+            // Subtitle skeleton
+            SkeletonBox(
+                modifier = Modifier
+                    .fillMaxWidth(0.5f)
+                    .height(12.dp)
+                    .clip(rememberArvioCardShape(ArvioSkin.radius.sm))
+            )
+        }
     }
 }
 
@@ -585,6 +589,7 @@ fun PosterCard(
         PlaceholderCard(
             width = width,
             isLandscape = false,
+            showTitle = false,
             modifier = modifier
         )
         return

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
@@ -2774,7 +2774,29 @@ private fun MobileHomeRowsLayer(
                 } else {
                     rowUsePosterCards
                 }
-                val itemsToRender = category.items
+                val itemsToRender = remember(category.items, rowHasMore, isPortrait) {
+                    if (category.items.isEmpty()) {
+                        (1..8).map { index ->
+                            MediaItem(
+                                id = -index,
+                                title = "",
+                                mediaType = MediaType.MOVIE,
+                                isPlaceholder = true
+                            )
+                        }
+                    } else if (rowHasMore) {
+                        val skeletonCount = if (isPortrait) 12 else 7
+                        category.items + List(skeletonCount) { idx ->
+                            MediaItem(
+                                id = -1000 - idx,
+                                title = "",
+                                isPlaceholder = true
+                            )
+                        }
+                    } else {
+                        category.items
+                    }
+                }
 
                 // Horizontal card row with touch scrolling
                 LazyRow(
@@ -3325,7 +3347,30 @@ private fun ContentRow(
     val cardAspectRatio = if (effectivePosterMode) 2f / 3f else 16f / 9f
     val itemWidth = if (effectivePosterMode) 105.dp else 210.dp
     val itemSpacing = 14.dp
-    val totalItems = category.items.size
+    val itemsToRender = remember(category.items, effectiveCategoryHasMore, effectivePosterMode) {
+        if (category.items.isEmpty()) {
+            (1..8).map { index ->
+                MediaItem(
+                    id = -index,
+                    title = "",
+                    mediaType = MediaType.MOVIE,
+                    isPlaceholder = true
+                )
+            }
+        } else if (effectiveCategoryHasMore) {
+            val skeletonCount = if (effectivePosterMode) 12 else 7
+            category.items + List(skeletonCount) { idx ->
+                MediaItem(
+                    id = -1000 - idx,
+                    title = "",
+                    isPlaceholder = true
+                )
+            }
+        } else {
+            category.items
+        }
+    }
+    val totalItems = itemsToRender.size
     val maxFirstIndex = remember(totalItems) {
         (totalItems - 1).coerceAtLeast(0)
     }
@@ -3482,8 +3527,6 @@ private fun ContentRow(
                 color = Color.White
             )
         }
-
-        val itemsToRender = category.items
 
         // Cards row - clipped to hide previous items when scrolling
         val clipModifier = if (isContinueWatching) Modifier else Modifier.clipToBounds()

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
@@ -401,31 +401,6 @@ private fun createHomeHeroPlaybackHandles(context: Context): HomeHeroPlaybackHan
     )
 }
 
-private suspend fun androidx.compose.foundation.lazy.LazyListState.animateHomeScrollDelta(
-    deltaPx: Float,
-    durationMillis: Int
-) {
-    if (abs(deltaPx) <= 1f) return
-    scroll(scrollPriority = MutatePriority.PreventUserInput) {
-        var previousValue = 0f
-        animate(
-            initialValue = 0f,
-            targetValue = deltaPx,
-            animationSpec = spring(
-                dampingRatio = 0.85f,
-                stiffness = 200f
-            )
-        ) { value, _ ->
-            val step = value - previousValue
-            if (abs(step) > 0.01f) {
-                scrollBy(step)
-            }
-            previousValue = value
-        }
-    }
-}
-
-
 
 @Composable
 private fun HomeBackdropCrossfade(
@@ -3010,37 +2985,7 @@ private fun TvHomeRowsLayer(
             if (initialPlacement || jumpDistance > 7) {
                 listState.scrollToItem(index = targetIndex, scrollOffset = 0)
             } else {
-                if (smoothScrolling) {
-                    val visibleTarget = listState.layoutInfo.visibleItemsInfo
-                        .firstOrNull { it.index == targetIndex }
-                    val deltaPx = if (visibleTarget != null) {
-                        visibleTarget.offset.toFloat()
-                    } else {
-                        if (targetIndex < currentIndex) {
-                            val intermediateSum = (targetIndex until currentIndex).sumOf { idx ->
-                                categoryHeightsPx.getOrNull(idx)?.toDouble() ?: (202.0 * density.density)
-                            }.toFloat()
-                            -(intermediateSum + currentOffset)
-                        } else {
-                            val intermediateSum = (currentIndex until targetIndex).sumOf { idx ->
-                                categoryHeightsPx.getOrNull(idx)?.toDouble() ?: (202.0 * density.density)
-                            }.toFloat()
-                            intermediateSum - currentOffset
-                        }
-                    }
-                    listState.animateHomeScrollDelta(
-                        deltaPx = deltaPx,
-                        durationMillis = if (jumpDistance >= 3) 180 else 150
-                    )
-                    if (
-                        listState.firstVisibleItemIndex != targetIndex ||
-                        abs(listState.firstVisibleItemScrollOffset) > 6
-                    ) {
-                        listState.scrollToItem(index = targetIndex, scrollOffset = 0)
-                    }
-                } else {
-                    listState.animateScrollToItem(index = targetIndex, scrollOffset = 0)
-                }
+                listState.animateScrollToItem(index = targetIndex, scrollOffset = 0)
             }
             lastAppliedTargetIndex = targetIndex
         }
@@ -3477,27 +3422,7 @@ private fun ContentRow(
             targetOutsideViewport ||
             offsetDelta > 1
         ) {
-            if (smoothScrolling) {
-                val deltaPx = ((scrollTargetIndex - currentFirstIndex) * itemSpanPx) + (extraOffset - currentFirstOffset)
-                rowState.animateHomeScrollDelta(
-                    deltaPx = deltaPx,
-                    durationMillis = when {
-                        isFastScrolling -> 115
-                        jumpDistance >= 3 -> 180
-                        else -> 150
-                    }
-                )
-                if (
-                    !isFastScrolling && (
-                        rowState.firstVisibleItemIndex != scrollTargetIndex ||
-                            abs(rowState.firstVisibleItemScrollOffset - extraOffset) > 6
-                        )
-                ) {
-                    rowState.scrollToItem(index = scrollTargetIndex, scrollOffset = extraOffset)
-                }
-            } else {
-                rowState.animateScrollToItem(index = scrollTargetIndex, scrollOffset = extraOffset)
-            }
+            rowState.animateScrollToItem(index = scrollTargetIndex, scrollOffset = extraOffset)
         } else {
             rowState.scrollToItem(index = scrollTargetIndex, scrollOffset = extraOffset)
         }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
@@ -401,6 +401,31 @@ private fun createHomeHeroPlaybackHandles(context: Context): HomeHeroPlaybackHan
     )
 }
 
+private suspend fun androidx.compose.foundation.lazy.LazyListState.animateHomeScrollDelta(
+    deltaPx: Float,
+    durationMillis: Int
+) {
+    if (abs(deltaPx) <= 1f) return
+    scroll(scrollPriority = MutatePriority.PreventUserInput) {
+        var previousValue = 0f
+        animate(
+            initialValue = 0f,
+            targetValue = deltaPx,
+            animationSpec = spring(
+                dampingRatio = 0.85f,
+                stiffness = 200f
+            )
+        ) { value, _ ->
+            val step = value - previousValue
+            if (abs(step) > 0.01f) {
+                scrollBy(step)
+            }
+            previousValue = value
+        }
+    }
+}
+
+
 
 @Composable
 private fun HomeBackdropCrossfade(
@@ -2985,7 +3010,37 @@ private fun TvHomeRowsLayer(
             if (initialPlacement || jumpDistance > 7) {
                 listState.scrollToItem(index = targetIndex, scrollOffset = 0)
             } else {
-                listState.animateScrollToItem(index = targetIndex, scrollOffset = 0)
+                if (smoothScrolling) {
+                    val visibleTarget = listState.layoutInfo.visibleItemsInfo
+                        .firstOrNull { it.index == targetIndex }
+                    val deltaPx = if (visibleTarget != null) {
+                        visibleTarget.offset.toFloat()
+                    } else {
+                        if (targetIndex < currentIndex) {
+                            val intermediateSum = (targetIndex until currentIndex).sumOf { idx ->
+                                categoryHeightsPx.getOrNull(idx)?.toDouble() ?: (202.0 * density.density)
+                            }.toFloat()
+                            -(intermediateSum + currentOffset)
+                        } else {
+                            val intermediateSum = (currentIndex until targetIndex).sumOf { idx ->
+                                categoryHeightsPx.getOrNull(idx)?.toDouble() ?: (202.0 * density.density)
+                            }.toFloat()
+                            intermediateSum - currentOffset
+                        }
+                    }
+                    listState.animateHomeScrollDelta(
+                        deltaPx = deltaPx,
+                        durationMillis = if (jumpDistance >= 3) 180 else 150
+                    )
+                    if (
+                        listState.firstVisibleItemIndex != targetIndex ||
+                        abs(listState.firstVisibleItemScrollOffset) > 6
+                    ) {
+                        listState.scrollToItem(index = targetIndex, scrollOffset = 0)
+                    }
+                } else {
+                    listState.animateScrollToItem(index = targetIndex, scrollOffset = 0)
+                }
             }
             lastAppliedTargetIndex = targetIndex
         }
@@ -3422,7 +3477,27 @@ private fun ContentRow(
             targetOutsideViewport ||
             offsetDelta > 1
         ) {
-            rowState.animateScrollToItem(index = scrollTargetIndex, scrollOffset = extraOffset)
+            if (smoothScrolling) {
+                val deltaPx = ((scrollTargetIndex - currentFirstIndex) * itemSpanPx) + (extraOffset - currentFirstOffset)
+                rowState.animateHomeScrollDelta(
+                    deltaPx = deltaPx,
+                    durationMillis = when {
+                        isFastScrolling -> 115
+                        jumpDistance >= 3 -> 180
+                        else -> 150
+                    }
+                )
+                if (
+                    !isFastScrolling && (
+                        rowState.firstVisibleItemIndex != scrollTargetIndex ||
+                            abs(rowState.firstVisibleItemScrollOffset - extraOffset) > 6
+                        )
+                ) {
+                    rowState.scrollToItem(index = scrollTargetIndex, scrollOffset = extraOffset)
+                }
+            } else {
+                rowState.animateScrollToItem(index = scrollTargetIndex, scrollOffset = extraOffset)
+            }
         } else {
             rowState.scrollToItem(index = scrollTargetIndex, scrollOffset = extraOffset)
         }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
@@ -2912,11 +2912,8 @@ class HomeViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(categoryHasMoreMap = hasMoreMap)
     }
 
-    private fun buildProfileSkeletonCategories(
-        savedCatalogs: List<com.arflix.tv.data.model.CatalogConfig>,
-        cachedContinueWatching: List<ContinueWatchingItem>
-    ): List<Category> {
-        val placeholderItems = (1..HOME_PLACEHOLDER_ITEM_COUNT).map { index ->
+    private fun createPlaceholderItems(count: Int = HOME_PLACEHOLDER_ITEM_COUNT): List<MediaItem> =
+        (1..count).map { index ->
             MediaItem(
                 id = -index,
                 title = "",
@@ -2924,6 +2921,12 @@ class HomeViewModel @Inject constructor(
                 isPlaceholder = true
             )
         }
+
+    private fun buildProfileSkeletonCategories(
+        savedCatalogs: List<com.arflix.tv.data.model.CatalogConfig>,
+        cachedContinueWatching: List<ContinueWatchingItem>
+    ): List<Category> {
+        val placeholderItems = createPlaceholderItems()
 
         val rows = mutableListOf<Category>()
         if (cachedContinueWatching.isNotEmpty()) {

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -892,6 +892,7 @@ fun SettingsScreen(
                                                 20 -> viewModel.setOledBlackBackground(!uiState.oledBlackBackground)
                                                 21 -> viewModel.cycleClockFormat()
                                                 22 -> viewModel.setShowBudget(!uiState.showBudget)
+                                                 36 -> viewModel.setSmoothScrolling(!uiState.smoothScrolling)
                                                 23 -> viewModel.setSpoilerBlurEnabled(!uiState.spoilerBlurEnabled)
                                                 24 -> viewModel.cycleAccentColor()
                                                 25 -> openDnsProviderPicker()
@@ -3828,8 +3829,17 @@ private fun MobileSettingsSubPage(
                         title = stringResource(R.string.accent_color),
                         value = uiState.accentColor,
                         isFocused = false,
-                        showDivider = false,
+                        showDivider = true,
                         onClick = { viewModel.cycleAccentColor() }
+                    )
+                    MobileSettingsRow(
+                        icon = Icons.Default.Palette,
+                        title = stringResource(R.string.smooth_scrolling),
+                        subtitle = stringResource(R.string.smooth_scrolling_desc),
+                        value = if (uiState.smoothScrolling) "On" else "Off",
+                        isFocused = false,
+                        showDivider = false,
+                        onClick = { viewModel.setSmoothScrolling(!uiState.smoothScrolling) }
                     )
                 }
             }
@@ -4810,6 +4820,7 @@ private fun TvGeneralSettingsRows(
                 20 -> SettingsToggleRow(stringResource(R.string.oled_black_background), stringResource(R.string.oled_black_background_desc), oledBlackBackground, focusedIndex == localIndex, onOledBlackBackgroundToggle, Modifier.settingsFocusSlot(localIndex))
                 21 -> SettingsRow(Icons.Default.Schedule, stringResource(R.string.clock_format), stringResource(R.string.clock_format_desc), if (clockFormat == "12h") "12-hour" else "24-hour", focusedIndex == localIndex, onClockFormatClick, Modifier.settingsFocusSlot(localIndex))
                 22 -> SettingsToggleRow(stringResource(R.string.show_budget), stringResource(R.string.show_budget_desc), showBudget, focusedIndex == localIndex, onShowBudgetToggle, Modifier.settingsFocusSlot(localIndex))
+                36 -> SettingsToggleRow(stringResource(R.string.smooth_scrolling), stringResource(R.string.smooth_scrolling_desc), smoothScrolling, focusedIndex == localIndex, onSmoothScrollingToggle, Modifier.settingsFocusSlot(localIndex))
                 23 -> SettingsToggleRow(stringResource(R.string.spoiler_blur), stringResource(R.string.spoiler_blur_desc), spoilerBlurEnabled, focusedIndex == localIndex, onSpoilerBlurToggle, Modifier.settingsFocusSlot(localIndex))
                 24 -> SettingsRow(Icons.Default.Palette, stringResource(R.string.accent_color), stringResource(R.string.accent_color_desc), accentColor, focusedIndex == localIndex, onAccentColorClick, Modifier.settingsFocusSlot(localIndex))
                 25 -> SettingsRow(Icons.Default.Language, stringResource(R.string.dns_provider), stringResource(R.string.dns_desc), dnsProvider, focusedIndex == localIndex, onDnsProviderClick, Modifier.settingsFocusSlot(localIndex))

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -892,7 +892,6 @@ fun SettingsScreen(
                                                 20 -> viewModel.setOledBlackBackground(!uiState.oledBlackBackground)
                                                 21 -> viewModel.cycleClockFormat()
                                                 22 -> viewModel.setShowBudget(!uiState.showBudget)
-                                                 36 -> viewModel.setSmoothScrolling(!uiState.smoothScrolling)
                                                 23 -> viewModel.setSpoilerBlurEnabled(!uiState.spoilerBlurEnabled)
                                                 24 -> viewModel.cycleAccentColor()
                                                 25 -> openDnsProviderPicker()
@@ -3829,17 +3828,8 @@ private fun MobileSettingsSubPage(
                         title = stringResource(R.string.accent_color),
                         value = uiState.accentColor,
                         isFocused = false,
-                        showDivider = true,
-                        onClick = { viewModel.cycleAccentColor() }
-                    )
-                    MobileSettingsRow(
-                        icon = Icons.Default.Palette,
-                        title = stringResource(R.string.smooth_scrolling),
-                        subtitle = stringResource(R.string.smooth_scrolling_desc),
-                        value = if (uiState.smoothScrolling) "On" else "Off",
-                        isFocused = false,
                         showDivider = false,
-                        onClick = { viewModel.setSmoothScrolling(!uiState.smoothScrolling) }
+                        onClick = { viewModel.cycleAccentColor() }
                     )
                 }
             }
@@ -4820,7 +4810,6 @@ private fun TvGeneralSettingsRows(
                 20 -> SettingsToggleRow(stringResource(R.string.oled_black_background), stringResource(R.string.oled_black_background_desc), oledBlackBackground, focusedIndex == localIndex, onOledBlackBackgroundToggle, Modifier.settingsFocusSlot(localIndex))
                 21 -> SettingsRow(Icons.Default.Schedule, stringResource(R.string.clock_format), stringResource(R.string.clock_format_desc), if (clockFormat == "12h") "12-hour" else "24-hour", focusedIndex == localIndex, onClockFormatClick, Modifier.settingsFocusSlot(localIndex))
                 22 -> SettingsToggleRow(stringResource(R.string.show_budget), stringResource(R.string.show_budget_desc), showBudget, focusedIndex == localIndex, onShowBudgetToggle, Modifier.settingsFocusSlot(localIndex))
-                36 -> SettingsToggleRow(stringResource(R.string.smooth_scrolling), stringResource(R.string.smooth_scrolling_desc), smoothScrolling, focusedIndex == localIndex, onSmoothScrollingToggle, Modifier.settingsFocusSlot(localIndex))
                 23 -> SettingsToggleRow(stringResource(R.string.spoiler_blur), stringResource(R.string.spoiler_blur_desc), spoilerBlurEnabled, focusedIndex == localIndex, onSpoilerBlurToggle, Modifier.settingsFocusSlot(localIndex))
                 24 -> SettingsRow(Icons.Default.Palette, stringResource(R.string.accent_color), stringResource(R.string.accent_color_desc), accentColor, focusedIndex == localIndex, onAccentColorClick, Modifier.settingsFocusSlot(localIndex))
                 25 -> SettingsRow(Icons.Default.Language, stringResource(R.string.dns_provider), stringResource(R.string.dns_desc), dnsProvider, focusedIndex == localIndex, onDnsProviderClick, Modifier.settingsFocusSlot(localIndex))

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -219,7 +219,7 @@ private fun tvGeneralRowsForSection(section: String): List<Int> {
         "subtitles" -> listOf(1, 2, 4, 5, 6, 7, 8, 9)
         "ai_subtitles" -> listOf(28, 29, 30, 31, 32, 33)
         "playback" -> listOf(10, 11, 12, 13, 14, 37, 34, 16, 15, 27)
-        "appearance" -> listOf(17, 18, 20, 21, 24, 23, 22, 36)
+        "appearance" -> listOf(17, 18, 20, 21, 24, 23, 22)
         "profiles" -> listOf(19)
         "network" -> listOf(25, 26, 35)
         else -> emptyList()
@@ -1308,8 +1308,6 @@ fun SettingsScreen(
                             onOledBlackBackgroundToggle = { viewModel.setOledBlackBackground(it) },
                             onClockFormatClick = { viewModel.cycleClockFormat() },
                             onShowBudgetToggle = { viewModel.setShowBudget(it) },
-                            smoothScrolling = uiState.smoothScrolling,
-                            onSmoothScrollingToggle = { viewModel.setSmoothScrolling(it) },
                             spoilerBlurEnabled = uiState.spoilerBlurEnabled,
                             onSpoilerBlurToggle = { viewModel.setSpoilerBlurEnabled(it) },
                             accentColor = uiState.accentColor,
@@ -4680,7 +4678,6 @@ private fun TvGeneralSettingsRows(
     oledBlackBackground: Boolean = false,
     clockFormat: String = "24h",
     showBudget: Boolean = true,
-    smoothScrolling: Boolean = true,
     spoilerBlurEnabled: Boolean = false,
     accentColor: String = "White",
     volumeBoostDb: Int = 0,
@@ -4700,7 +4697,6 @@ private fun TvGeneralSettingsRows(
     onOledBlackBackgroundToggle: (Boolean) -> Unit = {},
     onClockFormatClick: () -> Unit = {},
     onShowBudgetToggle: (Boolean) -> Unit = {},
-    onSmoothScrollingToggle: (Boolean) -> Unit = {},
     onSpoilerBlurToggle: (Boolean) -> Unit = {},
     onAccentColorClick: () -> Unit = {},
     showLoadingStats: Boolean = true,

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -219,7 +219,7 @@ private fun tvGeneralRowsForSection(section: String): List<Int> {
         "subtitles" -> listOf(1, 2, 4, 5, 6, 7, 8, 9)
         "ai_subtitles" -> listOf(28, 29, 30, 31, 32, 33)
         "playback" -> listOf(10, 11, 12, 13, 14, 37, 34, 16, 15, 27)
-        "appearance" -> listOf(17, 18, 20, 21, 24, 23, 22)
+        "appearance" -> listOf(17, 18, 20, 21, 24, 23, 22, 36)
         "profiles" -> listOf(19)
         "network" -> listOf(25, 26, 35)
         else -> emptyList()
@@ -1308,6 +1308,8 @@ fun SettingsScreen(
                             onOledBlackBackgroundToggle = { viewModel.setOledBlackBackground(it) },
                             onClockFormatClick = { viewModel.cycleClockFormat() },
                             onShowBudgetToggle = { viewModel.setShowBudget(it) },
+                            smoothScrolling = uiState.smoothScrolling,
+                            onSmoothScrollingToggle = { viewModel.setSmoothScrolling(it) },
                             spoilerBlurEnabled = uiState.spoilerBlurEnabled,
                             onSpoilerBlurToggle = { viewModel.setSpoilerBlurEnabled(it) },
                             accentColor = uiState.accentColor,
@@ -4678,6 +4680,7 @@ private fun TvGeneralSettingsRows(
     oledBlackBackground: Boolean = false,
     clockFormat: String = "24h",
     showBudget: Boolean = true,
+    smoothScrolling: Boolean = true,
     spoilerBlurEnabled: Boolean = false,
     accentColor: String = "White",
     volumeBoostDb: Int = 0,
@@ -4697,6 +4700,7 @@ private fun TvGeneralSettingsRows(
     onOledBlackBackgroundToggle: (Boolean) -> Unit = {},
     onClockFormatClick: () -> Unit = {},
     onShowBudgetToggle: (Boolean) -> Unit = {},
+    onSmoothScrollingToggle: (Boolean) -> Unit = {},
     onSpoilerBlurToggle: (Boolean) -> Unit = {},
     onAccentColorClick: () -> Unit = {},
     showLoadingStats: Boolean = true,


### PR DESCRIPTION
Restores clean dynamic poster and catalog skeletons in the home feed. Reverts data-layer workarounds and implements conditional title rendering for TV poster lists where card titles are disabled.