### PR TITLE
web: Remove clock display from top navigation

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -212,12 +212,6 @@ button {
   transform: scale(1.045);
 }
 
-.top-clock {
-  font-size: clamp(30px, 2.4vw, 46px);
-  font-weight: 350;
-  color: rgba(255, 255, 255, 0.86);
-}
-
 .content {
   min-height: 100vh;
   position: relative;
@@ -1295,8 +1289,7 @@ input:focus {
     grid-template-columns: 76px 1fr auto;
   }
 
-  .profile-name,
-  .top-clock {
+  .profile-name {
     display: none;
   }
 
@@ -3318,8 +3311,7 @@ select:focus {
     padding-inline: 14px;
   }
 
-  .profile-name-text,
-  .top-clock {
+  .profile-name-text {
     display: none;
   }
 
@@ -5004,7 +4996,6 @@ button,
 
   .sidebar::after,
   .profile-name-text,
-  .top-clock,
   .nav-item span {
     display: none !important;
   }

--- a/web/components/settings/SettingsScreen.tsx
+++ b/web/components/settings/SettingsScreen.tsx
@@ -1,14 +1,46 @@
 "use client";
 
 import {
-  ArrowDown, ArrowUp, Captions, Check, ChevronDown, Cloud, Eye, EyeOff, Languages, LayoutGrid, ListVideo, LogOut,
-  Network, Play, Plus, RefreshCw, RotateCcw, Server, Sparkles, Subtitles, Trash2, Tv, User, UserCircle
+  ArrowDown,
+  ArrowUp,
+  Captions,
+  Check,
+  ChevronDown,
+  Cloud,
+  Eye,
+  EyeOff,
+  Languages,
+  LayoutGrid,
+  ListVideo,
+  LogOut,
+  Network,
+  Play,
+  Plus,
+  RefreshCw,
+  RotateCcw,
+  Server,
+  Sparkles,
+  Subtitles,
+  Trash2,
+  Tv,
+  User,
+  UserCircle,
 } from "lucide-react";
 import { Component, useState, type ReactNode } from "react";
 import { defaultCatalogs, mergeCatalogs } from "@/lib/catalogs";
-import { hasNetlifyBackendConfig, hasSupabaseConfig, hasTraktConfig } from "@/lib/config";
+import {
+  hasNetlifyBackendConfig,
+  hasSupabaseConfig,
+  hasTraktConfig,
+} from "@/lib/config";
 import { defaultSettings, useApp } from "@/lib/store";
-import type { AppSettings, CatalogConfig, HomeServerConfig, IptvPlaylistEntry, QualityFilterConfig } from "@/lib/types";
+import type {
+  AppSettings,
+  CatalogConfig,
+  HomeServerConfig,
+  IptvPlaylistEntry,
+  QualityFilterConfig,
+} from "@/lib/types";
 
 const settingsKey = "arvio.web.settings";
 
@@ -24,7 +56,7 @@ const SECTIONS = [
   { id: "tv", label: "TV (IPTV)", icon: Tv },
   { id: "homeserver", label: "Home Server", icon: Server },
   { id: "catalogs", label: "Catalogs", icon: ListVideo },
-  { id: "addons", label: "Addons", icon: Sparkles }
+  { id: "addons", label: "Addons", icon: Sparkles },
 ] as const;
 
 type SectionId = (typeof SECTIONS)[number]["id"];
@@ -37,15 +69,17 @@ const SUBTITLE_COLOR_HEX: Record<AppSettings["subtitleColorName"], string> = {
   Red: "#f44336",
   Orange: "#ff9800",
   Blue: "#2196f3",
-  Violet: "#8b5cf6"
+  Violet: "#8b5cf6",
 };
 
-const QUALITY_PRESET_LABELS: Array<[AppSettings["qualityFilterPreset"], string]> = [
+const QUALITY_PRESET_LABELS: Array<
+  [AppSettings["qualityFilterPreset"], string]
+> = [
   ["off", "Off"],
   ["1080p-plus", "1080p and above"],
   ["1080p-only", "1080p only"],
   ["720p-plus", "720p and above"],
-  ["custom", "Custom"]
+  ["custom", "Custom"],
 ];
 
 const CONTENT_LANGUAGE_OPTIONS: Array<[string, string]> = [
@@ -66,7 +100,7 @@ const CONTENT_LANGUAGE_OPTIONS: Array<[string, string]> = [
   ["no-NO", "Norwegian"],
   ["ja-JP", "Japanese"],
   ["ko-KR", "Korean"],
-  ["zh-CN", "Chinese (Simplified)"]
+  ["zh-CN", "Chinese (Simplified)"],
 ];
 
 const TRACK_LANGUAGE_OPTIONS: Array<[string, string]> = [
@@ -86,41 +120,54 @@ const TRACK_LANGUAGE_OPTIONS: Array<[string, string]> = [
   ["no", "Norwegian"],
   ["ja", "Japanese"],
   ["ko", "Korean"],
-  ["zh", "Chinese"]
+  ["zh", "Chinese"],
 ];
 
-function optionsWithCurrent(options: Array<[string, string]>, value: string, fallbackLabel = "Current"): Array<[string, string]> {
+function optionsWithCurrent(
+  options: Array<[string, string]>,
+  value: string,
+  fallbackLabel = "Current",
+): Array<[string, string]> {
   if (!value || options.some(([option]) => option === value)) return options;
   return [[value, `${fallbackLabel}: ${value}`], ...options];
 }
 
-function qualityPresetFilters(preset: AppSettings["qualityFilterPreset"]): QualityFilterConfig[] {
-  const poorSources = "cam|hdcam|camrip|ts|hdts|telesync|tc|hdtc|telecine|screener|scr|dvdscr|r5";
+function qualityPresetFilters(
+  preset: AppSettings["qualityFilterPreset"],
+): QualityFilterConfig[] {
+  const poorSources =
+    "cam|hdcam|camrip|ts|hdts|telesync|tc|hdtc|telecine|screener|scr|dvdscr|r5";
   switch (preset) {
     case "1080p-plus":
-      return [{
-        id: "preset-quality-1080-plus",
-        deviceName: "Preset: 1080p+",
-        regexPattern: `(?:360|480|576|720)p|${poorSources}`,
-        enabled: true,
-        createdAt: Date.now()
-      }];
+      return [
+        {
+          id: "preset-quality-1080-plus",
+          deviceName: "Preset: 1080p+",
+          regexPattern: `(?:360|480|576|720)p|${poorSources}`,
+          enabled: true,
+          createdAt: Date.now(),
+        },
+      ];
     case "1080p-only":
-      return [{
-        id: "preset-quality-1080-only",
-        deviceName: "Preset: 1080p only",
-        regexPattern: `(?:2160|4k|uhd)|(?:360|480|576|720)p|${poorSources}`,
-        enabled: true,
-        createdAt: Date.now()
-      }];
+      return [
+        {
+          id: "preset-quality-1080-only",
+          deviceName: "Preset: 1080p only",
+          regexPattern: `(?:2160|4k|uhd)|(?:360|480|576|720)p|${poorSources}`,
+          enabled: true,
+          createdAt: Date.now(),
+        },
+      ];
     case "720p-plus":
-      return [{
-        id: "preset-quality-720-plus",
-        deviceName: "Preset: 720p+",
-        regexPattern: `(?:360|480|576)p|${poorSources}`,
-        enabled: true,
-        createdAt: Date.now()
-      }];
+      return [
+        {
+          id: "preset-quality-720-plus",
+          deviceName: "Preset: 720p+",
+          regexPattern: `(?:360|480|576)p|${poorSources}`,
+          enabled: true,
+          createdAt: Date.now(),
+        },
+      ];
     default:
       return [];
   }
@@ -170,7 +217,10 @@ class SettingsSectionBoundary extends Component<
   static getDerivedStateFromError(error: unknown) {
     return {
       hasError: true,
-      message: error instanceof Error ? error.message : "This settings section could not be opened."
+      message:
+        error instanceof Error
+          ? error.message
+          : "This settings section could not be opened.",
     };
   }
 
@@ -190,7 +240,11 @@ class SettingsSectionBoundary extends Component<
       <section className="settings-panel-card settings-error-card">
         <h2>Settings section unavailable</h2>
         <p className="empty">{this.state.message}</p>
-        <button type="button" className="secondary text-button" onClick={() => this.setState({ hasError: false, message: "" })}>
+        <button
+          type="button"
+          className="secondary text-button"
+          onClick={() => this.setState({ hasError: false, message: "" })}
+        >
           Try again
         </button>
       </section>
@@ -200,16 +254,35 @@ class SettingsSectionBoundary extends Component<
 
 /* ---------- reusable rows ---------- */
 
-function Row({ label, hint, children }: { label: string; hint?: string; children: ReactNode }) {
+function Row({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: ReactNode;
+}) {
   return (
     <div className="set-row">
-      <span className="set-label">{label}{hint && <em>{hint}</em>}</span>
+      <span className="set-label">
+        {label}
+        {hint && <em>{hint}</em>}
+      </span>
       <span className="set-control">{children}</span>
     </div>
   );
 }
 
-function Toggle({ value, onChange, disabled }: { value: boolean; onChange: (v: boolean) => void; disabled?: boolean }) {
+function Toggle({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: boolean;
+  onChange: (v: boolean) => void;
+  disabled?: boolean;
+}) {
   return (
     <button
       type="button"
@@ -224,7 +297,17 @@ function Toggle({ value, onChange, disabled }: { value: boolean; onChange: (v: b
   );
 }
 
-function Select<T extends string>({ value, options, onChange, disabled }: { value: T; options: Array<[T, string]>; onChange: (v: T) => void; disabled?: boolean }) {
+function Select<T extends string>({
+  value,
+  options,
+  onChange,
+  disabled,
+}: {
+  value: T;
+  options: Array<[T, string]>;
+  onChange: (v: T) => void;
+  disabled?: boolean;
+}) {
   const [open, setOpen] = useState(false);
   const selected = options.find(([option]) => option === value)?.[1] ?? value;
   const choose = (next: T) => {
@@ -233,19 +316,40 @@ function Select<T extends string>({ value, options, onChange, disabled }: { valu
   };
   return (
     <>
-      <button type="button" className="option-button" disabled={disabled} onClick={(event) => {
-        event.preventDefault();
-        setOpen(true);
-      }}>
+      <button
+        type="button"
+        className="option-button"
+        disabled={disabled}
+        onClick={(event) => {
+          event.preventDefault();
+          setOpen(true);
+        }}
+      >
         <span>{selected}</span>
         <ChevronDown size={17} />
       </button>
       {open && (
-        <div className="option-sheet-backdrop" role="presentation" onClick={() => setOpen(false)}>
-          <div className="option-sheet" role="dialog" aria-modal="true" aria-label="Choose option" onClick={(event) => event.stopPropagation()}>
+        <div
+          className="option-sheet-backdrop"
+          role="presentation"
+          onClick={() => setOpen(false)}
+        >
+          <div
+            className="option-sheet"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Choose option"
+            onClick={(event) => event.stopPropagation()}
+          >
             <div className="option-sheet-head">
               <strong>Choose option</strong>
-              <button type="button" className="secondary" onClick={() => setOpen(false)}>Close</button>
+              <button
+                type="button"
+                className="secondary"
+                onClick={() => setOpen(false)}
+              >
+                Close
+              </button>
             </div>
             <div className="option-sheet-list">
               {options.map(([option, label]) => (
@@ -275,11 +379,16 @@ function SectionBody({ section }: { section: SectionId }) {
   const set = (patch: Partial<AppSettings>) => app.updateSettings(patch);
   const [qualityFilterName, setQualityFilterName] = useState("");
   const [qualityFilterPattern, setQualityFilterPattern] = useState("");
-  const setSubtitleColor = (name: AppSettings["subtitleColorName"]) => set({ subtitleColorName: name, subtitleColor: SUBTITLE_COLOR_HEX[name] });
-  const setQualityPreset = (preset: AppSettings["qualityFilterPreset"]) => set({
-    qualityFilterPreset: preset,
-    qualityFilters: preset === "custom" ? settings.qualityFilters : qualityPresetFilters(preset)
-  });
+  const setSubtitleColor = (name: AppSettings["subtitleColorName"]) =>
+    set({ subtitleColorName: name, subtitleColor: SUBTITLE_COLOR_HEX[name] });
+  const setQualityPreset = (preset: AppSettings["qualityFilterPreset"]) =>
+    set({
+      qualityFilterPreset: preset,
+      qualityFilters:
+        preset === "custom"
+          ? settings.qualityFilters
+          : qualityPresetFilters(preset),
+    });
   const addQualityFilter = () => {
     const pattern = qualityFilterPattern.trim();
     if (!pattern) {
@@ -288,13 +397,16 @@ function SectionBody({ section }: { section: SectionId }) {
     }
     set({
       qualityFilterPreset: "custom",
-      qualityFilters: [{
-        id: crypto.randomUUID(),
-        deviceName: qualityFilterName.trim() || "Custom quality filter",
-        regexPattern: pattern,
-        enabled: true,
-        createdAt: Date.now()
-      }, ...safeArray(settings.qualityFilters)]
+      qualityFilters: [
+        {
+          id: crypto.randomUUID(),
+          deviceName: qualityFilterName.trim() || "Custom quality filter",
+          regexPattern: pattern,
+          enabled: true,
+          createdAt: Date.now(),
+        },
+        ...safeArray(settings.qualityFilters),
+      ],
     });
     setQualityFilterName("");
     setQualityFilterPattern("");
@@ -306,53 +418,212 @@ function SectionBody({ section }: { section: SectionId }) {
     case "profiles":
       return (
         <Panel title="Profiles">
-          <Row label="Skip profile selection on launch"><Toggle value={settings.skipProfileSelection} onChange={(v) => set({ skipProfileSelection: v })} /></Row>
-          <button type="button" className="secondary text-button" onClick={app.switchProfile}><User size={18} /> Manage profiles</button>
+          <Row label="Skip profile selection on launch">
+            <Toggle
+              value={settings.skipProfileSelection}
+              onChange={(v) => set({ skipProfileSelection: v })}
+            />
+          </Row>
+          <button
+            type="button"
+            className="secondary text-button"
+            onClick={app.switchProfile}
+          >
+            <User size={18} /> Manage profiles
+          </button>
         </Panel>
       );
     case "playback":
       return (
         <Panel title="Playback">
-          <Row label="Play in" hint="VLC/Infuse open the source directly; ARVIO still syncs Trakt when you return">
-            <Select value={settings.defaultPlayer} onChange={(v) => set({ defaultPlayer: v })}
-              options={[["browser", "ARVIO player"], ["vlc", "VLC"], ["infuse", "Infuse"]]} />
+          <Row
+            label="Play in"
+            hint="VLC/Infuse open the source directly; ARVIO still syncs Trakt when you return"
+          >
+            <Select
+              value={settings.defaultPlayer}
+              onChange={(v) => set({ defaultPlayer: v })}
+              options={[
+                ["browser", "ARVIO player"],
+                ["vlc", "VLC"],
+                ["infuse", "Infuse"],
+              ]}
+            />
           </Row>
-          <Row label="Auto play next episode"><Toggle value={settings.autoPlayNext} onChange={(v) => set({ autoPlayNext: v })} /></Row>
-          <Row label="Auto play single source"><Toggle value={settings.autoPlaySingleSource} onChange={(v) => set({ autoPlaySingleSource: v })} /></Row>
+          <Row label="Auto play next episode">
+            <Toggle
+              value={settings.autoPlayNext}
+              onChange={(v) => set({ autoPlayNext: v })}
+            />
+          </Row>
+          <Row label="Auto play single source">
+            <Toggle
+              value={settings.autoPlaySingleSource}
+              onChange={(v) => set({ autoPlaySingleSource: v })}
+            />
+          </Row>
           <Row label="Auto play minimum quality">
-            <Select value={settings.autoPlayMinQuality} onChange={(v) => set({ autoPlayMinQuality: v })}
-              options={[["any", "Any"], ["hd", "HD"], ["fhd", "FHD"], ["4k", "4K"]]} />
+            <Select
+              value={settings.autoPlayMinQuality}
+              onChange={(v) => set({ autoPlayMinQuality: v })}
+              options={[
+                ["any", "Any"],
+                ["hd", "HD"],
+                ["fhd", "FHD"],
+                ["4k", "4K"],
+              ]}
+            />
           </Row>
-          <Row label="Trailer auto play"><Toggle value={settings.trailerAutoPlay} onChange={(v) => set({ trailerAutoPlay: v })} /></Row>
-          <Row label="Trailer sound"><Toggle value={settings.trailerSound} onChange={(v) => set({ trailerSound: v })} /></Row>
-          <Row label="Trailer delay (seconds)"><input type="number" min={0} max={10} value={settings.trailerDelaySeconds} onChange={(e) => set({ trailerDelaySeconds: Number(e.target.value) })} /></Row>
-          <Row label="Show trailers inside cards"><Toggle value={settings.trailerInCards} onChange={(v) => set({ trailerInCards: v })} /></Row>
-          <Row label="Frame rate matching" hint="Applies on TV devices; synced from here">
-            <Select value={settings.frameRateMatchingMode} onChange={(v) => set({ frameRateMatchingMode: v })}
-              options={[["off", "Off"], ["seamless", "Seamless only"], ["always", "Always"]]} />
+          <Row label="Trailer auto play">
+            <Toggle
+              value={settings.trailerAutoPlay}
+              onChange={(v) => set({ trailerAutoPlay: v })}
+            />
           </Row>
-          <Row label="Volume boost" hint="Applies on TV devices; synced from here">
-            <Select value={String(settings.volumeBoostDb)} onChange={(v) => set({ volumeBoostDb: Number(v) })}
-              options={["0", "3", "6", "9", "12", "15"].map((value) => [value, `${value} dB`])} />
+          <Row label="Trailer sound">
+            <Toggle
+              value={settings.trailerSound}
+              onChange={(v) => set({ trailerSound: v })}
+            />
           </Row>
-          <Row label="Include specials"><Toggle value={settings.includeSpecials} onChange={(v) => set({ includeSpecials: v })} /></Row>
+          <Row label="Trailer delay (seconds)">
+            <input
+              type="number"
+              min={0}
+              max={10}
+              value={settings.trailerDelaySeconds}
+              onChange={(e) =>
+                set({ trailerDelaySeconds: Number(e.target.value) })
+              }
+            />
+          </Row>
+          <Row label="Show trailers inside cards">
+            <Toggle
+              value={settings.trailerInCards}
+              onChange={(v) => set({ trailerInCards: v })}
+            />
+          </Row>
+          <Row
+            label="Frame rate matching"
+            hint="Applies on TV devices; synced from here"
+          >
+            <Select
+              value={settings.frameRateMatchingMode}
+              onChange={(v) => set({ frameRateMatchingMode: v })}
+              options={[
+                ["off", "Off"],
+                ["seamless", "Seamless only"],
+                ["always", "Always"],
+              ]}
+            />
+          </Row>
+          <Row
+            label="Volume boost"
+            hint="Applies on TV devices; synced from here"
+          >
+            <Select
+              value={String(settings.volumeBoostDb)}
+              onChange={(v) => set({ volumeBoostDb: Number(v) })}
+              options={["0", "3", "6", "9", "12", "15"].map((value) => [
+                value,
+                `${value} dB`,
+              ])}
+            />
+          </Row>
+          <Row label="Include specials">
+            <Toggle
+              value={settings.includeSpecials}
+              onChange={(v) => set({ includeSpecials: v })}
+            />
+          </Row>
           <Row label="Quality filter preset">
-            <Select value={settings.qualityFilterPreset} onChange={setQualityPreset} options={QUALITY_PRESET_LABELS} />
+            <Select
+              value={settings.qualityFilterPreset}
+              onChange={setQualityPreset}
+              options={QUALITY_PRESET_LABELS}
+            />
           </Row>
           <div className="inline-form wide">
-            <input value={qualityFilterName} onChange={(e) => setQualityFilterName(e.target.value)} placeholder="Filter name" />
-            <input value={qualityFilterPattern} onChange={(e) => setQualityFilterPattern(e.target.value)} placeholder="Regex to hide matching sources" />
-            <button type="button" className="secondary text-button" onClick={addQualityFilter}><Plus size={18} /> Add filter</button>
+            <input
+              value={qualityFilterName}
+              onChange={(e) => setQualityFilterName(e.target.value)}
+              placeholder="Filter name"
+            />
+            <input
+              value={qualityFilterPattern}
+              onChange={(e) => setQualityFilterPattern(e.target.value)}
+              placeholder="Regex to hide matching sources"
+            />
+            <button
+              type="button"
+              className="secondary text-button"
+              onClick={addQualityFilter}
+            >
+              <Plus size={18} /> Add filter
+            </button>
           </div>
           <div className="settings-list">
             {safeArray(settings.qualityFilters).map((filter) => (
-              <div className="settings-list-row quality-filter-row" key={filter.id}>
-                <button type="button" className="icon-button" onClick={() => set({ qualityFilterPreset: "custom", qualityFilters: settings.qualityFilters.map((item) => item.id === filter.id ? { ...item, enabled: !item.enabled } : item) })}>
+              <div
+                className="settings-list-row quality-filter-row"
+                key={filter.id}
+              >
+                <button
+                  type="button"
+                  className="icon-button"
+                  onClick={() =>
+                    set({
+                      qualityFilterPreset: "custom",
+                      qualityFilters: settings.qualityFilters.map((item) =>
+                        item.id === filter.id
+                          ? { ...item, enabled: !item.enabled }
+                          : item,
+                      ),
+                    })
+                  }
+                >
                   {filter.enabled ? <Eye size={18} /> : <EyeOff size={18} />}
                 </button>
-                <input value={filter.deviceName} onChange={(e) => set({ qualityFilterPreset: "custom", qualityFilters: settings.qualityFilters.map((item) => item.id === filter.id ? { ...item, deviceName: e.target.value } : item) })} />
-                <input value={filter.regexPattern} onChange={(e) => set({ qualityFilterPreset: "custom", qualityFilters: settings.qualityFilters.map((item) => item.id === filter.id ? { ...item, regexPattern: e.target.value } : item) })} />
-                <button type="button" className="icon-button danger" onClick={() => set({ qualityFilterPreset: "custom", qualityFilters: settings.qualityFilters.filter((item) => item.id !== filter.id) })}><Trash2 size={18} /></button>
+                <input
+                  value={filter.deviceName}
+                  onChange={(e) =>
+                    set({
+                      qualityFilterPreset: "custom",
+                      qualityFilters: settings.qualityFilters.map((item) =>
+                        item.id === filter.id
+                          ? { ...item, deviceName: e.target.value }
+                          : item,
+                      ),
+                    })
+                  }
+                />
+                <input
+                  value={filter.regexPattern}
+                  onChange={(e) =>
+                    set({
+                      qualityFilterPreset: "custom",
+                      qualityFilters: settings.qualityFilters.map((item) =>
+                        item.id === filter.id
+                          ? { ...item, regexPattern: e.target.value }
+                          : item,
+                      ),
+                    })
+                  }
+                />
+                <button
+                  type="button"
+                  className="icon-button danger"
+                  onClick={() =>
+                    set({
+                      qualityFilterPreset: "custom",
+                      qualityFilters: settings.qualityFilters.filter(
+                        (item) => item.id !== filter.id,
+                      ),
+                    })
+                  }
+                >
+                  <Trash2 size={18} />
+                </button>
               </div>
             ))}
           </div>
@@ -362,20 +633,48 @@ function SectionBody({ section }: { section: SectionId }) {
       return (
         <Panel title="Language & Audio">
           <Row label="Content language">
-            <Select value={settings.language} onChange={(v) => set({ language: v })}
-              options={optionsWithCurrent(CONTENT_LANGUAGE_OPTIONS, settings.language, "Custom")} />
+            <Select
+              value={settings.language}
+              onChange={(v) => set({ language: v })}
+              options={optionsWithCurrent(
+                CONTENT_LANGUAGE_OPTIONS,
+                settings.language,
+                "Custom",
+              )}
+            />
           </Row>
           <Row label="Primary subtitle language">
-            <Select value={settings.defaultSubtitle || ""} onChange={(v) => set({ defaultSubtitle: v })}
-              options={optionsWithCurrent(TRACK_LANGUAGE_OPTIONS, settings.defaultSubtitle || "", "Custom")} />
+            <Select
+              value={settings.defaultSubtitle || ""}
+              onChange={(v) => set({ defaultSubtitle: v })}
+              options={optionsWithCurrent(
+                TRACK_LANGUAGE_OPTIONS,
+                settings.defaultSubtitle || "",
+                "Custom",
+              )}
+            />
           </Row>
           <Row label="Secondary subtitle language">
-            <Select value={settings.secondarySubtitle || ""} onChange={(v) => set({ secondarySubtitle: v })}
-              options={optionsWithCurrent(TRACK_LANGUAGE_OPTIONS, settings.secondarySubtitle || "", "Custom")} />
+            <Select
+              value={settings.secondarySubtitle || ""}
+              onChange={(v) => set({ secondarySubtitle: v })}
+              options={optionsWithCurrent(
+                TRACK_LANGUAGE_OPTIONS,
+                settings.secondarySubtitle || "",
+                "Custom",
+              )}
+            />
           </Row>
           <Row label="Audio language">
-            <Select value={settings.audioLanguage || ""} onChange={(v) => set({ audioLanguage: v })}
-              options={optionsWithCurrent(TRACK_LANGUAGE_OPTIONS, settings.audioLanguage || "", "Custom")} />
+            <Select
+              value={settings.audioLanguage || ""}
+              onChange={(v) => set({ audioLanguage: v })}
+              options={optionsWithCurrent(
+                TRACK_LANGUAGE_OPTIONS,
+                settings.audioLanguage || "",
+                "Custom",
+              )}
+            />
           </Row>
         </Panel>
       );
@@ -383,57 +682,190 @@ function SectionBody({ section }: { section: SectionId }) {
       return (
         <Panel title="Subtitles">
           <SubtitlePreview settings={settings} />
-          <Row label="Subtitle size (%)"><input type="number" min={60} max={200} value={settings.subtitleSize} onChange={(e) => set({ subtitleSize: Number(e.target.value) })} /></Row>
-          <Row label="Subtitle color">
-            <Select value={settings.subtitleColorName} onChange={setSubtitleColor}
-              options={(Object.keys(SUBTITLE_COLOR_HEX) as AppSettings["subtitleColorName"][]).map((name) => [name, name])} />
+          <Row label="Subtitle size (%)">
+            <input
+              type="number"
+              min={60}
+              max={200}
+              value={settings.subtitleSize}
+              onChange={(e) => set({ subtitleSize: Number(e.target.value) })}
+            />
           </Row>
-          <Row label="Custom subtitle color"><input type="color" value={settings.subtitleColor} onChange={(e) => set({ subtitleColor: e.target.value, subtitleColorName: "White" })} /></Row>
-          <Row label="Subtitle offset (ms)"><input type="number" value={settings.subtitleOffsetMs} onChange={(e) => set({ subtitleOffsetMs: Number(e.target.value) })} /></Row>
+          <Row label="Subtitle color">
+            <Select
+              value={settings.subtitleColorName}
+              onChange={setSubtitleColor}
+              options={(
+                Object.keys(
+                  SUBTITLE_COLOR_HEX,
+                ) as AppSettings["subtitleColorName"][]
+              ).map((name) => [name, name])}
+            />
+          </Row>
+          <Row label="Custom subtitle color">
+            <input
+              type="color"
+              value={settings.subtitleColor}
+              onChange={(e) =>
+                set({
+                  subtitleColor: e.target.value,
+                  subtitleColorName: "White",
+                })
+              }
+            />
+          </Row>
+          <Row label="Subtitle offset (ms)">
+            <input
+              type="number"
+              value={settings.subtitleOffsetMs}
+              onChange={(e) =>
+                set({ subtitleOffsetMs: Number(e.target.value) })
+              }
+            />
+          </Row>
           <Row label="Subtitle screen position">
-            <Select value={settings.subtitleOffset} onChange={(v) => set({ subtitleOffset: v })}
-              options={[["bottom", "Bottom"], ["low", "Low"], ["medium", "Medium"], ["high", "High"]]} />
+            <Select
+              value={settings.subtitleOffset}
+              onChange={(v) => set({ subtitleOffset: v })}
+              options={[
+                ["bottom", "Bottom"],
+                ["low", "Low"],
+                ["medium", "Medium"],
+                ["high", "High"],
+              ]}
+            />
           </Row>
           <Row label="Subtitle style">
-            <Select value={settings.subtitleStyle} onChange={(v) => set({ subtitleStyle: v })}
-              options={[["outline", "Bold / outline"], ["shadow", "Normal / shadow"], ["background", "Background"], ["raised", "Raised"]]} />
+            <Select
+              value={settings.subtitleStyle}
+              onChange={(v) => set({ subtitleStyle: v })}
+              options={[
+                ["outline", "Bold / outline"],
+                ["shadow", "Normal / shadow"],
+                ["background", "Background"],
+                ["raised", "Raised"],
+              ]}
+            />
           </Row>
-          <Row label="Stylized subtitles"><Toggle value={settings.subtitleStylized} onChange={(v) => set({ subtitleStylized: v })} /></Row>
-          <Row label="Filter subtitles by language"><Toggle value={settings.filterSubtitlesByLanguage} onChange={(v) => set({ filterSubtitlesByLanguage: v })} /></Row>
-          <Row label="Remove hearing-impaired [SDH] tags"><Toggle value={settings.removeHearingImpaired} onChange={(v) => set({ removeHearingImpaired: v })} /></Row>
+          <Row label="Stylized subtitles">
+            <Toggle
+              value={settings.subtitleStylized}
+              onChange={(v) => set({ subtitleStylized: v })}
+            />
+          </Row>
+          <Row label="Filter subtitles by language">
+            <Toggle
+              value={settings.filterSubtitlesByLanguage}
+              onChange={(v) => set({ filterSubtitlesByLanguage: v })}
+            />
+          </Row>
+          <Row label="Remove hearing-impaired [SDH] tags">
+            <Toggle
+              value={settings.removeHearingImpaired}
+              onChange={(v) => set({ removeHearingImpaired: v })}
+            />
+          </Row>
         </Panel>
       );
     case "ai":
       return (
         <Panel title="AI Subtitles">
-          <Row label="AI subtitle enhancement"><Toggle value={settings.aiSubtitlesEnabled} onChange={(v) => set({ aiSubtitlesEnabled: v })} /></Row>
-          <Row label="AI model">
-            <Select value={settings.aiSubtitleModel} onChange={(v) => set({ aiSubtitleModel: v })}
-              options={[["off", "Off"], ["groq", "Groq"], ["gemini", "Gemini"]]} />
+          <Row label="AI subtitle enhancement">
+            <Toggle
+              value={settings.aiSubtitlesEnabled}
+              onChange={(v) => set({ aiSubtitlesEnabled: v })}
+            />
           </Row>
-          <Row label="Auto-select best match"><Toggle value={settings.aiAutoSelect} onChange={(v) => set({ aiAutoSelect: v })} /></Row>
-          <Row label="AI API key"><input type="password" value={settings.aiApiKey} onChange={(e) => set({ aiApiKey: e.target.value })} placeholder="••••••••" /></Row>
+          <Row label="AI model">
+            <Select
+              value={settings.aiSubtitleModel}
+              onChange={(v) => set({ aiSubtitleModel: v })}
+              options={[
+                ["off", "Off"],
+                ["groq", "Groq"],
+                ["gemini", "Gemini"],
+              ]}
+            />
+          </Row>
+          <Row label="Auto-select best match">
+            <Toggle
+              value={settings.aiAutoSelect}
+              onChange={(v) => set({ aiAutoSelect: v })}
+            />
+          </Row>
+          <Row label="AI API key">
+            <input
+              type="password"
+              value={settings.aiApiKey}
+              onChange={(e) => set({ aiApiKey: e.target.value })}
+              placeholder="••••••••"
+            />
+          </Row>
         </Panel>
       );
     case "appearance":
       return (
         <Panel title="Appearance">
           <Row label="Card layout">
-            <Select value={settings.cardLayoutMode} onChange={(v) => set({ cardLayoutMode: v })} options={[["landscape", "Landscape"], ["poster", "Poster"]]} />
+            <Select
+              value={settings.cardLayoutMode}
+              onChange={(v) => set({ cardLayoutMode: v })}
+              options={[
+                ["landscape", "Landscape"],
+                ["poster", "Poster"],
+              ]}
+            />
           </Row>
           <Row label="Device mode">
-            <Select value={settings.deviceModeOverride} onChange={(v) => set({ deviceModeOverride: v })} options={[["auto", "Auto"], ["tv", "TV"], ["tablet", "Tablet"], ["phone", "Phone"], ["desktop", "Desktop / browser"]]} />
+            <Select
+              value={settings.deviceModeOverride}
+              onChange={(v) => set({ deviceModeOverride: v })}
+              options={[
+                ["auto", "Auto"],
+                ["tv", "TV"],
+                ["tablet", "Tablet"],
+                ["phone", "Phone"],
+                ["desktop", "Desktop / browser"],
+              ]}
+            />
           </Row>
-          <Row label="OLED black background"><Toggle value={settings.oledBlack} onChange={(v) => set({ oledBlack: v })} /></Row>
-          <Row label="Clock format">
-            <Select value={settings.clockFormat} onChange={(v) => set({ clockFormat: v })} options={[["24h", "24-hour"], ["12h", "12-hour"]]} />
+          <Row label="OLED black background">
+            <Toggle
+              value={settings.oledBlack}
+              onChange={(v) => set({ oledBlack: v })}
+            />
           </Row>
-          <Row label="Show budget / revenue"><Toggle value={settings.showBudget} onChange={(v) => set({ showBudget: v })} /></Row>
-          <Row label="Smooth scrolling"><Toggle value={settings.smoothScrolling} onChange={(v) => set({ smoothScrolling: v })} /></Row>
-          <Row label="Spoiler blur"><Toggle value={settings.spoilerBlur} onChange={(v) => set({ spoilerBlur: v })} /></Row>
+
+          <Row label="Show budget / revenue">
+            <Toggle
+              value={settings.showBudget}
+              onChange={(v) => set({ showBudget: v })}
+            />
+          </Row>
+          <Row label="Smooth scrolling">
+            <Toggle
+              value={settings.smoothScrolling}
+              onChange={(v) => set({ smoothScrolling: v })}
+            />
+          </Row>
+          <Row label="Spoiler blur">
+            <Toggle
+              value={settings.spoilerBlur}
+              onChange={(v) => set({ spoilerBlur: v })}
+            />
+          </Row>
           <Row label="Accent theme">
-            <Select value={settings.accentColor} onChange={(v) => set({ accentColor: v })}
-              options={[["arctic", "Arctic"], ["gold", "Gold"], ["green", "Green"], ["blue", "Blue"], ["purple", "Purple"]]} />
+            <Select
+              value={settings.accentColor}
+              onChange={(v) => set({ accentColor: v })}
+              options={[
+                ["arctic", "Arctic"],
+                ["gold", "Gold"],
+                ["green", "Green"],
+                ["blue", "Blue"],
+                ["purple", "Purple"],
+              ]}
+            />
           </Row>
         </Panel>
       );
@@ -441,12 +873,41 @@ function SectionBody({ section }: { section: SectionId }) {
       return (
         <Panel title="Network">
           <Row label="DNS provider">
-            <Select value={settings.dnsProvider} onChange={(v) => set({ dnsProvider: v })}
-              options={[["system", "System"], ["cloudflare", "Cloudflare"], ["google", "Google"], ["adguard", "AdGuard"], ["quad9", "Quad9"]]} />
+            <Select
+              value={settings.dnsProvider}
+              onChange={(v) => set({ dnsProvider: v })}
+              options={[
+                ["system", "System"],
+                ["cloudflare", "Cloudflare"],
+                ["google", "Google"],
+                ["adguard", "AdGuard"],
+                ["quad9", "Quad9"],
+              ]}
+            />
           </Row>
-          <Row label="Show loading statistics"><Toggle value={settings.showLoadingStats} onChange={(v) => set({ showLoadingStats: v })} /></Row>
-          <Row label="Custom user agent" hint="Cloud-saved for Android; browsers may ignore it"><input value={settings.customUserAgent} onChange={(e) => set({ customUserAgent: e.target.value })} placeholder="Default" /></Row>
-          <Row label="TorrServer base URL" hint="Cloud-saved for Android"><input value={settings.torrServerBaseUrl} onChange={(e) => set({ torrServerBaseUrl: e.target.value })} placeholder="http://127.0.0.1:8090" /></Row>
+          <Row label="Show loading statistics">
+            <Toggle
+              value={settings.showLoadingStats}
+              onChange={(v) => set({ showLoadingStats: v })}
+            />
+          </Row>
+          <Row
+            label="Custom user agent"
+            hint="Cloud-saved for Android; browsers may ignore it"
+          >
+            <input
+              value={settings.customUserAgent}
+              onChange={(e) => set({ customUserAgent: e.target.value })}
+              placeholder="Default"
+            />
+          </Row>
+          <Row label="TorrServer base URL" hint="Cloud-saved for Android">
+            <input
+              value={settings.torrServerBaseUrl}
+              onChange={(e) => set({ torrServerBaseUrl: e.target.value })}
+              placeholder="http://127.0.0.1:8090"
+            />
+          </Row>
         </Panel>
       );
     case "tv":
@@ -467,7 +928,9 @@ function safeArray<T>(value: T[] | null | undefined): T[] {
 }
 
 function fallbackId(prefix: string, index: number, preferred?: string | null) {
-  return preferred && String(preferred).trim() ? String(preferred) : `${prefix}-${index}`;
+  return preferred && String(preferred).trim()
+    ? String(preferred)
+    : `${prefix}-${index}`;
 }
 
 function Panel({ title, children }: { title: string; children: ReactNode }) {
@@ -482,11 +945,23 @@ function Panel({ title, children }: { title: string; children: ReactNode }) {
 /* ---------- Accounts ---------- */
 
 function AccountsSection() {
-  const { auth, traktConnected, deviceCode, signIn, signOut, beginTrakt, pollTrakt, disconnectTrakt, refreshData } = useApp();
+  const {
+    auth,
+    traktConnected,
+    deviceCode,
+    signIn,
+    signOut,
+    beginTrakt,
+    pollTrakt,
+    disconnectTrakt,
+    refreshData,
+  } = useApp();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loginError, setLoginError] = useState<string | null>(null);
-  const [loginBusy, setLoginBusy] = useState<"sign-in" | "sign-up" | null>(null);
+  const [loginBusy, setLoginBusy] = useState<"sign-in" | "sign-up" | null>(
+    null,
+  );
   const [traktError, setTraktError] = useState<string | null>(null);
   const [traktBusy, setTraktBusy] = useState<"start" | "poll" | null>(null);
   const [syncBusy, setSyncBusy] = useState(false);
@@ -504,7 +979,9 @@ function AccountsSection() {
       setEmail("");
       setPassword("");
     } catch (error) {
-      setLoginError(error instanceof Error ? error.message : "Authentication failed.");
+      setLoginError(
+        error instanceof Error ? error.message : "Authentication failed.",
+      );
     } finally {
       setLoginBusy(null);
     }
@@ -516,7 +993,11 @@ function AccountsSection() {
     try {
       await beginTrakt();
     } catch (error) {
-      setTraktError(error instanceof Error ? error.message : "Could not start Trakt device link.");
+      setTraktError(
+        error instanceof Error
+          ? error.message
+          : "Could not start Trakt device link.",
+      );
     } finally {
       setTraktBusy(null);
     }
@@ -528,7 +1009,11 @@ function AccountsSection() {
     try {
       await pollTrakt();
     } catch (error) {
-      setTraktError(error instanceof Error ? error.message : "Trakt has not approved this device yet.");
+      setTraktError(
+        error instanceof Error
+          ? error.message
+          : "Trakt has not approved this device yet.",
+      );
     } finally {
       setTraktBusy(null);
     }
@@ -546,22 +1031,59 @@ function AccountsSection() {
   return (
     <>
       <Panel title="ARVIO Account">
-        {!cloudConfigured && <p className="empty">ARVIO Cloud backend env is missing. Add backend values in web/.env.local.</p>}
+        {!cloudConfigured && (
+          <p className="empty">
+            ARVIO Cloud backend env is missing. Add backend values in
+            web/.env.local.
+          </p>
+        )}
         <div className="settings-status-grid">
-          <div><span>Cloud</span><strong>{auth ? "Connected" : cloudConfigured ? "Ready" : "Missing config"}</strong></div>
-          <div><span>Trakt</span><strong>{traktConnected ? "Connected" : hasTraktConfig() ? "Not linked" : "Missing config"}</strong></div>
-          <div><span>Sync</span><strong>{auth ? "Cloud saved" : "Local only"}</strong></div>
+          <div>
+            <span>Cloud</span>
+            <strong>
+              {auth
+                ? "Connected"
+                : cloudConfigured
+                  ? "Ready"
+                  : "Missing config"}
+            </strong>
+          </div>
+          <div>
+            <span>Trakt</span>
+            <strong>
+              {traktConnected
+                ? "Connected"
+                : hasTraktConfig()
+                  ? "Not linked"
+                  : "Missing config"}
+            </strong>
+          </div>
+          <div>
+            <span>Sync</span>
+            <strong>{auth ? "Cloud saved" : "Local only"}</strong>
+          </div>
         </div>
         {loginError && <p className="login-error">{loginError}</p>}
         {auth ? (
           <div className="account-row">
             <UserCircle size={34} />
-            <div className="account-copy"><strong>{auth.email}</strong><span title={auth.userId}>ARVIO Cloud account</span></div>
-            <button type="button" className="secondary" onClick={signOut}><LogOut size={18} /> Sign out</button>
+            <div className="account-copy">
+              <strong>{auth.email}</strong>
+              <span title={auth.userId}>ARVIO Cloud account</span>
+            </div>
+            <button type="button" className="secondary" onClick={signOut}>
+              <LogOut size={18} /> Sign out
+            </button>
           </div>
         ) : (
           <div className="login-form">
-            <input value={email} onChange={(e) => setEmail(e.target.value)} placeholder="Email" type="email" autoComplete="email" />
+            <input
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="Email"
+              type="email"
+              autoComplete="email"
+            />
             <input
               value={password}
               onChange={(e) => setPassword(e.target.value)}
@@ -573,10 +1095,20 @@ function AccountsSection() {
               }}
             />
             <div className="hero-actions">
-              <button type="button" className="primary" disabled={Boolean(loginBusy) || !cloudConfigured} onClick={() => void submitCloudAuth("sign-in")}>
+              <button
+                type="button"
+                className="primary"
+                disabled={Boolean(loginBusy) || !cloudConfigured}
+                onClick={() => void submitCloudAuth("sign-in")}
+              >
                 {loginBusy === "sign-in" ? "Signing in..." : "Sign in"}
               </button>
-              <button type="button" className="secondary" disabled={Boolean(loginBusy) || !cloudConfigured} onClick={() => void submitCloudAuth("sign-up")}>
+              <button
+                type="button"
+                className="secondary"
+                disabled={Boolean(loginBusy) || !cloudConfigured}
+                onClick={() => void submitCloudAuth("sign-up")}
+              >
                 {loginBusy === "sign-up" ? "Creating..." : "Create"}
               </button>
             </div>
@@ -585,20 +1117,34 @@ function AccountsSection() {
       </Panel>
 
       <Panel title="Trakt">
-        {!hasTraktConfig() && <p className="empty">Trakt client id is missing.</p>}
+        {!hasTraktConfig() && (
+          <p className="empty">Trakt client id is missing.</p>
+        )}
         {traktError && <p className="login-error">{traktError}</p>}
         {traktConnected ? (
-          <button type="button" className="secondary" onClick={disconnectTrakt}>Disconnect Trakt</button>
+          <button type="button" className="secondary" onClick={disconnectTrakt}>
+            Disconnect Trakt
+          </button>
         ) : (
           <>
-            <button type="button" className="primary" disabled={traktBusy === "start" || !hasTraktConfig()} onClick={() => void startTraktLink()}>
+            <button
+              type="button"
+              className="primary"
+              disabled={traktBusy === "start" || !hasTraktConfig()}
+              onClick={() => void startTraktLink()}
+            >
               {traktBusy === "start" ? "Starting..." : "Start device link"}
             </button>
             {deviceCode && (
               <div className="device-code">
                 <span>{deviceCode.user_code}</span>
                 <p>Open {deviceCode.verification_url}</p>
-                <button type="button" className="secondary" disabled={traktBusy === "poll"} onClick={() => void approveTraktLink()}>
+                <button
+                  type="button"
+                  className="secondary"
+                  disabled={traktBusy === "poll"}
+                  onClick={() => void approveTraktLink()}
+                >
                   {traktBusy === "poll" ? "Checking..." : "I approved it"}
                 </button>
               </div>
@@ -608,11 +1154,30 @@ function AccountsSection() {
       </Panel>
 
       <Panel title="Sync & Updates">
-        <button type="button" className="secondary text-button" disabled={syncBusy} onClick={() => void syncNow()}><RefreshCw size={18} /> {syncBusy ? "Syncing..." : "Force cloud sync now"}</button>
-        <p className="empty">Telegram bot setup is available in the Android app. The web app updates itself when a new version is deployed.</p>
+        <button
+          type="button"
+          className="secondary text-button"
+          disabled={syncBusy}
+          onClick={() => void syncNow()}
+        >
+          <RefreshCw size={18} />{" "}
+          {syncBusy ? "Syncing..." : "Force cloud sync now"}
+        </button>
         <p className="empty">
-          Web build: {process.env.NEXT_PUBLIC_BUILD_STAMP
-            ? new Date(Number(process.env.NEXT_PUBLIC_BUILD_STAMP)).toLocaleString("en-GB", { day: "2-digit", month: "short", hour: "2-digit", minute: "2-digit" })
+          Telegram bot setup is available in the Android app. The web app
+          updates itself when a new version is deployed.
+        </p>
+        <p className="empty">
+          Web build:{" "}
+          {process.env.NEXT_PUBLIC_BUILD_STAMP
+            ? new Date(
+                Number(process.env.NEXT_PUBLIC_BUILD_STAMP),
+              ).toLocaleString("en-GB", {
+                day: "2-digit",
+                month: "short",
+                hour: "2-digit",
+                minute: "2-digit",
+              })
             : "unknown"}
         </p>
       </Panel>
@@ -633,7 +1198,8 @@ function HomeServerSection() {
   const [testing, setTesting] = useState(false);
 
   const servers = safeArray(settings.homeServers);
-  const update = (next: HomeServerConfig[]) => updateSettings({ homeServers: next });
+  const update = (next: HomeServerConfig[]) =>
+    updateSettings({ homeServers: next });
 
   const buildDraft = (): HomeServerConfig => ({
     id: crypto.randomUUID(),
@@ -643,7 +1209,7 @@ function HomeServerSection() {
     token: token.trim() || undefined,
     username: username.trim() || undefined,
     password: password || undefined,
-    enabled: true
+    enabled: true,
   });
 
   const testConnection = async () => {
@@ -659,11 +1225,15 @@ function HomeServerSection() {
     try {
       const { testHomeServerConnection } = await import("@/lib/homeserver");
       const result = await testHomeServerConnection(buildDraft());
-      setToast(result.ok
-        ? `Connected to ${result.serverName || "server"}${result.libraryCount ? ` — ${result.libraryCount} libraries` : ""}.`
-        : `Could not connect: ${result.error}`);
+      setToast(
+        result.ok
+          ? `Connected to ${result.serverName || "server"}${result.libraryCount ? ` — ${result.libraryCount} libraries` : ""}.`
+          : `Could not connect: ${result.error}`,
+      );
     } catch (error) {
-      setToast(error instanceof Error ? error.message : "Connection test failed.");
+      setToast(
+        error instanceof Error ? error.message : "Connection test failed.",
+      );
     } finally {
       setTesting(false);
     }
@@ -671,40 +1241,116 @@ function HomeServerSection() {
 
   return (
     <Panel title="Home Server">
-      <p className="empty">Connect Plex, Jellyfin, or Emby. Plex requires an access token (X-Plex-Token). Jellyfin/Emby can use an API token or username + password. Matched movies and episodes appear as sources in the player, and cloud-sync with the Android app.</p>
+      <p className="empty">
+        Connect Plex, Jellyfin, or Emby. Plex requires an access token
+        (X-Plex-Token). Jellyfin/Emby can use an API token or username +
+        password. Matched movies and episodes appear as sources in the player,
+        and cloud-sync with the Android app.
+      </p>
       <div className="inline-form">
-        <Select value={type} onChange={setType} options={[["jellyfin", "Jellyfin"], ["emby", "Emby"], ["plex", "Plex"]]} />
-        <input value={name} onChange={(e) => setName(e.target.value)} placeholder="Name" />
-        <input value={url} onChange={(e) => setUrl(e.target.value)} placeholder="https://server:8096" />
-        <input value={token} onChange={(e) => setToken(e.target.value)} placeholder={type === "plex" ? "X-Plex-Token (required)" : "API token (optional)"} />
-        {type !== "plex" && <input value={username} onChange={(e) => setUsername(e.target.value)} placeholder="Username (optional)" />}
-        {type !== "plex" && <input value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Password" type="password" />}
-        <button type="button" className="secondary" disabled={testing} onClick={() => void testConnection()}>
+        <Select
+          value={type}
+          onChange={setType}
+          options={[
+            ["jellyfin", "Jellyfin"],
+            ["emby", "Emby"],
+            ["plex", "Plex"],
+          ]}
+        />
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Name"
+        />
+        <input
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://server:8096"
+        />
+        <input
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          placeholder={
+            type === "plex" ? "X-Plex-Token (required)" : "API token (optional)"
+          }
+        />
+        {type !== "plex" && (
+          <input
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            placeholder="Username (optional)"
+          />
+        )}
+        {type !== "plex" && (
+          <input
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Password"
+            type="password"
+          />
+        )}
+        <button
+          type="button"
+          className="secondary"
+          disabled={testing}
+          onClick={() => void testConnection()}
+        >
           {testing ? "Testing…" : "Test"}
         </button>
-        <button type="button" className="primary" onClick={() => {
-          if (!url.trim()) {
-            setToast("Enter a Home Server URL first.");
-            return;
-          }
-          update([buildDraft(), ...servers]);
-          setName(""); setUrl(""); setToken(""); setUsername(""); setPassword("");
-          setToast("Home server saved.");
-        }}><Plus size={18} /> Add</button>
+        <button
+          type="button"
+          className="primary"
+          onClick={() => {
+            if (!url.trim()) {
+              setToast("Enter a Home Server URL first.");
+              return;
+            }
+            update([buildDraft(), ...servers]);
+            setName("");
+            setUrl("");
+            setToken("");
+            setUsername("");
+            setPassword("");
+            setToast("Home server saved.");
+          }}
+        >
+          <Plus size={18} /> Add
+        </button>
       </div>
       <div className="settings-list">
         {servers.map((server, index) => (
-          <div className="settings-list-row server-row" key={fallbackId("server", index, server.id)}>
-            <button type="button" className="icon-button" onClick={() => update(servers.map((s) => s.id === server.id ? { ...s, enabled: !s.enabled } : s))}>
+          <div
+            className="settings-list-row server-row"
+            key={fallbackId("server", index, server.id)}
+          >
+            <button
+              type="button"
+              className="icon-button"
+              onClick={() =>
+                update(
+                  servers.map((s) =>
+                    s.id === server.id ? { ...s, enabled: !s.enabled } : s,
+                  ),
+                )
+              }
+            >
               {server.enabled ? <Eye size={18} /> : <EyeOff size={18} />}
             </button>
             <strong>{server.name || server.type || "Home server"}</strong>
             <span>{server.type || "server"}</span>
             <span>{server.url || "No URL"}</span>
-            <button type="button" className="icon-button danger" onClick={() => update(servers.filter((s) => s.id !== server.id))}><Trash2 size={18} /></button>
+            <button
+              type="button"
+              className="icon-button danger"
+              onClick={() => update(servers.filter((s) => s.id !== server.id))}
+            >
+              <Trash2 size={18} />
+            </button>
           </div>
         ))}
-        {servers.length === 0 && <p className="empty">No home servers configured.</p>}
+        {servers.length === 0 && (
+          <p className="empty">No home servers configured.</p>
+        )}
       </div>
     </Panel>
   );
@@ -716,7 +1362,8 @@ function TvSettingsSection() {
   const [m3uUrl, setM3uUrl] = useState("");
   const [epgUrl, setEpgUrl] = useState("");
   const playlists = safeArray(settings.iptvPlaylists);
-  const updatePlaylists = (next: IptvPlaylistEntry[]) => updateSettings({ iptvPlaylists: next });
+  const updatePlaylists = (next: IptvPlaylistEntry[]) =>
+    updateSettings({ iptvPlaylists: next });
   const isLoadingTv = Boolean(busy && busy.toLowerCase().includes("tv"));
 
   const addPlaylist = () => {
@@ -734,13 +1381,16 @@ function TvSettingsSection() {
       setToast("EPG URL must start with http:// or https://.");
       return;
     }
-    updatePlaylists([{
-      id: crypto.randomUUID(),
-      name: name.trim() || "IPTV Playlist",
-      m3uUrl: trimmedM3u,
-      epgUrl: trimmedEpg,
-      enabled: true
-    }, ...playlists]);
+    updatePlaylists([
+      {
+        id: crypto.randomUUID(),
+        name: name.trim() || "IPTV Playlist",
+        m3uUrl: trimmedM3u,
+        epgUrl: trimmedEpg,
+        enabled: true,
+      },
+      ...playlists,
+    ]);
     setName("");
     setM3uUrl("");
     setEpgUrl("");
@@ -749,30 +1399,128 @@ function TvSettingsSection() {
 
   return (
     <Panel title="TV (IPTV)">
-      <p className="empty">{playlists.length} playlist(s) configured. These are cloud-saved and used by the TV page.</p>
+      <p className="empty">
+        {playlists.length} playlist(s) configured. These are cloud-saved and
+        used by the TV page.
+      </p>
       <div className="inline-form wide">
-        <input value={name} onChange={(e) => setName(e.target.value)} placeholder="Playlist name" />
-        <input value={m3uUrl} onChange={(e) => setM3uUrl(e.target.value)} placeholder="M3U playlist URL" />
-        <input value={epgUrl} onChange={(e) => setEpgUrl(e.target.value)} placeholder="EPG XMLTV URL (optional)" />
-        <button type="button" className="primary" onClick={addPlaylist}><Plus size={18} /> Add playlist</button>
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Playlist name"
+        />
+        <input
+          value={m3uUrl}
+          onChange={(e) => setM3uUrl(e.target.value)}
+          placeholder="M3U playlist URL"
+        />
+        <input
+          value={epgUrl}
+          onChange={(e) => setEpgUrl(e.target.value)}
+          placeholder="EPG XMLTV URL (optional)"
+        />
+        <button type="button" className="primary" onClick={addPlaylist}>
+          <Plus size={18} /> Add playlist
+        </button>
       </div>
       <div className="settings-list">
         {playlists.map((playlist, index) => (
-          <div className="settings-list-row iptv-row" key={fallbackId("playlist", index, playlist.id)}>
-            <button type="button" className="icon-button" onClick={() => updatePlaylists(playlists.map((item) => item.id === playlist.id ? { ...item, enabled: !item.enabled } : item))}>
+          <div
+            className="settings-list-row iptv-row"
+            key={fallbackId("playlist", index, playlist.id)}
+          >
+            <button
+              type="button"
+              className="icon-button"
+              onClick={() =>
+                updatePlaylists(
+                  playlists.map((item) =>
+                    item.id === playlist.id
+                      ? { ...item, enabled: !item.enabled }
+                      : item,
+                  ),
+                )
+              }
+            >
               {playlist.enabled ? <Eye size={18} /> : <EyeOff size={18} />}
             </button>
-            <input value={playlist.name} onChange={(e) => updatePlaylists(playlists.map((item) => item.id === playlist.id ? { ...item, name: e.target.value } : item))} />
-            <input value={playlist.m3uUrl} onChange={(e) => updatePlaylists(playlists.map((item) => item.id === playlist.id ? { ...item, m3uUrl: e.target.value } : item))} />
-            <input value={playlist.epgUrl ?? ""} onChange={(e) => updatePlaylists(playlists.map((item) => item.id === playlist.id ? { ...item, epgUrl: e.target.value } : item))} placeholder="EPG URL" />
-            <button type="button" className="icon-button danger" onClick={() => updatePlaylists(playlists.filter((item) => item.id !== playlist.id))}><Trash2 size={18} /></button>
+            <input
+              value={playlist.name}
+              onChange={(e) =>
+                updatePlaylists(
+                  playlists.map((item) =>
+                    item.id === playlist.id
+                      ? { ...item, name: e.target.value }
+                      : item,
+                  ),
+                )
+              }
+            />
+            <input
+              value={playlist.m3uUrl}
+              onChange={(e) =>
+                updatePlaylists(
+                  playlists.map((item) =>
+                    item.id === playlist.id
+                      ? { ...item, m3uUrl: e.target.value }
+                      : item,
+                  ),
+                )
+              }
+            />
+            <input
+              value={playlist.epgUrl ?? ""}
+              onChange={(e) =>
+                updatePlaylists(
+                  playlists.map((item) =>
+                    item.id === playlist.id
+                      ? { ...item, epgUrl: e.target.value }
+                      : item,
+                  ),
+                )
+              }
+              placeholder="EPG URL"
+            />
+            <button
+              type="button"
+              className="icon-button danger"
+              onClick={() =>
+                updatePlaylists(
+                  playlists.filter((item) => item.id !== playlist.id),
+                )
+              }
+            >
+              <Trash2 size={18} />
+            </button>
           </div>
         ))}
-        {!playlists.length && <p className="empty">No IPTV playlists configured.</p>}
+        {!playlists.length && (
+          <p className="empty">No IPTV playlists configured.</p>
+        )}
       </div>
-      <button type="button" className="secondary text-button" disabled={isLoadingTv} onClick={() => void refreshIptv()}><RefreshCw size={18} /> {isLoadingTv ? "Refreshing..." : "Refresh TV now"}</button>
-      <Row label="Stalker portal URL"><input value={settings.iptvStalkerUrl} onChange={(e) => updateSettings({ iptvStalkerUrl: e.target.value })} placeholder="http://portal.example.com/c/" /></Row>
-      <Row label="Stalker MAC address"><input value={settings.iptvStalkerMac} onChange={(e) => updateSettings({ iptvStalkerMac: e.target.value })} placeholder="00:1A:79:00:00:00" /></Row>
+      <button
+        type="button"
+        className="secondary text-button"
+        disabled={isLoadingTv}
+        onClick={() => void refreshIptv()}
+      >
+        <RefreshCw size={18} />{" "}
+        {isLoadingTv ? "Refreshing..." : "Refresh TV now"}
+      </button>
+      <Row label="Stalker portal URL">
+        <input
+          value={settings.iptvStalkerUrl}
+          onChange={(e) => updateSettings({ iptvStalkerUrl: e.target.value })}
+          placeholder="http://portal.example.com/c/"
+        />
+      </Row>
+      <Row label="Stalker MAC address">
+        <input
+          value={settings.iptvStalkerMac}
+          onChange={(e) => updateSettings({ iptvStalkerMac: e.target.value })}
+          placeholder="00:1A:79:00:00:00"
+        />
+      </Row>
     </Panel>
   );
 }
@@ -781,13 +1529,17 @@ function TvSettingsSection() {
 
 function CatalogsSection() {
   const { settings, updateSettings, setToast } = useApp();
-  const catalogs = mergeCatalogs(safeArray(settings.catalogs), safeArray(settings.hiddenCatalogIds));
+  const catalogs = mergeCatalogs(
+    safeArray(settings.catalogs),
+    safeArray(settings.hiddenCatalogIds),
+  );
   const [customCatalogUrl, setCustomCatalogUrl] = useState("");
 
-  const updateCatalogs = (next: CatalogConfig[]) => updateSettings({
-    catalogs: next,
-    hiddenCatalogIds: next.filter((c) => !c.enabled).map((c) => c.id)
-  });
+  const updateCatalogs = (next: CatalogConfig[]) =>
+    updateSettings({
+      catalogs: next,
+      hiddenCatalogIds: next.filter((c) => !c.enabled).map((c) => c.id),
+    });
   const moveCatalog = (id: string, offset: number) => {
     const index = catalogs.findIndex((c) => c.id === id);
     const target = index + offset;
@@ -801,32 +1553,124 @@ function CatalogsSection() {
   return (
     <Panel title="Catalogs (Home Rows)">
       <div className="inline-form">
-        <input value={customCatalogUrl} onChange={(e) => setCustomCatalogUrl(e.target.value)} placeholder="https://mdblist.com/lists/user/list" />
-        <button type="button" className="primary" onClick={() => {
-          if (!customCatalogUrl.trim()) {
-            setToast("Enter a catalog URL first.");
-            return;
-          }
-          updateCatalogs([{ id: `custom_${crypto.randomUUID()}`, name: "Custom MDBList", sourceType: "mdblist", mediaType: "all", sourceUrl: customCatalogUrl.trim(), enabled: true }, ...catalogs]);
-          setCustomCatalogUrl("");
-        }}><Plus size={18} /> Add</button>
-        <button type="button" className="secondary text-button" onClick={() => updateCatalogs(defaultCatalogs)}><RotateCcw size={18} /> Reset</button>
+        <input
+          value={customCatalogUrl}
+          onChange={(e) => setCustomCatalogUrl(e.target.value)}
+          placeholder="https://mdblist.com/lists/user/list"
+        />
+        <button
+          type="button"
+          className="primary"
+          onClick={() => {
+            if (!customCatalogUrl.trim()) {
+              setToast("Enter a catalog URL first.");
+              return;
+            }
+            updateCatalogs([
+              {
+                id: `custom_${crypto.randomUUID()}`,
+                name: "Custom MDBList",
+                sourceType: "mdblist",
+                mediaType: "all",
+                sourceUrl: customCatalogUrl.trim(),
+                enabled: true,
+              },
+              ...catalogs,
+            ]);
+            setCustomCatalogUrl("");
+          }}
+        >
+          <Plus size={18} /> Add
+        </button>
+        <button
+          type="button"
+          className="secondary text-button"
+          onClick={() => updateCatalogs(defaultCatalogs)}
+        >
+          <RotateCcw size={18} /> Reset
+        </button>
       </div>
       <div className="settings-list">
         {catalogs.map((catalog, index) => (
-          <div className="settings-list-row catalog-row" key={fallbackId("catalog", index, catalog.id)}>
-            <button type="button" className="icon-button" onClick={() => updateCatalogs(catalogs.map((c) => c.id === catalog.id ? { ...c, enabled: !c.enabled } : c))}>
+          <div
+            className="settings-list-row catalog-row"
+            key={fallbackId("catalog", index, catalog.id)}
+          >
+            <button
+              type="button"
+              className="icon-button"
+              onClick={() =>
+                updateCatalogs(
+                  catalogs.map((c) =>
+                    c.id === catalog.id ? { ...c, enabled: !c.enabled } : c,
+                  ),
+                )
+              }
+            >
               {catalog.enabled ? <Eye size={18} /> : <EyeOff size={18} />}
             </button>
-            <input value={catalog.name} onChange={(e) => updateCatalogs(catalogs.map((c) => c.id === catalog.id ? { ...c, name: e.target.value } : c))} />
+            <input
+              value={catalog.name}
+              onChange={(e) =>
+                updateCatalogs(
+                  catalogs.map((c) =>
+                    c.id === catalog.id ? { ...c, name: e.target.value } : c,
+                  ),
+                )
+              }
+            />
             <span>{(catalog.sourceType || "custom").toUpperCase()}</span>
-            <Select value={catalog.layout ?? "landscape"} onChange={(layout) => updateCatalogs(catalogs.map((c) => c.id === catalog.id ? { ...c, layout } : c))}
-              options={[["landscape", "Landscape"], ["poster", "Poster"]]} />
-            <button type="button" className="icon-button" disabled={index === 0} onClick={() => moveCatalog(catalog.id, -1)} aria-label={`Move ${catalog.name} up`}><ArrowUp size={18} /></button>
-            <button type="button" className="icon-button" disabled={index === catalogs.length - 1} onClick={() => moveCatalog(catalog.id, 1)} aria-label={`Move ${catalog.name} down`}><ArrowDown size={18} /></button>
-            {!catalog.isPreinstalled && <button type="button" className="icon-button danger" onClick={() => updateCatalogs(catalogs.filter((c) => c.id !== catalog.id))}><Trash2 size={18} /></button>}
-            {(catalog.sourceUrl || catalog.endpoint || catalog.addonCatalogId) && (
-              <small className="catalog-source-line">{catalog.sourceUrl || catalog.endpoint || catalog.addonCatalogId}</small>
+            <Select
+              value={catalog.layout ?? "landscape"}
+              onChange={(layout) =>
+                updateCatalogs(
+                  catalogs.map((c) =>
+                    c.id === catalog.id ? { ...c, layout } : c,
+                  ),
+                )
+              }
+              options={[
+                ["landscape", "Landscape"],
+                ["poster", "Poster"],
+              ]}
+            />
+            <button
+              type="button"
+              className="icon-button"
+              disabled={index === 0}
+              onClick={() => moveCatalog(catalog.id, -1)}
+              aria-label={`Move ${catalog.name} up`}
+            >
+              <ArrowUp size={18} />
+            </button>
+            <button
+              type="button"
+              className="icon-button"
+              disabled={index === catalogs.length - 1}
+              onClick={() => moveCatalog(catalog.id, 1)}
+              aria-label={`Move ${catalog.name} down`}
+            >
+              <ArrowDown size={18} />
+            </button>
+            {!catalog.isPreinstalled && (
+              <button
+                type="button"
+                className="icon-button danger"
+                onClick={() =>
+                  updateCatalogs(catalogs.filter((c) => c.id !== catalog.id))
+                }
+              >
+                <Trash2 size={18} />
+              </button>
+            )}
+            {(catalog.sourceUrl ||
+              catalog.endpoint ||
+              catalog.addonCatalogId) && (
+              <small className="catalog-source-line">
+                {catalog.sourceUrl ||
+                  catalog.endpoint ||
+                  catalog.addonCatalogId}
+              </small>
             )}
           </div>
         ))}
@@ -838,7 +1682,8 @@ function CatalogsSection() {
 /* ---------- Addons ---------- */
 
 function AddonsSection() {
-  const { addons, installAddon, removeAddon, setAddonsState, setToast } = useApp();
+  const { addons, installAddon, removeAddon, setAddonsState, setToast } =
+    useApp();
   const [addonUrl, setAddonUrl] = useState("");
   const [installing, setInstalling] = useState(false);
   const install = async () => {
@@ -857,7 +1702,9 @@ function AddonsSection() {
       setAddonUrl("");
       setToast("Addon installed.");
     } catch (error) {
-      setToast(error instanceof Error ? error.message : "Could not install addon.");
+      setToast(
+        error instanceof Error ? error.message : "Could not install addon.",
+      );
     } finally {
       setInstalling(false);
     }
@@ -865,41 +1712,97 @@ function AddonsSection() {
   return (
     <Panel title="Stremio Addons">
       <div className="inline-form">
-        <input value={addonUrl} onChange={(e) => setAddonUrl(e.target.value)} placeholder="https://addon.example.com/manifest.json" />
-        <button type="button" className="primary" disabled={installing} onClick={() => void install()}><Plus size={18} /> {installing ? "Installing..." : "Install"}</button>
+        <input
+          value={addonUrl}
+          onChange={(e) => setAddonUrl(e.target.value)}
+          placeholder="https://addon.example.com/manifest.json"
+        />
+        <button
+          type="button"
+          className="primary"
+          disabled={installing}
+          onClick={() => void install()}
+        >
+          <Plus size={18} /> {installing ? "Installing..." : "Install"}
+        </button>
       </div>
       <div className="settings-list">
         {safeArray(addons).map((addon, index) => {
           const resources = safeArray(addon.resources);
           const addonCatalogs = safeArray(addon.catalogs);
-          const hasResource = (resource: string) => resources.length === 0 || resources.some((item) => typeof item === "string" ? item === resource : item?.name === resource);
+          const hasResource = (resource: string) =>
+            resources.length === 0 ||
+            resources.some((item) =>
+              typeof item === "string"
+                ? item === resource
+                : item?.name === resource,
+            );
           const canStream = hasResource("stream");
-          const resourceLabel = [
-            canStream ? "Streams" : "",
-            hasResource("subtitles") ? "Subtitles" : "",
-            addonCatalogs.length ? `${addonCatalogs.length} catalogs` : ""
-          ].filter(Boolean).join(" / ") || "Manifest";
+          const resourceLabel =
+            [
+              canStream ? "Streams" : "",
+              hasResource("subtitles") ? "Subtitles" : "",
+              addonCatalogs.length ? `${addonCatalogs.length} catalogs` : "",
+            ]
+              .filter(Boolean)
+              .join(" / ") || "Manifest";
           return (
-          <div className="settings-list-row addon-row" key={fallbackId("addon", index, addon.id || addon.manifestUrl)}>
-            <button type="button" className="icon-button" onClick={() => setAddonsState(addons.map((a) => a.id === addon.id ? { ...a, enabled: a.enabled === false } : a))}>
-              {addon.enabled === false ? <EyeOff size={18} /> : <Eye size={18} />}
-            </button>
-            <div className="addon-main">
-              <strong>{addon.name || "Unnamed addon"}</strong>
-              <span title={addon.manifestUrl}>{addon.manifestUrl}</span>
+            <div
+              className="settings-list-row addon-row"
+              key={fallbackId("addon", index, addon.id || addon.manifestUrl)}
+            >
+              <button
+                type="button"
+                className="icon-button"
+                onClick={() =>
+                  setAddonsState(
+                    addons.map((a) =>
+                      a.id === addon.id
+                        ? { ...a, enabled: a.enabled === false }
+                        : a,
+                    ),
+                  )
+                }
+              >
+                {addon.enabled === false ? (
+                  <EyeOff size={18} />
+                ) : (
+                  <Eye size={18} />
+                )}
+              </button>
+              <div className="addon-main">
+                <strong>{addon.name || "Unnamed addon"}</strong>
+                <span title={addon.manifestUrl}>{addon.manifestUrl}</span>
+              </div>
+              <span>{resourceLabel}</span>
+              <span>{addon.version || "1.0.0"}</span>
+              <button
+                type="button"
+                className="icon-button danger"
+                onClick={() => void removeAddon(addon)}
+                aria-label={`Remove ${addon.name || "addon"}`}
+              >
+                <Trash2 size={18} />
+              </button>
             </div>
-            <span>{resourceLabel}</span>
-            <span>{addon.version || "1.0.0"}</span>
-            <button type="button" className="icon-button danger" onClick={() => void removeAddon(addon)} aria-label={`Remove ${addon.name || "addon"}`}><Trash2 size={18} /></button>
-          </div>
           );
         })}
-        {addons.length === 0 && <p className="empty">Install Stremio-compatible addons by URL above.</p>}
+        {addons.length === 0 && (
+          <p className="empty">
+            Install Stremio-compatible addons by URL above.
+          </p>
+        )}
       </div>
-      <button type="button" className="secondary text-button danger reset-settings-button" onClick={() => {
-        localStorage.removeItem(settingsKey);
-        window.location.reload();
-      }}><Trash2 size={18} /> Reset all web settings</button>
+      <button
+        type="button"
+        className="secondary text-button danger reset-settings-button"
+        onClick={() => {
+          localStorage.removeItem(settingsKey);
+          window.location.reload();
+        }}
+      >
+        <Trash2 size={18} /> Reset all web settings
+      </button>
     </Panel>
   );
 }
@@ -913,14 +1816,16 @@ function SubtitlePreview({ settings }: { settings: AppSettings }) {
           className={previewClass}
           style={{
             color: settings.subtitleColor,
-            fontSize: `${Math.max(60, Math.min(200, settings.subtitleSize))}%`
+            fontSize: `${Math.max(60, Math.min(200, settings.subtitleSize))}%`,
           }}
         >
           This is how subtitles will appear.
         </span>
       </div>
-      <p>Preview updates instantly and is saved to cloud like Android subtitle settings.</p>
+      <p>
+        Preview updates instantly and is saved to cloud like Android subtitle
+        settings.
+      </p>
     </div>
   );
 }
-

--- a/web/components/shell/TopNav.tsx
+++ b/web/components/shell/TopNav.tsx
@@ -15,7 +15,6 @@ const nav = [
 
 export function TopNav() {
   const { section, setSection, switchProfile, activeProfile, avatarImages, settings, closeDetails, selected } = useApp();
-  const [clock, setClock] = useState("");
   const [scrolled, setScrolled] = useState(false);
 
   useEffect(() => {
@@ -25,18 +24,6 @@ export function TopNav() {
     return () => window.removeEventListener("scroll", onScroll);
   }, []);
 
-  useEffect(() => {
-    const updateClock = () => {
-      setClock(new Intl.DateTimeFormat([], {
-        hour: "2-digit",
-        minute: "2-digit",
-        hour12: settings.clockFormat === "12h"
-      }).format(new Date()));
-    };
-    updateClock();
-    const timer = window.setInterval(updateClock, 30_000);
-    return () => window.clearInterval(timer);
-  }, [settings.clockFormat]);
 
   return (
     <aside className={`sidebar ${scrolled ? "is-scrolled" : ""}`} aria-label="ARVIO navigation">
@@ -77,7 +64,7 @@ export function TopNav() {
         >
           <Settings size={26} />
         </button>
-        <span className="top-clock" suppressHydrationWarning>{clock}</span>
+
       </div>
     </aside>
   );


### PR DESCRIPTION
## Summary

Remove the clock/time display from the web application's top navigation bar.

## Rationale

A clock display is unnecessary in a web application. Unlike a TV or set-top box interface where the app is the primary full-screen experience, web users always have convenient access to the current time through:

- **Operating system taskbar/menu bar** (Windows, macOS, Linux)
- **Browser tab bar or status area**
- **Mobile device status bar** (iOS, Android)

Displaying a redundant clock in the navigation consumes valuable UI space and adds unnecessary JavaScript timer overhead (interval polling every 30 seconds).

## Changes

- **`web/components/shell/TopNav.tsx`** — Removed clock state, `useEffect` interval timer, and the `<span className="top-clock">` element
- **`web/app/globals.css`** — Removed `.top-clock` style block and cleaned up responsive media query selectors that referenced it