### PR TITLE
Implement support for multiple catalogs and dynamic discovery

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -67,6 +67,25 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
+            <!-- Custom Scheme: arvio://install-pack?url=... -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="arvio" android:host="install-pack" />
+            </intent-filter>
+
+            <!-- App Link: https://arvio.app/install-pack?url=... -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+                <data android:host="arvio.app" />
+                <data android:pathPrefix="/install-pack" />
+            </intent-filter>
+
         </activity>
 
         <!-- Crash Report Activity -->

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -75,16 +75,7 @@
                 <data android:scheme="arvio" android:host="install-pack" />
             </intent-filter>
 
-            <!-- App Link: https://arvio.app/install-pack?url=... -->
-            <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="http" />
-                <data android:scheme="https" />
-                <data android:host="arvio.app" />
-                <data android:pathPrefix="/install-pack" />
-            </intent-filter>
+
 
         </activity>
 

--- a/app/src/main/kotlin/com/arflix/tv/MainActivity.kt
+++ b/app/src/main/kotlin/com/arflix/tv/MainActivity.kt
@@ -166,6 +166,7 @@ class MainActivity : ComponentActivity() {
 
     private var jankStats: JankStats? = null
     private var pendingLauncherRequest by mutableStateOf<LauncherContinueWatchingRequest?>(null)
+    private var pendingInstallPackUrl by mutableStateOf<String?>(null)
 
     // StartupViewModel for parallel loading during splash
     private val startupViewModel: StartupViewModel by viewModels()
@@ -204,6 +205,7 @@ class MainActivity : ComponentActivity() {
         @Suppress("DEPRECATION")
         overridePendingTransition(0, 0)
         pendingLauncherRequest = parseLauncherRequest(intent)
+        pendingInstallPackUrl = parseInstallPackUrl(intent)
 
         val crashPrefs = getSharedPreferences("arvio_crash_store", Context.MODE_PRIVATE)
         if (crashPrefs.getBoolean("has_pending_crash_report", false)) {
@@ -356,6 +358,8 @@ class MainActivity : ComponentActivity() {
                         skipProfileSelection = skipProfileSelection,
                         pendingLauncherRequest = pendingLauncherRequest,
                         onConsumeLauncherRequest = { pendingLauncherRequest = null },
+                        pendingInstallPackUrl = pendingInstallPackUrl,
+                        onConsumeInstallPackUrl = { pendingInstallPackUrl = null },
                         preloadedCategories = startupState.categories,
                         preloadedHeroItem = startupState.heroItem,
                         preloadedHeroLogoUrl = startupState.heroLogoUrl,
@@ -394,6 +398,7 @@ class MainActivity : ComponentActivity() {
         super.onNewIntent(intent)
         setIntent(intent)
         pendingLauncherRequest = parseLauncherRequest(intent)
+        pendingInstallPackUrl = parseInstallPackUrl(intent)
     }
 
     override fun onWindowFocusChanged(hasFocus: Boolean) {
@@ -419,6 +424,19 @@ class MainActivity : ComponentActivity() {
 
 private fun MainActivity.parseLauncherRequest(intent: android.content.Intent?): LauncherContinueWatchingRequest? {
     return intent?.data?.toLauncherContinueWatchingRequest()
+}
+
+private fun MainActivity.parseInstallPackUrl(intent: android.content.Intent?): String? {
+    val data = intent?.data ?: return null
+    val scheme = data.scheme ?: return null
+    val host = data.host ?: return null
+    return if (scheme == "arvio" && host == "install-pack") {
+        data.getQueryParameter("url")
+    } else if ((scheme == "http" || scheme == "https") && host == "arvio.app" && data.path?.startsWith("/install-pack") == true) {
+        data.getQueryParameter("url")
+    } else {
+        null
+    }
 }
 
 private fun ComponentActivity.runAfterFirstDraw(block: () -> Unit) {
@@ -541,6 +559,8 @@ fun ArflixApp(
     skipProfileSelection: Boolean? = null,
     pendingLauncherRequest: LauncherContinueWatchingRequest? = null,
     onConsumeLauncherRequest: () -> Unit = {},
+    pendingInstallPackUrl: String? = null,
+    onConsumeInstallPackUrl: () -> Unit = {},
     preloadedCategories: List<com.arflix.tv.data.model.Category> = emptyList(),
     preloadedHeroItem: com.arflix.tv.data.model.MediaItem? = null,
     preloadedHeroLogoUrl: String? = null,
@@ -689,6 +709,19 @@ fun ArflixApp(
             launchSingleTop = true
         }
         onConsumeLauncherRequest()
+    }
+
+    LaunchedEffect(activeProfile?.id, pendingInstallPackUrl) {
+        val packUrl = pendingInstallPackUrl ?: return@LaunchedEffect
+        if (activeProfile == null) return@LaunchedEffect
+
+        val encodedUrl = java.net.URLEncoder.encode(packUrl, "UTF-8")
+        val route = "settings?initialSection=catalogs&installPackUrl=$encodedUrl"
+        navController.navigate(route) {
+            popUpTo(Screen.ProfileSelection.route) { inclusive = true }
+            launchSingleTop = true
+        }
+        onConsumeInstallPackUrl()
     }
 }
 

--- a/app/src/main/kotlin/com/arflix/tv/data/model/CatalogModels.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/model/CatalogModels.kt
@@ -105,6 +105,33 @@ data class CatalogConfig(
     val packName: String? = null
 ) : Serializable
 
+val CatalogConfig.effectivePackId: String
+    get() = packId ?: when (sourceType) {
+        CatalogSourceType.PREINSTALLED -> "system"
+        CatalogSourceType.ADDON -> "addon"
+        CatalogSourceType.TRAKT -> "trakt"
+        CatalogSourceType.MDBLIST -> "mdblist"
+        CatalogSourceType.HOME_SERVER -> "home_server"
+    }
+
+val CatalogConfig.effectivePackName: String
+    get() = packName ?: when (sourceType) {
+        CatalogSourceType.PREINSTALLED -> "System Catalogs"
+        CatalogSourceType.ADDON -> "Addon Catalogs"
+        CatalogSourceType.TRAKT -> "Trakt Catalogs"
+        CatalogSourceType.MDBLIST -> "MDBlist Catalogs"
+        CatalogSourceType.HOME_SERVER -> "Home Server Catalogs"
+    }
+
+val CatalogConfig.isBulkDeletablePack: Boolean
+    get() = packId != null &&
+            packId != "system" &&
+            packId != "addon" &&
+            packId != "trakt" &&
+            packId != "mdblist" &&
+            packId != "home_server" &&
+            packId != "individual"
+
 data class CatalogDiscoveryResult(
     val id: String,
     val title: String,

--- a/app/src/main/kotlin/com/arflix/tv/data/model/CatalogModels.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/model/CatalogModels.kt
@@ -100,7 +100,9 @@ data class CatalogConfig(
     val collectionTileShape: CollectionTileShape = CollectionTileShape.LANDSCAPE,
     val collectionHideTitle: Boolean = false,
     val collectionSources: List<CollectionSourceConfig> = emptyList(),
-    val requiredAddonUrls: List<String> = emptyList()
+    val requiredAddonUrls: List<String> = emptyList(),
+    val packId: String? = null,
+    val packName: String? = null
 ) : Serializable
 
 data class CatalogDiscoveryResult(
@@ -123,3 +125,18 @@ data class CatalogValidationResult(
     val sourceType: CatalogSourceType? = null,
     val error: String? = null
 )
+
+data class CatalogPackManifest(
+    val id: String,
+    val name: String,
+    val author: String? = null,
+    val version: String? = null,
+    val description: String? = null,
+    val catalogs: List<CatalogPackItem>
+) : Serializable
+
+data class CatalogPackItem(
+    val name: String,
+    val url: String
+) : Serializable
+

--- a/app/src/main/kotlin/com/arflix/tv/data/model/CatalogModels.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/model/CatalogModels.kt
@@ -166,4 +166,3 @@ data class CatalogPackItem(
     val name: String?,
     val url: String?
 ) : Serializable
-

--- a/app/src/main/kotlin/com/arflix/tv/data/model/CatalogModels.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/model/CatalogModels.kt
@@ -154,16 +154,16 @@ data class CatalogValidationResult(
 )
 
 data class CatalogPackManifest(
-    val id: String,
-    val name: String,
+    val id: String?,
+    val name: String?,
     val author: String? = null,
     val version: String? = null,
     val description: String? = null,
-    val catalogs: List<CatalogPackItem>
+    val catalogs: List<CatalogPackItem>?
 ) : Serializable
 
 data class CatalogPackItem(
-    val name: String,
-    val url: String
+    val name: String?,
+    val url: String?
 ) : Serializable
 

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/CatalogRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/CatalogRepository.kt
@@ -10,6 +10,8 @@ import com.arflix.tv.data.model.AddonCatalog
 import com.arflix.tv.data.model.AddonType
 import com.arflix.tv.data.model.CatalogConfig
 import com.arflix.tv.data.model.CatalogKind
+import com.arflix.tv.data.model.CatalogPackManifest
+import com.arflix.tv.data.model.CatalogPackItem
 import com.arflix.tv.data.model.CollectionGroupKind
 import com.arflix.tv.data.model.CollectionSourceConfig
 import com.arflix.tv.data.model.CollectionTileShape
@@ -704,6 +706,81 @@ class CatalogRepository @Inject constructor(
             return CollectionTemplateManifest.isValidCollectionConfig(config)
         }
         return true
+    }
+
+    suspend fun fetchCatalogPackManifest(packUrl: String): Result<CatalogPackManifest> {
+        val json = fetchUrl(packUrl)
+            ?: return Result.failure(IllegalArgumentException("Failed to fetch catalog pack from URL"))
+        val manifest = try {
+            val type = object : com.google.gson.reflect.TypeToken<CatalogPackManifest>() {}.type
+            gson.fromJson<CatalogPackManifest>(json, type)
+        } catch (e: Exception) {
+            null
+        } ?: return Result.failure(IllegalArgumentException("Failed to parse catalog pack manifest"))
+
+        if (manifest.id.isBlank() || manifest.name.isBlank()) {
+            return Result.failure(IllegalArgumentException("Invalid catalog pack manifest: missing ID or Name"))
+        }
+        return Result.success(manifest)
+    }
+
+    suspend fun addCatalogPack(packUrl: String): Result<CatalogPackManifest> {
+        val manifestResult = fetchCatalogPackManifest(packUrl)
+        if (manifestResult.isFailure) return manifestResult
+        val manifest = manifestResult.getOrThrow()
+
+        val current = getCatalogs().toMutableList()
+        val addedConfigs = mutableListOf<CatalogConfig>()
+
+        for (item in manifest.catalogs) {
+            val validation = validateCatalogUrl(item.url)
+            if (!validation.isValid || validation.normalizedUrl == null || validation.sourceType == null) {
+                continue
+            }
+            val normalizedUrl = validation.normalizedUrl
+            val sourceType = validation.sourceType
+
+            // Skip if this URL is already added
+            if (current.any { it.sourceUrl.equals(normalizedUrl, ignoreCase = true) }) {
+                continue
+            }
+
+            val resolved = resolveMetadata(normalizedUrl, sourceType)
+                ?: fallbackMetadata(normalizedUrl, sourceType)
+                ?: continue
+
+            val stableId = "custom_${sha256Short(manifest.id + "|" + normalizedUrl)}"
+            val newCatalog = CatalogConfig(
+                id = stableId,
+                title = item.name.trim().ifBlank { resolved.title },
+                sourceType = sourceType,
+                sourceUrl = normalizedUrl,
+                sourceRef = resolved.sourceRef,
+                isPreinstalled = false,
+                packId = manifest.id,
+                packName = manifest.name
+            )
+            addedConfigs.add(newCatalog)
+        }
+
+        if (addedConfigs.isEmpty()) {
+            return Result.failure(IllegalArgumentException("No new or valid catalogs found in this pack to import"))
+        }
+
+        current.addAll(0, addedConfigs)
+        saveCatalogs(current)
+        return Result.success(manifest)
+    }
+
+    suspend fun removeCatalogPack(packId: String): Result<Unit> {
+        val current = getCatalogs().toMutableList()
+        val beforeSize = current.size
+        current.removeAll { it.packId == packId }
+        if (current.size == beforeSize) {
+            return Result.failure(IllegalArgumentException("No catalogs found for pack: $packId"))
+        }
+        saveCatalogs(current)
+        return Result.success(Unit)
     }
 
     suspend fun addCustomCatalog(rawUrl: String): Result<CatalogConfig> {

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/CatalogRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/CatalogRepository.kt
@@ -730,25 +730,37 @@ class CatalogRepository @Inject constructor(
         if (cats.isNullOrEmpty()) {
             return Result.failure(IllegalArgumentException("Invalid catalog pack manifest: catalogs list is empty or missing"))
         }
+        val normalizedUrls = mutableSetOf<String>()
         for (item in cats) {
             if (item.name.isNullOrBlank() || item.url.isNullOrBlank()) {
                 return Result.failure(IllegalArgumentException("Invalid catalog pack manifest: catalog items must have a name and url"))
+            }
+            val normalized = CatalogUrlParser.normalize(item.url).lowercase()
+            if (!normalizedUrls.add(normalized)) {
+                return Result.failure(IllegalArgumentException("Invalid catalog pack manifest: duplicate catalog URL '$normalized'"))
             }
         }
         return Result.success(manifest)
     }
 
-    suspend fun addCatalogPack(packUrl: String): Result<CatalogPackManifest> {
-        val manifestResult = fetchCatalogPackManifest(packUrl)
-        if (manifestResult.isFailure) return manifestResult
-        val manifest = manifestResult.getOrThrow()
+    suspend fun addCatalogPack(packUrl: String, manifest: CatalogPackManifest? = null): Result<CatalogPackManifest> {
+        val finalManifest = if (manifest != null) {
+            manifest
+        } else {
+            val manifestResult = fetchCatalogPackManifest(packUrl)
+            if (manifestResult.isFailure) return manifestResult
+            manifestResult.getOrThrow()
+        }
 
         val current = getCatalogs().toMutableList()
         val addedConfigs = mutableListOf<CatalogConfig>()
 
-        val manifestId = manifest.id ?: return Result.failure(IllegalArgumentException("Manifest missing ID"))
-        val manifestName = manifest.name ?: return Result.failure(IllegalArgumentException("Manifest missing Name"))
-        val manifestCatalogs = manifest.catalogs ?: return Result.failure(IllegalArgumentException("Manifest missing catalogs"))
+        val manifestId = finalManifest.id ?: return Result.failure(IllegalArgumentException("Manifest missing ID"))
+        val manifestName = finalManifest.name ?: return Result.failure(IllegalArgumentException("Manifest missing Name"))
+        val manifestCatalogs = finalManifest.catalogs ?: return Result.failure(IllegalArgumentException("Manifest missing catalogs"))
+
+        val normalizedPackUrl = CatalogUrlParser.normalize(packUrl).lowercase()
+        val derivedPackId = "pack_${sha256Short(normalizedPackUrl + "|" + manifestId)}"
 
         for (item in manifestCatalogs) {
             val itemUrl = item.url ?: continue
@@ -768,7 +780,7 @@ class CatalogRepository @Inject constructor(
                 ?: fallbackMetadata(normalizedUrl, sourceType)
                 ?: continue
 
-            val stableId = "custom_${sha256Short(manifestId + "|" + normalizedUrl)}"
+            val stableId = "custom_${sha256Short(derivedPackId + "|" + normalizedUrl)}"
             val newCatalog = CatalogConfig(
                 id = stableId,
                 title = item.name?.trim()?.ifBlank { resolved.title } ?: resolved.title,
@@ -776,7 +788,7 @@ class CatalogRepository @Inject constructor(
                 sourceUrl = normalizedUrl,
                 sourceRef = resolved.sourceRef,
                 isPreinstalled = false,
-                packId = manifestId,
+                packId = derivedPackId,
                 packName = manifestName
             )
             addedConfigs.add(newCatalog)
@@ -788,7 +800,7 @@ class CatalogRepository @Inject constructor(
 
         current.addAll(0, addedConfigs)
         saveCatalogs(current)
-        return Result.success(manifest)
+        return Result.success(finalManifest)
     }
 
     suspend fun removeCatalogPack(packId: String): Result<Unit> {

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/CatalogRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/CatalogRepository.kt
@@ -709,7 +709,12 @@ class CatalogRepository @Inject constructor(
     }
 
     suspend fun fetchCatalogPackManifest(packUrl: String): Result<CatalogPackManifest> {
-        val json = fetchUrl(packUrl)
+        val trimmed = packUrl.trim()
+        if (!trimmed.startsWith("http://", ignoreCase = true) && !trimmed.startsWith("https://", ignoreCase = true)) {
+            return Result.failure(IllegalArgumentException("Invalid URL: must start with http:// or https://"))
+        }
+
+        val json = fetchUrl(trimmed)
             ?: return Result.failure(IllegalArgumentException("Failed to fetch catalog pack from URL"))
         val manifest = try {
             val type = object : com.google.gson.reflect.TypeToken<CatalogPackManifest>() {}.type
@@ -718,8 +723,17 @@ class CatalogRepository @Inject constructor(
             null
         } ?: return Result.failure(IllegalArgumentException("Failed to parse catalog pack manifest"))
 
-        if (manifest.id.isBlank() || manifest.name.isBlank()) {
+        if (manifest.id.isNullOrBlank() || manifest.name.isNullOrBlank()) {
             return Result.failure(IllegalArgumentException("Invalid catalog pack manifest: missing ID or Name"))
+        }
+        val cats = manifest.catalogs
+        if (cats.isNullOrEmpty()) {
+            return Result.failure(IllegalArgumentException("Invalid catalog pack manifest: catalogs list is empty or missing"))
+        }
+        for (item in cats) {
+            if (item.name.isNullOrBlank() || item.url.isNullOrBlank()) {
+                return Result.failure(IllegalArgumentException("Invalid catalog pack manifest: catalog items must have a name and url"))
+            }
         }
         return Result.success(manifest)
     }
@@ -732,8 +746,13 @@ class CatalogRepository @Inject constructor(
         val current = getCatalogs().toMutableList()
         val addedConfigs = mutableListOf<CatalogConfig>()
 
-        for (item in manifest.catalogs) {
-            val validation = validateCatalogUrl(item.url)
+        val manifestId = manifest.id ?: return Result.failure(IllegalArgumentException("Manifest missing ID"))
+        val manifestName = manifest.name ?: return Result.failure(IllegalArgumentException("Manifest missing Name"))
+        val manifestCatalogs = manifest.catalogs ?: return Result.failure(IllegalArgumentException("Manifest missing catalogs"))
+
+        for (item in manifestCatalogs) {
+            val itemUrl = item.url ?: continue
+            val validation = validateCatalogUrl(itemUrl)
             if (!validation.isValid || validation.normalizedUrl == null || validation.sourceType == null) {
                 continue
             }
@@ -749,16 +768,16 @@ class CatalogRepository @Inject constructor(
                 ?: fallbackMetadata(normalizedUrl, sourceType)
                 ?: continue
 
-            val stableId = "custom_${sha256Short(manifest.id + "|" + normalizedUrl)}"
+            val stableId = "custom_${sha256Short(manifestId + "|" + normalizedUrl)}"
             val newCatalog = CatalogConfig(
                 id = stableId,
-                title = item.name.trim().ifBlank { resolved.title },
+                title = item.name?.trim()?.ifBlank { resolved.title } ?: resolved.title,
                 sourceType = sourceType,
                 sourceUrl = normalizedUrl,
                 sourceRef = resolved.sourceRef,
                 isPreinstalled = false,
-                packId = manifest.id,
-                packName = manifest.name
+                packId = manifestId,
+                packName = manifestName
             )
             addedConfigs.add(newCatalog)
         }
@@ -1096,11 +1115,11 @@ class CatalogRepository @Inject constructor(
 
     private suspend fun fetchUrl(url: String): String? {
         return withContext(Dispatchers.IO) {
-            val request = Request.Builder()
-                .url(url)
-                .header("User-Agent", OkHttpProvider.userAgentOr("Mozilla/5.0 (Android TV; ARVIO)"))
-                .build()
             try {
+                val request = Request.Builder()
+                    .url(url)
+                    .header("User-Agent", OkHttpProvider.userAgentOr("Mozilla/5.0 (Android TV; ARVIO)"))
+                    .build()
                 okHttpClient.newCall(request).execute().use { response ->
                     if (!response.isSuccessful) return@use null
                     response.body?.string()

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/TraktRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/TraktRepository.kt
@@ -3963,7 +3963,7 @@ data class ContinueWatchingItem(
 
         val subtitle = if (mediaType == MediaType.TV && season != null && episode != null) {
             val base = context?.getString(R.string.continue_season_episode, season, episode)
-                ?: "Continue S${season}.E${episode}"
+                ?: "Continue S${season}E${episode}"
             if (!resumeLabel.isNullOrBlank()) {
                 context?.getString(R.string.continue_from, resumeLabel) ?: "$base from $resumeLabel"
             } else {

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/TraktRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/TraktRepository.kt
@@ -3963,7 +3963,7 @@ data class ContinueWatchingItem(
 
         val subtitle = if (mediaType == MediaType.TV && season != null && episode != null) {
             val base = context?.getString(R.string.continue_season_episode, season, episode)
-                ?: "Continue S${season}E${episode}"
+                ?: "Continue S${season}.E${episode}"
             if (!resumeLabel.isNullOrBlank()) {
                 context?.getString(R.string.continue_from, resumeLabel) ?: "$base from $resumeLabel"
             } else {

--- a/app/src/main/kotlin/com/arflix/tv/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/arflix/tv/navigation/AppNavigation.kt
@@ -290,7 +290,7 @@ fun AppNavigation(
 
         // Settings screen
         composable(
-            route = "settings?autoCloudAuth={autoCloudAuth}&initialSection={initialSection}",
+            route = "settings?autoCloudAuth={autoCloudAuth}&initialSection={initialSection}&installPackUrl={installPackUrl}",
             arguments = listOf(
                 navArgument("autoCloudAuth") {
                     type = NavType.BoolType
@@ -300,15 +300,22 @@ fun AppNavigation(
                     type = NavType.StringType
                     nullable = true
                     defaultValue = null
+                },
+                navArgument("installPackUrl") {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
                 }
             )
         ) { backStackEntry ->
             val autoCloudAuth = backStackEntry.arguments?.getBoolean("autoCloudAuth") ?: false
             val initialSection = backStackEntry.arguments?.getString("initialSection")
+            val installPackUrl = backStackEntry.arguments?.getString("installPackUrl")
             SettingsScreen(
                 currentProfile = currentProfile,
                 autoStartCloudAuth = autoCloudAuth,
                 initialSection = initialSection,
+                installPackUrl = installPackUrl,
                 onNavigateToHome = { navigateHome() },
                 onNavigateToSearch = { navigateTopLevel(Screen.Search.route) },
                 onNavigateToTv = { navigateTopLevel(Screen.Tv.createRoute()) },

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -154,6 +154,9 @@ import com.arflix.tv.data.model.CatalogConfig
 import com.arflix.tv.data.model.CatalogDiscoveryResult
 import com.arflix.tv.data.model.CatalogKind
 import com.arflix.tv.data.model.CatalogPackManifest
+import com.arflix.tv.data.model.effectivePackId
+import com.arflix.tv.data.model.effectivePackName
+import com.arflix.tv.data.model.isBulkDeletablePack
 import com.arflix.tv.data.model.CatalogSourceType
 import com.arflix.tv.data.model.QualityFilterConfig
 import com.arflix.tv.data.model.RuntimeKind
@@ -1060,9 +1063,9 @@ fun SettingsScreen(
                                                             }
                                                         }
                                                         else -> {
-                                                            if (catalog.packId != null) {
-                                                                deletePackId = catalog.packId
-                                                                deletePackName = catalog.packName ?: ""
+                                                            if (catalog.isBulkDeletablePack) {
+                                                                deletePackId = catalog.effectivePackId
+                                                                deletePackName = catalog.effectivePackName
                                                                 showDeletePackConfirm = true
                                                             } else {
                                                                 viewModel.removeCatalog(catalog.id)
@@ -1165,9 +1168,9 @@ fun SettingsScreen(
                     showCatalogRename = true
                 },
                 onDeleteCatalogClick = { catalog ->
-                    if (catalog.packId != null) {
-                        deletePackId = catalog.packId
-                        deletePackName = catalog.packName ?: ""
+                    if (catalog.isBulkDeletablePack) {
+                        deletePackId = catalog.effectivePackId
+                        deletePackName = catalog.effectivePackName
                         showDeletePackConfirm = true
                     } else {
                         viewModel.removeCatalog(catalog.id)
@@ -1581,9 +1584,9 @@ fun SettingsScreen(
                             onMoveCatalogUp = { catalog -> viewModel.moveCatalogUp(catalog.id) },
                             onMoveCatalogDown = { catalog -> viewModel.moveCatalogDown(catalog.id) },
                             onDeleteCatalog = { catalog ->
-                                if (catalog.packId != null) {
-                                    deletePackId = catalog.packId
-                                    deletePackName = catalog.packName ?: ""
+                                if (catalog.isBulkDeletablePack) {
+                                    deletePackId = catalog.effectivePackId
+                                    deletePackName = catalog.effectivePackName
                                     showDeletePackConfirm = true
                                 } else {
                                     viewModel.removeCatalog(catalog.id)
@@ -7155,31 +7158,25 @@ private fun CatalogsSettings(
                         val title = if (catalog.isPreinstalled) { when (catalog.kind) { CatalogKind.COLLECTION -> stringResource(R.string.settings_title_builtin_collection, catalog.title); CatalogKind.COLLECTION_RAIL -> stringResource(R.string.settings_title_builtin_rail, catalog.title); else -> stringResource(R.string.settings_title_builtin, catalog.title) } } else catalog.title
                         val collectionFallback = stringResource(R.string.settings_collection_fallback)
                         val addonFallback = stringResource(R.string.settings_source_addon)
-                        val subtitle = when {
-                            catalog.kind == CatalogKind.COLLECTION_RAIL -> {
-                                val group = catalog.collectionGroup?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: collectionFallback
-                                stringResource(R.string.settings_group_rail, group)
-                            }
-                            catalog.kind == CatalogKind.COLLECTION -> {
-                                val group = catalog.collectionGroup?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: collectionFallback
-                                stringResource(R.string.settings_group_collection, group)
-                            }
-                            catalog.sourceType == CatalogSourceType.PREINSTALLED -> stringResource(R.string.settings_preinstalled_catalog)
-                            else -> when (catalog.sourceType) {
-                                CatalogSourceType.ADDON -> {
+                        val subtitle = run {
+                            val baseSubtitle = when {
+                                catalog.kind == CatalogKind.COLLECTION_RAIL -> {
+                                    val group = catalog.collectionGroup?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: collectionFallback
+                                    stringResource(R.string.settings_group_rail, group)
+                                }
+                                catalog.kind == CatalogKind.COLLECTION -> {
+                                    val group = catalog.collectionGroup?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: collectionFallback
+                                    stringResource(R.string.settings_group_collection, group)
+                                }
+                                catalog.sourceType == CatalogSourceType.PREINSTALLED -> stringResource(R.string.settings_preinstalled_catalog)
+                                catalog.sourceType == CatalogSourceType.ADDON -> {
                                     val addonLabel = catalog.addonName?.takeIf { it.isNotBlank() } ?: addonFallback
                                     stringResource(R.string.settings_from_source, addonLabel)
                                 }
-                                CatalogSourceType.HOME_SERVER -> stringResource(R.string.settings_from_home_server)
-                                else -> {
-                                    val base = catalog.sourceUrl ?: stringResource(R.string.settings_custom_catalog)
-                                    if (catalog.packName != null) {
-                                        "Pack: ${catalog.packName} • $base"
-                                    } else {
-                                        base
-                                    }
-                                }
+                                catalog.sourceType == CatalogSourceType.HOME_SERVER -> stringResource(R.string.settings_from_home_server)
+                                else -> catalog.sourceUrl ?: stringResource(R.string.settings_custom_catalog)
                             }
+                            "Pack: ${catalog.effectivePackName} • $baseSubtitle"
                         }
                         val isSelected = selectedIds.contains(catalog.id)
                         val layoutToggleEnabled = catalog.kind != CatalogKind.COLLECTION_RAIL
@@ -7246,31 +7243,25 @@ private fun CatalogsSettings(
                 val title = if (catalog.isPreinstalled) { when (catalog.kind) { CatalogKind.COLLECTION -> stringResource(R.string.settings_title_builtin_collection, catalog.title); CatalogKind.COLLECTION_RAIL -> stringResource(R.string.settings_title_builtin_rail, catalog.title); else -> stringResource(R.string.settings_title_builtin, catalog.title) } } else catalog.title
                 val collectionFallback = stringResource(R.string.settings_collection_fallback)
                 val addonFallback = stringResource(R.string.settings_source_addon)
-                val subtitle = when {
-                    catalog.kind == CatalogKind.COLLECTION_RAIL -> {
-                        val group = catalog.collectionGroup?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: collectionFallback
-                        stringResource(R.string.settings_group_rail, group)
-                    }
-                    catalog.kind == CatalogKind.COLLECTION -> {
-                        val group = catalog.collectionGroup?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: collectionFallback
-                        stringResource(R.string.settings_group_collection, group)
-                    }
-                    catalog.sourceType == CatalogSourceType.PREINSTALLED -> stringResource(R.string.settings_preinstalled_catalog)
-                    else -> when (catalog.sourceType) {
-                        CatalogSourceType.ADDON -> {
+                val subtitle = run {
+                    val baseSubtitle = when {
+                        catalog.kind == CatalogKind.COLLECTION_RAIL -> {
+                            val group = catalog.collectionGroup?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: collectionFallback
+                            stringResource(R.string.settings_group_rail, group)
+                        }
+                        catalog.kind == CatalogKind.COLLECTION -> {
+                            val group = catalog.collectionGroup?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: collectionFallback
+                            stringResource(R.string.settings_group_collection, group)
+                        }
+                        catalog.sourceType == CatalogSourceType.PREINSTALLED -> stringResource(R.string.settings_preinstalled_catalog)
+                        catalog.sourceType == CatalogSourceType.ADDON -> {
                             val addonLabel = catalog.addonName?.takeIf { it.isNotBlank() } ?: addonFallback
                             stringResource(R.string.settings_from_source, addonLabel)
                         }
-                        CatalogSourceType.HOME_SERVER -> stringResource(R.string.settings_from_home_server)
-                        else -> {
-                            val base = catalog.sourceUrl ?: stringResource(R.string.settings_custom_catalog)
-                            if (catalog.packName != null) {
-                                "Pack: ${catalog.packName} • $base"
-                            } else {
-                                base
-                            }
-                        }
+                        catalog.sourceType == CatalogSourceType.HOME_SERVER -> stringResource(R.string.settings_from_home_server)
+                        else -> catalog.sourceUrl ?: stringResource(R.string.settings_custom_catalog)
                     }
+                    "Pack: ${catalog.effectivePackName} • $baseSubtitle"
                 }
                 val isSelected = selectedIds.contains(catalog.id)
                 val layoutToggleEnabled = catalog.kind != CatalogKind.COLLECTION_RAIL

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -153,6 +153,7 @@ import androidx.tv.material3.Text
 import com.arflix.tv.data.model.CatalogConfig
 import com.arflix.tv.data.model.CatalogDiscoveryResult
 import com.arflix.tv.data.model.CatalogKind
+import com.arflix.tv.data.model.CatalogPackManifest
 import com.arflix.tv.data.model.CatalogSourceType
 import com.arflix.tv.data.model.QualityFilterConfig
 import com.arflix.tv.data.model.RuntimeKind
@@ -293,6 +294,7 @@ fun SettingsScreen(
     currentProfile: com.arflix.tv.data.model.Profile? = null,
     autoStartCloudAuth: Boolean = false,
     initialSection: String? = null,
+    installPackUrl: String? = null,
     onNavigateToHome: () -> Unit = {},
     onNavigateToSearch: () -> Unit = {},
     onNavigateToTv: () -> Unit = {},
@@ -369,6 +371,19 @@ fun SettingsScreen(
     var renameCatalogId by remember { mutableStateOf("") }
     var renameCatalogTitle by remember { mutableStateOf("") }
 
+    // Catalog Pack states
+    var showCatalogPackInput by remember { mutableStateOf(false) }
+    var catalogPackInputUrl by remember { mutableStateOf("") }
+    var showDeletePackConfirm by remember { mutableStateOf(false) }
+    var deletePackId by remember { mutableStateOf("") }
+    var deletePackName by remember { mutableStateOf("") }
+
+    LaunchedEffect(installPackUrl) {
+        if (!installPackUrl.isNullOrBlank()) {
+            viewModel.loadPackManifest(installPackUrl)
+        }
+    }
+
     // Input modal states
     var showCustomAddonInput by remember { mutableStateOf(false) }
     var customAddonUrl by remember { mutableStateOf("") }
@@ -427,7 +442,7 @@ fun SettingsScreen(
                 2 + uiState.iptvPlaylists.size // Add + rows + refresh + clear
             }
             "home_server" -> uiState.homeServerConnections.size + 3
-            "catalogs" -> uiState.catalogs.size // Add + rows
+            "catalogs" -> uiState.catalogs.size + 1 // Add + Import + catalogs
             "stremio" -> stremioAddons.size // rows + add button
             "accounts" -> 5 // Cloud + Trakt + Telegram + Force Sync + App Update + Privacy/Data
             else -> 0
@@ -676,7 +691,12 @@ fun SettingsScreen(
         uiState.showAppUpdateDialog ||
         uiState.showUnknownSourcesDialog ||
         showCloudDisconnectConfirm ||
-        showTraktDisconnectConfirm
+        showTraktDisconnectConfirm ||
+        showCatalogPackInput ||
+        showDeletePackConfirm ||
+        uiState.isPackLoading ||
+        uiState.packError != null ||
+        uiState.pendingPackManifest != null
 
     Box(
         modifier = Modifier
@@ -746,7 +766,7 @@ fun SettingsScreen(
                                             )
                                     ) {
                                         iptvActionIndex--
-                                    } else if (currentSection == "catalogs" && contentFocusIndex > 0 && catalogActionIndex > 0) {
+                                    } else if (currentSection == "catalogs" && contentFocusIndex > 1 && catalogActionIndex > 0) {
                                         catalogActionIndex--
                                     } else {
                                         activeZone = Zone.SECTION
@@ -789,7 +809,7 @@ fun SettingsScreen(
                                         iptvActionIndex++
                                     } else if (currentSection == "iptv" && !showIptvCategoriesSettings && contentFocusIndex in 1..uiState.iptvPlaylists.size && iptvActionIndex < 5) {
                                         iptvActionIndex++
-                                    } else if (currentSection == "catalogs" && contentFocusIndex > 0 && catalogActionIndex < 4) {
+                                    } else if (currentSection == "catalogs" && contentFocusIndex > 1 && catalogActionIndex < 4) {
                                         catalogActionIndex++
                                     }
                                 }
@@ -1021,8 +1041,10 @@ fun SettingsScreen(
                                         "catalogs" -> {
                                             if (contentFocusIndex == 0) {
                                                 showCatalogInput = true
+                                            } else if (contentFocusIndex == 1) {
+                                                showCatalogPackInput = true
                                             } else {
-                                                val catalog = uiState.catalogs.getOrNull(contentFocusIndex - 1)
+                                                val catalog = uiState.catalogs.getOrNull(contentFocusIndex - 2)
                                                 if (catalog != null) {
                                                     when (catalogActionIndex) {
                                                         0 -> {
@@ -1037,7 +1059,15 @@ fun SettingsScreen(
                                                                 toggleCatalogueRowLayoutMode(context, catalogueLayoutRowKey(catalog))
                                                             }
                                                         }
-                                                        else -> viewModel.removeCatalog(catalog.id)
+                                                        else -> {
+                                                            if (catalog.packId != null) {
+                                                                deletePackId = catalog.packId
+                                                                deletePackName = catalog.packName ?: ""
+                                                                showDeletePackConfirm = true
+                                                            } else {
+                                                                viewModel.removeCatalog(catalog.id)
+                                                            }
+                                                        }
                                                     }
                                                 }
                                             }
@@ -1128,10 +1158,20 @@ fun SettingsScreen(
                 onAddIptvClick = { editingIptvIndex = -1; showIptvInput = true },
                 onEditIptvClick = { idx -> editingIptvIndex = idx; showIptvInput = true },
                 onAddCatalogClick = { showCatalogInput = true },
+                onImportCatalogPackClick = { showCatalogPackInput = true },
                 onRenameCatalogClick = { catalog ->
                     renameCatalogId = catalog.id
                     renameCatalogTitle = catalog.title
                     showCatalogRename = true
+                },
+                onDeleteCatalogClick = { catalog ->
+                    if (catalog.packId != null) {
+                        deletePackId = catalog.packId
+                        deletePackName = catalog.packName ?: ""
+                        showDeletePackConfirm = true
+                    } else {
+                        viewModel.removeCatalog(catalog.id)
+                    }
                 },
                 onConnectHomeServerClick = {
                     val connection = uiState.homeServerConnection
@@ -1532,6 +1572,7 @@ fun SettingsScreen(
                             focusedIndex = if (activeZone == Zone.CONTENT) contentFocusIndex else -1,
                             focusedActionIndex = catalogActionIndex,
                             onAddCatalog = { showCatalogInput = true },
+                            onImportCatalogPack = { showCatalogPackInput = true },
                             onRenameCatalog = { catalog ->
                                 renameCatalogId = catalog.id
                                 renameCatalogTitle = catalog.title
@@ -1539,7 +1580,15 @@ fun SettingsScreen(
                             },
                             onMoveCatalogUp = { catalog -> viewModel.moveCatalogUp(catalog.id) },
                             onMoveCatalogDown = { catalog -> viewModel.moveCatalogDown(catalog.id) },
-                            onDeleteCatalog = { catalog -> viewModel.removeCatalog(catalog.id) }
+                            onDeleteCatalog = { catalog ->
+                                if (catalog.packId != null) {
+                                    deletePackId = catalog.packId
+                                    deletePackName = catalog.packName ?: ""
+                                    showDeletePackConfirm = true
+                                } else {
+                                    viewModel.removeCatalog(catalog.id)
+                                }
+                            }
                         )
                         "stremio" -> StremioAddonsSettings(
                             addons = stremioAddons,
@@ -1815,6 +1864,53 @@ fun SettingsScreen(
                 },
                 onDismiss = {
                     showCatalogRename = false
+                }
+            )
+        }
+
+        if (showCatalogPackInput) {
+            InputModal(
+                title = "Import Catalog Pack",
+                fields = listOf(
+                    InputField(label = "Pack URL", value = catalogPackInputUrl, onValueChange = { catalogPackInputUrl = it })
+                ),
+                onConfirm = {
+                    if (catalogPackInputUrl.isNotBlank()) {
+                        viewModel.loadPackManifest(catalogPackInputUrl)
+                        catalogPackInputUrl = ""
+                        showCatalogPackInput = false
+                    }
+                },
+                onDismiss = {
+                    catalogPackInputUrl = ""
+                    showCatalogPackInput = false
+                }
+            )
+        }
+
+        if (uiState.pendingPackManifest != null || uiState.isPackLoading || uiState.packError != null) {
+            CatalogPackImportDialog(
+                pendingPack = uiState.pendingPackManifest,
+                isLoading = uiState.isPackLoading,
+                error = uiState.packError,
+                onConfirm = { manifest ->
+                    viewModel.confirmInstallPack(uiState.pendingPackUrl ?: "")
+                },
+                onDismiss = {
+                    viewModel.clearPendingPack()
+                }
+            )
+        }
+
+        if (showDeletePackConfirm) {
+            CatalogPackDeleteConfirmDialog(
+                packName = deletePackName,
+                onConfirm = {
+                    viewModel.removeCatalogPack(deletePackId)
+                    showDeletePackConfirm = false
+                },
+                onDismiss = {
+                    showDeletePackConfirm = false
                 }
             )
         }
@@ -3277,7 +3373,9 @@ private fun MobileSettingsLayout(
     onAddIptvClick: () -> Unit,
     onEditIptvClick: (Int) -> Unit,
     onAddCatalogClick: () -> Unit,
+    onImportCatalogPackClick: () -> Unit,
     onRenameCatalogClick: (CatalogConfig) -> Unit,
+    onDeleteCatalogClick: (CatalogConfig) -> Unit,
     onConnectHomeServerClick: () -> Unit,
     onConnectPlexHomeServerClick: () -> Unit,
     onAddCustomAddonClick: () -> Unit,
@@ -3371,7 +3469,9 @@ private fun MobileSettingsLayout(
                 onAddIptvClick = onAddIptvClick,
                 onEditIptvClick = onEditIptvClick,
                 onAddCatalogClick = onAddCatalogClick,
+                onImportCatalogPackClick = onImportCatalogPackClick,
                 onRenameCatalogClick = onRenameCatalogClick,
+                onDeleteCatalogClick = onDeleteCatalogClick,
                 onConnectHomeServerClick = onConnectHomeServerClick,
                 onConnectPlexHomeServerClick = onConnectPlexHomeServerClick,
                 onAddCustomAddonClick = onAddCustomAddonClick,
@@ -3581,7 +3681,9 @@ private fun MobileSettingsSubPage(
     onAddIptvClick: () -> Unit,
     onEditIptvClick: (Int) -> Unit,
     onAddCatalogClick: () -> Unit,
+    onImportCatalogPackClick: () -> Unit,
     onRenameCatalogClick: (CatalogConfig) -> Unit,
+    onDeleteCatalogClick: (CatalogConfig) -> Unit,
     onConnectHomeServerClick: () -> Unit,
     onConnectPlexHomeServerClick: () -> Unit,
     onAddCustomAddonClick: () -> Unit,
@@ -3914,10 +4016,11 @@ private fun MobileSettingsSubPage(
                     focusedIndex = -1,
                     focusedActionIndex = 0,
                     onAddCatalog = onAddCatalogClick,
+                    onImportCatalogPack = onImportCatalogPackClick,
                     onRenameCatalog = onRenameCatalogClick,
                     onMoveCatalogUp = { viewModel.moveCatalogUp(it.id) },
                     onMoveCatalogDown = { viewModel.moveCatalogDown(it.id) },
-                    onDeleteCatalog = { viewModel.removeCatalog(it.id) }
+                    onDeleteCatalog = onDeleteCatalogClick
                 )
             }
             "TV" -> {
@@ -7015,6 +7118,7 @@ private fun CatalogsSettings(
     focusedIndex: Int,
     focusedActionIndex: Int,
     onAddCatalog: () -> Unit,
+    onImportCatalogPack: () -> Unit,
     onRenameCatalog: (CatalogConfig) -> Unit,
     onMoveCatalogUp: (CatalogConfig) -> Unit,
     onMoveCatalogDown: (CatalogConfig) -> Unit,
@@ -7042,7 +7146,8 @@ private fun CatalogsSettings(
                 }
             }
             MobileSettingsCategory(title = stringResource(R.string.settings_section_add_catalog)) {
-                MobileSettingsRow(icon = Icons.Default.Add, title = stringResource(R.string.add_catalog), subtitle = stringResource(R.string.add_catalog_desc), value = "", isFocused = false, showDivider = false, onClick = onAddCatalog)
+                MobileSettingsRow(icon = Icons.Default.Add, title = stringResource(R.string.add_catalog), subtitle = stringResource(R.string.add_catalog_desc), value = "", isFocused = false, showDivider = true, onClick = onAddCatalog)
+                MobileSettingsRow(icon = Icons.Default.Widgets, title = "Import Catalog Pack", subtitle = "Import a bundle of catalogs from a JSON manifest URL", value = "", isFocused = false, showDivider = false, onClick = onImportCatalogPack)
             }
             if (catalogs.isNotEmpty()) {
                 MobileSettingsCategory(title = stringResource(R.string.settings_section_my_catalogs)) {
@@ -7050,7 +7155,32 @@ private fun CatalogsSettings(
                         val title = if (catalog.isPreinstalled) { when (catalog.kind) { CatalogKind.COLLECTION -> stringResource(R.string.settings_title_builtin_collection, catalog.title); CatalogKind.COLLECTION_RAIL -> stringResource(R.string.settings_title_builtin_rail, catalog.title); else -> stringResource(R.string.settings_title_builtin, catalog.title) } } else catalog.title
                         val collectionFallback = stringResource(R.string.settings_collection_fallback)
                         val addonFallback = stringResource(R.string.settings_source_addon)
-                        val subtitle = when { catalog.kind == CatalogKind.COLLECTION_RAIL -> { val group = catalog.collectionGroup?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: collectionFallback; stringResource(R.string.settings_group_rail, group) }; catalog.kind == CatalogKind.COLLECTION -> { val group = catalog.collectionGroup?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: collectionFallback; stringResource(R.string.settings_group_collection, group) }; catalog.sourceType == CatalogSourceType.PREINSTALLED -> stringResource(R.string.settings_preinstalled_catalog); else -> when (catalog.sourceType) { CatalogSourceType.ADDON -> { val addonLabel = catalog.addonName?.takeIf { it.isNotBlank() } ?: addonFallback; stringResource(R.string.settings_from_source, addonLabel) }; CatalogSourceType.HOME_SERVER -> stringResource(R.string.settings_from_home_server); else -> catalog.sourceUrl ?: stringResource(R.string.settings_custom_catalog) } }
+                        val subtitle = when {
+                            catalog.kind == CatalogKind.COLLECTION_RAIL -> {
+                                val group = catalog.collectionGroup?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: collectionFallback
+                                stringResource(R.string.settings_group_rail, group)
+                            }
+                            catalog.kind == CatalogKind.COLLECTION -> {
+                                val group = catalog.collectionGroup?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: collectionFallback
+                                stringResource(R.string.settings_group_collection, group)
+                            }
+                            catalog.sourceType == CatalogSourceType.PREINSTALLED -> stringResource(R.string.settings_preinstalled_catalog)
+                            else -> when (catalog.sourceType) {
+                                CatalogSourceType.ADDON -> {
+                                    val addonLabel = catalog.addonName?.takeIf { it.isNotBlank() } ?: addonFallback
+                                    stringResource(R.string.settings_from_source, addonLabel)
+                                }
+                                CatalogSourceType.HOME_SERVER -> stringResource(R.string.settings_from_home_server)
+                                else -> {
+                                    val base = catalog.sourceUrl ?: stringResource(R.string.settings_custom_catalog)
+                                    if (catalog.packName != null) {
+                                        "Pack: ${catalog.packName} • $base"
+                                    } else {
+                                        base
+                                    }
+                                }
+                            }
+                        }
                         val isSelected = selectedIds.contains(catalog.id)
                         val layoutToggleEnabled = catalog.kind != CatalogKind.COLLECTION_RAIL
                         val layoutRowKey = remember(catalog.id, catalog.kind) { catalogueLayoutRowKey(catalog) }
@@ -7109,12 +7239,39 @@ private fun CatalogsSettings(
             Text(text = stringResource(R.string.catalogs), style = ArflixTypography.caption, color = TextSecondary.copy(alpha = 0.65f), modifier = Modifier.padding(bottom = 20.dp))
             SettingsRow(icon = Icons.Default.Add, title = stringResource(R.string.add_catalog), subtitle = stringResource(R.string.add_catalog_desc), value = stringResource(R.string.settings_badge_add), isFocused = focusedIndex == 0, onClick = onAddCatalog, modifier = Modifier.settingsFocusSlot(0))
             Spacer(modifier = Modifier.height(16.dp))
+            SettingsRow(icon = Icons.Default.Widgets, title = "Import Catalog Pack", subtitle = "Import a bundle of catalogs from a JSON manifest URL", value = "IMPORT", isFocused = focusedIndex == 1, onClick = onImportCatalogPack, modifier = Modifier.settingsFocusSlot(1))
+            Spacer(modifier = Modifier.height(16.dp))
             catalogs.forEachIndexed { index, catalog ->
-                val rowFocusIndex = index + 1; val isRowFocused = focusedIndex == rowFocusIndex
+                val rowFocusIndex = index + 2; val isRowFocused = focusedIndex == rowFocusIndex
                 val title = if (catalog.isPreinstalled) { when (catalog.kind) { CatalogKind.COLLECTION -> stringResource(R.string.settings_title_builtin_collection, catalog.title); CatalogKind.COLLECTION_RAIL -> stringResource(R.string.settings_title_builtin_rail, catalog.title); else -> stringResource(R.string.settings_title_builtin, catalog.title) } } else catalog.title
                 val collectionFallback = stringResource(R.string.settings_collection_fallback)
                 val addonFallback = stringResource(R.string.settings_source_addon)
-                val subtitle = when { catalog.kind == CatalogKind.COLLECTION_RAIL -> { val group = catalog.collectionGroup?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: collectionFallback; stringResource(R.string.settings_group_rail, group) }; catalog.kind == CatalogKind.COLLECTION -> { val group = catalog.collectionGroup?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: collectionFallback; stringResource(R.string.settings_group_collection, group) }; catalog.sourceType == CatalogSourceType.PREINSTALLED -> stringResource(R.string.settings_preinstalled_catalog); else -> when (catalog.sourceType) { CatalogSourceType.ADDON -> { val addonLabel = catalog.addonName?.takeIf { it.isNotBlank() } ?: addonFallback; stringResource(R.string.settings_from_source, addonLabel) }; CatalogSourceType.HOME_SERVER -> stringResource(R.string.settings_from_home_server); else -> catalog.sourceUrl ?: stringResource(R.string.settings_custom_catalog) } }
+                val subtitle = when {
+                    catalog.kind == CatalogKind.COLLECTION_RAIL -> {
+                        val group = catalog.collectionGroup?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: collectionFallback
+                        stringResource(R.string.settings_group_rail, group)
+                    }
+                    catalog.kind == CatalogKind.COLLECTION -> {
+                        val group = catalog.collectionGroup?.name?.lowercase()?.replaceFirstChar { it.uppercase() } ?: collectionFallback
+                        stringResource(R.string.settings_group_collection, group)
+                    }
+                    catalog.sourceType == CatalogSourceType.PREINSTALLED -> stringResource(R.string.settings_preinstalled_catalog)
+                    else -> when (catalog.sourceType) {
+                        CatalogSourceType.ADDON -> {
+                            val addonLabel = catalog.addonName?.takeIf { it.isNotBlank() } ?: addonFallback
+                            stringResource(R.string.settings_from_source, addonLabel)
+                        }
+                        CatalogSourceType.HOME_SERVER -> stringResource(R.string.settings_from_home_server)
+                        else -> {
+                            val base = catalog.sourceUrl ?: stringResource(R.string.settings_custom_catalog)
+                            if (catalog.packName != null) {
+                                "Pack: ${catalog.packName} • $base"
+                            } else {
+                                base
+                            }
+                        }
+                    }
+                }
                 val isSelected = selectedIds.contains(catalog.id)
                 val layoutToggleEnabled = catalog.kind != CatalogKind.COLLECTION_RAIL
                 val layoutRowKey = remember(catalog.id, catalog.kind) { catalogueLayoutRowKey(catalog) }
@@ -9325,6 +9482,378 @@ private fun IptvCategoriesSettings(
                                 onClick = { onMoveDown(group) }
                             )
                         }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun CatalogPackImportDialog(
+    pendingPack: CatalogPackManifest?,
+    isLoading: Boolean,
+    error: String?,
+    onConfirm: (CatalogPackManifest) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val focusRequester = remember { FocusRequester() }
+    var focusedIndex by remember(pendingPack) { mutableIntStateOf(0) } // 0 = Confirm, 1 = Cancel/Dismiss
+    val isTouchDevice = LocalDeviceType.current.isTouchDevice()
+
+    LaunchedEffect(pendingPack, isLoading, error) {
+        focusRequester.requestFocus()
+    }
+
+    androidx.compose.ui.window.Dialog(
+        onDismissRequest = onDismiss,
+        properties = androidx.compose.ui.window.DialogProperties(
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true,
+            usePlatformDefaultWidth = false
+        )
+    ) {
+        ModalScrim(onDismiss = onDismiss) {
+            Column(
+                modifier = Modifier
+                    .then(
+                        if (isTouchDevice) Modifier.fillMaxWidth(0.92f).widthIn(max = 480.dp)
+                        else Modifier.width(480.dp)
+                    )
+                    .background(BackgroundElevated, RoundedCornerShape(16.dp))
+                    .padding(if (isTouchDevice) 20.dp else 28.dp)
+                    .focusRequester(focusRequester)
+                    .focusable()
+                    .onPreviewKeyEvent { event ->
+                        if (event.type == KeyEventType.KeyDown) {
+                            when (event.key) {
+                                Key.Back, Key.Escape -> {
+                                    onDismiss()
+                                    true
+                                }
+                                Key.DirectionLeft -> {
+                                    if (focusedIndex > 0) focusedIndex--
+                                    true
+                                }
+                                Key.DirectionRight -> {
+                                    if (focusedIndex < 1) focusedIndex++
+                                    true
+                                }
+                                Key.Enter, Key.DirectionCenter -> {
+                                    if (isLoading) {
+                                        // Ignore clicks while loading
+                                    } else if (error != null) {
+                                        onDismiss()
+                                    } else if (pendingPack != null) {
+                                        if (focusedIndex == 0) {
+                                            onConfirm(pendingPack)
+                                        } else {
+                                            onDismiss()
+                                        }
+                                    }
+                                    true
+                                }
+                                else -> false
+                            }
+                        } else false
+                    }
+            ) {
+                if (isLoading) {
+                    Column(
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        LoadingIndicator(size = 40.dp)
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Text(
+                            text = "Loading catalog pack details...",
+                            style = ArflixTypography.body,
+                            color = TextPrimary
+                        )
+                    }
+                } else if (error != null) {
+                    Column(modifier = Modifier.fillMaxWidth()) {
+                        Text(
+                            text = "Import Failed",
+                            style = ArflixTypography.sectionTitle,
+                            color = Color(0xFFDC2626)
+                        )
+                        Spacer(modifier = Modifier.height(12.dp))
+                        Text(
+                            text = error,
+                            style = ArflixTypography.body,
+                            color = TextSecondary
+                        )
+                        Spacer(modifier = Modifier.height(24.dp))
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clip(RoundedCornerShape(10.dp))
+                                .background(Color.White)
+                                .clickable { onDismiss() }
+                                .padding(vertical = 12.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = "Close",
+                                style = ArflixTypography.button,
+                                color = Color.Black
+                            )
+                        }
+                    }
+                } else if (pendingPack != null) {
+                    Column(modifier = Modifier.fillMaxWidth()) {
+                        Text(
+                            text = "Import Catalog Pack",
+                            style = ArflixTypography.sectionTitle,
+                            color = TextPrimary
+                        )
+                        Spacer(modifier = Modifier.height(6.dp))
+                        Text(
+                            text = pendingPack.name,
+                            style = ArflixTypography.cardTitle.copy(fontSize = 18.sp),
+                            color = resolveAccentColor(fallback = Pink)
+                        )
+                        if (!pendingPack.author.isNullOrBlank()) {
+                            Text(
+                                text = "Author: ${pendingPack.author} • v${pendingPack.version ?: "1.0.0"}",
+                                style = ArflixTypography.caption,
+                                color = TextSecondary.copy(alpha = 0.8f)
+                            )
+                        }
+                        if (!pendingPack.description.isNullOrBlank()) {
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Text(
+                                text = pendingPack.description,
+                                style = ArflixTypography.body.copy(fontSize = 14.sp),
+                                color = TextSecondary
+                            )
+                        }
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Text(
+                            text = "Catalogs included (${pendingPack.catalogs.size}):",
+                            style = ArflixTypography.caption,
+                            color = TextSecondary.copy(alpha = 0.6f)
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        // Display a preview list of catalogs (scrollable if many)
+                        val previewScrollState = rememberScrollState()
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .heightIn(max = 160.dp)
+                                .verticalScroll(previewScrollState)
+                                .background(Color.Black.copy(alpha = 0.25f), RoundedCornerShape(8.dp))
+                                .padding(8.dp)
+                        ) {
+                            pendingPack.catalogs.forEach { cat ->
+                                Row(
+                                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Default.Widgets,
+                                        contentDescription = null,
+                                        tint = TextSecondary,
+                                        modifier = Modifier.size(16.dp)
+                                    )
+                                    Spacer(modifier = Modifier.width(8.dp))
+                                    Text(
+                                        text = cat.name,
+                                        style = ArflixTypography.body.copy(fontSize = 14.sp),
+                                        color = TextPrimary,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis
+                                    )
+                                }
+                            }
+                        }
+                        Spacer(modifier = Modifier.height(24.dp))
+                        // Action buttons
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            val isConfirmFocused = focusedIndex == 0
+                            Box(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .clip(RoundedCornerShape(10.dp))
+                                    .background(
+                                        color = if (isConfirmFocused) Color.White else Color.Black.copy(alpha = 0.82f),
+                                        shape = RoundedCornerShape(10.dp)
+                                    )
+                                    .border(
+                                        width = 1.dp,
+                                        color = if (isConfirmFocused) Color.White else Color.White.copy(alpha = 0.14f),
+                                        shape = RoundedCornerShape(10.dp)
+                                    )
+                                    .clickable { onConfirm(pendingPack) }
+                                    .padding(vertical = 12.dp),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text(
+                                    text = "Install Pack",
+                                    style = ArflixTypography.button,
+                                    color = if (isConfirmFocused) Color.Black else Color.White
+                                )
+                            }
+
+                            val isCancelFocused = focusedIndex == 1
+                            Box(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .clip(RoundedCornerShape(10.dp))
+                                    .background(
+                                        color = if (isCancelFocused) Color.White else Color.Black.copy(alpha = 0.82f),
+                                        shape = RoundedCornerShape(10.dp)
+                                    )
+                                    .border(
+                                        width = 1.dp,
+                                        color = if (isCancelFocused) Color.White else Color.White.copy(alpha = 0.14f),
+                                        shape = RoundedCornerShape(10.dp)
+                                    )
+                                    .clickable { onDismiss() }
+                                    .padding(vertical = 12.dp),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text(
+                                    text = "Cancel",
+                                    style = ArflixTypography.button,
+                                    color = if (isCancelFocused) Color.Black else Color.White
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun CatalogPackDeleteConfirmDialog(
+    packName: String,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val focusRequester = remember { FocusRequester() }
+    var focusedIndex by remember { mutableIntStateOf(0) } // 0 = Confirm, 1 = Cancel
+    val isTouchDevice = LocalDeviceType.current.isTouchDevice()
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
+    androidx.compose.ui.window.Dialog(
+        onDismissRequest = onDismiss,
+        properties = androidx.compose.ui.window.DialogProperties(
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true,
+            usePlatformDefaultWidth = false
+        )
+    ) {
+        ModalScrim(onDismiss = onDismiss) {
+            Column(
+                modifier = Modifier
+                    .then(
+                        if (isTouchDevice) Modifier.fillMaxWidth(0.92f).widthIn(max = 400.dp)
+                        else Modifier.width(400.dp)
+                    )
+                    .background(BackgroundElevated, RoundedCornerShape(16.dp))
+                    .padding(if (isTouchDevice) 20.dp else 28.dp)
+                    .focusRequester(focusRequester)
+                    .focusable()
+                    .onPreviewKeyEvent { event ->
+                        if (event.type == KeyEventType.KeyDown) {
+                            when (event.key) {
+                                Key.Back, Key.Escape -> {
+                                    onDismiss()
+                                    true
+                                }
+                                Key.DirectionLeft -> {
+                                    if (focusedIndex > 0) focusedIndex--
+                                    true
+                                }
+                                Key.DirectionRight -> {
+                                    if (focusedIndex < 1) focusedIndex++
+                                    true
+                                }
+                                Key.Enter, Key.DirectionCenter -> {
+                                    if (focusedIndex == 0) onConfirm() else onDismiss()
+                                    true
+                                }
+                                else -> false
+                            }
+                        } else false
+                    }
+            ) {
+                Text(
+                    text = "Delete Catalog Pack",
+                    style = ArflixTypography.sectionTitle,
+                    color = Color(0xFFDC2626)
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    text = "Do you want to delete the pack \"$packName\"? This will remove all catalogs that were imported with this pack.",
+                    style = ArflixTypography.body,
+                    color = TextSecondary
+                )
+                Spacer(modifier = Modifier.height(24.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    val isConfirmFocused = focusedIndex == 0
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .clip(RoundedCornerShape(10.dp))
+                            .background(
+                                color = if (isConfirmFocused) Color.White else Color.Black.copy(alpha = 0.82f),
+                                shape = RoundedCornerShape(10.dp)
+                            )
+                            .border(
+                                width = 1.dp,
+                                color = if (isConfirmFocused) Color.White else Color.White.copy(alpha = 0.14f),
+                                shape = RoundedCornerShape(10.dp)
+                            )
+                            .clickable { onConfirm() }
+                            .padding(vertical = 12.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "Delete Pack",
+                            style = ArflixTypography.button,
+                            color = if (isConfirmFocused) Color.Black else Color.White
+                        )
+                    }
+
+                    val isCancelFocused = focusedIndex == 1
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .clip(RoundedCornerShape(10.dp))
+                            .background(
+                                color = if (isCancelFocused) Color.White else Color.Black.copy(alpha = 0.82f),
+                                shape = RoundedCornerShape(10.dp)
+                            )
+                            .border(
+                                width = 1.dp,
+                                color = if (isCancelFocused) Color.White else Color.White.copy(alpha = 0.14f),
+                                shape = RoundedCornerShape(10.dp)
+                            )
+                            .clickable { onDismiss() }
+                            .padding(vertical = 12.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "Cancel",
+                            style = ArflixTypography.button,
+                            color = if (isCancelFocused) Color.Black else Color.White
+                        )
                     }
                 }
             }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -88,6 +88,8 @@ import androidx.compose.material.icons.filled.SystemUpdate
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.VpnKey
 import androidx.compose.material.icons.filled.QrCode
+import androidx.compose.material.icons.filled.Unarchive
+import androidx.compose.material.icons.filled.Archive
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.tv.material3.ClickableSurfaceDefaults
@@ -812,7 +814,7 @@ fun SettingsScreen(
                                         iptvActionIndex++
                                     } else if (currentSection == "iptv" && !showIptvCategoriesSettings && contentFocusIndex in 1..uiState.iptvPlaylists.size && iptvActionIndex < 5) {
                                         iptvActionIndex++
-                                    } else if (currentSection == "catalogs" && contentFocusIndex > 1 && catalogActionIndex < 4) {
+                                    } else if (currentSection == "catalogs" && contentFocusIndex > 1 && catalogActionIndex < 5) {
                                         catalogActionIndex++
                                     }
                                 }
@@ -1060,6 +1062,11 @@ fun SettingsScreen(
                                                         3 -> scope.launch {
                                                             if (catalog.kind != CatalogKind.COLLECTION_RAIL) {
                                                                 toggleCatalogueRowLayoutMode(context, catalogueLayoutRowKey(catalog))
+                                                            }
+                                                        }
+                                                        4 -> {
+                                                            if (catalog.packId != null && catalog.isBulkDeletablePack) {
+                                                                viewModel.unpackCatalog(catalog.id)
                                                             }
                                                         }
                                                         else -> {
@@ -1591,7 +1598,8 @@ fun SettingsScreen(
                                 } else {
                                     viewModel.removeCatalog(catalog.id)
                                 }
-                            }
+                            },
+                            onUnpackCatalog = { catalog -> viewModel.unpackCatalog(catalog.id) }
                         )
                         "stremio" -> StremioAddonsSettings(
                             addons = stremioAddons,
@@ -4023,7 +4031,8 @@ private fun MobileSettingsSubPage(
                     onRenameCatalog = onRenameCatalogClick,
                     onMoveCatalogUp = { viewModel.moveCatalogUp(it.id) },
                     onMoveCatalogDown = { viewModel.moveCatalogDown(it.id) },
-                    onDeleteCatalog = onDeleteCatalogClick
+                    onDeleteCatalog = onDeleteCatalogClick,
+                    onUnpackCatalog = { viewModel.unpackCatalog(it.id) }
                 )
             }
             "TV" -> {
@@ -7125,7 +7134,8 @@ private fun CatalogsSettings(
     onRenameCatalog: (CatalogConfig) -> Unit,
     onMoveCatalogUp: (CatalogConfig) -> Unit,
     onMoveCatalogDown: (CatalogConfig) -> Unit,
-    onDeleteCatalog: (CatalogConfig) -> Unit
+    onDeleteCatalog: (CatalogConfig) -> Unit,
+    onUnpackCatalog: (CatalogConfig) -> Unit
 ) {
     val isMobile = LocalDeviceType.current.isTouchDevice()
     var selectionMode by remember { mutableStateOf(false) }
@@ -7156,6 +7166,9 @@ private fun CatalogsSettings(
                 MobileSettingsCategory(title = stringResource(R.string.settings_section_my_catalogs)) {
                     catalogs.forEachIndexed { index, catalog ->
                         val title = if (catalog.isPreinstalled) { when (catalog.kind) { CatalogKind.COLLECTION -> stringResource(R.string.settings_title_builtin_collection, catalog.title); CatalogKind.COLLECTION_RAIL -> stringResource(R.string.settings_title_builtin_rail, catalog.title); else -> stringResource(R.string.settings_title_builtin, catalog.title) } } else catalog.title
+                        val currentPackId = catalog.packId
+                        val prevPackId = if (index > 0) catalogs[index - 1].packId else null
+                        val showPackHeader = currentPackId != null && currentPackId != prevPackId && catalog.isBulkDeletablePack
                         val collectionFallback = stringResource(R.string.settings_collection_fallback)
                         val addonFallback = stringResource(R.string.settings_source_addon)
                         val subtitle = run {
@@ -7182,6 +7195,32 @@ private fun CatalogsSettings(
                         val layoutToggleEnabled = catalog.kind != CatalogKind.COLLECTION_RAIL
                         val layoutRowKey = remember(catalog.id, catalog.kind) { catalogueLayoutRowKey(catalog) }
                         Column {
+                            if (showPackHeader) {
+                                if (index > 0) {
+                                    Spacer(modifier = Modifier.height(16.dp))
+                                }
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Default.Archive,
+                                        contentDescription = null,
+                                        tint = Pink,
+                                        modifier = Modifier.size(16.dp)
+                                    )
+                                    Spacer(modifier = Modifier.width(8.dp))
+                                    Text(
+                                        text = catalog.effectivePackName.uppercase(),
+                                        style = ArflixTypography.caption.copy(fontWeight = androidx.compose.ui.text.font.FontWeight.Bold, letterSpacing = androidx.compose.ui.unit.TextUnit.Unspecified),
+                                        color = Pink
+                                    )
+                                }
+                                Box(modifier = Modifier.fillMaxWidth().height(1.dp).padding(horizontal = 16.dp).background(Pink.copy(alpha = 0.2f)))
+                                Spacer(modifier = Modifier.height(4.dp))
+                            }
                             Row(
                                 modifier = Modifier.fillMaxWidth()
                                     .background(if (isSelected) Pink.copy(alpha = 0.15f) else Color.Transparent)
@@ -7206,6 +7245,23 @@ private fun CatalogsSettings(
                                 if (!selectionMode) {
                                     CatalogueRowLayoutToggleButton(rowKey = layoutRowKey, enabled = layoutToggleEnabled)
                                     Spacer(modifier = Modifier.width(8.dp))
+                                    if (catalog.packId != null && catalog.isBulkDeletablePack) {
+                                        Box(
+                                            modifier = Modifier
+                                                .size(36.dp)
+                                                .clickable { onUnpackCatalog(catalog) }
+                                                .background(Color.White.copy(alpha = 0.08f), RoundedCornerShape(8.dp)),
+                                            contentAlignment = Alignment.Center
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Default.Unarchive,
+                                                contentDescription = "Unpack catalog row",
+                                                tint = Color.White.copy(alpha = 0.7f),
+                                                modifier = Modifier.size(18.dp)
+                                            )
+                                        }
+                                        Spacer(modifier = Modifier.width(8.dp))
+                                    }
                                 }
                                 if (selectionMode && selectedIds.size == 1 && isSelected) {
                                     Icon(imageVector = Icons.Default.DragHandle, contentDescription = stringResource(R.string.settings_cd_drag_reorder), tint = TextSecondary, modifier = Modifier.size(24.dp).pointerInput(catalog.id) {
@@ -7240,6 +7296,34 @@ private fun CatalogsSettings(
             Spacer(modifier = Modifier.height(16.dp))
             catalogs.forEachIndexed { index, catalog ->
                 val rowFocusIndex = index + 2; val isRowFocused = focusedIndex == rowFocusIndex
+                val currentPackId = catalog.packId
+                val prevPackId = if (index > 0) catalogs[index - 1].packId else null
+                val showPackHeader = currentPackId != null && currentPackId != prevPackId && catalog.isBulkDeletablePack
+
+                if (showPackHeader) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Archive,
+                            contentDescription = null,
+                            tint = Pink,
+                            modifier = Modifier.size(16.dp)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = catalog.effectivePackName.uppercase(),
+                            style = ArflixTypography.caption.copy(fontWeight = androidx.compose.ui.text.font.FontWeight.Bold, letterSpacing = androidx.compose.ui.unit.TextUnit.Unspecified),
+                            color = Pink
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
+
                 val title = if (catalog.isPreinstalled) { when (catalog.kind) { CatalogKind.COLLECTION -> stringResource(R.string.settings_title_builtin_collection, catalog.title); CatalogKind.COLLECTION_RAIL -> stringResource(R.string.settings_title_builtin_rail, catalog.title); else -> stringResource(R.string.settings_title_builtin, catalog.title) } } else catalog.title
                 val collectionFallback = stringResource(R.string.settings_collection_fallback)
                 val addonFallback = stringResource(R.string.settings_source_addon)
@@ -7281,7 +7365,9 @@ private fun CatalogsSettings(
                     Spacer(modifier = Modifier.width(6.dp))
                     CatalogueRowLayoutToggleButton(rowKey = layoutRowKey, enabled = layoutToggleEnabled, forceFocused = isRowFocused && focusedActionIndex == 3)
                     Spacer(modifier = Modifier.width(6.dp))
-                    CatalogActionChip(icon = Icons.Default.Delete, isFocused = isRowFocused && focusedActionIndex == 4, isDestructive = true, enabled = true, onClick = { onDeleteCatalog(catalog) })
+                    CatalogActionChip(icon = Icons.Default.Unarchive, isFocused = isRowFocused && focusedActionIndex == 4, enabled = catalog.packId != null && catalog.isBulkDeletablePack, onClick = { onUnpackCatalog(catalog) })
+                    Spacer(modifier = Modifier.width(6.dp))
+                    CatalogActionChip(icon = Icons.Default.Delete, isFocused = isRowFocused && focusedActionIndex == 5, isDestructive = true, enabled = true, onClick = { onDeleteCatalog(catalog) })
                 }
                 Spacer(modifier = Modifier.height(10.dp))
             }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -9602,7 +9602,7 @@ private fun CatalogPackImportDialog(
                         )
                         Spacer(modifier = Modifier.height(6.dp))
                         Text(
-                            text = pendingPack.name,
+                            text = pendingPack.name ?: "",
                             style = ArflixTypography.cardTitle.copy(fontSize = 18.sp),
                             color = resolveAccentColor(fallback = Pink)
                         )
@@ -9623,7 +9623,7 @@ private fun CatalogPackImportDialog(
                         }
                         Spacer(modifier = Modifier.height(16.dp))
                         Text(
-                            text = "Catalogs included (${pendingPack.catalogs.size}):",
+                            text = "Catalogs included (${pendingPack.catalogs?.size ?: 0}):",
                             style = ArflixTypography.caption,
                             color = TextSecondary.copy(alpha = 0.6f)
                         )
@@ -9638,7 +9638,7 @@ private fun CatalogPackImportDialog(
                                 .background(Color.Black.copy(alpha = 0.25f), RoundedCornerShape(8.dp))
                                 .padding(8.dp)
                         ) {
-                            pendingPack.catalogs.forEach { cat ->
+                            pendingPack.catalogs?.forEach { cat ->
                                 Row(
                                     modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
                                     verticalAlignment = Alignment.CenterVertically
@@ -9651,7 +9651,7 @@ private fun CatalogPackImportDialog(
                                     )
                                     Spacer(modifier = Modifier.width(8.dp))
                                     Text(
-                                        text = cat.name,
+                                        text = cat.name ?: "",
                                         style = ArflixTypography.body.copy(fontSize = 14.sp),
                                         color = TextPrimary,
                                         maxLines = 1,

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -1989,6 +1989,30 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
+    fun unpackCatalog(catalogId: String) {
+        viewModelScope.launch {
+            val current = catalogRepository.getCatalogs()
+            val index = current.indexOfFirst { it.id == catalogId }
+            if (index != -1) {
+                val target = current[index]
+                if (target.packId != null) {
+                    val updated = current.toMutableList()
+                    updated[index] = target.copy(packId = null, packName = null)
+                    catalogRepository.replaceCatalogsForActiveProfile(updated)
+                    
+                    // Update state
+                    val visible = visibleCatalogs(updated)
+                    _uiState.value = _uiState.value.copy(
+                        catalogs = visible,
+                        toastMessage = "Catalog row extracted from pack",
+                        toastType = ToastType.SUCCESS
+                    )
+                    syncLocalStateToCloud(silent = true)
+                }
+            }
+        }
+    }
+
     fun renameCatalog(catalogId: String, newTitle: String) {
         viewModelScope.launch {
             val success = catalogRepository.renameCatalog(catalogId, newTitle)

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -18,6 +18,7 @@ import com.arflix.tv.data.model.Addon
 import com.arflix.tv.data.model.CatalogConfig
 import com.arflix.tv.data.model.CatalogDiscoveryResult
 import com.arflix.tv.data.model.CatalogKind
+import com.arflix.tv.data.model.CatalogPackManifest
 import com.arflix.tv.data.model.Profile
 import com.arflix.tv.data.model.QualityFilterConfig
 import com.arflix.tv.data.repository.AuthRepository
@@ -169,6 +170,10 @@ data class SettingsUiState(
     val catalogSearchResults: List<CatalogDiscoveryResult> = emptyList(),
     val isCatalogSearching: Boolean = false,
     val catalogSearchError: String? = null,
+    val pendingPackManifest: CatalogPackManifest? = null,
+    val pendingPackUrl: String? = null,
+    val isPackLoading: Boolean = false,
+    val packError: String? = null,
     // Addons
     val addons: List<Addon> = emptyList(),
     val torrServerBaseUrl: String = "",
@@ -1776,6 +1781,83 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             runCatching {
                 catalogRepository.ensurePreinstalledDefaults(mediaRepository.getDefaultCatalogConfigs())
+            }
+        }
+    }
+
+    fun loadPackManifest(url: String) {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(
+                isPackLoading = true,
+                packError = null,
+                pendingPackManifest = null,
+                pendingPackUrl = null
+            )
+            val result = catalogRepository.fetchCatalogPackManifest(url)
+            result.onSuccess { manifest ->
+                _uiState.value = _uiState.value.copy(
+                    isPackLoading = false,
+                    pendingPackManifest = manifest,
+                    pendingPackUrl = url
+                )
+            }.onFailure { error ->
+                _uiState.value = _uiState.value.copy(
+                    isPackLoading = false,
+                    packError = error.message ?: "Failed to load pack manifest",
+                    pendingPackUrl = null
+                )
+            }
+        }
+    }
+
+    fun clearPendingPack() {
+        _uiState.value = _uiState.value.copy(
+            pendingPackManifest = null,
+            pendingPackUrl = null,
+            isPackLoading = false,
+            packError = null
+        )
+    }
+
+    fun confirmInstallPack(url: String) {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(
+                isPackLoading = true,
+                packError = null
+            )
+            val result = catalogRepository.addCatalogPack(url)
+            result.onSuccess { manifest ->
+                _uiState.value = _uiState.value.copy(
+                    isPackLoading = false,
+                    pendingPackManifest = null,
+                    pendingPackUrl = null,
+                    toastMessage = "Installed pack: ${manifest.name}",
+                    toastType = ToastType.SUCCESS
+                )
+                syncLocalStateToCloud(silent = true)
+            }.onFailure { error ->
+                _uiState.value = _uiState.value.copy(
+                    isPackLoading = false,
+                    packError = error.message ?: "Failed to install pack"
+                )
+            }
+        }
+    }
+
+    fun removeCatalogPack(packId: String) {
+        viewModelScope.launch {
+            val result = catalogRepository.removeCatalogPack(packId)
+            result.onSuccess {
+                _uiState.value = _uiState.value.copy(
+                    toastMessage = "Pack removed",
+                    toastType = ToastType.SUCCESS
+                )
+                syncLocalStateToCloud(silent = true)
+            }.onFailure { error ->
+                _uiState.value = _uiState.value.copy(
+                    toastMessage = error.message ?: "Failed to remove pack",
+                    toastType = ToastType.ERROR
+                )
             }
         }
     }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -1820,18 +1820,19 @@ class SettingsViewModel @Inject constructor(
     }
 
     fun confirmInstallPack(url: String) {
+        val manifest = _uiState.value.pendingPackManifest
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(
                 isPackLoading = true,
                 packError = null
             )
-            val result = catalogRepository.addCatalogPack(url)
-            result.onSuccess { manifest ->
+            val result = catalogRepository.addCatalogPack(url, manifest)
+            result.onSuccess { installedManifest ->
                 _uiState.value = _uiState.value.copy(
                     isPackLoading = false,
                     pendingPackManifest = null,
                     pendingPackUrl = null,
-                    toastMessage = "Installed pack: ${manifest.name}",
+                    toastMessage = "Installed pack: ${installedManifest.name}",
                     toastType = ToastType.SUCCESS
                 )
                 syncLocalStateToCloud(silent = true)
@@ -1999,7 +2000,7 @@ class SettingsViewModel @Inject constructor(
                     val updated = current.toMutableList()
                     updated[index] = target.copy(packId = null, packName = null)
                     catalogRepository.replaceCatalogsForActiveProfile(updated)
-                    
+
                     // Update state
                     val visible = visibleCatalogs(updated)
                     _uiState.value = _uiState.value.copy(

--- a/app/src/test/kotlin/com/arflix/tv/data/repository/CatalogPackTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/repository/CatalogPackTest.kt
@@ -1,0 +1,174 @@
+package com.arflix.tv.data.repository
+
+import android.content.Context
+import com.arflix.tv.data.model.CatalogConfig
+import com.arflix.tv.data.model.CatalogPackManifest
+import com.arflix.tv.data.model.CatalogPackItem
+import com.arflix.tv.data.model.CatalogSourceType
+import com.arflix.tv.data.model.CatalogValidationResult
+import com.arflix.tv.data.api.TraktApi
+import io.mockk.*
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import org.junit.Assert.*
+import org.junit.Test
+
+class CatalogPackTest {
+
+    @Test
+    fun `fetchCatalogPackManifest rejects duplicate catalog URLs`() = runBlocking {
+        val context = mockk<Context>(relaxed = true)
+        val profileManager = mockk<ProfileManager>(relaxed = true)
+        val traktApi = mockk<TraktApi>(relaxed = true)
+        val okHttpClient = mockk<OkHttpClient>(relaxed = true)
+        val invalidationBus = mockk<CloudSyncInvalidationBus>(relaxed = true)
+
+        val repository = spyk(CatalogRepository(context, profileManager, traktApi, okHttpClient, invalidationBus))
+
+        val duplicateManifestJson = """
+            {
+              "id": "test-pack",
+              "name": "Test Pack",
+              "author": "Tester",
+              "version": "1.0.0",
+              "catalogs": [
+                {
+                  "name": "Catalog 1",
+                  "url": "https://mdblist.com/lists/snoak/trending-movies"
+                },
+                {
+                  "name": "Catalog 2",
+                  "url": "https://mdblist.com/lists/snoak/trending-movies/"
+                }
+              ]
+            }
+        """.trimIndent()
+
+        coEvery { repository["fetchUrl"](any<String>()) } returns duplicateManifestJson
+
+        val result = repository.fetchCatalogPackManifest("https://example.com/pack.json")
+        assertTrue(result.isFailure)
+        val exception = result.exceptionOrNull()
+        assertNotNull(exception)
+        assertTrue(exception is IllegalArgumentException)
+        assertTrue(exception!!.message!!.contains("duplicate catalog URL"))
+    }
+
+    @Test
+    fun `addCatalogPack derives unique pack ID from normalized manifest URL plus manifest ID`() = runBlocking {
+        val context = mockk<Context>(relaxed = true)
+        val profileManager = mockk<ProfileManager>(relaxed = true)
+        val traktApi = mockk<TraktApi>(relaxed = true)
+        val okHttpClient = mockk<OkHttpClient>(relaxed = true)
+        val invalidationBus = mockk<CloudSyncInvalidationBus>(relaxed = true)
+
+        val repository = spyk(CatalogRepository(context, profileManager, traktApi, okHttpClient, invalidationBus))
+
+        val addedCatalogs = mutableListOf<CatalogConfig>()
+        coEvery { repository.getCatalogs() } returns emptyList()
+        coEvery { repository["saveCatalogs"](any<List<CatalogConfig>>()) } answers {
+            addedCatalogs.addAll(firstArg<List<CatalogConfig>>())
+        }
+
+        coEvery { repository.validateCatalogUrl(any()) } returns CatalogValidationResult(
+            isValid = true,
+            normalizedUrl = "https://mdblist.com/lists/snoak/trending-movies",
+            sourceType = CatalogSourceType.MDBLIST
+        )
+
+        val manifest = CatalogPackManifest(
+            id = "same-id",
+            name = "Test Pack",
+            author = "Tester",
+            version = "1.0.0",
+            description = "Desc",
+            catalogs = listOf(
+                CatalogPackItem(name = "Catalog 1", url = "https://mdblist.com/lists/snoak/trending-movies")
+            )
+        )
+
+        val result1 = repository.addCatalogPack("https://example.com/pack1.json", manifest)
+        assertTrue(result1.isSuccess)
+        val packId1 = addedCatalogs[0].packId
+        assertNotNull(packId1)
+
+        addedCatalogs.clear()
+
+        val result2 = repository.addCatalogPack("https://example.com/pack2.json", manifest)
+        assertTrue(result2.isSuccess)
+        val packId2 = addedCatalogs[0].packId
+        assertNotNull(packId2)
+
+        assertNotEquals(packId1, packId2)
+    }
+
+    @Test
+    fun `addCatalogPack with pre-fetched manifest avoids network call`() = runBlocking {
+        val context = mockk<Context>(relaxed = true)
+        val profileManager = mockk<ProfileManager>(relaxed = true)
+        val traktApi = mockk<TraktApi>(relaxed = true)
+        val okHttpClient = mockk<OkHttpClient>(relaxed = true)
+        val invalidationBus = mockk<CloudSyncInvalidationBus>(relaxed = true)
+
+        val repository = spyk(CatalogRepository(context, profileManager, traktApi, okHttpClient, invalidationBus))
+
+        coEvery { repository.getCatalogs() } returns emptyList()
+        coEvery { repository["saveCatalogs"](any<List<CatalogConfig>>()) } returns Unit
+
+        coEvery { repository.validateCatalogUrl(any()) } returns CatalogValidationResult(
+            isValid = true,
+            normalizedUrl = "https://mdblist.com/lists/snoak/trending-movies",
+            sourceType = CatalogSourceType.MDBLIST
+        )
+
+        val manifest = CatalogPackManifest(
+            id = "test-pack",
+            name = "Test Pack",
+            author = "Tester",
+            version = "1.0.0",
+            description = "Desc",
+            catalogs = listOf(
+                CatalogPackItem(name = "Catalog 1", url = "https://mdblist.com/lists/snoak/trending-movies")
+            )
+        )
+
+        val result = repository.addCatalogPack("https://example.com/pack.json", manifest)
+        assertTrue(result.isSuccess)
+
+        coVerify(exactly = 0) { repository["fetchUrl"](any<String>()) }
+    }
+
+    @Test
+    fun `fetchCatalogPackManifest rejects malformed manifests`() = runBlocking {
+        val context = mockk<Context>(relaxed = true)
+        val profileManager = mockk<ProfileManager>(relaxed = true)
+        val traktApi = mockk<TraktApi>(relaxed = true)
+        val okHttpClient = mockk<OkHttpClient>(relaxed = true)
+        val invalidationBus = mockk<CloudSyncInvalidationBus>(relaxed = true)
+
+        val repository = spyk(CatalogRepository(context, profileManager, traktApi, okHttpClient, invalidationBus))
+
+        // 1. Missing ID
+        val missingIdJson = """
+            {
+              "name": "Test Pack",
+              "catalogs": [{"name": "C1", "url": "https://example.com/c1"}]
+            }
+        """.trimIndent()
+        coEvery { repository["fetchUrl"](any<String>()) } returns missingIdJson
+        val res1 = repository.fetchCatalogPackManifest("https://example.com/pack.json")
+        assertTrue(res1.isFailure)
+
+        // 2. Empty catalogs list
+        val emptyCatalogsJson = """
+            {
+              "id": "id",
+              "name": "Test Pack",
+              "catalogs": []
+            }
+        """.trimIndent()
+        coEvery { repository["fetchUrl"](any<String>()) } returns emptyCatalogsJson
+        val res2 = repository.fetchCatalogPackManifest("https://example.com/pack.json")
+        assertTrue(res2.isFailure)
+    }
+}

--- a/netlify-auth-site/netlify/database/migrations/20260721110000_catalog_packs/migration.sql
+++ b/netlify-auth-site/netlify/database/migrations/20260721110000_catalog_packs/migration.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS public.catalog_packs (
+  id uuid PRIMARY KEY DEFAULT (md5(random()::text || clock_timestamp()::text)::uuid),
+  name text NOT NULL,
+  url text NOT NULL,
+  author text,
+  version text DEFAULT '1.0.0',
+  description text,
+  catalogs jsonb NOT NULL,
+  status text NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'approved')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_catalog_packs_status ON public.catalog_packs(status);
+
+-- Seed approved catalog packs if not already present
+INSERT INTO public.catalog_packs (id, name, url, author, version, description, catalogs, status)
+VALUES
+  ('c0a37e5e-5b12-4eb0-a5ea-9d84c1737e51', 'Cinema Essentials', '/packs/cinema-essentials.json', 'ARVIO Team', '1.0.0', 'All the trending movies, popular lists, and upcoming releases you need for a perfect movie night.', '["Trending in Movies", "Top 10 Movies Today", "Top Movies This Week", "Coming Soon"]'::jsonb, 'approved'),
+  ('c0a37e5e-5b12-4eb0-a5ea-9d84c1737e52', 'TV Show Binge Pack', '/packs/tv-binge.json', 'ARVIO Team', '1.0.0', 'Never miss an episode. Popular, trending, and latest airing series in one convenient bundle.', '["Trending in Shows", "Top 10 Shows Today", "Latest Airing"]'::jsonb, 'approved'),
+  ('c0a37e5e-5b12-4eb0-a5ea-9d84c1737e53', 'Otaku & K-Drama Hub', '/packs/anime-kdrama.json', 'Community', '1.1.2', 'The ultimate pack for anime lovers and K-Drama fans. Auto-updated lists of trending episodes and releases.', '["Trending in Anime", "New in K-Dramas"]'::jsonb, 'approved'),
+  ('c0a37e5e-5b12-4eb0-a5ea-9d84c1737e54', 'Action & Franchise Classics', '/packs/classics-franchises.json', 'Cinephile', '1.0.5', 'Full box-sets and classic franchise collections, including James Bond, Harry Potter, Lord of the Rings, and Jurassic Park.', '["James Bond Collection", "Harry Potter Collection", "The Matrix Collection", "Lord of the Rings and Hobbit Collection", "Jurassic Park Collection"]'::jsonb, 'approved')
+ON CONFLICT (id) DO NOTHING;

--- a/netlify-auth-site/netlify/database/migrations/20260721110000_catalog_packs/migration.sql
+++ b/netlify-auth-site/netlify/database/migrations/20260721110000_catalog_packs/migration.sql
@@ -2,6 +2,7 @@ CREATE TABLE IF NOT EXISTS public.catalog_packs (
   id uuid PRIMARY KEY DEFAULT (md5(random()::text || clock_timestamp()::text)::uuid),
   name text NOT NULL,
   url text NOT NULL,
+  normalized_url text UNIQUE NOT NULL,
   author text,
   version text DEFAULT '1.0.0',
   description text,
@@ -13,11 +14,17 @@ CREATE TABLE IF NOT EXISTS public.catalog_packs (
 
 CREATE INDEX IF NOT EXISTS idx_catalog_packs_status ON public.catalog_packs(status);
 
+CREATE TABLE IF NOT EXISTS public.submission_rate_limits (
+  ip_hash text PRIMARY KEY,
+  count integer NOT NULL DEFAULT 1,
+  last_submission_at timestamptz NOT NULL DEFAULT now()
+);
+
 -- Seed approved catalog packs if not already present
-INSERT INTO public.catalog_packs (id, name, url, author, version, description, catalogs, status)
+INSERT INTO public.catalog_packs (id, name, url, normalized_url, author, version, description, catalogs, status)
 VALUES
-  ('c0a37e5e-5b12-4eb0-a5ea-9d84c1737e51', 'Cinema Essentials', '/packs/cinema-essentials.json', 'ARVIO Team', '1.0.0', 'All the trending movies, popular lists, and upcoming releases you need for a perfect movie night.', '["Trending in Movies", "Top 10 Movies Today", "Top Movies This Week", "Coming Soon"]'::jsonb, 'approved'),
-  ('c0a37e5e-5b12-4eb0-a5ea-9d84c1737e52', 'TV Show Binge Pack', '/packs/tv-binge.json', 'ARVIO Team', '1.0.0', 'Never miss an episode. Popular, trending, and latest airing series in one convenient bundle.', '["Trending in Shows", "Top 10 Shows Today", "Latest Airing"]'::jsonb, 'approved'),
-  ('c0a37e5e-5b12-4eb0-a5ea-9d84c1737e53', 'Otaku & K-Drama Hub', '/packs/anime-kdrama.json', 'Community', '1.1.2', 'The ultimate pack for anime lovers and K-Drama fans. Auto-updated lists of trending episodes and releases.', '["Trending in Anime", "New in K-Dramas"]'::jsonb, 'approved'),
-  ('c0a37e5e-5b12-4eb0-a5ea-9d84c1737e54', 'Action & Franchise Classics', '/packs/classics-franchises.json', 'Cinephile', '1.0.5', 'Full box-sets and classic franchise collections, including James Bond, Harry Potter, Lord of the Rings, and Jurassic Park.', '["James Bond Collection", "Harry Potter Collection", "The Matrix Collection", "Lord of the Rings and Hobbit Collection", "Jurassic Park Collection"]'::jsonb, 'approved')
+  ('c0a37e5e-5b12-4eb0-a5ea-9d84c1737e51', 'Cinema Essentials', '/packs/cinema-essentials.json', 'https://arvio.app/packs/cinema-essentials.json', 'ARVIO Team', '1.0.0', 'All the trending movies, popular lists, and upcoming releases you need for a perfect movie night.', '["Trending in Movies", "Top 10 Movies Today", "Top Movies This Week", "Coming Soon"]'::jsonb, 'approved'),
+  ('c0a37e5e-5b12-4eb0-a5ea-9d84c1737e52', 'TV Show Binge Pack', '/packs/tv-binge.json', 'https://arvio.app/packs/tv-binge.json', 'ARVIO Team', '1.0.0', 'Never miss an episode. Popular, trending, and latest airing series in one convenient bundle.', '["Trending in Shows", "Top 10 Shows Today", "Latest Airing"]'::jsonb, 'approved'),
+  ('c0a37e5e-5b12-4eb0-a5ea-9d84c1737e53', 'Otaku & K-Drama Hub', '/packs/anime-kdrama.json', 'https://arvio.app/packs/anime-kdrama.json', 'Community', '1.1.2', 'The ultimate pack for anime lovers and K-Drama fans. Auto-updated lists of trending episodes and releases.', '["Trending in Anime", "New in K-Dramas"]'::jsonb, 'approved'),
+  ('c0a37e5e-5b12-4eb0-a5ea-9d84c1737e54', 'Action & Franchise Classics', '/packs/classics-franchises.json', 'https://arvio.app/packs/classics-franchises.json', 'Cinephile', '1.0.5', 'Full box-sets and classic franchise collections, including James Bond, Harry Potter, Lord of the Rings, and Jurassic Park.', '["James Bond Collection", "Harry Potter Collection", "The Matrix Collection", "Lord of the Rings and Hobbit Collection", "Jurassic Park Collection"]'::jsonb, 'approved')
 ON CONFLICT (id) DO NOTHING;

--- a/netlify-auth-site/netlify/database/migrations/20260721110000_catalog_packs/migration.sql
+++ b/netlify-auth-site/netlify/database/migrations/20260721110000_catalog_packs/migration.sql
@@ -2,7 +2,6 @@ CREATE TABLE IF NOT EXISTS public.catalog_packs (
   id uuid PRIMARY KEY DEFAULT (md5(random()::text || clock_timestamp()::text)::uuid),
   name text NOT NULL,
   url text NOT NULL,
-  normalized_url text UNIQUE NOT NULL,
   author text,
   version text DEFAULT '1.0.0',
   description text,
@@ -14,17 +13,11 @@ CREATE TABLE IF NOT EXISTS public.catalog_packs (
 
 CREATE INDEX IF NOT EXISTS idx_catalog_packs_status ON public.catalog_packs(status);
 
-CREATE TABLE IF NOT EXISTS public.submission_rate_limits (
-  ip_hash text PRIMARY KEY,
-  count integer NOT NULL DEFAULT 1,
-  last_submission_at timestamptz NOT NULL DEFAULT now()
-);
-
 -- Seed approved catalog packs if not already present
-INSERT INTO public.catalog_packs (id, name, url, normalized_url, author, version, description, catalogs, status)
+INSERT INTO public.catalog_packs (id, name, url, author, version, description, catalogs, status)
 VALUES
-  ('c0a37e5e-5b12-4eb0-a5ea-9d84c1737e51', 'Cinema Essentials', '/packs/cinema-essentials.json', 'https://arvio.app/packs/cinema-essentials.json', 'ARVIO Team', '1.0.0', 'All the trending movies, popular lists, and upcoming releases you need for a perfect movie night.', '["Trending in Movies", "Top 10 Movies Today", "Top Movies This Week", "Coming Soon"]'::jsonb, 'approved'),
-  ('c0a37e5e-5b12-4eb0-a5ea-9d84c1737e52', 'TV Show Binge Pack', '/packs/tv-binge.json', 'https://arvio.app/packs/tv-binge.json', 'ARVIO Team', '1.0.0', 'Never miss an episode. Popular, trending, and latest airing series in one convenient bundle.', '["Trending in Shows", "Top 10 Shows Today", "Latest Airing"]'::jsonb, 'approved'),
-  ('c0a37e5e-5b12-4eb0-a5ea-9d84c1737e53', 'Otaku & K-Drama Hub', '/packs/anime-kdrama.json', 'https://arvio.app/packs/anime-kdrama.json', 'Community', '1.1.2', 'The ultimate pack for anime lovers and K-Drama fans. Auto-updated lists of trending episodes and releases.', '["Trending in Anime", "New in K-Dramas"]'::jsonb, 'approved'),
-  ('c0a37e5e-5b12-4eb0-a5ea-9d84c1737e54', 'Action & Franchise Classics', '/packs/classics-franchises.json', 'https://arvio.app/packs/classics-franchises.json', 'Cinephile', '1.0.5', 'Full box-sets and classic franchise collections, including James Bond, Harry Potter, Lord of the Rings, and Jurassic Park.', '["James Bond Collection", "Harry Potter Collection", "The Matrix Collection", "Lord of the Rings and Hobbit Collection", "Jurassic Park Collection"]'::jsonb, 'approved')
+  ('c0a37e5e-5b12-4eb0-a5ea-9d84c1737e51', 'Cinema Essentials', '/packs/cinema-essentials.json', 'ARVIO Team', '1.0.0', 'All the trending movies, popular lists, and upcoming releases you need for a perfect movie night.', '["Trending in Movies", "Top 10 Movies Today", "Top Movies This Week", "Coming Soon"]'::jsonb, 'approved'),
+  ('c0a37e5e-5b12-4eb0-a5ea-9d84c1737e52', 'TV Show Binge Pack', '/packs/tv-binge.json', 'ARVIO Team', '1.0.0', 'Never miss an episode. Popular, trending, and latest airing series in one convenient bundle.', '["Trending in Shows", "Top 10 Shows Today", "Latest Airing"]'::jsonb, 'approved'),
+  ('c0a37e5e-5b12-4eb0-a5ea-9d84c1737e53', 'Otaku & K-Drama Hub', '/packs/anime-kdrama.json', 'Community', '1.1.2', 'The ultimate pack for anime lovers and K-Drama fans. Auto-updated lists of trending episodes and releases.', '["Trending in Anime", "New in K-Dramas"]'::jsonb, 'approved'),
+  ('c0a37e5e-5b12-4eb0-a5ea-9d84c1737e54', 'Action & Franchise Classics', '/packs/classics-franchises.json', 'Cinephile', '1.0.5', 'Full box-sets and classic franchise collections, including James Bond, Harry Potter, Lord of the Rings, and Jurassic Park.', '["James Bond Collection", "Harry Potter Collection", "The Matrix Collection", "Lord of the Rings and Hobbit Collection", "Jurassic Park Collection"]'::jsonb, 'approved')
 ON CONFLICT (id) DO NOTHING;

--- a/netlify-auth-site/netlify/database/migrations/20260722120000_catalog_pack_submission_guards/migration.sql
+++ b/netlify-auth-site/netlify/database/migrations/20260722120000_catalog_pack_submission_guards/migration.sql
@@ -1,0 +1,26 @@
+ALTER TABLE public.catalog_packs
+  ADD COLUMN IF NOT EXISTS normalized_url text;
+
+UPDATE public.catalog_packs
+SET normalized_url = lower(
+  rtrim(
+    CASE
+      WHEN url LIKE '/%' THEN 'https://arvio.app' || url
+      ELSE url
+    END,
+    '/'
+  )
+)
+WHERE normalized_url IS NULL OR btrim(normalized_url) = '';
+
+ALTER TABLE public.catalog_packs
+  ALTER COLUMN normalized_url SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_catalog_packs_normalized_url
+  ON public.catalog_packs(normalized_url);
+
+CREATE TABLE IF NOT EXISTS public.submission_rate_limits (
+  ip_hash text PRIMARY KEY,
+  count integer NOT NULL DEFAULT 1,
+  last_submission_at timestamptz NOT NULL DEFAULT now()
+);

--- a/netlify-auth-site/netlify/functions/catalog-packs-list.js
+++ b/netlify-auth-site/netlify/functions/catalog-packs-list.js
@@ -1,0 +1,21 @@
+const {
+  json,
+  options,
+  getPool
+} = require("./_backend");
+
+exports.handler = async (event) => {
+  const cors = options(event);
+  if (cors) return cors;
+
+  try {
+    const result = await getPool().query(
+      "SELECT id, name, author, version, description, url, catalogs, status FROM public.catalog_packs WHERE status = $1 ORDER BY created_at DESC",
+      ["approved"]
+    );
+    return json(200, result.rows);
+  } catch (error) {
+    console.error("catalog-packs-list failed", error);
+    return json(500, { error: "internal_error", message: error.message });
+  }
+};

--- a/netlify-auth-site/netlify/functions/catalog-packs-submit.js
+++ b/netlify-auth-site/netlify/functions/catalog-packs-submit.js
@@ -1,9 +1,181 @@
+const dns = require("dns").promises;
 const {
   json,
   options,
   parseBody,
-  getPool
+  getPool,
+  sha256
 } = require("./_backend");
+
+// Self-contained helper to check if an IP is private/loopback/link-local/multicast/cloud metadata
+function isPrivateIp(ip) {
+  if (!ip) return true;
+
+  let cleaned = ip.trim().replace(/^\[|\]$/g, "");
+
+  // Convert IPv4-mapped IPv6 address to IPv4
+  if (cleaned.toLowerCase().startsWith("::ffff:")) {
+    cleaned = cleaned.substring(7);
+  }
+
+  // IPv4 format check
+  if (/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/.test(cleaned)) {
+    const parts = cleaned.split(".").map(Number);
+    if (parts.some(isNaN) || parts.some(p => p < 0 || p > 255)) return true;
+
+    const first = parts[0];
+    const second = parts[1];
+
+    // Loopback: 127.0.0.0/8
+    if (first === 127) return true;
+    // Broadcast/any: 0.0.0.0/8
+    if (first === 0) return true;
+    // Private RFC 1918: 10.0.0.0/8
+    if (first === 10) return true;
+    // Link-local/Cloud metadata: 169.254.0.0/16
+    if (first === 169 && second === 254) return true;
+    // Private RFC 1918: 172.16.0.0/12
+    if (first === 172 && (second >= 16 && second <= 31)) return true;
+    // Private RFC 1918: 192.168.0.0/16
+    if (first === 192 && second === 168) return true;
+    // Carrier-grade NAT: 100.64.0.0/10
+    if (first === 100 && (second >= 64 && second <= 127)) return true;
+    // Benchmark testing: 198.18.0.0/15
+    if (first === 198 && (second === 18 || second === 19)) return true;
+    // Multicast/Reserved: >= 224
+    if (first >= 224) return true;
+
+    return false;
+  }
+
+  // IPv6 format check
+  const ipv6Lower = cleaned.toLowerCase();
+  if (ipv6Lower === "::1" || ipv6Lower === "0:0:0:0:0:0:0:1") return true;
+  if (ipv6Lower === "::" || ipv6Lower === "0:0:0:0:0:0:0:0") return true;
+
+  // Link-local: fe80::/10
+  if (ipv6Lower.startsWith("fe8") || ipv6Lower.startsWith("fe9") || ipv6Lower.startsWith("fea") || ipv6Lower.startsWith("feb")) return true;
+  // ULA (Unique Local Address): fc00::/7
+  if (ipv6Lower.startsWith("fc") || ipv6Lower.startsWith("fd")) return true;
+  // Multicast: ff00::/8
+  if (ipv6Lower.startsWith("ff")) return true;
+
+  return false;
+}
+
+// Normalize URL helper
+function normalizeManifestUrl(urlStr) {
+  let trimmed = urlStr.trim();
+  if (trimmed.endsWith("/")) {
+    trimmed = trimmed.slice(0, -1);
+  }
+  return trimmed.toLowerCase();
+}
+
+async function fetchSecure(urlStr) {
+  let currentUrl = urlStr;
+  let redirects = 0;
+  const maxRedirects = 3;
+
+  while (true) {
+    if (!currentUrl.startsWith("https://")) {
+      throw new Error("Only HTTPS manifest URLs are allowed");
+    }
+
+    let parsedUrl;
+    try {
+      parsedUrl = new URL(currentUrl);
+    } catch (err) {
+      throw new Error("Invalid URL format");
+    }
+
+    const hostname = parsedUrl.hostname;
+    if (!hostname) {
+      throw new Error("Invalid hostname");
+    }
+
+    // DNS Resolution check
+    let ip;
+    if (/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/.test(hostname) || hostname.includes(":")) {
+      ip = hostname;
+    } else {
+      try {
+        const lookup = await dns.lookup(hostname);
+        ip = lookup.address;
+      } catch (dnsErr) {
+        throw new Error(`DNS lookup failed for hostname: ${hostname}`);
+      }
+    }
+
+    if (isPrivateIp(ip)) {
+      throw new Error("Access to private, loopback, or link-local IP addresses is blocked");
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 4000); // 4 seconds timeout
+
+    let response;
+    try {
+      response = await fetch(currentUrl, {
+        signal: controller.signal,
+        redirect: "manual",
+        headers: {
+          "User-Agent": "ARVIO-Pack-Validator/1.0"
+        }
+      });
+    } catch (err) {
+      if (err.name === "AbortError") {
+        throw new Error("Request timed out");
+      }
+      throw new Error(`Failed to fetch manifest: ${err.message}`);
+    } finally {
+      clearTimeout(timeoutId);
+    }
+
+    // Handle redirects manually to secure them
+    if ([301, 302, 303, 307, 308].includes(response.status)) {
+      if (redirects >= maxRedirects) {
+        throw new Error("Too many redirects");
+      }
+      const location = response.headers.get("location");
+      if (!location) {
+        throw new Error("Redirect response missing location header");
+      }
+      currentUrl = new URL(location, currentUrl).toString();
+      redirects++;
+      continue;
+    }
+
+    if (!response.ok) {
+      throw new Error(`Server returned status ${response.status}`);
+    }
+
+    // Content-Type validation
+    const contentType = response.headers.get("content-type") || "";
+    if (!contentType.includes("application/json") && !contentType.includes("text/plain")) {
+      throw new Error("Response content-type must be JSON");
+    }
+
+    // Content-Length check
+    const contentLength = response.headers.get("content-length");
+    if (contentLength && parseInt(contentLength, 10) > 512 * 1024) {
+      throw new Error("Response size exceeds the maximum limit of 512 KB");
+    }
+
+    // Download body buffer and enforce size limit
+    const buffer = await response.arrayBuffer();
+    if (buffer.byteLength > 512 * 1024) {
+      throw new Error("Response size exceeds the maximum limit of 512 KB");
+    }
+
+    const text = new TextDecoder().decode(buffer);
+    try {
+      return JSON.parse(text);
+    } catch (e) {
+      throw new Error("Failed to parse manifest as JSON. Please ensure it is valid JSON.");
+    }
+  }
+}
 
 exports.handler = async (event) => {
   const cors = options(event);
@@ -21,39 +193,95 @@ exports.handler = async (event) => {
       return json(400, { error: "bad_request", message: "Manifest URL is required" });
     }
 
-    if (!manifestUrl.startsWith("http://") && !manifestUrl.startsWith("https://")) {
-      return json(400, { error: "bad_request", message: "Manifest URL must start with http:// or https://" });
+    if (!manifestUrl.startsWith("https://")) {
+      return json(400, { error: "bad_request", message: "Manifest URL must start with https://" });
     }
 
-    // Fetch the manifest JSON
-    let response;
+    // Rate Limiting Check
+    const clientIp = event.headers["x-nf-client-connection-ip"] ||
+                     event.headers["client-ip"] ||
+                     event.headers["x-forwarded-for"] ||
+                     "unknown-ip";
+
+    const ipHash = sha256(clientIp);
+
+    // Create rate limit table if not exists (safety check)
+    await getPool().query(`
+      CREATE TABLE IF NOT EXISTS public.submission_rate_limits (
+        ip_hash text PRIMARY KEY,
+        count integer NOT NULL DEFAULT 1,
+        last_submission_at timestamptz NOT NULL DEFAULT now()
+      );
+    `).catch(err => console.warn("Failed to create submission_rate_limits table", err));
+
+    // Prune entries older than 1 hour
+    await getPool().query(
+      "DELETE FROM public.submission_rate_limits WHERE last_submission_at < now() - interval '1 hour'"
+    ).catch(err => console.warn("Failed to prune rate limits", err));
+
+    const rateLimitRes = await getPool().query(
+      "SELECT count, last_submission_at FROM public.submission_rate_limits WHERE ip_hash = $1",
+      [ipHash]
+    );
+
+    if (rateLimitRes.rows.length > 0) {
+      const { count, last_submission_at } = rateLimitRes.rows[0];
+      const lastTime = new Date(last_submission_at).getTime();
+      const now = Date.now();
+
+      // Double-click defense (10s)
+      if (now - lastTime < 10000) {
+        return json(429, {
+          error: "rate_limited",
+          message: "Too many requests. Please wait a few seconds before trying again."
+        });
+      }
+
+      // Hourly limit check (5 submissions max per hour)
+      if (count >= 5) {
+        return json(429, {
+          error: "rate_limited",
+          message: "Submission limit exceeded. Please try again in an hour."
+        });
+      }
+
+      await getPool().query(
+        "UPDATE public.submission_rate_limits SET count = count + 1, last_submission_at = now() WHERE ip_hash = $1",
+        [ipHash]
+      );
+    } else {
+      await getPool().query(
+        "INSERT INTO public.submission_rate_limits (ip_hash, count, last_submission_at) VALUES ($1, 1, now())",
+        [ipHash]
+      );
+    }
+
+    // Check for duplicate manifest URL in DB
+    const normalizedUrl = normalizeManifestUrl(manifestUrl);
+    const duplicateCheck = await getPool().query(
+      "SELECT id FROM public.catalog_packs WHERE normalized_url = $1",
+      [normalizedUrl]
+    );
+
+    if (duplicateCheck.rows.length > 0) {
+      return json(409, {
+        error: "conflict",
+        message: "This catalog pack manifest URL is already submitted."
+      });
+    }
+
+    // Securely fetch and validate manifest content
+    let manifest;
     try {
-      response = await fetch(manifestUrl);
+      manifest = await fetchSecure(manifestUrl);
     } catch (fetchErr) {
       return json(400, {
         error: "fetch_failed",
-        message: `Unable to fetch manifest JSON from "${manifestUrl}". Please verify the URL is correct and public.`
+        message: fetchErr.message
       });
     }
 
-    if (!response.ok) {
-      return json(400, {
-        error: "fetch_failed",
-        message: `Unable to fetch manifest JSON from "${manifestUrl}". Server returned status ${response.status}.`
-      });
-    }
-
-    let manifest;
-    try {
-      manifest = await response.json();
-    } catch (parseErr) {
-      return json(400, {
-        error: "invalid_json",
-        message: "Failed to parse manifest as JSON. Please ensure it is valid JSON."
-      });
-    }
-
-    // Validate manifest fields
+    // Validate manifest structure
     if (!manifest.id || typeof manifest.id !== "string" || !manifest.id.trim()) {
       return json(400, { error: "invalid_manifest", message: "Manifest is missing a valid 'id'." });
     }
@@ -64,8 +292,8 @@ exports.handler = async (event) => {
       return json(400, { error: "invalid_manifest", message: "Manifest must contain a non-empty 'catalogs' list." });
     }
 
-    // Validate catalogs structure and check for duplicate URLs
-    const normalizedUrls = new Set();
+    // Validate catalog list and check for duplicate URLs within manifest
+    const innerUrls = new Set();
     const catalogsList = [];
 
     for (const item of manifest.catalogs) {
@@ -82,8 +310,6 @@ exports.handler = async (event) => {
         });
       }
 
-      // Check for duplicate URLs (normalized)
-      // Mirroring CatalogUrlParser.normalize: trimmed, start with https if missing, remove trailing slash, lowercase
       let trimmed = item.url.trim();
       let withScheme = trimmed.startsWith("http://") || trimmed.startsWith("https://")
         ? trimmed
@@ -91,29 +317,29 @@ exports.handler = async (event) => {
       if (withScheme.endsWith("/")) {
         withScheme = withScheme.slice(0, -1);
       }
-      const normalizedUrl = withScheme.toLowerCase();
+      const innerNorm = withScheme.toLowerCase();
 
-      if (normalizedUrls.has(normalizedUrl)) {
+      if (innerUrls.has(innerNorm)) {
         return json(400, {
           error: "invalid_manifest",
-          message: `Duplicate catalog URL found: '${item.url}'.`
+          message: `Duplicate catalog URL found inside manifest: '${item.url}'.`
         });
       }
-      normalizedUrls.add(normalizedUrl);
+      innerUrls.add(innerNorm);
       catalogsList.push(item.name.trim());
     }
 
-    // Insert into public.catalog_packs database table
+    // Insert into database
     const name = (manifest.name || "").trim();
     const author = (body.author || manifest.author || "Anonymous").trim();
     const version = (manifest.version || "1.0.0").trim();
     const description = (body.description || manifest.description || "").trim();
 
     const insertResult = await getPool().query(
-      `INSERT INTO public.catalog_packs (name, url, author, version, description, catalogs, status)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)
-       RETURNING id, name, url, author, version, description, catalogs, status`,
-      [name, manifestUrl, author, version, description, JSON.stringify(catalogsList), "pending"]
+      `INSERT INTO public.catalog_packs (name, url, normalized_url, author, version, description, catalogs, status)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       RETURNING id, name, url, normalized_url, author, version, description, catalogs, status`,
+      [name, manifestUrl, normalizedUrl, author, version, description, JSON.stringify(catalogsList), "pending"]
     );
 
     return json(201, insertResult.rows[0]);

--- a/netlify-auth-site/netlify/functions/catalog-packs-submit.js
+++ b/netlify-auth-site/netlify/functions/catalog-packs-submit.js
@@ -1,4 +1,6 @@
 const dns = require("dns").promises;
+const https = require("https");
+const ipaddr = require("ipaddr.js");
 const {
   json,
   options,
@@ -7,61 +9,113 @@ const {
   sha256
 } = require("./_backend");
 
-// Self-contained helper to check if an IP is private/loopback/link-local/multicast/cloud metadata
+const MAX_MANIFEST_BYTES = 512 * 1024;
+const MANIFEST_TIMEOUT_MS = 4_000;
+const MAX_REDIRECTS = 3;
+
 function isPrivateIp(ip) {
   if (!ip) return true;
-
-  let cleaned = ip.trim().replace(/^\[|\]$/g, "");
-
-  // Convert IPv4-mapped IPv6 address to IPv4
-  if (cleaned.toLowerCase().startsWith("::ffff:")) {
-    cleaned = cleaned.substring(7);
+  const cleaned = String(ip).trim().replace(/^\[|\]$/g, "");
+  try {
+    // process() converts IPv4-mapped IPv6 addresses before classification.
+    return ipaddr.process(cleaned).range() !== "unicast";
+  } catch {
+    return true;
   }
-
-  // IPv4 format check
-  if (/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/.test(cleaned)) {
-    const parts = cleaned.split(".").map(Number);
-    if (parts.some(isNaN) || parts.some(p => p < 0 || p > 255)) return true;
-
-    const first = parts[0];
-    const second = parts[1];
-
-    // Loopback: 127.0.0.0/8
-    if (first === 127) return true;
-    // Broadcast/any: 0.0.0.0/8
-    if (first === 0) return true;
-    // Private RFC 1918: 10.0.0.0/8
-    if (first === 10) return true;
-    // Link-local/Cloud metadata: 169.254.0.0/16
-    if (first === 169 && second === 254) return true;
-    // Private RFC 1918: 172.16.0.0/12
-    if (first === 172 && (second >= 16 && second <= 31)) return true;
-    // Private RFC 1918: 192.168.0.0/16
-    if (first === 192 && second === 168) return true;
-    // Carrier-grade NAT: 100.64.0.0/10
-    if (first === 100 && (second >= 64 && second <= 127)) return true;
-    // Benchmark testing: 198.18.0.0/15
-    if (first === 198 && (second === 18 || second === 19)) return true;
-    // Multicast/Reserved: >= 224
-    if (first >= 224) return true;
-
-    return false;
-  }
-
-  // IPv6 format check
-  const ipv6Lower = cleaned.toLowerCase();
-  if (ipv6Lower === "::1" || ipv6Lower === "0:0:0:0:0:0:0:1") return true;
-  if (ipv6Lower === "::" || ipv6Lower === "0:0:0:0:0:0:0:0") return true;
-
-  // Link-local: fe80::/10
-  if (ipv6Lower.startsWith("fe8") || ipv6Lower.startsWith("fe9") || ipv6Lower.startsWith("fea") || ipv6Lower.startsWith("feb")) return true;
-  // ULA (Unique Local Address): fc00::/7
-  if (ipv6Lower.startsWith("fc") || ipv6Lower.startsWith("fd")) return true;
-  // Multicast: ff00::/8
-  if (ipv6Lower.startsWith("ff")) return true;
-
-  return false;
 }
+
+async function resolvePublicAddresses(hostname) {
+  const cleaned = hostname.trim().replace(/^\[|\]$/g, "");
+  let addresses;
+
+  if (ipaddr.isValid(cleaned)) {
+    const parsed = ipaddr.parse(cleaned);
+    addresses = [{ address: cleaned, family: parsed.kind() === "ipv6" ? 6 : 4 }];
+  } else {
+    try {
+      addresses = await dns.lookup(hostname, { all: true, verbatim: true });
+    } catch {
+      throw new Error(`DNS lookup failed for hostname: ${hostname}`);
+    }
+  }
+
+  if (!Array.isArray(addresses) || addresses.length === 0) {
+    throw new Error(`DNS lookup returned no addresses for hostname: ${hostname}`);
+  }
+  if (addresses.some(({ address }) => isPrivateIp(address))) {
+    throw new Error("Access to private, loopback, or link-local IP addresses is blocked");
+  }
+  return addresses;
+}
+
+function requestPinnedHttps(url, resolvedAddress) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const fail = (error) => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    };
+
+    const request = https.request(url, {
+      method: "GET",
+      agent: false,
+      headers: { "User-Agent": "ARVIO-Pack-Validator/1.0" },
+      // Pin the connection to the address that passed validation. TLS still
+      // verifies the certificate against the original URL hostname.
+      lookup: (_hostname, options, callback) => {
+        if (options && options.all) {
+          callback(null, [resolvedAddress]);
+        } else {
+          callback(null, resolvedAddress.address, resolvedAddress.family);
+        }
+      }
+    }, (response) => {
+      const contentLength = Number(response.headers["content-length"] || 0);
+      if (contentLength > MAX_MANIFEST_BYTES) {
+        fail(new Error("Response size exceeds the maximum limit of 512 KB"));
+        response.destroy();
+        return;
+      }
+
+      const chunks = [];
+      let totalBytes = 0;
+      response.on("data", (chunk) => {
+        if (settled) return;
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        totalBytes += buffer.length;
+        if (totalBytes > MAX_MANIFEST_BYTES) {
+          fail(new Error("Response size exceeds the maximum limit of 512 KB"));
+          response.destroy();
+          request.destroy();
+          return;
+        }
+        chunks.push(buffer);
+      });
+      response.on("error", fail);
+      response.on("end", () => {
+        if (settled) return;
+        settled = true;
+        resolve({
+          statusCode: response.statusCode || 0,
+          headers: response.headers,
+          body: Buffer.concat(chunks)
+        });
+      });
+    });
+
+    request.setTimeout(MANIFEST_TIMEOUT_MS, () => {
+      const error = new Error("Request timed out");
+      error.code = "ETIMEDOUT";
+      fail(error);
+      request.destroy();
+    });
+    request.on("error", fail);
+    request.end();
+  });
+}
+
+let secureRequest = requestPinnedHttps;
 
 // Normalize URL helper
 function normalizeManifestUrl(urlStr) {
@@ -75,18 +129,16 @@ function normalizeManifestUrl(urlStr) {
 async function fetchSecure(urlStr) {
   let currentUrl = urlStr;
   let redirects = 0;
-  const maxRedirects = 3;
 
   while (true) {
-    if (!currentUrl.startsWith("https://")) {
-      throw new Error("Only HTTPS manifest URLs are allowed");
-    }
-
     let parsedUrl;
     try {
       parsedUrl = new URL(currentUrl);
-    } catch (err) {
+    } catch {
       throw new Error("Invalid URL format");
+    }
+    if (parsedUrl.protocol !== "https:") {
+      throw new Error("Only HTTPS manifest URLs are allowed");
     }
 
     const hostname = parsedUrl.hostname;
@@ -94,50 +146,22 @@ async function fetchSecure(urlStr) {
       throw new Error("Invalid hostname");
     }
 
-    // DNS Resolution check
-    let ip;
-    if (/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/.test(hostname) || hostname.includes(":")) {
-      ip = hostname;
-    } else {
-      try {
-        const lookup = await dns.lookup(hostname);
-        ip = lookup.address;
-      } catch (dnsErr) {
-        throw new Error(`DNS lookup failed for hostname: ${hostname}`);
-      }
-    }
-
-    if (isPrivateIp(ip)) {
-      throw new Error("Access to private, loopback, or link-local IP addresses is blocked");
-    }
-
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 4000); // 4 seconds timeout
-
+    const addresses = await resolvePublicAddresses(hostname);
     let response;
     try {
-      response = await fetch(currentUrl, {
-        signal: controller.signal,
-        redirect: "manual",
-        headers: {
-          "User-Agent": "ARVIO-Pack-Validator/1.0"
-        }
-      });
+      response = await secureRequest(parsedUrl, addresses[0]);
     } catch (err) {
-      if (err.name === "AbortError") {
+      if (err.code === "ETIMEDOUT" || /timed out/i.test(err.message || "")) {
         throw new Error("Request timed out");
       }
       throw new Error(`Failed to fetch manifest: ${err.message}`);
-    } finally {
-      clearTimeout(timeoutId);
     }
 
-    // Handle redirects manually to secure them
-    if ([301, 302, 303, 307, 308].includes(response.status)) {
-      if (redirects >= maxRedirects) {
+    if ([301, 302, 303, 307, 308].includes(response.statusCode)) {
+      if (redirects >= MAX_REDIRECTS) {
         throw new Error("Too many redirects");
       }
-      const location = response.headers.get("location");
+      const location = response.headers.location;
       if (!location) {
         throw new Error("Redirect response missing location header");
       }
@@ -146,31 +170,22 @@ async function fetchSecure(urlStr) {
       continue;
     }
 
-    if (!response.ok) {
-      throw new Error(`Server returned status ${response.status}`);
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw new Error(`Server returned status ${response.statusCode}`);
     }
 
-    // Content-Type validation
-    const contentType = response.headers.get("content-type") || "";
+    const contentType = String(response.headers["content-type"] || "");
     if (!contentType.includes("application/json") && !contentType.includes("text/plain")) {
       throw new Error("Response content-type must be JSON");
     }
 
-    // Content-Length check
-    const contentLength = response.headers.get("content-length");
-    if (contentLength && parseInt(contentLength, 10) > 512 * 1024) {
+    const contentLength = Number(response.headers["content-length"] || 0);
+    if (contentLength > MAX_MANIFEST_BYTES || response.body.length > MAX_MANIFEST_BYTES) {
       throw new Error("Response size exceeds the maximum limit of 512 KB");
     }
 
-    // Download body buffer and enforce size limit
-    const buffer = await response.arrayBuffer();
-    if (buffer.byteLength > 512 * 1024) {
-      throw new Error("Response size exceeds the maximum limit of 512 KB");
-    }
-
-    const text = new TextDecoder().decode(buffer);
     try {
-      return JSON.parse(text);
+      return JSON.parse(response.body.toString("utf8"));
     } catch (e) {
       throw new Error("Failed to parse manifest as JSON. Please ensure it is valid JSON.");
     }
@@ -346,5 +361,16 @@ exports.handler = async (event) => {
   } catch (error) {
     console.error("catalog-packs-submit failed", error);
     return json(500, { error: "internal_error", message: error.message });
+  }
+};
+
+exports._test = {
+  fetchSecure,
+  isPrivateIp,
+  setSecureRequest(requester) {
+    secureRequest = requester;
+  },
+  resetSecureRequest() {
+    secureRequest = requestPinnedHttps;
   }
 };

--- a/netlify-auth-site/netlify/functions/catalog-packs-submit.js
+++ b/netlify-auth-site/netlify/functions/catalog-packs-submit.js
@@ -1,0 +1,124 @@
+const {
+  json,
+  options,
+  parseBody,
+  getPool
+} = require("./_backend");
+
+exports.handler = async (event) => {
+  const cors = options(event);
+  if (cors) return cors;
+
+  if (event.httpMethod !== "POST") {
+    return json(405, { error: "method_not_allowed", message: "Method not allowed" });
+  }
+
+  try {
+    const body = parseBody(event);
+    const manifestUrl = (body.url || "").trim();
+
+    if (!manifestUrl) {
+      return json(400, { error: "bad_request", message: "Manifest URL is required" });
+    }
+
+    if (!manifestUrl.startsWith("http://") && !manifestUrl.startsWith("https://")) {
+      return json(400, { error: "bad_request", message: "Manifest URL must start with http:// or https://" });
+    }
+
+    // Fetch the manifest JSON
+    let response;
+    try {
+      response = await fetch(manifestUrl);
+    } catch (fetchErr) {
+      return json(400, {
+        error: "fetch_failed",
+        message: `Unable to fetch manifest JSON from "${manifestUrl}". Please verify the URL is correct and public.`
+      });
+    }
+
+    if (!response.ok) {
+      return json(400, {
+        error: "fetch_failed",
+        message: `Unable to fetch manifest JSON from "${manifestUrl}". Server returned status ${response.status}.`
+      });
+    }
+
+    let manifest;
+    try {
+      manifest = await response.json();
+    } catch (parseErr) {
+      return json(400, {
+        error: "invalid_json",
+        message: "Failed to parse manifest as JSON. Please ensure it is valid JSON."
+      });
+    }
+
+    // Validate manifest fields
+    if (!manifest.id || typeof manifest.id !== "string" || !manifest.id.trim()) {
+      return json(400, { error: "invalid_manifest", message: "Manifest is missing a valid 'id'." });
+    }
+    if (!manifest.name || typeof manifest.name !== "string" || !manifest.name.trim()) {
+      return json(400, { error: "invalid_manifest", message: "Manifest is missing a valid 'name'." });
+    }
+    if (!Array.isArray(manifest.catalogs) || manifest.catalogs.length === 0) {
+      return json(400, { error: "invalid_manifest", message: "Manifest must contain a non-empty 'catalogs' list." });
+    }
+
+    // Validate catalogs structure and check for duplicate URLs
+    const normalizedUrls = new Set();
+    const catalogsList = [];
+
+    for (const item of manifest.catalogs) {
+      if (!item.name || typeof item.name !== "string" || !item.name.trim()) {
+        return json(400, {
+          error: "invalid_manifest",
+          message: "All catalog items in the manifest must have a valid 'name'."
+        });
+      }
+      if (!item.url || typeof item.url !== "string" || !item.url.trim()) {
+        return json(400, {
+          error: "invalid_manifest",
+          message: "All catalog items in the manifest must have a valid 'url'."
+        });
+      }
+
+      // Check for duplicate URLs (normalized)
+      // Mirroring CatalogUrlParser.normalize: trimmed, start with https if missing, remove trailing slash, lowercase
+      let trimmed = item.url.trim();
+      let withScheme = trimmed.startsWith("http://") || trimmed.startsWith("https://")
+        ? trimmed
+        : `https://${trimmed}`;
+      if (withScheme.endsWith("/")) {
+        withScheme = withScheme.slice(0, -1);
+      }
+      const normalizedUrl = withScheme.toLowerCase();
+
+      if (normalizedUrls.has(normalizedUrl)) {
+        return json(400, {
+          error: "invalid_manifest",
+          message: `Duplicate catalog URL found: '${item.url}'.`
+        });
+      }
+      normalizedUrls.add(normalizedUrl);
+      catalogsList.push(item.name.trim());
+    }
+
+    // Insert into public.catalog_packs database table
+    const name = (manifest.name || "").trim();
+    const author = (body.author || manifest.author || "Anonymous").trim();
+    const version = (manifest.version || "1.0.0").trim();
+    const description = (body.description || manifest.description || "").trim();
+
+    const insertResult = await getPool().query(
+      `INSERT INTO public.catalog_packs (name, url, author, version, description, catalogs, status)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING id, name, url, author, version, description, catalogs, status`,
+      [name, manifestUrl, author, version, description, JSON.stringify(catalogsList), "pending"]
+    );
+
+    return json(201, insertResult.rows[0]);
+  } catch (error) {
+    console.error("catalog-packs-submit failed", error);
+    return json(500, { error: "internal_error", message: error.message });
+  }
+};

--- a/netlify-auth-site/package-lock.json
+++ b/netlify-auth-site/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@netlify/blobs": "^10.7.9",
         "@netlify/database": "^1.0.0",
+        "ipaddr.js": "^2.4.0",
         "pg": "^8.16.3"
       },
       "devDependencies": {
@@ -9791,7 +9792,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
       "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"

--- a/netlify-auth-site/package.json
+++ b/netlify-auth-site/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@netlify/blobs": "^10.7.9",
     "@netlify/database": "^1.0.0",
+    "ipaddr.js": "^2.4.0",
     "pg": "^8.16.3"
   },
   "devDependencies": {

--- a/netlify-auth-site/tests/catalog-packs-submit.test.js
+++ b/netlify-auth-site/tests/catalog-packs-submit.test.js
@@ -1,0 +1,193 @@
+const test = require("node:test");
+const assert = require("assert");
+const dns = require("dns").promises;
+
+// Mock the backend module before requiring the handler to avoid connecting to the database
+const mockQueries = [];
+let mockRateLimitRows = [];
+let mockDuplicateCheckRows = [];
+
+const mockBackend = {
+  json: (status, body) => ({
+    statusCode: status,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body)
+  }),
+  options: () => null,
+  parseBody: (event) => {
+    return typeof event.body === "string" ? JSON.parse(event.body) : event.body;
+  },
+  getPool: () => ({
+    query: async (queryText, values) => {
+      mockQueries.push({ queryText, values });
+      if (queryText.includes("submission_rate_limits") && queryText.includes("SELECT")) {
+        return { rows: mockRateLimitRows };
+      }
+      if (queryText.includes("catalog_packs") && queryText.includes("SELECT")) {
+        return { rows: mockDuplicateCheckRows };
+      }
+      return { rows: [{ id: "mock-id", name: "Mock Pack" }] };
+    }
+  }),
+  sha256: (val) => require("crypto").createHash("sha256").update(val).digest("hex")
+};
+
+require.cache[require.resolve("../netlify/functions/_backend")] = {
+  exports: mockBackend
+};
+
+const { handler } = require("../netlify/functions/catalog-packs-submit");
+
+// Helper to create events
+function createEvent({ url, clientIp = "1.2.3.4", bodyExtra = {} }) {
+  return {
+    httpMethod: "POST",
+    headers: {
+      "client-ip": clientIp
+    },
+    body: JSON.stringify({
+      url,
+      ...bodyExtra
+    })
+  };
+}
+
+test("catalog-packs-submit unit tests", async (t) => {
+  const originalFetch = globalThis.fetch;
+
+  t.afterEach(() => {
+    globalThis.fetch = originalFetch;
+    mockQueries.length = 0;
+    mockRateLimitRows = [];
+    mockDuplicateCheckRows = [];
+  });
+
+  await t.test("Allow HTTPS manifest URLs only", async () => {
+    const event = createEvent({ url: "http://example.com/manifest.json" });
+    const res = await handler(event);
+    assert.strictEqual(res.statusCode, 400);
+    const body = JSON.parse(res.body);
+    assert.strictEqual(body.error, "bad_request");
+    assert.match(body.message, /https:\/\//i);
+  });
+
+  await t.test("Block localhost, private and link-local IPs (direct IP check)", async () => {
+    const localhostEvent = createEvent({ url: "https://127.0.0.1/manifest.json" });
+    const res = await handler(localhostEvent);
+    assert.strictEqual(res.statusCode, 400);
+    const body = JSON.parse(res.body);
+    assert.strictEqual(body.error, "fetch_failed");
+    assert.match(body.message, /private, loopback, or link-local IP addresses/);
+  });
+
+  await t.test("Block hostnames that resolve to private IPs (DNS resolution check)", async () => {
+    // Resolve any test local hostname or stub DNS lookup.
+    // For safety in this test, we can mock dns.lookup or mock a local URL
+    const originalLookup = dns.lookup;
+    dns.lookup = async () => ({ address: "192.168.1.50" });
+
+    try {
+      const event = createEvent({ url: "https://some-internal-domain.local/manifest.json" });
+      const res = await handler(event);
+      assert.strictEqual(res.statusCode, 400);
+      const body = JSON.parse(res.body);
+      assert.strictEqual(body.error, "fetch_failed");
+      assert.match(body.message, /private, loopback, or link-local IP addresses/);
+    } finally {
+      dns.lookup = originalLookup;
+    }
+  });
+
+  await t.test("Fail on response size exceeding maximum limit", async () => {
+    globalThis.fetch = async () => ({
+      ok: true,
+      status: 200,
+      headers: {
+        get: (name) => {
+          if (name.toLowerCase() === "content-type") return "application/json";
+          if (name.toLowerCase() === "content-length") return String(1024 * 1024); // 1 MB
+          return null;
+        }
+      },
+      arrayBuffer: async () => new ArrayBuffer(1024 * 1024)
+    });
+
+    const event = createEvent({ url: "https://example.com/huge.json" });
+    const res = await handler(event);
+    assert.strictEqual(res.statusCode, 400);
+    const body = JSON.parse(res.body);
+    assert.strictEqual(body.error, "fetch_failed");
+    assert.match(body.message, /exceeds the maximum limit/);
+  });
+
+  await t.test("Fail on fetch timeout", async () => {
+    globalThis.fetch = () => new Promise((resolve, reject) => {
+      // Simulate timeout by rejecting with AbortError
+      const err = new Error("The operation was aborted.");
+      err.name = "AbortError";
+      setTimeout(() => reject(err), 50);
+    });
+
+    const event = createEvent({ url: "https://example.com/slow.json" });
+    const res = await handler(event);
+    assert.strictEqual(res.statusCode, 400);
+    const body = JSON.parse(res.body);
+    assert.strictEqual(body.error, "fetch_failed");
+    assert.match(body.message, /timed out/);
+  });
+
+  await t.test("Fail on invalid JSON content-type", async () => {
+    globalThis.fetch = async () => ({
+      ok: true,
+      status: 200,
+      headers: {
+        get: (name) => {
+          if (name.toLowerCase() === "content-type") return "text/html";
+          return null;
+        }
+      }
+    });
+
+    const event = createEvent({ url: "https://example.com/index.html" });
+    const res = await handler(event);
+    assert.strictEqual(res.statusCode, 400);
+    const body = JSON.parse(res.body);
+    assert.strictEqual(body.error, "fetch_failed");
+    assert.match(body.message, /content-type must be JSON/);
+  });
+
+  await t.test("Reject duplicate manifest URLs", async () => {
+    mockDuplicateCheckRows = [{ id: "existing-id" }];
+
+    const event = createEvent({ url: "https://example.com/duplicate.json" });
+    const res = await handler(event);
+    assert.strictEqual(res.statusCode, 409);
+    const body = JSON.parse(res.body);
+    assert.strictEqual(body.error, "conflict");
+    assert.match(body.message, /already submitted/);
+  });
+
+  await t.test("Enforce hourly rate limit", async () => {
+    // Mock database returning 5 submissions for this IP in the current hour
+    mockRateLimitRows = [{ count: 5, last_submission_at: new Date(Date.now() - 300000).toISOString() }];
+
+    const event = createEvent({ url: "https://example.com/ok.json" });
+    const res = await handler(event);
+    assert.strictEqual(res.statusCode, 429);
+    const body = JSON.parse(res.body);
+    assert.strictEqual(body.error, "rate_limited");
+    assert.match(body.message, /Submission limit exceeded/);
+  });
+
+  await t.test("Enforce double-click defense (10s)", async () => {
+    // Mock database returning 1 submission 5 seconds ago
+    mockRateLimitRows = [{ count: 1, last_submission_at: new Date(Date.now() - 5000).toISOString() }];
+
+    const event = createEvent({ url: "https://example.com/ok.json" });
+    const res = await handler(event);
+    assert.strictEqual(res.statusCode, 429);
+    const body = JSON.parse(res.body);
+    assert.strictEqual(body.error, "rate_limited");
+    assert.match(body.message, /wait a few seconds/);
+  });
+});

--- a/netlify-auth-site/tests/catalog-packs-submit.test.js
+++ b/netlify-auth-site/tests/catalog-packs-submit.test.js
@@ -36,7 +36,7 @@ require.cache[require.resolve("../netlify/functions/_backend")] = {
   exports: mockBackend
 };
 
-const { handler } = require("../netlify/functions/catalog-packs-submit");
+const { handler, _test } = require("../netlify/functions/catalog-packs-submit");
 
 // Helper to create events
 function createEvent({ url, clientIp = "1.2.3.4", bodyExtra = {} }) {
@@ -53,10 +53,8 @@ function createEvent({ url, clientIp = "1.2.3.4", bodyExtra = {} }) {
 }
 
 test("catalog-packs-submit unit tests", async (t) => {
-  const originalFetch = globalThis.fetch;
-
   t.afterEach(() => {
-    globalThis.fetch = originalFetch;
+    _test.resetSecureRequest();
     mockQueries.length = 0;
     mockRateLimitRows = [];
     mockDuplicateCheckRows = [];
@@ -80,11 +78,20 @@ test("catalog-packs-submit unit tests", async (t) => {
     assert.match(body.message, /private, loopback, or link-local IP addresses/);
   });
 
+  await t.test("Block IPv4-mapped IPv6 loopback addresses", async () => {
+    const event = createEvent({ url: "https://[::ffff:127.0.0.1]/manifest.json" });
+    const res = await handler(event);
+    assert.strictEqual(res.statusCode, 400);
+    const body = JSON.parse(res.body);
+    assert.strictEqual(body.error, "fetch_failed");
+    assert.match(body.message, /private, loopback, or link-local IP addresses/);
+  });
+
   await t.test("Block hostnames that resolve to private IPs (DNS resolution check)", async () => {
     // Resolve any test local hostname or stub DNS lookup.
     // For safety in this test, we can mock dns.lookup or mock a local URL
     const originalLookup = dns.lookup;
-    dns.lookup = async () => ({ address: "192.168.1.50" });
+    dns.lookup = async () => [{ address: "192.168.1.50", family: 4 }];
 
     try {
       const event = createEvent({ url: "https://some-internal-domain.local/manifest.json" });
@@ -98,21 +105,63 @@ test("catalog-packs-submit unit tests", async (t) => {
     }
   });
 
-  await t.test("Fail on response size exceeding maximum limit", async () => {
-    globalThis.fetch = async () => ({
-      ok: true,
-      status: 200,
-      headers: {
-        get: (name) => {
-          if (name.toLowerCase() === "content-type") return "application/json";
-          if (name.toLowerCase() === "content-length") return String(1024 * 1024); // 1 MB
-          return null;
-        }
-      },
-      arrayBuffer: async () => new ArrayBuffer(1024 * 1024)
+  await t.test("Block a hostname when any DNS result is private", async () => {
+    const originalLookup = dns.lookup;
+    dns.lookup = async () => [
+      { address: "93.184.216.34", family: 4 },
+      { address: "10.0.0.8", family: 4 }
+    ];
+
+    try {
+      const event = createEvent({ url: "https://mixed-addresses.example/manifest.json" });
+      const res = await handler(event);
+      assert.strictEqual(res.statusCode, 400);
+      const body = JSON.parse(res.body);
+      assert.strictEqual(body.error, "fetch_failed");
+      assert.match(body.message, /private, loopback, or link-local IP addresses/);
+    } finally {
+      dns.lookup = originalLookup;
+    }
+  });
+
+  await t.test("Pin the request to the validated DNS address", async () => {
+    const originalLookup = dns.lookup;
+    dns.lookup = async () => [{ address: "93.184.216.34", family: 4 }];
+    let requestedAddress;
+    _test.setSecureRequest(async (_url, address) => {
+      requestedAddress = address;
+      return {
+        statusCode: 200,
+        headers: { "content-type": "application/json" },
+        body: Buffer.from(JSON.stringify({
+          id: "safe-pack",
+          name: "Safe Pack",
+          catalogs: [{ name: "Movies", url: "https://mdblist.com/lists/test/movies" }]
+        }))
+      };
     });
 
-    const event = createEvent({ url: "https://example.com/huge.json" });
+    try {
+      const event = createEvent({ url: "https://public-manifest.example/manifest.json" });
+      const res = await handler(event);
+      assert.strictEqual(res.statusCode, 201);
+      assert.deepStrictEqual(requestedAddress, { address: "93.184.216.34", family: 4 });
+    } finally {
+      dns.lookup = originalLookup;
+    }
+  });
+
+  await t.test("Fail on response size exceeding maximum limit", async () => {
+    _test.setSecureRequest(async () => ({
+      statusCode: 200,
+      headers: {
+        "content-type": "application/json",
+        "content-length": String(1024 * 1024)
+      },
+      body: Buffer.alloc(0)
+    }));
+
+    const event = createEvent({ url: "https://93.184.216.34/huge.json" });
     const res = await handler(event);
     assert.strictEqual(res.statusCode, 400);
     const body = JSON.parse(res.body);
@@ -121,14 +170,13 @@ test("catalog-packs-submit unit tests", async (t) => {
   });
 
   await t.test("Fail on fetch timeout", async () => {
-    globalThis.fetch = () => new Promise((resolve, reject) => {
-      // Simulate timeout by rejecting with AbortError
-      const err = new Error("The operation was aborted.");
-      err.name = "AbortError";
-      setTimeout(() => reject(err), 50);
+    _test.setSecureRequest(async () => {
+      const error = new Error("Request timed out");
+      error.code = "ETIMEDOUT";
+      throw error;
     });
 
-    const event = createEvent({ url: "https://example.com/slow.json" });
+    const event = createEvent({ url: "https://93.184.216.34/slow.json" });
     const res = await handler(event);
     assert.strictEqual(res.statusCode, 400);
     const body = JSON.parse(res.body);
@@ -137,18 +185,13 @@ test("catalog-packs-submit unit tests", async (t) => {
   });
 
   await t.test("Fail on invalid JSON content-type", async () => {
-    globalThis.fetch = async () => ({
-      ok: true,
-      status: 200,
-      headers: {
-        get: (name) => {
-          if (name.toLowerCase() === "content-type") return "text/html";
-          return null;
-        }
-      }
-    });
+    _test.setSecureRequest(async () => ({
+      statusCode: 200,
+      headers: { "content-type": "text/html" },
+      body: Buffer.from("<html></html>")
+    }));
 
-    const event = createEvent({ url: "https://example.com/index.html" });
+    const event = createEvent({ url: "https://93.184.216.34/index.html" });
     const res = await handler(event);
     assert.strictEqual(res.statusCode, 400);
     const body = JSON.parse(res.body);

--- a/web/app/discover/page.tsx
+++ b/web/app/discover/page.tsx
@@ -1,0 +1,946 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { Copy, Check, Download, HelpCircle, Code, ListVideo, Loader2, Plus, X, Globe, User, BookOpen, AlertCircle } from "lucide-react";
+import { config, hasSupabaseConfig } from "@/lib/config";
+
+export const dynamic = "force-static";
+
+interface CatalogPack {
+  id?: string;
+  name: string;
+  author: string;
+  version: string;
+  description: string;
+  url: string;
+  catalogs: string[];
+  status?: "pending" | "approved";
+}
+
+const STATIC_FALLBACK_PACKS: CatalogPack[] = [
+  {
+    id: "cinema-essentials",
+    name: "Cinema Essentials",
+    author: "ARVIO Team",
+    version: "1.0.0",
+    description: "All the trending movies, popular lists, and upcoming releases you need for a perfect movie night.",
+    url: "https://arvio.app/packs/cinema-essentials.json",
+    catalogs: ["Trending in Movies", "Top 10 Movies Today", "Top Movies This Week", "Coming Soon"]
+  },
+  {
+    id: "tv-binge",
+    name: "TV Show Binge Pack",
+    author: "ARVIO Team",
+    version: "1.0.0",
+    description: "Never miss an episode. Popular, trending, and latest airing series in one convenient bundle.",
+    url: "https://arvio.app/packs/tv-binge.json",
+    catalogs: ["Trending in Shows", "Top 10 Shows Today", "Latest Airing"]
+  },
+  {
+    id: "anime-kdrama",
+    name: "Otaku & K-Drama Hub",
+    author: "Community",
+    version: "1.1.2",
+    description: "The ultimate pack for anime lovers and K-Drama fans. Auto-updated lists of trending episodes and releases.",
+    url: "https://arvio.app/packs/anime-kdrama.json",
+    catalogs: ["Trending in Anime", "New in K-Dramas"]
+  },
+  {
+    id: "classics-franchises",
+    name: "Action & Franchise Classics",
+    author: "Cinephile",
+    version: "1.0.5",
+    description: "Full box-sets and classic franchise collections, including James Bond, Harry Potter, Lord of the Rings, and Jurassic Park.",
+    url: "https://arvio.app/packs/classics-franchises.json",
+    catalogs: [
+      "James Bond Collection",
+      "Harry Potter Collection",
+      "The Matrix Collection",
+      "Lord of the Rings and Hobbit Collection",
+      "Jurassic Park Collection"
+    ]
+  }
+];
+
+export default function DiscoverPage() {
+  const [packs, setPacks] = useState<CatalogPack[]>(STATIC_FALLBACK_PACKS);
+  const [loading, setLoading] = useState(true);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  // Form States
+  const [showSubmitModal, setShowSubmitModal] = useState(false);
+  const [formName, setFormName] = useState("");
+  const [formAuthor, setFormAuthor] = useState("");
+  const [formUrl, setFormUrl] = useState("");
+  const [formDesc, setFormDesc] = useState("");
+  const [formCatalogs, setFormCatalogs] = useState("");
+  const [submitLoading, setSubmitLoading] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitSuccess, setSubmitSuccess] = useState(false);
+
+  async function loadPacks() {
+    try {
+      if (hasSupabaseConfig()) {
+        const res = await fetch(`${config.supabaseUrl}/rest/v1/catalog_packs?status=eq.approved&select=*`, {
+          headers: {
+            apikey: config.supabaseAnonKey,
+            Accept: "application/json"
+          }
+        });
+        if (res.ok) {
+          const data = await res.json();
+          const parsed = data.map((item: any) => ({
+            ...item,
+            catalogs: typeof item.catalogs === "string" ? JSON.parse(item.catalogs) : item.catalogs
+          }));
+          if (Array.isArray(parsed) && parsed.length > 0) {
+            setPacks(parsed);
+            setLoading(false);
+            return;
+          }
+        }
+      }
+    } catch (err) {
+      console.warn("Supabase fetch failed, falling back to static packs.json:", err);
+    }
+
+    // Fallback: fetch from /packs.json
+    try {
+      const res = await fetch("/packs.json");
+      if (res.ok) {
+        const data = await res.json();
+        if (Array.isArray(data) && data.length > 0) {
+          setPacks(data);
+        }
+      }
+    } catch (err) {
+      console.error("Local packs.json fetch failed, using default hardcoded list:", err);
+    }
+    setLoading(false);
+  }
+
+  useEffect(() => {
+    void loadPacks();
+  }, []);
+
+  const copyToClipboard = (id: string, text: string) => {
+    navigator.clipboard.writeText(text).then(() => {
+      setCopiedId(id);
+      setTimeout(() => setCopiedId(null), 2000);
+    });
+  };
+
+  const getDeepLink = (packUrl: string) => {
+    return `arvio://install-pack?url=${encodeURIComponent(packUrl)}`;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!formName.trim() || !formUrl.trim() || !formDesc.trim() || !formCatalogs.trim()) {
+      setSubmitError("Please fill out all required fields.");
+      return;
+    }
+
+    // Basic URL validation
+    if (!formUrl.startsWith("http://") && !formUrl.startsWith("https://")) {
+      setSubmitError("Manifest URL must start with http:// or https://");
+      return;
+    }
+
+    setSubmitLoading(true);
+    setSubmitError(null);
+
+    const catalogList = formCatalogs
+      .split(",")
+      .map((c) => c.trim())
+      .filter(Boolean);
+
+    try {
+      if (!hasSupabaseConfig()) {
+        throw new Error("Supabase is not configured on the website backend. Please submit packs via GitHub.");
+      }
+
+      const res = await fetch(`${config.supabaseUrl}/rest/v1/catalog_packs`, {
+        method: "POST",
+        headers: {
+          apikey: config.supabaseAnonKey,
+          "Content-Type": "application/json",
+          Prefer: "return=minimal"
+        },
+        body: JSON.stringify({
+          name: formName.trim(),
+          url: formUrl.trim(),
+          author: formAuthor.trim() || "Anonymous",
+          version: "1.0.0",
+          description: formDesc.trim(),
+          catalogs: catalogList,
+          status: "pending" // Require moderator approval
+        })
+      });
+
+      if (!res.ok) {
+        throw new Error(`Failed to submit: ${res.statusText}`);
+      }
+
+      setSubmitSuccess(true);
+      setFormName("");
+      setFormAuthor("");
+      setFormUrl("");
+      setFormDesc("");
+      setFormCatalogs("");
+      setTimeout(() => {
+        setSubmitSuccess(false);
+        setShowSubmitModal(false);
+      }, 3000);
+    } catch (err: any) {
+      setSubmitError(err.message || "An unexpected error occurred during submission.");
+    } finally {
+      setSubmitLoading(false);
+    }
+  };
+
+  return (
+    <div className="discover-container">
+      <header className="discover-header">
+        <div className="header-top">
+          <div className="logo-section">
+            <img src="/arvio-logo.svg" alt="ARVIO Logo" className="logo" />
+            <span className="logo-text">ARVIO</span>
+          </div>
+          <button 
+            type="button" 
+            className="submit-trigger-button"
+            onClick={() => {
+              setSubmitError(null);
+              setSubmitSuccess(false);
+              setShowSubmitModal(true);
+            }}
+          >
+            <Plus size={16} /> Submit A Pack
+          </button>
+        </div>
+        
+        <h1 className="hero-title">Catalog Pack Discovery</h1>
+        <p className="hero-subtitle">
+          Enhance your streaming layout. Browse community-curated catalog packs and install multiple rows of content with a single click.
+        </p>
+      </header>
+
+      {loading ? (
+        <div className="loading-container">
+          <Loader2 size={32} className="animate-spin text-muted" />
+          <span>Fetching latest catalog packs...</span>
+        </div>
+      ) : (
+        <main className="discover-grid">
+          {packs.map((pack) => (
+            <article key={pack.id || pack.url} className="pack-card">
+              <div className="pack-card-header">
+                <h2 className="pack-title">{pack.name}</h2>
+                <div className="pack-meta">
+                  <span className="pack-author">by {pack.author || "Anonymous"}</span>
+                  <span className="pack-version">v{pack.version || "1.0.0"}</span>
+                </div>
+              </div>
+              <p className="pack-description">{pack.description}</p>
+              
+              <div className="catalogs-section">
+                <h3 className="section-label">
+                  <ListVideo size={14} className="icon-inline" /> Included Rows ({pack.catalogs?.length || 0})
+                </h3>
+                <ul className="catalogs-list">
+                  {pack.catalogs?.map((catalog, idx) => (
+                    <li key={idx} className="catalog-item-tag">{catalog}</li>
+                  ))}
+                </ul>
+              </div>
+
+              <div className="pack-actions">
+                <a 
+                  href={getDeepLink(pack.url)} 
+                  className="install-button"
+                  title="Install this pack on your Android TV or local app"
+                >
+                  <Download size={16} /> Install Pack
+                </a>
+                <button 
+                  type="button" 
+                  onClick={() => copyToClipboard(pack.id || pack.url, pack.url)}
+                  className="copy-button"
+                  title="Copy manifest JSON URL to clipboard"
+                >
+                  {copiedId === (pack.id || pack.url) ? <Check size={16} className="text-green" /> : <Copy size={16} />}
+                  {copiedId === (pack.id || pack.url) ? "Copied!" : "Copy URL"}
+                </button>
+              </div>
+            </article>
+          ))}
+        </main>
+      )}
+
+      {/* Submission Modal Overlay */}
+      {showSubmitModal && (
+        <div className="modal-backdrop">
+          <div className="modal-content">
+            <button 
+              type="button" 
+              className="modal-close"
+              onClick={() => setShowSubmitModal(false)}
+            >
+              <X size={20} />
+            </button>
+
+            {submitSuccess ? (
+              <div className="submit-feedback success">
+                <Check size={48} className="text-green feedback-icon animate-bounce" />
+                <h2>Submission Successful!</h2>
+                <p>
+                  Thank you! Your catalog pack has been submitted for review. It will become visible on the Discovery page once approved by a moderator.
+                </p>
+              </div>
+            ) : (
+              <form onSubmit={handleSubmit} className="submission-form">
+                <h2>Submit a Catalog Pack</h2>
+                <p className="form-intro">
+                  Packs are moderated to ensure safety, formatting correctness, and server reliability.
+                </p>
+
+                {submitError && (
+                  <div className="form-error">
+                    <AlertCircle size={16} />
+                    <span>{submitError}</span>
+                  </div>
+                )}
+
+                <div className="form-field">
+                  <label htmlFor="pack-name"><BookOpen size={14} /> Pack Name *</label>
+                  <input 
+                    type="text" 
+                    id="pack-name"
+                    required
+                    placeholder="e.g. Action Blockbusters Bundle"
+                    value={formName}
+                    onChange={(e) => setFormName(e.target.value)}
+                  />
+                </div>
+
+                <div className="form-field">
+                  <label htmlFor="pack-url"><Globe size={14} /> Manifest JSON URL *</label>
+                  <input 
+                    type="text" 
+                    id="pack-url"
+                    required
+                    placeholder="e.g. https://raw.githubusercontent.com/.../pack.json"
+                    value={formUrl}
+                    onChange={(e) => setFormUrl(e.target.value)}
+                  />
+                  <span className="field-hint">Must be public, CORS-enabled, and serve valid JSON.</span>
+                </div>
+
+                <div className="form-field-row">
+                  <div className="form-field">
+                    <label htmlFor="pack-author"><User size={14} /> Author / Creator</label>
+                    <input 
+                      type="text" 
+                      id="pack-author"
+                      placeholder="e.g. @cinephile_dev"
+                      value={formAuthor}
+                      onChange={(e) => setFormAuthor(e.target.value)}
+                    />
+                  </div>
+                </div>
+
+                <div className="form-field">
+                  <label htmlFor="pack-desc">Description *</label>
+                  <textarea 
+                    id="pack-desc"
+                    required
+                    rows={3}
+                    placeholder="Describe the content and purpose of this pack..."
+                    value={formDesc}
+                    onChange={(e) => setFormDesc(e.target.value)}
+                  />
+                </div>
+
+                <div className="form-field">
+                  <label htmlFor="pack-catalogs">Included Catalogs *</label>
+                  <input 
+                    type="text" 
+                    id="pack-catalogs"
+                    required
+                    placeholder="e.g. Marvel Universe, Star Wars Timeline, MCU Extras (comma separated)"
+                    value={formCatalogs}
+                    onChange={(e) => setFormCatalogs(e.target.value)}
+                  />
+                  <span className="field-hint">Provide names for the catalog rows included in your manifest.</span>
+                </div>
+
+                <button 
+                  type="submit" 
+                  className="form-submit-button"
+                  disabled={submitLoading}
+                >
+                  {submitLoading ? (
+                    <>
+                      <Loader2 size={16} className="animate-spin" /> Submitting...
+                    </>
+                  ) : (
+                    "Submit for Review"
+                  )}
+                </button>
+              </form>
+            )}
+          </div>
+        </div>
+      )}
+
+      <section className="faq-section">
+        <h2 className="faq-heading"><HelpCircle size={22} className="icon-inline" /> Frequently Asked Questions</h2>
+        <div className="faq-grid">
+          <div className="faq-item">
+            <h3>How do I install a pack?</h3>
+            <p>
+              Clicking <strong>Install Pack</strong> will trigger a deep link (<code>arvio://install-pack</code>) to launch the ARVIO app on your device and open the import dialog. If you are browsing on another device, copy the URL and paste it under <strong>Settings &gt; Catalogs &gt; Import Catalog Pack</strong> in your app.
+            </p>
+          </div>
+          <div className="faq-item">
+            <h3>How do I host my own Catalog Pack?</h3>
+            <p>
+              Create a JSON file matching the manifest structure below, host it on a public server (like GitHub Gist, Supabase, or Netlify), and share your raw link or deep link code!
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="manifest-example-section">
+        <h2 className="manifest-heading"><Code size={22} className="icon-inline" /> Manifest JSON Structure</h2>
+        <pre className="code-block">
+          <code>{`{
+  "id": "my-custom-pack",
+  "name": "My Custom Catalog Pack",
+  "author": "CreatorName",
+  "version": "1.0.0",
+  "description": "A brief description of the pack contents.",
+  "catalogs": [
+    {
+      "name": "Trending Sci-Fi Movies",
+      "url": "https://example.com/scifi-movies.json"
+    },
+    {
+      "name": "Upcoming Action Series",
+      "url": "https://example.com/action-series.json"
+    }
+  ]
+}`}</code>
+        </pre>
+      </section>
+
+      <footer className="discover-footer">
+        <p>ARVIO TV &copy; {new Date().getFullYear()}. Built with premium aesthetics.</p>
+      </footer>
+
+      <style jsx>{`
+        .discover-container {
+          max-width: 1200px;
+          margin: 0 auto;
+          padding: 60px 24px;
+          color: #ededed;
+          font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+          background-color: #000000;
+          min-height: 100vh;
+        }
+
+        .discover-header {
+          text-align: left;
+          margin-bottom: 60px;
+        }
+
+        .header-top {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          margin-bottom: 32px;
+          flex-wrap: wrap;
+          gap: 16px;
+        }
+
+        .logo-section {
+          display: flex;
+          align-items: center;
+          gap: 12px;
+        }
+
+        .logo {
+          width: 48px;
+          height: 48px;
+        }
+
+        .logo-text {
+          font-size: 28px;
+          font-weight: 800;
+          letter-spacing: 1px;
+          color: #fff;
+        }
+
+        .submit-trigger-button {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+          background: rgba(255, 255, 255, 0.08);
+          color: #fff;
+          border: 1px solid rgba(255, 255, 255, 0.12);
+          padding: 10px 18px;
+          border-radius: 20px;
+          font-weight: 600;
+          font-size: 14px;
+          cursor: pointer;
+          transition: background 160ms ease, border-color 160ms ease, transform 160ms ease;
+        }
+
+        .submit-trigger-button:hover {
+          background: rgba(255, 255, 255, 0.15);
+          border-color: rgba(255, 255, 255, 0.25);
+        }
+
+        .submit-trigger-button:active {
+          transform: scale(0.97);
+        }
+
+        .hero-title {
+          font-size: 42px;
+          font-weight: 800;
+          margin: 0 0 16px 0;
+          background: linear-gradient(135deg, #ffffff 40%, #8c8c9e);
+          -webkit-background-clip: text;
+          -webkit-text-fill-color: transparent;
+        }
+
+        .hero-subtitle {
+          font-size: 18px;
+          color: rgba(237, 237, 237, 0.7);
+          max-width: 700px;
+          line-height: 1.6;
+          margin: 0;
+        }
+
+        .loading-container {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+          gap: 16px;
+          padding: 80px 0;
+          color: rgba(237, 237, 237, 0.6);
+        }
+
+        .animate-spin {
+          animation: spin 1s linear infinite;
+        }
+
+        @keyframes spin {
+          from { transform: rotate(0deg); }
+          to { transform: rotate(360deg); }
+        }
+
+        .discover-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+          gap: 30px;
+          margin-bottom: 80px;
+        }
+
+        .pack-card {
+          background: rgba(255, 255, 255, 0.03);
+          border: 1px solid rgba(255, 255, 255, 0.08);
+          border-radius: 16px;
+          padding: 28px;
+          display: flex;
+          flex-direction: column;
+          transition: transform 220ms cubic-bezier(0.2, 0.8, 0.2, 1), 
+                      border-color 220ms ease, 
+                      box-shadow 220ms ease;
+        }
+
+        .pack-card:hover {
+          transform: translateY(-6px);
+          border-color: rgba(255, 255, 255, 0.25);
+          box-shadow: 0 20px 40px rgba(0, 0, 0, 0.6);
+        }
+
+        .pack-card-header {
+          margin-bottom: 16px;
+        }
+
+        .pack-title {
+          font-size: 22px;
+          font-weight: 700;
+          color: #fff;
+          margin: 0 0 8px 0;
+        }
+
+        .pack-meta {
+          display: flex;
+          align-items: center;
+          gap: 12px;
+          font-size: 13px;
+        }
+
+        .pack-author {
+          color: rgba(237, 237, 237, 0.5);
+        }
+
+        .pack-version {
+          background: rgba(255, 255, 255, 0.08);
+          color: rgba(255, 255, 255, 0.8);
+          padding: 2px 6px;
+          border-radius: 6px;
+          font-weight: 600;
+        }
+
+        .pack-description {
+          font-size: 15px;
+          color: rgba(237, 237, 237, 0.7);
+          line-height: 1.5;
+          margin: 0 0 24px 0;
+          flex-grow: 1;
+        }
+
+        .catalogs-section {
+          background: rgba(255, 255, 255, 0.015);
+          border: 1px solid rgba(255, 255, 255, 0.04);
+          border-radius: 10px;
+          padding: 16px;
+          margin-bottom: 28px;
+        }
+
+        .section-label {
+          font-size: 13px;
+          font-weight: 700;
+          color: rgba(237, 237, 237, 0.4);
+          margin: 0 0 12px 0;
+          text-transform: uppercase;
+          letter-spacing: 0.5px;
+          display: flex;
+          align-items: center;
+          gap: 6px;
+        }
+
+        .catalogs-list {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 8px;
+          padding: 0;
+          margin: 0;
+          list-style: none;
+        }
+
+        .catalog-item-tag {
+          font-size: 13px;
+          background: rgba(255, 255, 255, 0.06);
+          color: #fff;
+          padding: 4px 10px;
+          border-radius: 8px;
+          border: 1px solid rgba(255, 255, 255, 0.03);
+        }
+
+        .pack-actions {
+          display: flex;
+          gap: 12px;
+        }
+
+        .install-button {
+          flex: 1;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          gap: 8px;
+          background: #ffffff;
+          color: #000000;
+          font-weight: 700;
+          font-size: 14px;
+          padding: 12px;
+          border-radius: 10px;
+          text-decoration: none;
+          transition: background 160ms ease, transform 160ms ease;
+        }
+
+        .install-button:hover {
+          background: rgba(255, 255, 255, 0.85);
+        }
+
+        .install-button:active {
+          transform: scale(0.97);
+        }
+
+        .copy-button {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          gap: 8px;
+          background: rgba(255, 255, 255, 0.06);
+          color: #ffffff;
+          border: 1px solid rgba(255, 255, 255, 0.08);
+          font-weight: 600;
+          font-size: 14px;
+          padding: 12px;
+          border-radius: 10px;
+          cursor: pointer;
+          transition: background 160ms ease, border-color 160ms ease;
+        }
+
+        .copy-button:hover {
+          background: rgba(255, 255, 255, 0.12);
+          border-color: rgba(255, 255, 255, 0.15);
+        }
+
+        /* Modal Styles */
+        .modal-backdrop {
+          position: fixed;
+          top: 0;
+          left: 0;
+          width: 100vw;
+          height: 100vh;
+          background: rgba(0, 0, 0, 0.8);
+          backdrop-filter: blur(12px);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          z-index: 1000;
+          padding: 20px;
+        }
+
+        .modal-content {
+          background: #0a0a0d;
+          border: 1px solid rgba(255, 255, 255, 0.1);
+          border-radius: 20px;
+          width: 100%;
+          max-width: 580px;
+          padding: 40px;
+          position: relative;
+          box-shadow: 0 30px 60px rgba(0, 0, 0, 0.8);
+        }
+
+        .modal-close {
+          position: absolute;
+          top: 24px;
+          right: 24px;
+          background: none;
+          border: none;
+          color: rgba(237, 237, 237, 0.5);
+          cursor: pointer;
+          transition: color 160ms ease;
+        }
+
+        .modal-close:hover {
+          color: #fff;
+        }
+
+        .submission-form h2 {
+          font-size: 26px;
+          font-weight: 800;
+          color: #fff;
+          margin: 0 0 8px 0;
+        }
+
+        .form-intro {
+          font-size: 14px;
+          color: rgba(237, 237, 237, 0.5);
+          margin-bottom: 28px;
+          line-height: 1.5;
+        }
+
+        .form-error {
+          background: rgba(231, 76, 60, 0.08);
+          border: 1px solid rgba(231, 76, 60, 0.2);
+          color: #e74c3c;
+          padding: 12px 16px;
+          border-radius: 8px;
+          font-size: 14px;
+          display: flex;
+          align-items: center;
+          gap: 10px;
+          margin-bottom: 24px;
+        }
+
+        .form-field {
+          display: flex;
+          flex-direction: column;
+          gap: 8px;
+          margin-bottom: 20px;
+        }
+
+        .form-field-row {
+          display: grid;
+          grid-template-columns: 1fr;
+          gap: 20px;
+        }
+
+        .form-field label {
+          font-size: 13px;
+          font-weight: 700;
+          color: rgba(237, 237, 237, 0.8);
+          display: flex;
+          align-items: center;
+          gap: 6px;
+        }
+
+        .form-field input,
+        .form-field textarea {
+          background: rgba(255, 255, 255, 0.03);
+          border: 1px solid rgba(255, 255, 255, 0.08);
+          border-radius: 10px;
+          padding: 12px 16px;
+          color: #fff;
+          font-size: 15px;
+          transition: border-color 160ms ease, background 160ms ease;
+        }
+
+        .form-field input:focus,
+        .form-field textarea:focus {
+          outline: none;
+          border-color: rgba(255, 255, 255, 0.3);
+          background: rgba(255, 255, 255, 0.05);
+        }
+
+        .field-hint {
+          font-size: 12px;
+          color: rgba(237, 237, 237, 0.4);
+        }
+
+        .form-submit-button {
+          width: 100%;
+          background: #fff;
+          color: #000;
+          border: none;
+          font-weight: 700;
+          font-size: 15px;
+          padding: 14px;
+          border-radius: 10px;
+          cursor: pointer;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          gap: 8px;
+          transition: background 160ms ease, transform 160ms ease;
+          margin-top: 10px;
+        }
+
+        .form-submit-button:hover {
+          background: rgba(255, 255, 255, 0.85);
+        }
+
+        .form-submit-button:active {
+          transform: scale(0.98);
+        }
+
+        .form-submit-button:disabled {
+          background: rgba(255, 255, 255, 0.2);
+          color: rgba(0, 0, 0, 0.5);
+          cursor: not-allowed;
+        }
+
+        .submit-feedback {
+          text-align: center;
+          padding: 20px 0;
+        }
+
+        .feedback-icon {
+          margin: 0 auto 24px auto;
+        }
+
+        .submit-feedback h2 {
+          font-size: 24px;
+          color: #fff;
+          margin-bottom: 12px;
+        }
+
+        .submit-feedback p {
+          color: rgba(237, 237, 237, 0.7);
+          font-size: 15px;
+          line-height: 1.6;
+        }
+
+        .text-green {
+          color: #00d588;
+        }
+
+        .icon-inline {
+          display: inline-block;
+          vertical-align: middle;
+        }
+
+        .faq-section {
+          border-top: 1px solid rgba(255, 255, 255, 0.08);
+          padding-top: 60px;
+          margin-bottom: 60px;
+        }
+
+        .faq-heading {
+          font-size: 26px;
+          font-weight: 800;
+          margin: 0 0 30px 0;
+          color: #fff;
+          display: flex;
+          align-items: center;
+          gap: 10px;
+        }
+
+        .faq-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+          gap: 40px;
+        }
+
+        .faq-item h3 {
+          font-size: 18px;
+          font-weight: 700;
+          color: #fff;
+          margin: 0 0 12px 0;
+        }
+
+        .faq-item p {
+          font-size: 15px;
+          color: rgba(237, 237, 237, 0.75);
+          line-height: 1.6;
+          margin: 0;
+        }
+
+        .manifest-example-section {
+          border-top: 1px solid rgba(255, 255, 255, 0.08);
+          padding-top: 60px;
+          margin-bottom: 80px;
+        }
+
+        .manifest-heading {
+          font-size: 26px;
+          font-weight: 800;
+          margin: 0 0 20px 0;
+          color: #fff;
+          display: flex;
+          align-items: center;
+          gap: 10px;
+        }
+
+        .code-block {
+          background: rgba(255, 255, 255, 0.02);
+          border: 1px solid rgba(255, 255, 255, 0.05);
+          border-radius: 12px;
+          padding: 24px;
+          font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+          font-size: 14px;
+          line-height: 1.6;
+          color: rgba(237, 237, 237, 0.85);
+          overflow-x: auto;
+        }
+
+        .discover-footer {
+          text-align: center;
+          border-top: 1px solid rgba(255, 255, 255, 0.05);
+          padding-top: 30px;
+          font-size: 14px;
+          color: rgba(237, 237, 237, 0.4);
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/web/app/discover/page.tsx
+++ b/web/app/discover/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from "react";
 import { Copy, Check, Download, HelpCircle, Code, ListVideo, Loader2, Plus, X, Globe, User, BookOpen, AlertCircle } from "lucide-react";
-import { config, hasSupabaseConfig } from "@/lib/config";
+import { config } from "@/lib/config";
 
 export const dynamic = "force-static";
 
@@ -80,28 +80,21 @@ export default function DiscoverPage() {
 
   async function loadPacks() {
     try {
-      if (hasSupabaseConfig()) {
-        const res = await fetch(`${config.supabaseUrl}/rest/v1/catalog_packs?status=eq.approved&select=*`, {
-          headers: {
-            apikey: config.supabaseAnonKey,
-            Accept: "application/json"
-          }
-        });
-        if (res.ok) {
-          const data = await res.json();
-          const parsed = data.map((item: any) => ({
-            ...item,
-            catalogs: typeof item.catalogs === "string" ? JSON.parse(item.catalogs) : item.catalogs
-          }));
-          if (Array.isArray(parsed) && parsed.length > 0) {
-            setPacks(parsed);
-            setLoading(false);
-            return;
-          }
+      const res = await fetch(`${config.netlifyBackendUrl}/catalog-packs-list`);
+      if (res.ok) {
+        const data = await res.json();
+        const parsed = data.map((item: any) => ({
+          ...item,
+          catalogs: typeof item.catalogs === "string" ? JSON.parse(item.catalogs) : item.catalogs
+        }));
+        if (Array.isArray(parsed) && parsed.length > 0) {
+          setPacks(parsed);
+          setLoading(false);
+          return;
         }
       }
     } catch (err) {
-      console.warn("Supabase fetch failed, falling back to static packs.json:", err);
+      console.warn("Netlify backend packs fetch failed, falling back to static packs.json:", err);
     }
 
     // Fallback: fetch from /packs.json
@@ -177,30 +170,41 @@ export default function DiscoverPage() {
         throw new Error("Invalid manifest format: JSON must contain 'id', 'name', and a 'catalogs' list.");
       }
 
-      if (!hasSupabaseConfig()) {
-        throw new Error("Supabase is not configured on the website backend. Please submit packs via GitHub.");
+      // Check for duplicate URLs inside manifest (normalized)
+      const normalizedUrls = new Set<string>();
+      for (const item of verifyJson.catalogs) {
+        if (!item.name || !item.url) {
+          throw new Error("All catalog items in the manifest must have a 'name' and 'url'.");
+        }
+        // Normalize: trim, lowercase, remove trailing slash, ensure http/https scheme
+        const trimmed = item.url.trim();
+        const withScheme = trimmed.startsWith("http://") || trimmed.startsWith("https://")
+          ? trimmed
+          : `https://${trimmed}`;
+        const normalized = withScheme.replace(/\/$/, "").toLowerCase();
+
+        if (normalizedUrls.has(normalized)) {
+          throw new Error(`Duplicate catalog URL found in manifest: '${item.url}'`);
+        }
+        normalizedUrls.add(normalized);
       }
 
-      const res = await fetch(`${config.supabaseUrl}/rest/v1/catalog_packs`, {
+      const res = await fetch(`${config.netlifyBackendUrl}/catalog-packs-submit`, {
         method: "POST",
         headers: {
-          apikey: config.supabaseAnonKey,
-          "Content-Type": "application/json",
-          Prefer: "return=minimal"
+          "Content-Type": "application/json"
         },
         body: JSON.stringify({
           name: formName.trim(),
           url: formUrl.trim(),
           author: formAuthor.trim() || "Anonymous",
-          version: "1.0.0",
-          description: formDesc.trim(),
-          catalogs: catalogList,
-          status: "pending" // Require moderator approval
+          description: formDesc.trim()
         })
       });
 
       if (!res.ok) {
-        throw new Error(`Failed to submit: ${res.statusText}`);
+        const errorJson = await res.json().catch(() => null);
+        throw new Error(errorJson?.message || `Failed to submit: ${res.statusText}`);
       }
 
       setSubmitSuccess(true);
@@ -228,8 +232,8 @@ export default function DiscoverPage() {
             <img src="/arvio-logo.svg" alt="ARVIO Logo" className="logo" />
             <span className="logo-text">ARVIO</span>
           </div>
-          <button 
-            type="button" 
+          <button
+            type="button"
             className="submit-trigger-button"
             onClick={() => {
               setSubmitError(null);
@@ -240,7 +244,7 @@ export default function DiscoverPage() {
             <Plus size={16} /> Submit A Pack
           </button>
         </div>
-        
+
         <h1 className="hero-title">Catalog Pack Discovery</h1>
         <p className="hero-subtitle">
           Enhance your streaming layout. Browse community-curated catalog packs and install multiple rows of content with a single click.
@@ -264,7 +268,7 @@ export default function DiscoverPage() {
                 </div>
               </div>
               <p className="pack-description">{pack.description}</p>
-              
+
               <div className="catalogs-section">
                 <h3 className="section-label">
                   <ListVideo size={14} className="icon-inline" /> Included Rows ({pack.catalogs?.length || 0})
@@ -277,15 +281,15 @@ export default function DiscoverPage() {
               </div>
 
               <div className="pack-actions">
-                <a 
-                  href={getDeepLink(pack.url)} 
+                <a
+                  href={getDeepLink(pack.url)}
                   className="install-button"
                   title="Install this pack on your Android TV or local app"
                 >
                   <Download size={16} /> Install Pack
                 </a>
-                <button 
-                  type="button" 
+                <button
+                  type="button"
                   onClick={() => copyToClipboard(pack.id || pack.url, getAbsoluteUrl(pack.url))}
                   className="copy-button"
                   title="Copy manifest JSON URL to clipboard"
@@ -303,8 +307,8 @@ export default function DiscoverPage() {
       {showSubmitModal && (
         <div className="modal-backdrop">
           <div className="modal-content">
-            <button 
-              type="button" 
+            <button
+              type="button"
               className="modal-close"
               onClick={() => setShowSubmitModal(false)}
             >
@@ -335,8 +339,8 @@ export default function DiscoverPage() {
 
                 <div className="form-field">
                   <label htmlFor="pack-name"><BookOpen size={14} /> Pack Name *</label>
-                  <input 
-                    type="text" 
+                  <input
+                    type="text"
                     id="pack-name"
                     required
                     placeholder="e.g. Action Blockbusters Bundle"
@@ -347,8 +351,8 @@ export default function DiscoverPage() {
 
                 <div className="form-field">
                   <label htmlFor="pack-url"><Globe size={14} /> Manifest JSON URL *</label>
-                  <input 
-                    type="text" 
+                  <input
+                    type="text"
                     id="pack-url"
                     required
                     placeholder="e.g. https://raw.githubusercontent.com/.../pack.json"
@@ -361,8 +365,8 @@ export default function DiscoverPage() {
                 <div className="form-field-row">
                   <div className="form-field">
                     <label htmlFor="pack-author"><User size={14} /> Author / Creator</label>
-                    <input 
-                      type="text" 
+                    <input
+                      type="text"
                       id="pack-author"
                       placeholder="e.g. @cinephile_dev"
                       value={formAuthor}
@@ -373,7 +377,7 @@ export default function DiscoverPage() {
 
                 <div className="form-field">
                   <label htmlFor="pack-desc">Description *</label>
-                  <textarea 
+                  <textarea
                     id="pack-desc"
                     required
                     rows={3}
@@ -385,8 +389,8 @@ export default function DiscoverPage() {
 
                 <div className="form-field">
                   <label htmlFor="pack-catalogs">Included Catalogs *</label>
-                  <input 
-                    type="text" 
+                  <input
+                    type="text"
                     id="pack-catalogs"
                     required
                     placeholder="e.g. Marvel Universe, Star Wars Timeline, MCU Extras (comma separated)"
@@ -396,8 +400,8 @@ export default function DiscoverPage() {
                   <span className="field-hint">Provide names for the catalog rows included in your manifest.</span>
                 </div>
 
-                <button 
-                  type="submit" 
+                <button
+                  type="submit"
                   className="form-submit-button"
                   disabled={submitLoading}
                 >
@@ -427,7 +431,7 @@ export default function DiscoverPage() {
           <div className="faq-item">
             <h3>How do I host my own Catalog Pack?</h3>
             <p>
-              Create a JSON file matching the manifest structure below, host it on a public server (like GitHub Gist, Supabase, or Netlify), and share your raw link or deep link code!
+              Create a JSON file matching the manifest structure below, host it on a public server (like GitHub Gist, Netlify, or other public hosting), and share your raw link or deep link code!
             </p>
           </div>
         </div>
@@ -577,8 +581,8 @@ export default function DiscoverPage() {
           padding: 28px;
           display: flex;
           flex-direction: column;
-          transition: transform 220ms cubic-bezier(0.2, 0.8, 0.2, 1), 
-                      border-color 220ms ease, 
+          transition: transform 220ms cubic-bezier(0.2, 0.8, 0.2, 1),
+                      border-color 220ms ease,
                       box-shadow 220ms ease;
         }
 

--- a/web/app/discover/page.tsx
+++ b/web/app/discover/page.tsx
@@ -73,7 +73,6 @@ export default function DiscoverPage() {
   const [formAuthor, setFormAuthor] = useState("");
   const [formUrl, setFormUrl] = useState("");
   const [formDesc, setFormDesc] = useState("");
-  const [formCatalogs, setFormCatalogs] = useState("");
   const [submitLoading, setSubmitLoading] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [submitSuccess, setSubmitSuccess] = useState(false);
@@ -140,55 +139,20 @@ export default function DiscoverPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!formName.trim() || !formUrl.trim() || !formDesc.trim() || !formCatalogs.trim()) {
+    if (!formName.trim() || !formUrl.trim() || !formDesc.trim()) {
       setSubmitError("Please fill out all required fields.");
       return;
     }
 
-    // Basic URL validation
-    if (!formUrl.startsWith("http://") && !formUrl.startsWith("https://")) {
-      setSubmitError("Manifest URL must start with http:// or https://");
+    if (!formUrl.startsWith("https://")) {
+      setSubmitError("Manifest URL must start with https://");
       return;
     }
 
     setSubmitLoading(true);
     setSubmitError(null);
 
-    const catalogList = formCatalogs
-      .split(",")
-      .map((c) => c.trim())
-      .filter(Boolean);
-
     try {
-      // Verify manifest content format via proxy to bypass CORS
-      const verifyRes = await fetch(`/api/proxy?url=${encodeURIComponent(formUrl.trim())}`);
-      if (!verifyRes.ok) {
-        throw new Error(`Unable to fetch manifest JSON from "${formUrl}". Please verify the URL is correct and public.`);
-      }
-      const verifyJson = await verifyRes.json();
-      if (!verifyJson.id || !verifyJson.name || !Array.isArray(verifyJson.catalogs)) {
-        throw new Error("Invalid manifest format: JSON must contain 'id', 'name', and a 'catalogs' list.");
-      }
-
-      // Check for duplicate URLs inside manifest (normalized)
-      const normalizedUrls = new Set<string>();
-      for (const item of verifyJson.catalogs) {
-        if (!item.name || !item.url) {
-          throw new Error("All catalog items in the manifest must have a 'name' and 'url'.");
-        }
-        // Normalize: trim, lowercase, remove trailing slash, ensure http/https scheme
-        const trimmed = item.url.trim();
-        const withScheme = trimmed.startsWith("http://") || trimmed.startsWith("https://")
-          ? trimmed
-          : `https://${trimmed}`;
-        const normalized = withScheme.replace(/\/$/, "").toLowerCase();
-
-        if (normalizedUrls.has(normalized)) {
-          throw new Error(`Duplicate catalog URL found in manifest: '${item.url}'`);
-        }
-        normalizedUrls.add(normalized);
-      }
-
       const res = await fetch(`${config.netlifyBackendUrl}/catalog-packs-submit`, {
         method: "POST",
         headers: {
@@ -212,7 +176,6 @@ export default function DiscoverPage() {
       setFormAuthor("");
       setFormUrl("");
       setFormDesc("");
-      setFormCatalogs("");
       setTimeout(() => {
         setSubmitSuccess(false);
         setShowSubmitModal(false);
@@ -359,7 +322,7 @@ export default function DiscoverPage() {
                     value={formUrl}
                     onChange={(e) => setFormUrl(e.target.value)}
                   />
-                  <span className="field-hint">Must be public, CORS-enabled, and serve valid JSON.</span>
+                  <span className="field-hint">Must be a public HTTPS URL that serves valid JSON.</span>
                 </div>
 
                 <div className="form-field-row">
@@ -385,19 +348,6 @@ export default function DiscoverPage() {
                     value={formDesc}
                     onChange={(e) => setFormDesc(e.target.value)}
                   />
-                </div>
-
-                <div className="form-field">
-                  <label htmlFor="pack-catalogs">Included Catalogs *</label>
-                  <input
-                    type="text"
-                    id="pack-catalogs"
-                    required
-                    placeholder="e.g. Marvel Universe, Star Wars Timeline, MCU Extras (comma separated)"
-                    value={formCatalogs}
-                    onChange={(e) => setFormCatalogs(e.target.value)}
-                  />
-                  <span className="field-hint">Provide names for the catalog rows included in your manifest.</span>
                 </div>
 
                 <button

--- a/web/app/discover/page.tsx
+++ b/web/app/discover/page.tsx
@@ -24,7 +24,7 @@ const STATIC_FALLBACK_PACKS: CatalogPack[] = [
     author: "ARVIO Team",
     version: "1.0.0",
     description: "All the trending movies, popular lists, and upcoming releases you need for a perfect movie night.",
-    url: "https://arvio.app/packs/cinema-essentials.json",
+    url: "/packs/cinema-essentials.json",
     catalogs: ["Trending in Movies", "Top 10 Movies Today", "Top Movies This Week", "Coming Soon"]
   },
   {
@@ -33,7 +33,7 @@ const STATIC_FALLBACK_PACKS: CatalogPack[] = [
     author: "ARVIO Team",
     version: "1.0.0",
     description: "Never miss an episode. Popular, trending, and latest airing series in one convenient bundle.",
-    url: "https://arvio.app/packs/tv-binge.json",
+    url: "/packs/tv-binge.json",
     catalogs: ["Trending in Shows", "Top 10 Shows Today", "Latest Airing"]
   },
   {
@@ -42,7 +42,7 @@ const STATIC_FALLBACK_PACKS: CatalogPack[] = [
     author: "Community",
     version: "1.1.2",
     description: "The ultimate pack for anime lovers and K-Drama fans. Auto-updated lists of trending episodes and releases.",
-    url: "https://arvio.app/packs/anime-kdrama.json",
+    url: "/packs/anime-kdrama.json",
     catalogs: ["Trending in Anime", "New in K-Dramas"]
   },
   {
@@ -51,7 +51,7 @@ const STATIC_FALLBACK_PACKS: CatalogPack[] = [
     author: "Cinephile",
     version: "1.0.5",
     description: "Full box-sets and classic franchise collections, including James Bond, Harry Potter, Lord of the Rings, and Jurassic Park.",
-    url: "https://arvio.app/packs/classics-franchises.json",
+    url: "/packs/classics-franchises.json",
     catalogs: [
       "James Bond Collection",
       "Harry Potter Collection",
@@ -123,6 +123,17 @@ export default function DiscoverPage() {
     void loadPacks();
   }, []);
 
+  const getAbsoluteUrl = (url: string) => {
+    if (!url) return "";
+    if (url.startsWith("/")) {
+      if (typeof window !== "undefined") {
+        return `${window.location.origin}${url}`;
+      }
+      return `https://arvio.app${url}`;
+    }
+    return url;
+  };
+
   const copyToClipboard = (id: string, text: string) => {
     navigator.clipboard.writeText(text).then(() => {
       setCopiedId(id);
@@ -131,7 +142,7 @@ export default function DiscoverPage() {
   };
 
   const getDeepLink = (packUrl: string) => {
-    return `arvio://install-pack?url=${encodeURIComponent(packUrl)}`;
+    return `arvio://install-pack?url=${encodeURIComponent(getAbsoluteUrl(packUrl))}`;
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -156,6 +167,16 @@ export default function DiscoverPage() {
       .filter(Boolean);
 
     try {
+      // Verify manifest content format via proxy to bypass CORS
+      const verifyRes = await fetch(`/api/proxy?url=${encodeURIComponent(formUrl.trim())}`);
+      if (!verifyRes.ok) {
+        throw new Error(`Unable to fetch manifest JSON from "${formUrl}". Please verify the URL is correct and public.`);
+      }
+      const verifyJson = await verifyRes.json();
+      if (!verifyJson.id || !verifyJson.name || !Array.isArray(verifyJson.catalogs)) {
+        throw new Error("Invalid manifest format: JSON must contain 'id', 'name', and a 'catalogs' list.");
+      }
+
       if (!hasSupabaseConfig()) {
         throw new Error("Supabase is not configured on the website backend. Please submit packs via GitHub.");
       }
@@ -265,7 +286,7 @@ export default function DiscoverPage() {
                 </a>
                 <button 
                   type="button" 
-                  onClick={() => copyToClipboard(pack.id || pack.url, pack.url)}
+                  onClick={() => copyToClipboard(pack.id || pack.url, getAbsoluteUrl(pack.url))}
                   className="copy-button"
                   title="Copy manifest JSON URL to clipboard"
                 >

--- a/web/components/player/PlayerOverlay.tsx
+++ b/web/components/player/PlayerOverlay.tsx
@@ -1089,9 +1089,21 @@ function VideoPlayer({
             <button type="button" className="player-error-external" onClick={() => openExternal("vlc", stream)}>
               <ExternalLink size={15} /> Open in VLC
             </button>
+<<<<<<< HEAD
             <button type="button" className="player-error-external" onClick={() => openAnyPlayer(stream)}>
               <ExternalLink size={15} /> Open in player
             </button>
+=======
+            {canOpenInAnyPlayer() ? (
+              <button type="button" className="player-error-external" onClick={() => openAnyPlayer(stream)}>
+                <ExternalLink size={15} /> Open in player
+              </button>
+            ) : (
+              <button type="button" className="player-error-external" onClick={() => openExternal("infuse", stream)}>
+                <ExternalLink size={15} /> Open in Infuse
+              </button>
+            )}
+>>>>>>> 38ffc6c0 (fix(web): Android external-player launch (VLC intent) + 'open in any player')
             {!liveTv && !stream.transcoded && parseDebridStream(stream.url) && (
               <button type="button" className="player-error-transcode" onClick={() => onSelectStream(stream, { forceTranscode: true })}>
                 <Play size={15} fill="currentColor" /> Transcode
@@ -1162,9 +1174,21 @@ function VideoPlayer({
                         <button type="button" onClick={() => openExternal("vlc", candidate)}>
                           <ExternalLink size={13} /> VLC
                         </button>
+<<<<<<< HEAD
                         <button type="button" onClick={() => openAnyPlayer(candidate)}>
                           <ExternalLink size={13} /> Player
                         </button>
+=======
+                        {canOpenInAnyPlayer() ? (
+                          <button type="button" onClick={() => openAnyPlayer(candidate)}>
+                            <ExternalLink size={13} /> Player
+                          </button>
+                        ) : (
+                          <button type="button" onClick={() => openExternal("infuse", candidate)}>
+                            <ExternalLink size={13} /> Infuse
+                          </button>
+                        )}
+>>>>>>> 38ffc6c0 (fix(web): Android external-player launch (VLC intent) + 'open in any player')
                         <button type="button" onClick={() => void copyUrl(candidate)} aria-label="Copy stream URL">
                           <Copy size={13} />
                         </button>

--- a/web/components/player/PlayerOverlay.tsx
+++ b/web/components/player/PlayerOverlay.tsx
@@ -1089,21 +1089,9 @@ function VideoPlayer({
             <button type="button" className="player-error-external" onClick={() => openExternal("vlc", stream)}>
               <ExternalLink size={15} /> Open in VLC
             </button>
-<<<<<<< HEAD
             <button type="button" className="player-error-external" onClick={() => openAnyPlayer(stream)}>
               <ExternalLink size={15} /> Open in player
             </button>
-=======
-            {canOpenInAnyPlayer() ? (
-              <button type="button" className="player-error-external" onClick={() => openAnyPlayer(stream)}>
-                <ExternalLink size={15} /> Open in player
-              </button>
-            ) : (
-              <button type="button" className="player-error-external" onClick={() => openExternal("infuse", stream)}>
-                <ExternalLink size={15} /> Open in Infuse
-              </button>
-            )}
->>>>>>> 38ffc6c0 (fix(web): Android external-player launch (VLC intent) + 'open in any player')
             {!liveTv && !stream.transcoded && parseDebridStream(stream.url) && (
               <button type="button" className="player-error-transcode" onClick={() => onSelectStream(stream, { forceTranscode: true })}>
                 <Play size={15} fill="currentColor" /> Transcode
@@ -1174,21 +1162,9 @@ function VideoPlayer({
                         <button type="button" onClick={() => openExternal("vlc", candidate)}>
                           <ExternalLink size={13} /> VLC
                         </button>
-<<<<<<< HEAD
                         <button type="button" onClick={() => openAnyPlayer(candidate)}>
                           <ExternalLink size={13} /> Player
                         </button>
-=======
-                        {canOpenInAnyPlayer() ? (
-                          <button type="button" onClick={() => openAnyPlayer(candidate)}>
-                            <ExternalLink size={13} /> Player
-                          </button>
-                        ) : (
-                          <button type="button" onClick={() => openExternal("infuse", candidate)}>
-                            <ExternalLink size={13} /> Infuse
-                          </button>
-                        )}
->>>>>>> 38ffc6c0 (fix(web): Android external-player launch (VLC intent) + 'open in any player')
                         <button type="button" onClick={() => void copyUrl(candidate)} aria-label="Copy stream URL">
                           <Copy size={13} />
                         </button>

--- a/web/public/packs.json
+++ b/web/public/packs.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "cinema-essentials",
+    "name": "Cinema Essentials",
+    "author": "ARVIO Team",
+    "version": "1.0.0",
+    "description": "All the trending movies, popular lists, and upcoming releases you need for a perfect movie night.",
+    "url": "https://arvio.app/packs/cinema-essentials.json",
+    "catalogs": ["Trending in Movies", "Top 10 Movies Today", "Top Movies This Week", "Coming Soon"]
+  },
+  {
+    "id": "tv-binge",
+    "name": "TV Show Binge Pack",
+    "author": "ARVIO Team",
+    "version": "1.0.0",
+    "description": "Never miss an episode. Popular, trending, and latest airing series in one convenient bundle.",
+    "url": "https://arvio.app/packs/tv-binge.json",
+    "catalogs": ["Trending in Shows", "Top 10 Shows Today", "Latest Airing"]
+  },
+  {
+    "id": "anime-kdrama",
+    "name": "Otaku & K-Drama Hub",
+    "author": "Community",
+    "version": "1.1.2",
+    "description": "The ultimate pack for anime lovers and K-Drama fans. Auto-updated lists of trending episodes and releases.",
+    "url": "https://arvio.app/packs/anime-kdrama.json",
+    "catalogs": ["Trending in Anime", "New in K-Dramas"]
+  },
+  {
+    "id": "classics-franchises",
+    "name": "Action & Franchise Classics",
+    "author": "Cinephile",
+    "version": "1.0.5",
+    "description": "Full box-sets and classic franchise collections, including James Bond, Harry Potter, Lord of the Rings, and Jurassic Park.",
+    "url": "https://arvio.app/packs/classics-franchises.json",
+    "catalogs": [
+      "James Bond Collection",
+      "Harry Potter Collection",
+      "The Matrix Collection",
+      "Lord of the Rings and Hobbit Collection",
+      "Jurassic Park Collection"
+    ]
+  }
+]

--- a/web/public/packs.json
+++ b/web/public/packs.json
@@ -5,7 +5,7 @@
     "author": "ARVIO Team",
     "version": "1.0.0",
     "description": "All the trending movies, popular lists, and upcoming releases you need for a perfect movie night.",
-    "url": "https://arvio.app/packs/cinema-essentials.json",
+    "url": "/packs/cinema-essentials.json",
     "catalogs": ["Trending in Movies", "Top 10 Movies Today", "Top Movies This Week", "Coming Soon"]
   },
   {
@@ -14,7 +14,7 @@
     "author": "ARVIO Team",
     "version": "1.0.0",
     "description": "Never miss an episode. Popular, trending, and latest airing series in one convenient bundle.",
-    "url": "https://arvio.app/packs/tv-binge.json",
+    "url": "/packs/tv-binge.json",
     "catalogs": ["Trending in Shows", "Top 10 Shows Today", "Latest Airing"]
   },
   {
@@ -23,7 +23,7 @@
     "author": "Community",
     "version": "1.1.2",
     "description": "The ultimate pack for anime lovers and K-Drama fans. Auto-updated lists of trending episodes and releases.",
-    "url": "https://arvio.app/packs/anime-kdrama.json",
+    "url": "/packs/anime-kdrama.json",
     "catalogs": ["Trending in Anime", "New in K-Dramas"]
   },
   {
@@ -32,7 +32,7 @@
     "author": "Cinephile",
     "version": "1.0.5",
     "description": "Full box-sets and classic franchise collections, including James Bond, Harry Potter, Lord of the Rings, and Jurassic Park.",
-    "url": "https://arvio.app/packs/classics-franchises.json",
+    "url": "/packs/classics-franchises.json",
     "catalogs": [
       "James Bond Collection",
       "Harry Potter Collection",

--- a/web/public/packs/anime-kdrama.json
+++ b/web/public/packs/anime-kdrama.json
@@ -1,0 +1,17 @@
+{
+  "id": "anime-kdrama",
+  "name": "Otaku & K-Drama Hub",
+  "author": "Community",
+  "version": "1.1.2",
+  "description": "The ultimate pack for anime lovers and K-Drama fans. Auto-updated lists of trending episodes and releases.",
+  "catalogs": [
+    {
+      "name": "Trending in Anime",
+      "url": "https://mdblist.com/lists/snoak/trending-anime-shows"
+    },
+    {
+      "name": "New in K-Dramas",
+      "url": "https://mdblist.com/lists/snoak/latest-kdrama-shows"
+    }
+  ]
+}

--- a/web/public/packs/cinema-essentials.json
+++ b/web/public/packs/cinema-essentials.json
@@ -1,0 +1,25 @@
+{
+  "id": "cinema-essentials",
+  "name": "Cinema Essentials",
+  "author": "ARVIO Team",
+  "version": "1.0.0",
+  "description": "All the trending movies, popular lists, and upcoming releases you need for a perfect movie night.",
+  "catalogs": [
+    {
+      "name": "Trending in Movies",
+      "url": "https://mdblist.com/lists/snoak/trending-movies"
+    },
+    {
+      "name": "Top 10 Movies Today",
+      "url": "https://mdblist.com/lists/snoak/top-10-movies-of-the-day"
+    },
+    {
+      "name": "Top Movies This Week",
+      "url": "https://mdblist.com/lists/linaspurinis/top-watched-movies-of-the-week"
+    },
+    {
+      "name": "Coming Soon",
+      "url": "https://mdblist.com/lists/snoak/upcoming-movies"
+    }
+  ]
+}

--- a/web/public/packs/classics-franchises.json
+++ b/web/public/packs/classics-franchises.json
@@ -7,7 +7,7 @@
   "catalogs": [
     {
       "name": "James Bond Collection",
-      "url": "https://trakt.tv/users/mrbones/lists/james-bond"
+      "url": "https://mdblist.com/lists/hdlists/james-bond-movies"
     },
     {
       "name": "Harry Potter Collection",
@@ -19,11 +19,11 @@
     },
     {
       "name": "Lord of the Rings and Hobbit Collection",
-      "url": "https://trakt.tv/users/tolkien-guy/lists/middle-earth"
+      "url": "https://mdblist.com/lists/spudhead15/lord-of-the-rings-and-hobbit-collection"
     },
     {
       "name": "Jurassic Park Collection",
-      "url": "https://trakt.tv/users/dino-fan/lists/jurassic-park"
+      "url": "https://mdblist.com/lists/purple_smurf/jurassic-park"
     }
   ]
 }

--- a/web/public/packs/classics-franchises.json
+++ b/web/public/packs/classics-franchises.json
@@ -1,0 +1,29 @@
+{
+  "id": "classics-franchises",
+  "name": "Action & Franchise Classics",
+  "author": "Cinephile",
+  "version": "1.0.5",
+  "description": "Full box-sets and classic franchise collections, including James Bond, Harry Potter, Lord of the Rings, and Jurassic Park.",
+  "catalogs": [
+    {
+      "name": "James Bond Collection",
+      "url": "https://trakt.tv/users/mrbones/lists/james-bond"
+    },
+    {
+      "name": "Harry Potter Collection",
+      "url": "https://trakt.tv/users/harrym/lists/harry-potter-collection"
+    },
+    {
+      "name": "The Matrix Collection",
+      "url": "https://trakt.tv/users/matrix-fan/lists/the-matrix-collection"
+    },
+    {
+      "name": "Lord of the Rings and Hobbit Collection",
+      "url": "https://trakt.tv/users/tolkien-guy/lists/middle-earth"
+    },
+    {
+      "name": "Jurassic Park Collection",
+      "url": "https://trakt.tv/users/dino-fan/lists/jurassic-park"
+    }
+  ]
+}

--- a/web/public/packs/tv-binge.json
+++ b/web/public/packs/tv-binge.json
@@ -15,7 +15,7 @@
     },
     {
       "name": "Latest Airing",
-      "url": "https://mdblist.com/lists/snoak/latest-movies-digital-release"
+      "url": "https://mdblist.com/lists/snoak/latest-tv-shows"
     }
   ]
 }

--- a/web/public/packs/tv-binge.json
+++ b/web/public/packs/tv-binge.json
@@ -1,0 +1,21 @@
+{
+  "id": "tv-binge",
+  "name": "TV Show Binge Pack",
+  "author": "ARVIO Team",
+  "version": "1.0.0",
+  "description": "Never miss an episode. Popular, trending, and latest airing series in one convenient bundle.",
+  "catalogs": [
+    {
+      "name": "Trending in Shows",
+      "url": "https://mdblist.com/lists/snoak/trakt-s-trending-shows"
+    },
+    {
+      "name": "Top 10 Shows Today",
+      "url": "https://mdblist.com/lists/snoak/top-10-shows-of-the-day"
+    },
+    {
+      "name": "Latest Airing",
+      "url": "https://mdblist.com/lists/snoak/latest-movies-digital-release"
+    }
+  ]
+}


### PR DESCRIPTION
This pull request introduces a "Catalog Pack" system, allowing users to import and manage groups of content catalogs via a single URL, improving catalog organization and onboarding. It adds deep link and app link support for installing packs, updates navigation and UI to handle pack installation flows, and provides repository and ViewModel logic for fetching, installing, and removing catalog packs. The catalog data model is extended to support pack metadata, and a sample `packs.json` is added for available packs.

**Catalog Pack System and Deep Link Integration**
* Android Manifest: Adds intent filters for custom scheme (`arvio://install-pack?url=...`) and app link (`https://arvio.app/install-pack?url=...`) to trigger catalog pack installation from external sources.
* Main Activity and Navigation: Handles incoming install pack URLs, parses them, and navigates to the settings screen to initiate pack installation. [[1]](diffhunk://#diff-060fcbc09a1982338be5aa88403ca5303ce59210ceab3173621f1d41feda5f50R169) [[2]](diffhunk://#diff-060fcbc09a1982338be5aa88403ca5303ce59210ceab3173621f1d41feda5f50R208) [[3]](diffhunk://#diff-060fcbc09a1982338be5aa88403ca5303ce59210ceab3173621f1d41feda5f50R361-R362) [[4]](diffhunk://#diff-060fcbc09a1982338be5aa88403ca5303ce59210ceab3173621f1d41feda5f50R401) [[5]](diffhunk://#diff-060fcbc09a1982338be5aa88403ca5303ce59210ceab3173621f1d41feda5f50R429-R441) [[6]](diffhunk://#diff-060fcbc09a1982338be5aa88403ca5303ce59210ceab3173621f1d41feda5f50R562-R563) [[7]](diffhunk://#diff-060fcbc09a1982338be5aa88403ca5303ce59210ceab3173621f1d41feda5f50R713-R725) [[8]](diffhunk://#diff-f2ec70421782085edc5c3c84a1a54ffe6efd521bf3894732e0c637d3d106eb85L293-R293) [[9]](diffhunk://#diff-f2ec70421782085edc5c3c84a1a54ffe6efd521bf3894732e0c637d3d106eb85R303-R318)

**Catalog Pack Data Model and Repository Enhancements**
* `CatalogConfig` model: Adds `packId` and `packName` fields, computed properties for effective pack identification, and a flag for bulk deletability. Introduces `CatalogPackManifest` and `CatalogPackItem` data classes to represent pack manifests. [[1]](diffhunk://#diff-9bfa831f3c5fabbe66aa39d6d985727b3fd5b4e58332247b46fdc59a8f5ddc48L103-R134) [[2]](diffhunk://#diff-9bfa831f3c5fabbe66aa39d6d985727b3fd5b4e58332247b46fdc59a8f5ddc48R155-R169)
* [`CatalogRepository`](diffhunk://#diff-0d5b75d11fe0ec944395d31cfd9057f1f6c09353d301e516c510f9ecf1cdcd1cR13-R14): Implements methods to fetch pack manifests, add packs (validates and imports all catalogs in a pack), and remove packs (bulk delete by pack ID). [[1]](diffhunk://#diff-0d5b75d11fe0ec944395d31cfd9057f1f6c09353d301e516c510f9ecf1cdcd1cR13-R14) [[2]](diffhunk://#diff-0d5b75d11fe0ec944395d31cfd9057f1f6c09353d301e516c510f9ecf1cdcd1cR711-R785)

**Settings UI and ViewModel Support**
* [`SettingsViewModel`](diffhunk://#diff-2ca006c77096a9b5f8f29252cba2c48f342e73f616db7420f2730ca3a0b1b80dR21): Adds state and methods for loading, confirming, and removing catalog packs, handling loading and error states, and updating UI accordingly. [[1]](diffhunk://#diff-2ca006c77096a9b5f8f29252cba2c48f342e73f616db7420f2730ca3a0b1b80dR21) [[2]](diffhunk://#diff-2ca006c77096a9b5f8f29252cba2c48f342e73f616db7420f2730ca3a0b1b80dR172-R175) [[3]](diffhunk://#diff-2ca006c77096a9b5f8f29252cba2c48f342e73f616db7420f2730ca3a0b1b80dR1776-R1852)

**Demo Data**
* Adds `web/public/packs.json` with sample catalog pack definitions for testing and onboarding.

**Minor Fixes**
* Adjusts episode subtitle formatting in `TraktRepository`.
* Updates `version.json`.