### PR TITLE
fix cloud sync conflicts

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncRepository.kt
@@ -100,6 +100,12 @@ class CloudSyncRepository @Inject constructor(
     private val cloudSyncLocalDirtyAtKey = longPreferencesKey("cloud_sync_local_dirty_at")
     private val cloudSyncLastPushAtKey = longPreferencesKey("cloud_sync_last_push_at")
     private val cloudSyncLastAppliedAtKey = longPreferencesKey("cloud_sync_last_applied_at")
+    // Per-field last-writer-wins support (multi-device conflict resolution). `fieldTs` maps a
+    // canonical field key ("g:accentColor", "p:<profileId>:autoPlayNext") → epochMs of the last
+    // LOCAL change; `fieldBase` stores the value we last stamped, so we can detect local changes by
+    // diffing without hooking every write site.
+    private val cloudSyncFieldTsKey = stringPreferencesKey("cloud_sync_field_ts")
+    private val cloudSyncFieldBaseKey = stringPreferencesKey("cloud_sync_field_base")
     private val globalDnsProviderKey = stringPreferencesKey(OkHttpProvider.DNS_PROVIDER_PREF_KEY)
     private val customUserAgentKey = stringPreferencesKey(OkHttpProvider.USER_AGENT_PREF_KEY)
     @Volatile
@@ -406,6 +412,155 @@ class CloudSyncRepository @Inject constructor(
     }
 
     // ══════════════════════════════════════════════════════════
+    //  PER-FIELD TIMESTAMP LAST-WRITER-WINS (multi-device merge)
+    // ══════════════════════════════════════════════════════════
+    //
+    // The cloud payload is one whole-account blob written last-writer-wins with no clock, so an
+    // already-open device can revert a peer's setting by pushing its stale snapshot. To fix that
+    // without a backend change, every scalar setting carries a per-field `fieldUpdatedAt` timestamp
+    // and both PUSH and APPLY merge field-by-field: a field is only overwritten by a value with a
+    // NEWER timestamp. Scope = genuine globals + per-profile settings; list domains keep their
+    // existing merges; `defaultSubtitle` keeps its own `subtitleSettingsUpdatedAt` logic.
+
+    private val globalMergeKeys = listOf(
+        "accentColor", "oledBlackBackground", "skipProfileSelection", "customUserAgent",
+        "dnsProvider", "subtitleAiEnabled", "subtitleAiAutoSelect", "subtitleAiFindBestMatch",
+        "subtitlePreloadEnabled", "dolbyVisionCompatEnabled", "subtitleAiApiKey",
+        "subtitleAiModel", "subtitleRemoveHearingImpaired"
+    )
+    // Per-profile fields excluded from the generic merge (handled by their own logic / not values).
+    private val profileMergeExclude = setOf("defaultSubtitle", "subtitleSettingsUpdatedAt")
+
+    /** Canonical field keys present in [root]: "g:<globalKey>" and "p:<profileId>:<field>". */
+    private fun mergeKeysOf(root: JSONObject): List<String> {
+        val keys = ArrayList<String>()
+        for (g in globalMergeKeys) if (root.has(g)) keys.add("g:$g")
+        root.optJSONObject("profileSettingsById")?.let { ps ->
+            for (pid in ps.keys()) {
+                ps.optJSONObject(pid)?.let { p ->
+                    for (f in p.keys()) if (f !in profileMergeExclude) keys.add("p:$pid:$f")
+                }
+            }
+        }
+        return keys
+    }
+
+    private fun mergeFieldValue(root: JSONObject, key: String): Any? {
+        if (key.startsWith("g:")) {
+            val k = key.substring(2)
+            return if (root.has(k)) root.get(k) else null
+        }
+        val rest = key.substring(2)
+        val pid = rest.substringBefore(':')
+        val field = rest.substringAfter(':')
+        val p = root.optJSONObject("profileSettingsById")?.optJSONObject(pid) ?: return null
+        return if (p.has(field)) p.get(field) else null
+    }
+
+    private fun setMergeFieldValue(root: JSONObject, key: String, value: Any) {
+        if (key.startsWith("g:")) {
+            root.put(key.substring(2), value)
+            return
+        }
+        val rest = key.substring(2)
+        val pid = rest.substringBefore(':')
+        val field = rest.substringAfter(':')
+        val ps = root.optJSONObject("profileSettingsById") ?: JSONObject().also { root.put("profileSettingsById", it) }
+        val p = ps.optJSONObject(pid) ?: JSONObject().also { ps.put(pid, it) }
+        p.put(field, value)
+    }
+
+    private suspend fun loadJsonMap(key: androidx.datastore.preferences.core.Preferences.Key<String>): JSONObject {
+        val raw = context.settingsDataStore.data.first()[key]
+        return runCatching { if (raw.isNullOrBlank()) JSONObject() else JSONObject(raw) }.getOrDefault(JSONObject())
+    }
+
+    /**
+     * Diff current local field values in [localRoot] against the stored baseline; stamp changed
+     * fields with now() and persist the timestamp + baseline maps. Returns the timestamp map so the
+     * caller can embed it as `fieldUpdatedAt`. Generic — no per-write hooks; a change is stamped on
+     * the next snapshot build, within the push debounce.
+     */
+    private suspend fun stampAndLoadFieldTs(localRoot: JSONObject): JSONObject {
+        val tsMap = loadJsonMap(cloudSyncFieldTsKey)
+        val baseMap = loadJsonMap(cloudSyncFieldBaseKey)
+        val now = System.currentTimeMillis()
+        var changed = false
+        for (key in mergeKeysOf(localRoot)) {
+            val current = mergeFieldValue(localRoot, key)?.toString() ?: continue
+            val base = if (baseMap.has(key)) baseMap.optString(key) else null
+            if (base == null) {
+                baseMap.put(key, current)
+                if (!tsMap.has(key)) tsMap.put(key, now)
+                changed = true
+            } else if (base != current) {
+                baseMap.put(key, current)
+                tsMap.put(key, now)
+                changed = true
+            }
+        }
+        if (changed) {
+            context.settingsDataStore.edit {
+                it[cloudSyncFieldTsKey] = tsMap.toString()
+                it[cloudSyncFieldBaseKey] = baseMap.toString()
+            }
+        }
+        return tsMap
+    }
+
+    /**
+     * After applying a merged remote payload, reset the local baseline + timestamps to match it so
+     * the next snapshot build doesn't re-stamp remote-applied values as fresh local changes (which
+     * would ping-pong them back).
+     */
+    private suspend fun persistFieldStateFromApplied(appliedRoot: JSONObject) {
+        val ts = appliedRoot.optJSONObject("fieldUpdatedAt") ?: JSONObject()
+        val base = JSONObject()
+        for (key in mergeKeysOf(appliedRoot)) {
+            mergeFieldValue(appliedRoot, key)?.let { base.put(key, it.toString()) }
+        }
+        context.settingsDataStore.edit {
+            it[cloudSyncFieldTsKey] = ts.toString()
+            it[cloudSyncFieldBaseKey] = base.toString()
+        }
+    }
+
+    private data class SettingsMergeResult(val json: String, val otherWonKeys: Set<String>)
+
+    /**
+     * Field-level last-writer-wins: returns [baseStr] with each merge field replaced by [otherStr]'s
+     * value where [otherStr]'s per-field timestamp is strictly newer; `fieldUpdatedAt` becomes the
+     * per-key max. `otherWonKeys` = the fields where [otherStr] won. Used both ways: on PUSH
+     * base=local/other=remote (never write a field older than cloud's); on APPLY base=remote/
+     * other=local (never let an older remote value overwrite a newer-unpushed local one).
+     */
+    private fun mergeSettingsByTimestamp(baseStr: String, otherStr: String): SettingsMergeResult {
+        val base = runCatching { JSONObject(baseStr) }.getOrNull() ?: return SettingsMergeResult(baseStr, emptySet())
+        val other = runCatching { JSONObject(otherStr) }.getOrNull() ?: return SettingsMergeResult(baseStr, emptySet())
+        val baseTs = base.optJSONObject("fieldUpdatedAt") ?: JSONObject()
+        val otherTs = other.optJSONObject("fieldUpdatedAt") ?: JSONObject()
+        val mergedTs = runCatching { JSONObject(baseTs.toString()) }.getOrDefault(JSONObject())
+        val otherWon = HashSet<String>()
+        val allKeys = LinkedHashSet<String>().apply { addAll(mergeKeysOf(base)); addAll(mergeKeysOf(other)) }
+        for (key in allKeys) {
+            val bt = baseTs.optLong(key, 0L)
+            val ot = otherTs.optLong(key, 0L)
+            if (ot > bt) {
+                val v = mergeFieldValue(other, key)
+                if (v != null) {
+                    setMergeFieldValue(base, key, v)
+                    mergedTs.put(key, ot)
+                    otherWon.add(key)
+                }
+            } else if (bt > 0L) {
+                mergedTs.put(key, bt)
+            }
+        }
+        base.put("fieldUpdatedAt", mergedTs)
+        return SettingsMergeResult(base.toString(), otherWon)
+    }
+
+    // ══════════════════════════════════════════════════════════
     //  BUILD CLOUD SNAPSHOT JSON
     // ══════════════════════════════════════════════════════════
 
@@ -638,6 +793,10 @@ class CloudSyncRepository @Inject constructor(
         root.put("traktLinked", isTraktLinked)
         root.put("traktExpiration", JSONObject.NULL)
 
+        // Per-field last-writer-wins timestamps (multi-device merge). Diff-stamps any locally
+        // changed scalar setting and embeds the map so push/apply can merge field-by-field.
+        root.put("fieldUpdatedAt", stampAndLoadFieldTs(root))
+
         return root.toString()
     }
 
@@ -745,10 +904,18 @@ class CloudSyncRepository @Inject constructor(
             )
         }
 
-        val effectivePayload = if (existingRemotePayload != null && !iptvRepository.isGroupOrderLocallyDirty()) {
+        val groupOrderMerged = if (existingRemotePayload != null && !iptvRepository.isGroupOrderLocallyDirty()) {
             mergeRemoteGroupOrder(payload, existingRemotePayload)
         } else {
             payload
+        }
+        // Field-level merge against the already-loaded remote: keep local fields we changed more
+        // recently, but never overwrite a cloud field with an older local value. This is what stops
+        // a stale device from reverting a peer's setting (even via the pull's pre-push).
+        val effectivePayload = if (existingRemotePayload != null) {
+            mergeSettingsByTimestamp(baseStr = groupOrderMerged, otherStr = existingRemotePayload).json
+        } else {
+            groupOrderMerged
         }
 
         val payloadHash = runCatching {
@@ -989,7 +1156,25 @@ class CloudSyncRepository @Inject constructor(
      * Applies a cloud JSON payload to all local repositories.
      */
     private suspend fun applyCloudPayload(payload: String) {
-        val root = JSONObject(payload)
+        // Field-level merge BEFORE applying: overlay any local scalar setting that is NEWER than the
+        // remote's onto the incoming payload, so a pull can't overwrite a not-yet-pushed local
+        // change. `defaultSubtitle` is excluded (kept by its own subtitleSettingsUpdatedAt logic
+        // below). Skipped when the remote predates this feature (no `fieldUpdatedAt`) so rollout
+        // behaves exactly like today until every device is on the new code. The rest of this
+        // function then writes the merged values exactly as before.
+        val incomingHasFieldTs = runCatching {
+            JSONObject(payload).optJSONObject("fieldUpdatedAt") != null
+        }.getOrDefault(false)
+        val localSnapshotForMerge = if (incomingHasFieldTs) {
+            runCatching { buildCloudSnapshotJson() }.getOrNull()
+        } else {
+            null
+        }
+        val settingsMerge = localSnapshotForMerge?.let {
+            mergeSettingsByTimestamp(baseStr = payload, otherStr = it)
+        }
+        val preservedLocalSettings = settingsMerge?.otherWonKeys?.isNotEmpty() == true
+        val root = JSONObject(settingsMerge?.json ?: payload)
 
         val fallbackDefaultSubtitle = root.optString("defaultSubtitle", "Off")
         val fallbackDefaultAudioLanguage = root.optString("defaultAudioLanguage", "Auto (Original)")
@@ -1505,6 +1690,15 @@ class CloudSyncRepository @Inject constructor(
             }
             if (root.has("pluginsEnabled")) pluginDataStore.setPluginsEnabled(root.optBoolean("pluginsEnabled", false))
         }.onFailure { AppLogger.recordException(it, mapOf("error_area" to "CloudSync", "cloud_flow" to "apply_plugins")) }
+
+        // Reset the per-field baseline/timestamps to the merged result so the next snapshot build
+        // does not see remote-applied values as fresh local changes (ping-pong guard). If we
+        // preserved a newer-local setting, mark dirty so it gets pushed up — safe now that push
+        // merges by timestamp and can't revert a peer.
+        if (incomingHasFieldTs) {
+            persistFieldStateFromApplied(root)
+            if (preservedLocalSettings) markLocalStateDirty()
+        }
 
         System.err.println("[CLOUD-SYNC] Full cloud restore applied successfully")
     }

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncRepository.kt
@@ -43,17 +43,35 @@ import javax.inject.Singleton
  * ABSENT from the cloud was removed on another device, so it is dropped here; this is what makes
  * addon REMOVALS propagate across devices. (The previous behavior UNIONED the two lists, re-adding
  * anything the cloud had dropped, which is exactly why a removal never took effect on other
- * devices.) One guard: an EMPTY cloud list never wipes a non-empty local list — a blank or partial
- * pull must not delete everything. The Boolean (kept for the call sites) is always false: we adopt
- * the cloud, so there is nothing local to preserve or re-push.
+ * devices.)
+ *
+ * The tricky case is an EMPTY cloud list, which could be either an intentional "removed everything"
+ * or a blank/partial pull. They are told apart by a set-level timestamp: [cloudAddonsUpdatedAt] is
+ * bumped on any user add/remove. An empty cloud is honored (all local addons dropped) only when it
+ * is genuinely NEWER than what we have ([cloudAddonsUpdatedAt] > [localAddonsUpdatedAt]); otherwise
+ * the empty is treated as a bad pull and local addons are preserved.
+ *
+ * The Boolean (kept for the call sites) is always false: we adopt the cloud, nothing to re-push.
  */
 internal fun reconcileAddonsWithCloud(
     cloudAddons: List<Addon>,
-    localAddons: List<Addon>
+    localAddons: List<Addon>,
+    cloudAddonsUpdatedAt: Long = 0L,
+    localAddonsUpdatedAt: Long = 0L
 ): Pair<List<Addon>, Boolean> {
     val cloud = cloudAddons.filter { it.id.trim().isNotBlank() }
-    // Empty-guard: a blank cloud snapshot must never wipe local addons.
-    if (cloud.isEmpty()) return localAddons to false
+    if (cloud.isEmpty()) {
+        // Intentional removal of everything (STRICTLY newer set-timestamp) → honor it; otherwise
+        // this is a blank/partial pull (or a fresh install with default addons) → keep local.
+        return if (cloudAddonsUpdatedAt > localAddonsUpdatedAt) {
+            emptyList<Addon>() to false
+        } else {
+            localAddons to false
+        }
+    }
+    // A local set-change newer than the cloud's hasn't been pushed yet — keep it so a stale pull
+    // can't revert a just-made local add/remove.
+    if (localAddonsUpdatedAt > cloudAddonsUpdatedAt) return localAddons to false
     val reconciled = LinkedHashMap<String, Addon>()
     cloud.forEach { reconciled[it.id.trim()] = it }
     return reconciled.values.toList() to false
@@ -480,8 +498,12 @@ class CloudSyncRepository @Inject constructor(
             val current = mergeFieldValue(localRoot, key)?.toString() ?: continue
             val base = if (baseMap.has(key)) baseMap.optString(key) else null
             if (base == null) {
+                // First time we've seen this field (e.g. a fresh upgrade): record the baseline but
+                // do NOT stamp a timestamp. A field with no prior baseline is not evidence of a
+                // local change, so it must not out-timestamp a peer's newer cloud value and revert
+                // it — it stays untimestamped (loses to any real cloud timestamp) until the user
+                // actually changes it, which the next build detects via this baseline.
                 baseMap.put(key, current)
-                if (!tsMap.has(key)) tsMap.put(key, now)
                 changed = true
             } else if (base != current) {
                 baseMap.put(key, current)
@@ -706,6 +728,9 @@ class CloudSyncRepository @Inject constructor(
             }
         }
         root.put("addonsByProfile", JSONObject(gson.toJson(addonsByProfile)))
+        // Set-level timestamp so an intentional "removed everything" can be told apart from a blank
+        // pull on apply (see reconcileAddonsWithCloud).
+        root.put("addonsUpdatedAt", streamRepository.getAddonsUpdatedAt())
 
         // Catalogs per profile
         val catalogsByProfile = buildMap<String, List<CatalogConfig>> {
@@ -1446,32 +1471,35 @@ class CloudSyncRepository @Inject constructor(
 
         // ── Addons ──
         runCatching {
-            var preservedLocalAddon = false
+            val cloudAddonsTs = root.optLong("addonsUpdatedAt", 0L)
+            val localAddonsTs = streamRepository.getAddonsUpdatedAt()
+            var appliedCloudAddons = false
             root.optJSONObject("addonsByProfile")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
                 val type = TypeToken.getParameterized(Map::class.java, String::class.java, TypeToken.getParameterized(List::class.java, Addon::class.java).type).type
                 val map: Map<String, List<Addon>> = gson.fromJson(json, type) ?: emptyMap()
                 val sharedAddons = mergeAddonsForSharedRestore(map.values)
                 val localAddons = streamRepository.installedAddons.first()
-                val (resolvedAddons, preserved) = reconcileAddonsWithCloud(sharedAddons, localAddons)
-                preservedLocalAddon = preservedLocalAddon || preserved
-                if (resolvedAddons.isNotEmpty()) {
-                    streamRepository.replaceSharedAddonsFromCloud(resolvedAddons)
-                }
+                val (resolvedAddons, _) = reconcileAddonsWithCloud(sharedAddons, localAddons, cloudAddonsTs, localAddonsTs)
+                // Apply the reconciled list even when it is empty — an intentional "removed all"
+                // must propagate (reconcile only returns empty when the cloud set is genuinely newer;
+                // opensubtitles is re-enforced downstream so playback isn't left with nothing).
+                streamRepository.replaceSharedAddonsFromCloud(resolvedAddons)
+                appliedCloudAddons = true
             }
             root.optJSONArray("addons")?.toString()?.takeIf { it.isNotBlank() }?.let { json ->
                 if (!root.has("addonsByProfile")) {
                     val type = TypeToken.getParameterized(List::class.java, Addon::class.java).type
                     val addons: List<Addon> = gson.fromJson(json, type) ?: emptyList()
                     val localAddons = streamRepository.installedAddons.first()
-                    val (resolvedAddons, preserved) = reconcileAddonsWithCloud(addons, localAddons)
-                    preservedLocalAddon = preservedLocalAddon || preserved
-                    if (resolvedAddons.isNotEmpty()) {
-                        streamRepository.replaceSharedAddonsFromCloud(resolvedAddons)
-                    }
+                    val (resolvedAddons, _) = reconcileAddonsWithCloud(addons, localAddons, cloudAddonsTs, localAddonsTs)
+                    streamRepository.replaceSharedAddonsFromCloud(resolvedAddons)
+                    appliedCloudAddons = true
                 }
             }
-            if (preservedLocalAddon) {
-                markLocalStateDirty()
+            // Keep the local set-timestamp in step with the cloud we just adopted, so we don't
+            // re-adopt/loop on the next pull.
+            if (appliedCloudAddons && cloudAddonsTs > localAddonsTs) {
+                streamRepository.setAddonsUpdatedAt(cloudAddonsTs)
             }
         }.onFailure { AppLogger.recordException(it, mapOf("error_area" to "CloudSync", "cloud_flow" to "apply_addons")) }
 

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncRepository.kt
@@ -38,35 +38,25 @@ import kotlin.math.max
 import javax.inject.Inject
 import javax.inject.Singleton
 
-internal fun mergeCloudAddonsPreservingLocalDirectAddons(
+/**
+ * Reconcile local addons to the cloud list — the cloud is authoritative. A local addon that is
+ * ABSENT from the cloud was removed on another device, so it is dropped here; this is what makes
+ * addon REMOVALS propagate across devices. (The previous behavior UNIONED the two lists, re-adding
+ * anything the cloud had dropped, which is exactly why a removal never took effect on other
+ * devices.) One guard: an EMPTY cloud list never wipes a non-empty local list — a blank or partial
+ * pull must not delete everything. The Boolean (kept for the call sites) is always false: we adopt
+ * the cloud, so there is nothing local to preserve or re-push.
+ */
+internal fun reconcileAddonsWithCloud(
     cloudAddons: List<Addon>,
     localAddons: List<Addon>
 ): Pair<List<Addon>, Boolean> {
-    val merged = LinkedHashMap<String, Addon>()
-    cloudAddons.forEach { addon ->
-        val id = addon.id.trim()
-        if (id.isNotBlank()) {
-            merged[id] = addon
-        }
-    }
-
-    var preservedLocalAddon = false
-    localAddons.forEach { addon ->
-        val id = addon.id.trim()
-        val shouldPreserve = id.isNotBlank() &&
-            id !in merged &&
-            id != "opensubtitles" &&
-            addon.isInstalled &&
-            addon.type == AddonType.CUSTOM &&
-            !addon.url.isNullOrBlank()
-
-        if (shouldPreserve) {
-            merged[id] = addon
-            preservedLocalAddon = true
-        }
-    }
-
-    return merged.values.toList() to preservedLocalAddon
+    val cloud = cloudAddons.filter { it.id.trim().isNotBlank() }
+    // Empty-guard: a blank cloud snapshot must never wipe local addons.
+    if (cloud.isEmpty()) return localAddons to false
+    val reconciled = LinkedHashMap<String, Addon>()
+    cloud.forEach { reconciled[it.id.trim()] = it }
+    return reconciled.values.toList() to false
 }
 
 /**
@@ -1462,7 +1452,7 @@ class CloudSyncRepository @Inject constructor(
                 val map: Map<String, List<Addon>> = gson.fromJson(json, type) ?: emptyMap()
                 val sharedAddons = mergeAddonsForSharedRestore(map.values)
                 val localAddons = streamRepository.installedAddons.first()
-                val (resolvedAddons, preserved) = mergeCloudAddonsPreservingLocalDirectAddons(sharedAddons, localAddons)
+                val (resolvedAddons, preserved) = reconcileAddonsWithCloud(sharedAddons, localAddons)
                 preservedLocalAddon = preservedLocalAddon || preserved
                 if (resolvedAddons.isNotEmpty()) {
                     streamRepository.replaceSharedAddonsFromCloud(resolvedAddons)
@@ -1473,7 +1463,7 @@ class CloudSyncRepository @Inject constructor(
                     val type = TypeToken.getParameterized(List::class.java, Addon::class.java).type
                     val addons: List<Addon> = gson.fromJson(json, type) ?: emptyList()
                     val localAddons = streamRepository.installedAddons.first()
-                    val (resolvedAddons, preserved) = mergeCloudAddonsPreservingLocalDirectAddons(addons, localAddons)
+                    val (resolvedAddons, preserved) = reconcileAddonsWithCloud(addons, localAddons)
                     preservedLocalAddon = preservedLocalAddon || preserved
                     if (resolvedAddons.isNotEmpty()) {
                         streamRepository.replaceSharedAddonsFromCloud(resolvedAddons)

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
@@ -892,7 +892,7 @@ class StreamRepository @Inject constructor(
     }
 
     suspend fun replaceAddonsFromCloud(addons: List<Addon>) {
-        saveAddons(enforceOpenSubtitles(addons).filterNot(::isIncompleteExternalAddon))
+        saveAddons(enforceOpenSubtitles(addons).filterNot(::isIncompleteExternalAddon), stampChange = false)
     }
 
     suspend fun getAddonsForProfile(profileId: String): List<Addon> {
@@ -924,7 +924,19 @@ class StreamRepository @Inject constructor(
         invalidationBus.markDirty(CloudSyncScope.ADDONS, profileManager.getProfileIdSync(), "replace shared addons")
     }
 
-    private suspend fun saveAddons(addons: List<Addon>) {
+    // Bumped whenever the local addon SET is changed by the USER (add/remove/reorder). Lets cloud
+    // sync distinguish an intentional "removed everything" from a blank/partial pull, so an
+    // intentional empty state can propagate (see reconcileAddonsWithCloud). Not bumped when applying
+    // the cloud's addons, which would create false "local change" churn.
+    private val addonsUpdatedAtKey = androidx.datastore.preferences.core.longPreferencesKey("addons_updated_at")
+
+    suspend fun getAddonsUpdatedAt(): Long = context.streamDataStore.data.first()[addonsUpdatedAtKey] ?: 0L
+
+    suspend fun setAddonsUpdatedAt(value: Long) {
+        context.streamDataStore.edit { prefs -> prefs[addonsUpdatedAtKey] = value }
+    }
+
+    private suspend fun saveAddons(addons: List<Addon>, stampChange: Boolean = true) {
         val json = gson.toJson(addons.map { sanitizeAddonDisplayName(it) })
 
         // Save locally to the shared account-level addon list. Mirror to the
@@ -934,6 +946,7 @@ class StreamRepository @Inject constructor(
             prefs.remove(sharedPendingAddonsKey)
             prefs[addonsKey()] = json
             prefs.remove(pendingAddonsKey())
+            if (stampChange) prefs[addonsUpdatedAtKey] = System.currentTimeMillis()
         }
         synchronized(streamResultCache) { streamResultCache.clear() }
         invalidationBus.markDirty(CloudSyncScope.ADDONS, profileManager.getProfileIdSync(), "save addons")

--- a/app/src/test/kotlin/com/arflix/tv/data/repository/CloudSyncRepositoryAddonMergeTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/repository/CloudSyncRepositoryAddonMergeTest.kt
@@ -4,7 +4,6 @@ import com.arflix.tv.data.model.Addon
 import com.arflix.tv.data.model.AddonType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class CloudSyncRepositoryAddonMergeTest {
@@ -13,7 +12,7 @@ class CloudSyncRepositoryAddonMergeTest {
         val local = addon(id = "flix", name = "Local Flix")
         val cloud = addon(id = "flix", name = "Cloud Flix", isEnabled = false)
 
-        val (merged, preserved) = mergeCloudAddonsPreservingLocalDirectAddons(
+        val (merged, preserved) = reconcileAddonsWithCloud(
             cloudAddons = listOf(cloud),
             localAddons = listOf(local)
         )
@@ -24,30 +23,32 @@ class CloudSyncRepositoryAddonMergeTest {
     }
 
     @Test
-    fun `missing local custom addon is preserved from stale cloud payload`() {
+    fun `local addon absent from cloud is removed (removal propagates)`() {
+        // The other device removed "flix" — the cloud no longer lists it. Reconcile must drop it
+        // locally instead of re-adding it (the old union bug).
         val cloud = addon(id = "torrentio", name = "Torrentio")
         val localFlix = addon(id = "flix", name = "FlixStreams")
 
-        val (merged, preserved) = mergeCloudAddonsPreservingLocalDirectAddons(
+        val (merged, preserved) = reconcileAddonsWithCloud(
             cloudAddons = listOf(cloud),
-            localAddons = listOf(localFlix)
-        )
-
-        assertTrue(preserved)
-        assertEquals(listOf("torrentio", "flix"), merged.map { it.id })
-    }
-
-    @Test
-    fun `missing subtitle addon is not preserved`() {
-        val localSubtitle = addon(id = "subtitle-only", name = "Subtitle Only", type = AddonType.SUBTITLE)
-
-        val (merged, preserved) = mergeCloudAddonsPreservingLocalDirectAddons(
-            cloudAddons = emptyList(),
-            localAddons = listOf(localSubtitle)
+            localAddons = listOf(cloud, localFlix)
         )
 
         assertFalse(preserved)
-        assertEquals(emptyList<Addon>(), merged)
+        assertEquals(listOf("torrentio"), merged.map { it.id })
+    }
+
+    @Test
+    fun `empty cloud preserves local addons (empty-guard)`() {
+        val localFlix = addon(id = "flix", name = "FlixStreams")
+
+        val (merged, preserved) = reconcileAddonsWithCloud(
+            cloudAddons = emptyList(),
+            localAddons = listOf(localFlix)
+        )
+
+        assertFalse(preserved)
+        assertEquals(listOf("flix"), merged.map { it.id })
     }
 
     private fun addon(

--- a/app/src/test/kotlin/com/arflix/tv/data/repository/CloudSyncRepositoryAddonMergeTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/repository/CloudSyncRepositoryAddonMergeTest.kt
@@ -51,6 +51,37 @@ class CloudSyncRepositoryAddonMergeTest {
         assertEquals(listOf("flix"), merged.map { it.id })
     }
 
+    @Test
+    fun `intentional empty cloud (newer set-timestamp) removes all local addons`() {
+        val localFlix = addon(id = "flix", name = "FlixStreams")
+
+        val (merged, preserved) = reconcileAddonsWithCloud(
+            cloudAddons = emptyList(),
+            localAddons = listOf(localFlix),
+            cloudAddonsUpdatedAt = 100L,
+            localAddonsUpdatedAt = 50L
+        )
+
+        assertFalse(preserved)
+        assertEquals(emptyList<Addon>(), merged)
+    }
+
+    @Test
+    fun `newer local set is kept over a stale cloud (unpushed local change)`() {
+        val cloud = addon(id = "torrentio", name = "Torrentio")
+        val localFlix = addon(id = "flix", name = "FlixStreams")
+
+        val (merged, preserved) = reconcileAddonsWithCloud(
+            cloudAddons = listOf(cloud),
+            localAddons = listOf(localFlix),
+            cloudAddonsUpdatedAt = 50L,
+            localAddonsUpdatedAt = 100L
+        )
+
+        assertFalse(preserved)
+        assertEquals(listOf("flix"), merged.map { it.id })
+    }
+
     private fun addon(
         id: String,
         name: String,

--- a/web/lib/cloud.ts
+++ b/web/lib/cloud.ts
@@ -122,6 +122,29 @@ function setScopedValue<T>(root: RawPayload, key: string, profileId: string, val
   root[key] = byProfile;
 }
 
+// ── Per-field last-writer-wins support (multi-device conflict resolution) ──
+// Mirrors the Android CloudSyncRepository scheme: a scalar setting carries a per-field timestamp
+// under `fieldUpdatedAt` ("g:accentColor", "p:<profileId>:autoPlayNext"). Only the fields this web
+// session actually changed get their timestamp bumped, so the web can't revert a phone's newer
+// change and its own changes are respected by the Android merge.
+function bumpFieldTs(root: RawPayload, key: string) {
+  const map = (root.fieldUpdatedAt && typeof root.fieldUpdatedAt === "object"
+    ? root.fieldUpdatedAt
+    : {}) as Record<string, number>;
+  map[key] = Date.now();
+  root.fieldUpdatedAt = map;
+}
+
+/** Value equality tolerant of object/array fields (avoids reference-inequality false positives). */
+function sameFieldValue(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    return false;
+  }
+}
+
 function stringArray(value: unknown): string[] {
   return arrayValue(value).map((item) => String(item ?? "").trim()).filter(Boolean);
 }
@@ -691,7 +714,11 @@ export async function saveCloudSettings(
   settings: AppSettings,
   addons: InstalledAddon[],
   profileId?: string | null,
-  profiles: Profile[] = []
+  profiles: Profile[] = [],
+  // The web session's last-synced settings (same profile). Used to detect which fields THIS session
+  // actually changed, so we only assert (and timestamp) those — never reverting a field a phone
+  // changed. Null → treat every field as changed (bootstrap / after a profile switch).
+  baseline?: AppSettings | null
 ) {
   await mutateCloudPayload(auth, (root) => {
     root.version = 2;
@@ -701,6 +728,32 @@ export async function saveCloudSettings(
     // partial in-memory addon list must never leak into the shared payload.
     void addons;
     root.settings = settings;
+
+    // ── Genuine global settings that Android merges by per-field timestamp. Only write + bump the
+    //    timestamp when the web actually changed the field vs its baseline; otherwise leave the
+    //    (freshly read-modify-written) cloud value so a phone's newer change survives.
+    const globalFields: Array<[string, unknown, unknown]> = [
+      ["accentColor", settings.accentColor, baseline?.accentColor],
+      ["oledBlackBackground", settings.oledBlack, baseline?.oledBlack],
+      ["skipProfileSelection", settings.skipProfileSelection, baseline?.skipProfileSelection],
+      ["customUserAgent", settings.customUserAgent, baseline?.customUserAgent],
+      ["dnsProvider", settings.dnsProvider, baseline?.dnsProvider],
+      ["subtitleAiEnabled", settings.aiSubtitlesEnabled, baseline?.aiSubtitlesEnabled],
+      ["subtitleAiAutoSelect", settings.aiAutoSelect, baseline?.aiAutoSelect],
+      ["subtitleAiApiKey", settings.aiApiKey, baseline?.aiApiKey],
+      ["subtitleAiModel", settings.aiSubtitleModel, baseline?.aiSubtitleModel],
+      ["subtitleRemoveHearingImpaired", settings.removeHearingImpaired, baseline?.removeHearingImpaired]
+    ];
+    for (const [rootKey, newVal, baseVal] of globalFields) {
+      if (!baseline || !sameFieldValue(newVal, baseVal)) {
+        root[rootKey] = newVal;
+        bumpFieldTs(root, `g:${rootKey}`);
+      }
+    }
+    root.focusBorderColor = settings.accentColor; // mirror of accentColor (not a merge key)
+
+    // ── Root legacy flat mirrors: only OLD Android clients read these (current clients read
+    //    profileSettingsById below). Kept for backward compat; not timestamp-managed.
     root.defaultSubtitle = settings.defaultSubtitle || "Off";
     root.defaultAudioLanguage = settings.audioLanguage || "Auto (Original)";
     root.cardLayoutMode = settings.cardLayoutMode;
@@ -709,19 +762,8 @@ export async function saveCloudSettings(
     root.autoPlaySingleSource = settings.autoPlaySingleSource;
     root.autoPlayMinQuality = androidQuality(settings.autoPlayMinQuality);
     root.includeSpecials = settings.includeSpecials;
-    root.dnsProvider = settings.dnsProvider;
-    root.customUserAgent = settings.customUserAgent;
     root.torrServerBaseUrl = settings.torrServerBaseUrl;
     root.qualityFilters = settings.qualityFilters;
-    root.oledBlackBackground = settings.oledBlack;
-    root.accentColor = settings.accentColor;
-    root.focusBorderColor = settings.accentColor;
-    root.skipProfileSelection = settings.skipProfileSelection;
-    root.subtitleAiEnabled = settings.aiSubtitlesEnabled;
-    root.subtitleAiAutoSelect = settings.aiAutoSelect;
-    root.subtitleAiApiKey = settings.aiApiKey;
-    root.subtitleAiModel = settings.aiSubtitleModel;
-    root.subtitleRemoveHearingImpaired = settings.removeHearingImpaired;
     root.catalogs = settings.catalogs;
     root.hiddenPreinstalledCatalogs = settings.hiddenCatalogIds;
     root.iptvFavoriteChannels = settings.favoriteChannelIds;
@@ -735,7 +777,29 @@ export async function saveCloudSettings(
 
     if (profiles.length) root.profiles = profiles;
     if (profileId) {
-      setScopedValue(root, "profileSettingsById", profileId, androidProfileSettings(settings));
+      // ── Per-profile settings: merge field-by-field over the freshly-read cloud object. Only
+      //    web-changed fields are overwritten + timestamped; everything else keeps the cloud value.
+      const newProfile = androidProfileSettings(settings) as Record<string, unknown>;
+      const baseProfile = baseline ? (androidProfileSettings(baseline) as Record<string, unknown>) : null;
+      const existing = (scopedValue<Record<string, unknown>>(root, "profileSettingsById", profileId) ?? {}) as Record<string, unknown>;
+      const merged: Record<string, unknown> = { ...existing };
+      // Fields the web doesn't genuinely own (always sends empty) — never write them, so they can't
+      // wipe a phone's value. defaultSubtitle keeps its own timestamp logic (handled below).
+      const skip = new Set(["catalogueRowLayoutModes", "subtitleUsageJson", "defaultSubtitle", "subtitleSettingsUpdatedAt"]);
+      for (const field of Object.keys(newProfile)) {
+        if (skip.has(field)) continue;
+        if (!baseProfile || !sameFieldValue(newProfile[field], baseProfile[field])) {
+          merged[field] = newProfile[field];
+          bumpFieldTs(root, `p:${profileId}:${field}`);
+        }
+      }
+      // defaultSubtitle uses Android's own subtitleSettingsUpdatedAt LWW — assert it only when the
+      // web actually changed it, bumping that timestamp so Android adopts it.
+      if (!baseline || !sameFieldValue(settings.defaultSubtitle, baseline.defaultSubtitle)) {
+        merged.defaultSubtitle = settings.defaultSubtitle || "Off";
+        merged.subtitleSettingsUpdatedAt = Date.now();
+      }
+      setScopedValue(root, "profileSettingsById", profileId, merged);
       setScopedValue(root, "addonsByProfile", profileId, addons);
       setScopedValue(root, "catalogsByProfile", profileId, settings.catalogs);
       setScopedValue(root, "hiddenPreinstalledByProfile", profileId, settings.hiddenCatalogIds);

--- a/web/lib/cloud.ts
+++ b/web/lib/cloud.ts
@@ -662,6 +662,24 @@ export async function pullCloudPayload(auth: AuthClient, profileId?: string | nu
   const legacySettings = objectRecord<unknown>(root.settings) as Partial<AppSettings>;
   const legacyCatalogs = arrayValue(root.catalogs) as AppSettings["catalogs"];
   const legacyHiddenCatalogIds = arrayValue<string>(root.hiddenPreinstalledCatalogs);
+  // Canonical, timestamp-managed GLOBAL settings live at the top level of the payload (written by
+  // Android with per-field timestamps), NOT in the legacy `root.settings` blob. Map them so an
+  // Android change (accent color, AI subtitles, etc.) is actually visible on web.
+  const globalSettings: Partial<AppSettings> = {};
+  if ("accentColor" in root) globalSettings.accentColor = String(root.accentColor ?? "");
+  if ("oledBlackBackground" in root) globalSettings.oledBlack = Boolean(root.oledBlackBackground);
+  if ("customUserAgent" in root) globalSettings.customUserAgent = String(root.customUserAgent ?? "");
+  if ("skipProfileSelection" in root) globalSettings.skipProfileSelection = Boolean(root.skipProfileSelection);
+  if ("subtitleAiEnabled" in root) globalSettings.aiSubtitlesEnabled = Boolean(root.subtitleAiEnabled);
+  if ("subtitleAiAutoSelect" in root) globalSettings.aiAutoSelect = Boolean(root.subtitleAiAutoSelect);
+  if ("subtitleAiApiKey" in root) globalSettings.aiApiKey = String(root.subtitleAiApiKey ?? "");
+  // The web's model is a small enum ("off"/"groq"/"gemini") while Android stores a full model id —
+  // only adopt the value when it's already in the web's vocabulary (i.e. the web wrote it last).
+  if ("subtitleAiModel" in root) {
+    const model = String(root.subtitleAiModel ?? "");
+    if (model === "off" || model === "groq" || model === "gemini") globalSettings.aiSubtitleModel = model;
+  }
+  if ("subtitleRemoveHearingImpaired" in root) globalSettings.removeHearingImpaired = Boolean(root.subtitleRemoveHearingImpaired);
   return {
     version: typeof root.version === "number" ? root.version : 1,
     // Union the per-profile scope with the global list. An empty/partial profile
@@ -670,6 +688,7 @@ export async function pullCloudPayload(auth: AuthClient, profileId?: string | nu
     settings: {
       ...legacySettings,
       ...profileSettings,
+      ...globalSettings,
       ...iptvSettings,
       ...(arrayValue(profileCatalogs).length ? { catalogs: arrayValue(profileCatalogs) as AppSettings["catalogs"] } : legacyCatalogs.length ? { catalogs: legacyCatalogs } : {}),
       ...(arrayValue(hiddenCatalogIds).length ? { hiddenCatalogIds: arrayValue<string>(hiddenCatalogIds) } : legacyHiddenCatalogIds.length ? { hiddenCatalogIds: legacyHiddenCatalogIds } : {})
@@ -706,6 +725,9 @@ export async function saveCloudAddons(
       const scoped = scopedValue<InstalledAddon[]>(root, "addonsByProfile", profileId);
       setScopedValue(root, "addonsByProfile", profileId, applyRemovals(unionAddons(addons, scoped)));
     }
+    // Set-level timestamp: lets Android tell an intentional "removed everything" from a blank pull,
+    // so removing the last add-on(s) from web actually propagates (reconcileAddonsWithCloud).
+    root.addonsUpdatedAt = Date.now();
   });
 }
 
@@ -800,7 +822,9 @@ export async function saveCloudSettings(
         merged.subtitleSettingsUpdatedAt = Date.now();
       }
       setScopedValue(root, "profileSettingsById", profileId, merged);
-      setScopedValue(root, "addonsByProfile", profileId, addons);
+      // NOTE: settings saves must NOT touch add-ons. Android now reconciles add-ons to the cloud
+      // authoritatively, so writing this session's (possibly stale) add-on list here could delete an
+      // add-on installed on another device. Add-ons are written exclusively by saveCloudAddons().
       setScopedValue(root, "catalogsByProfile", profileId, settings.catalogs);
       setScopedValue(root, "hiddenPreinstalledByProfile", profileId, settings.hiddenCatalogIds);
       setScopedValue(root, "iptvByProfile", profileId, {

--- a/web/lib/store.tsx
+++ b/web/lib/store.tsx
@@ -842,8 +842,20 @@ export function AppProvider({
       return;
     }
     const handle = setTimeout(() => {
+      // The settings we last synced for THIS profile — lets saveCloudSettings detect exactly which
+      // fields this session changed so it only asserts (and timestamps) those, never reverting a
+      // field another device changed. Ignore the baseline if the active profile has since changed.
+      let baseline: AppSettings | null = null;
+      try {
+        if (lastSyncedSettingsRef.current) {
+          const parsed = JSON.parse(lastSyncedSettingsRef.current) as { settings?: AppSettings; activeProfileId?: string | null };
+          if (parsed.activeProfileId === activeProfileId && parsed.settings) baseline = parsed.settings;
+        }
+      } catch {
+        baseline = null;
+      }
       lastSyncedSettingsRef.current = JSON.stringify({ settings: settingsRef.current, activeProfileId });
-      void saveCloudSettings(authClient, settingsRef.current, addonsRef.current, activeProfileId, profiles).catch(() => undefined);
+      void saveCloudSettings(authClient, settingsRef.current, addonsRef.current, activeProfileId, profiles, baseline).catch(() => undefined);
     }, 1200);
     return () => clearTimeout(handle);
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
 Fix: multi-device settings sync reverting each other                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                    
  Problem                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                    
  Cloud settings are stored as one whole-account JSON blob written last-writer-wins with no clock. Any device that pushed — for any reason (playback progress, token refresh, or a pull's pre-push) — rewrote the entire blob with its own stale copy, silently reverting another device's setting change. No device
  had to even open settings; just being open and pushing was enough.                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                    
  Fix                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                    
  Per-field timestamp last-writer-wins for scalar settings, client-only (no backend change).                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                    
  Android (CloudSyncRepository.kt)                                                                                                                                                                                                                                                                                  
  - Every scalar setting carries a fieldUpdatedAt timestamp (g:accentColor, p:<profileId>:autoPlayNext), stamped by diffing against a baseline — no per-write hooks.                                                                                                                                                
  - Push merges against the already-loaded remote: only overwrites a field it changed more recently → a stale device can't revert a peer.                                                                                                                                                                           
  - Apply merges the other way: adopts remote-newer fields, preserves local newer-unpushed ones → a pull can't lose your own just-made change.                                                                                                                                                                      
  - Applying a value stamps the winner's timestamp (not now()) → converges, no ping-pong. Skipped when the remote predates the feature, so rollout matches today until all devices update.                                                                                                                          
  - Scope: genuine globals + per-profile settings; list domains keep existing merges; defaultSubtitle keeps its own timestamp logic.                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                    
  Web (web/lib/cloud.ts, web/lib/store.tsx)                                                                                                                                                                                                                                                                         
  - saveCloudSettings now diffs against the session's last-synced baseline and writes/timestamps only the fields the web actually changed (same key scheme), instead of overwriting the whole settings blob. Web and phones no longer revert each other.                          