### PR TITLE
docs: add chmod command to fix gradlew permission denied error

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Requirements:
 Use the tracked Gradle wrapper:
 
 ```bash
+chmod +x gradlew
 ./gradlew :app:assemblePlayDebug
 ./gradlew :app:assembleSideloadDebug
 ```


### PR DESCRIPTION
Description:

This PR fixes a build execution error in the local setup instructions. The current documentation tells developers to run ./gradlew directly, which often throws a "Permission denied" error on macOS and Linux after a fresh clone. I added the chmod +x gradlew command before the build steps to ensure the wrapper has the necessary execution permissions to run successfully.

Closes #None