### PR TITLE
feat(ui): add episode rating heatmap to DetailsScreen

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncRepository.kt
@@ -268,6 +268,7 @@ class CloudSyncRepository @Inject constructor(
         val trailerInCards: Boolean = true,
         val clockFormat: String = "24h",
         val showBudget: Boolean = true,
+        val showEpisodeRatings: Boolean = true,
         val showLoadingStats: Boolean? = null,
         val spoilerBlurEnabled: Boolean = false,
         val volumeBoostDb: Int = 0,
@@ -298,6 +299,8 @@ class CloudSyncRepository @Inject constructor(
         profileManager.profileStringKeyFor(profileId, "clock_format")
     private fun showBudgetKeyFor(profileId: String) =
         profileManager.profileBooleanKeyFor(profileId, "show_budget_on_home")
+    private fun showEpisodeRatingsKeyFor(profileId: String) =
+        profileManager.profileBooleanKeyFor(profileId, "show_episode_ratings")
     private fun showLoadingStatsKeyFor(profileId: String) =
         profileManager.profileBooleanKeyFor(profileId, "show_loading_stats")
     private fun spoilerBlurKeyFor(profileId: String) =
@@ -435,6 +438,7 @@ class CloudSyncRepository @Inject constructor(
                         trailerInCards = prefs[trailerInCardsKeyFor(profile.id)] ?: true,
                         clockFormat = prefs[clockFormatKeyFor(profile.id)] ?: "24h",
                         showBudget = prefs[showBudgetKeyFor(profile.id)] ?: true,
+                        showEpisodeRatings = prefs[showEpisodeRatingsKeyFor(profile.id)] ?: true,
                         showLoadingStats = prefs[showLoadingStatsKeyFor(profile.id)] ?: true,
                         spoilerBlurEnabled = prefs[spoilerBlurKeyFor(profile.id)] ?: false,
                         volumeBoostDb = prefs[volumeBoostDbKeyFor(profile.id)]?.toIntOrNull()?.coerceIn(0, 15) ?: 0,
@@ -1104,6 +1108,7 @@ class CloudSyncRepository @Inject constructor(
                         prefs[trailerInCardsKeyFor(profileId)] = state.trailerInCards
                         prefs[clockFormatKeyFor(profileId)] = state.clockFormat
                         prefs[showBudgetKeyFor(profileId)] = state.showBudget
+                        prefs[showEpisodeRatingsKeyFor(profileId)] = state.showEpisodeRatings
                         state.showLoadingStats?.let { prefs[showLoadingStatsKeyFor(profileId)] = it }
                         prefs[spoilerBlurKeyFor(profileId)] = state.spoilerBlurEnabled
                         prefs[volumeBoostDbKeyFor(profileId)] = state.volumeBoostDb.coerceIn(0, 15).toString()

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
@@ -151,6 +151,8 @@ import com.arflix.tv.ui.components.SkeletonDetailsPage
 import com.arflix.tv.ui.components.StreamSelector
 import com.arflix.tv.ui.components.TrailerPlayer
 import androidx.activity.compose.BackHandler
+import androidx.compose.material.icons.filled.ChevronLeft
+import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.ui.zIndex
 import androidx.compose.ui.input.key.onKeyEvent
@@ -222,6 +224,7 @@ fun DetailsScreen(
     var focusedSection by remember { mutableStateOf(FocusSection.BUTTONS) }
     var buttonIndex by remember { mutableIntStateOf(0) }
     var episodeIndex by rememberSaveable { mutableIntStateOf(0) }
+    var ratingsIndex by rememberSaveable { mutableIntStateOf(0) }
     var seasonIndex by rememberSaveable { mutableIntStateOf(0) }
     var castIndex by remember { mutableIntStateOf(0) }
     var reviewIndex by remember { mutableIntStateOf(0) }
@@ -280,6 +283,7 @@ fun DetailsScreen(
         focusedSection = FocusSection.BUTTONS
         buttonIndex = 0
         episodeIndex = 0
+        ratingsIndex = 0
         seasonIndex = 0
         castIndex = 0
         reviewIndex = 0
@@ -384,6 +388,7 @@ fun DetailsScreen(
     LaunchedEffect(uiState.initialEpisodeIndex, uiState.episodes) {
         if (uiState.initialEpisodeIndex > 0 && uiState.episodes.isNotEmpty()) {
             episodeIndex = uiState.initialEpisodeIndex
+            ratingsIndex = uiState.initialEpisodeIndex / 12
         }
     }
 
@@ -454,6 +459,7 @@ fun DetailsScreen(
         { idx: Int ->
             seasonIndex = idx
             episodeIndex = 0
+            ratingsIndex = 0
             viewModel.loadSeason(idx + 1)
         }
     }
@@ -567,6 +573,7 @@ fun DetailsScreen(
                                 val atLeftmost = when (focusedSection) {
                                     FocusSection.BUTTONS -> buttonIndex == 0
                                     FocusSection.EPISODES -> episodeIndex == 0
+                                    FocusSection.RATINGS -> ratingsIndex == 0
                                     FocusSection.SEASONS -> seasonIndex == 0
                                     FocusSection.CAST -> castIndex == 0
                                     FocusSection.REVIEWS -> reviewIndex == 0
@@ -577,8 +584,8 @@ fun DetailsScreen(
                                     true
                                 } else {
                                     handleLeft(
-                                        focusedSection, buttonIndex, episodeIndex, seasonIndex, castIndex, reviewIndex, similarIndex, collectionIndex,
-                                        { buttonIndex = it }, { episodeIndex = it }, { seasonIndex = it },
+                                        focusedSection, buttonIndex, episodeIndex, ratingsIndex, seasonIndex, castIndex, reviewIndex, similarIndex, collectionIndex,
+                                        { buttonIndex = it }, { episodeIndex = it }, { ratingsIndex = it }, { seasonIndex = it },
                                         { castIndex = it }, { reviewIndex = it }, { similarIndex = it },
                                         { collectionIndex = it }
                                     )
@@ -593,8 +600,8 @@ fun DetailsScreen(
                                 true
                             } else {
                                 handleRight(
-                                    focusedSection, buttonIndex, episodeIndex, seasonIndex, castIndex, reviewIndex, similarIndex, collectionIndex,
-                                    uiState, { buttonIndex = it }, { episodeIndex = it }, { seasonIndex = it },
+                                    focusedSection, buttonIndex, episodeIndex, ratingsIndex, seasonIndex, castIndex, reviewIndex, similarIndex, collectionIndex,
+                                    uiState, { buttonIndex = it }, { episodeIndex = it }, { ratingsIndex = it }, { seasonIndex = it },
                                     { castIndex = it }, { reviewIndex = it }, { similarIndex = it },
                                     { collectionIndex = it }
                                 )
@@ -607,6 +614,8 @@ fun DetailsScreen(
                                 // Navigation: BUTTONS -> SEASONS -> EPISODES -> CAST -> REVIEWS -> SIMILAR -> COLLECTION
                                 val isTV = mediaType == MediaType.TV
                                 val hasEpisodes = uiState.episodes.isNotEmpty()
+                                val hasAnyValidRating = uiState.episodes.any { (it.imdbRating.toFloatOrNull() ?: 0f) > 0f }
+                                val hasRatings = isTV && hasEpisodes && uiState.showEpisodeRatings && hasAnyValidRating
                                 val hasCast = uiState.cast.isNotEmpty()
                                 val hasReviews = uiState.reviews.isNotEmpty()
                                 val hasSimilar = uiState.similar.isNotEmpty()
@@ -623,11 +632,19 @@ fun DetailsScreen(
                                     FocusSection.CAST -> {
                                         if (isTV) {
                                             when {
+                                                hasRatings -> FocusSection.RATINGS
                                                 hasEpisodes -> FocusSection.EPISODES
                                                 uiState.totalSeasons > 1 -> FocusSection.SEASONS
                                                 else -> FocusSection.BUTTONS
                                             }
                                         } else FocusSection.BUTTONS
+                                    }
+                                    FocusSection.RATINGS -> {
+                                        when {
+                                            hasEpisodes -> FocusSection.EPISODES
+                                            uiState.totalSeasons > 1 -> FocusSection.SEASONS
+                                            else -> FocusSection.BUTTONS
+                                        }
                                     }
                                     FocusSection.REVIEWS -> if (hasCast) FocusSection.CAST else FocusSection.BUTTONS
                                     FocusSection.SIMILAR -> {
@@ -653,6 +670,8 @@ fun DetailsScreen(
                                 // Navigation: BUTTONS -> SEASONS -> EPISODES -> CAST -> REVIEWS -> SIMILAR -> COLLECTION
                                 val isTV = mediaType == MediaType.TV
                                 val hasEpisodes = uiState.episodes.isNotEmpty()
+                                val hasAnyValidRating = uiState.episodes.any { (it.imdbRating.toFloatOrNull() ?: 0f) > 0f }
+                                val hasRatings = isTV && hasEpisodes && uiState.showEpisodeRatings && hasAnyValidRating
                                 val hasSeasons = uiState.totalSeasons > 1
                                 val hasCast = uiState.cast.isNotEmpty()
                                 val hasReviews = uiState.reviews.isNotEmpty()
@@ -662,6 +681,7 @@ fun DetailsScreen(
                                     FocusSection.BUTTONS -> {
                                         if (isTV && hasSeasons) FocusSection.SEASONS
                                         else if (isTV && hasEpisodes) FocusSection.EPISODES
+                                        else if (hasRatings) FocusSection.RATINGS
                                         else if (hasCast) FocusSection.CAST
                                         else if (hasReviews) FocusSection.REVIEWS
                                         else if (hasCollection) FocusSection.COLLECTION
@@ -670,6 +690,7 @@ fun DetailsScreen(
                                     }
                                     FocusSection.SEASONS -> {
                                         if (hasEpisodes) FocusSection.EPISODES
+                                        else if (hasRatings) FocusSection.RATINGS
                                         else if (hasCast) FocusSection.CAST
                                         else if (hasReviews) FocusSection.REVIEWS
                                         else if (hasCollection) FocusSection.COLLECTION
@@ -677,11 +698,19 @@ fun DetailsScreen(
                                         else FocusSection.SEASONS
                                     }
                                     FocusSection.EPISODES -> {
-                                        if (hasCast) FocusSection.CAST
+                                        if (hasRatings) FocusSection.RATINGS
+                                        else if (hasCast) FocusSection.CAST
                                         else if (hasReviews) FocusSection.REVIEWS
                                         else if (hasCollection) FocusSection.COLLECTION
                                         else if (hasSimilar) FocusSection.SIMILAR
                                         else FocusSection.EPISODES
+                                    }
+                                    FocusSection.RATINGS -> {
+                                        if (hasCast) FocusSection.CAST
+                                        else if (hasReviews) FocusSection.REVIEWS
+                                        else if (hasCollection) FocusSection.COLLECTION
+                                        else if (hasSimilar) FocusSection.SIMILAR
+                                        else FocusSection.RATINGS
                                     }
                                     FocusSection.CAST -> {
                                         if (hasReviews) FocusSection.REVIEWS
@@ -789,7 +818,10 @@ fun DetailsScreen(
                                 }
                                 FocusSection.SEASONS -> {
                                     episodeIndex = 0
+                                    ratingsIndex = 0
                                     viewModel.loadSeason(seasonIndex + 1)
+                                }
+                                FocusSection.RATINGS -> {
                                 }
                                 FocusSection.CAST -> {
                                     val member = uiState.cast.getOrNull(castIndex)
@@ -834,6 +866,7 @@ fun DetailsScreen(
                             showSeasonContextMenu = true
                         } else {
                             episodeIndex = 0
+                            ratingsIndex = 0
                             viewModel.loadSeason(seasonIndex + 1)
                         }
                         true
@@ -879,6 +912,7 @@ fun DetailsScreen(
                     focusedSection = focusedSection,
                     buttonIndex = buttonIndex,
                     episodeIndex = episodeIndex,
+                    ratingsIndex = ratingsIndex,
                     seasonIndex = seasonIndex,
                     castIndex = castIndex,
                     reviewIndex = reviewIndex,
@@ -888,6 +922,7 @@ fun DetailsScreen(
                     budget = uiState.budget,
                     seasonProgress = uiState.seasonProgress,
                     playLabel = uiState.playLabel,
+                    showEpisodeRatings = uiState.showEpisodeRatings,
                     hasTrailer = uiState.trailerKey != null,
                     contentHasFocus = !isSidebarFocused,
                     usePosterCards = usePosterCards,
@@ -1066,7 +1101,7 @@ fun DetailsScreen(
 }
 
 private enum class FocusSection {
-    BUTTONS, EPISODES, SEASONS, CAST, REVIEWS, SIMILAR, COLLECTION
+    BUTTONS, EPISODES, SEASONS, RATINGS, CAST, REVIEWS, SIMILAR, COLLECTION
 }
 
 private data class PendingAutoPlayRequest(
@@ -1078,15 +1113,16 @@ private data class PendingAutoPlayRequest(
 
 private fun handleLeft(
     section: FocusSection,
-    buttonIdx: Int, episodeIdx: Int, seasonIdx: Int, castIdx: Int, reviewIdx: Int, similarIdx: Int,
+    buttonIdx: Int, episodeIdx: Int, ratingsIdx: Int, seasonIdx: Int, castIdx: Int, reviewIdx: Int, similarIdx: Int,
     collectionIdx: Int,
-    setButton: (Int) -> Unit, setEpisode: (Int) -> Unit, setSeason: (Int) -> Unit,
+    setButton: (Int) -> Unit, setEpisode: (Int) -> Unit, setRatings: (Int) -> Unit, setSeason: (Int) -> Unit,
     setCast: (Int) -> Unit, setReview: (Int) -> Unit, setSimilar: (Int) -> Unit,
     setCollection: (Int) -> Unit
 ): Boolean {
     when (section) {
         FocusSection.BUTTONS -> if (buttonIdx > 0) setButton(buttonIdx - 1)
         FocusSection.EPISODES -> if (episodeIdx > 0) setEpisode(episodeIdx - 1)
+        FocusSection.RATINGS -> if (ratingsIdx > 0) setRatings(ratingsIdx - 1)
         FocusSection.SEASONS -> if (seasonIdx > 0) setSeason(seasonIdx - 1)
         FocusSection.CAST -> if (castIdx > 0) setCast(castIdx - 1)
         FocusSection.REVIEWS -> if (reviewIdx > 0) setReview(reviewIdx - 1)
@@ -1098,10 +1134,10 @@ private fun handleLeft(
 
 private fun handleRight(
     section: FocusSection,
-    buttonIdx: Int, episodeIdx: Int, seasonIdx: Int, castIdx: Int, reviewIdx: Int, similarIdx: Int,
+    buttonIdx: Int, episodeIdx: Int, ratingsIdx: Int, seasonIdx: Int, castIdx: Int, reviewIdx: Int, similarIdx: Int,
     collectionIdx: Int,
     uiState: DetailsUiState,
-    setButton: (Int) -> Unit, setEpisode: (Int) -> Unit, setSeason: (Int) -> Unit,
+    setButton: (Int) -> Unit, setEpisode: (Int) -> Unit, setRatings: (Int) -> Unit, setSeason: (Int) -> Unit,
     setCast: (Int) -> Unit, setReview: (Int) -> Unit, setSimilar: (Int) -> Unit,
     setCollection: (Int) -> Unit
 ): Boolean {
@@ -1111,6 +1147,11 @@ private fun handleRight(
             if (buttonIdx < maxButton) setButton(buttonIdx + 1)
         }
         FocusSection.EPISODES -> if (episodeIdx < uiState.episodes.size - 1) setEpisode(episodeIdx + 1)
+        FocusSection.RATINGS -> {
+            val pageSize = 12
+            val totalPages = (uiState.episodes.size + pageSize - 1) / pageSize
+            if (ratingsIdx < totalPages - 1) setRatings(ratingsIdx + 1)
+        }
         FocusSection.SEASONS -> if (seasonIdx < uiState.totalSeasons - 1) setSeason(seasonIdx + 1)
         FocusSection.CAST -> if (castIdx < uiState.cast.size - 1) setCast(castIdx + 1)
         FocusSection.REVIEWS -> if (reviewIdx < uiState.reviews.size - 1) setReview(reviewIdx + 1)
@@ -1140,6 +1181,7 @@ private fun DetailsContent(
     focusedSection: FocusSection,
     buttonIndex: Int,
     episodeIndex: Int,
+    ratingsIndex: Int,
     seasonIndex: Int,
     castIndex: Int,
     reviewIndex: Int,
@@ -1152,6 +1194,7 @@ private fun DetailsContent(
     hasTrailer: Boolean = false,
     contentHasFocus: Boolean = true,
     usePosterCards: Boolean = false,
+    showEpisodeRatings: Boolean = true,
     isMobile: Boolean = false,
     // Persistent back callback used by the phone-layout back button overlay
     // (issue #43). No-op by default so tablet/TV callers don't need to pass it.
@@ -1532,6 +1575,19 @@ private fun DetailsContent(
                             )
                         }
                     }
+                }
+
+                val hasAnyValidRating = remember(episodes) {
+                    episodes.any { (it.imdbRating.toFloatOrNull() ?: 0f) > 0f }
+                }
+                if (item.mediaType == MediaType.TV && episodes.isNotEmpty() && showEpisodeRatings && hasAnyValidRating) {
+                    DetailsEpisodeRatingsRail(
+                        episodes = episodes,
+                        totalSeasons = totalSeasons,
+                        currentSeason = currentSeason,
+                        episodeIndex = episodeIndex,
+                        isMobile = true
+                    )
                 }
 
                 // Cast section
@@ -2093,12 +2149,14 @@ private fun DetailsContent(
             focusedSection = focusedSection,
             focusSectionForUi = focusSectionForUi,
             episodeIndex = episodeIndex,
+            ratingsIndex = ratingsIndex,
             seasonIndex = seasonIndex,
             castIndex = castIndex,
             reviewIndex = reviewIndex,
             similarIndex = similarIndex,
             seasonProgress = seasonProgress,
             usePosterCards = usePosterCards,
+            showEpisodeRatings = showEpisodeRatings,
             spoilerBlurEnabled = spoilerBlurEnabled,
             contentRowHeight = contentRowHeight,
             contentRowBottomPadding = contentRowBottomPadding,
@@ -2130,12 +2188,14 @@ private fun DetailsTvRows(
     focusedSection: FocusSection,
     focusSectionForUi: FocusSection?,
     episodeIndex: Int,
+    ratingsIndex: Int,
     seasonIndex: Int,
     castIndex: Int,
     reviewIndex: Int,
     similarIndex: Int,
     seasonProgress: Map<Int, Pair<Int, Int>>,
     usePosterCards: Boolean,
+    showEpisodeRatings: Boolean,
     spoilerBlurEnabled: Boolean,
     contentRowHeight: Dp,
     contentRowBottomPadding: Dp,
@@ -2152,6 +2212,10 @@ private fun DetailsTvRows(
     val density = LocalDensity.current
     val isTV = item.mediaType == MediaType.TV
     val hasEpisodes = isTV && episodes.isNotEmpty()
+    val hasAnyValidRating = remember(episodes) {
+        episodes.any { (it.imdbRating.toFloatOrNull() ?: 0f) > 0f }
+    }
+    val hasRatings = hasEpisodes && showEpisodeRatings && hasAnyValidRating
     val hasSeasons = isTV && totalSeasons > 1
     val hasCast = cast.isNotEmpty()
     val hasReviews = reviews.isNotEmpty()
@@ -2161,6 +2225,7 @@ private fun DetailsTvRows(
     var idx = 0
     val seasonsIdx = if (hasSeasons) idx.also { idx++ } else -1
     val episodesIdx = if (hasEpisodes) idx.also { idx++ } else -1
+    val ratingsIdx = if (hasRatings) idx.also { idx++ } else -1
     if (hasCast) idx++
     val castIdx = if (hasCast) idx.also { idx++ } else -1
     if (hasReviews) idx++
@@ -2179,6 +2244,7 @@ private fun DetailsTvRows(
 
         val targetIndex = when (focusedSection) {
             FocusSection.BUTTONS, FocusSection.EPISODES, FocusSection.SEASONS -> 0
+            FocusSection.RATINGS -> ratingsIdx
             FocusSection.CAST -> castIdx
             FocusSection.REVIEWS -> reviewsIdx
             FocusSection.COLLECTION -> collectionIdx
@@ -2188,6 +2254,7 @@ private fun DetailsTvRows(
         val firstFocusableRailIndex = listOf(
             seasonsIdx,
             episodesIdx,
+            ratingsIdx,
             castIdx,
             reviewsIdx,
             collectionIdx,
@@ -2281,6 +2348,22 @@ private fun DetailsTvRows(
                     contentOuterStartPadding = contentOuterStartPadding,
                     spoilerBlurEnabled = spoilerBlurEnabled,
                     onEpisodeClick = onEpisodeClick
+                )
+            }
+        }
+
+        if (item.mediaType == MediaType.TV && episodes.isNotEmpty() && showEpisodeRatings && hasAnyValidRating) {
+            item {
+                DetailsEpisodeRatingsRail(
+                    episodes = episodes,
+                    totalSeasons = totalSeasons,
+                    currentSeason = currentSeason,
+                    episodeIndex = episodeIndex,
+                    ratingsIndex = ratingsIndex,
+                    isMobile = false,
+                    focusSectionForUi = focusSectionForUi,
+                    contentStartPadding = contentStartPadding,
+                    contentOuterStartPadding = contentOuterStartPadding
                 )
             }
         }
@@ -2414,6 +2497,261 @@ private fun DetailsSeasonRail(
                 totalCount = currentSeasonProgress?.second ?: progress?.second ?: 0,
                 onClick = onClickForSeason
             )
+        }
+    }
+}
+
+private fun getEpisodeRatingColor(rating: Float): Color {
+    return when {
+        rating >= 9.0f -> Color(0xFF186A3B)
+        rating >= 8.0f -> Color(0xFF28B463)
+        rating >= 7.5f -> Color(0xFFF4D03F)
+        rating >= 7.0f -> Color(0xFFF39C12)
+        rating >= 6.0f -> Color(0xFFE74C3C)
+        rating > 0.0f -> Color(0xFF633974)
+        else -> Color.DarkGray
+    }
+}
+
+private fun getEpisodeRatingTextColor(rating: Float): Color {
+    return when {
+        rating >= 7.0f && rating < 8.0f -> Color(0xFF1D1D1F)
+        else -> Color.White
+    }
+}
+
+private fun formatEpisodeRating(ratingStr: String): String {
+    val rating = ratingStr.toFloatOrNull() ?: return "—"
+    if (rating <= 0f) return "—"
+    val formatted = String.format(java.util.Locale.US, "%.1f", rating)
+    return if (formatted.endsWith(".0")) formatted.substringBefore(".") else formatted
+}
+
+@Composable
+private fun DetailsEpisodeRatingsRail(
+    episodes: List<Episode>,
+    totalSeasons: Int,
+    currentSeason: Int,
+    episodeIndex: Int,
+    ratingsIndex: Int = 0,
+    isMobile: Boolean,
+    focusSectionForUi: FocusSection? = null,
+    contentStartPadding: Dp = 0.dp,
+    contentOuterStartPadding: Dp = 0.dp
+) {
+    if (episodes.isEmpty()) return
+
+    var previousRatingsIndex by remember { mutableIntStateOf(ratingsIndex) }
+    var leftChevronBump by remember { mutableStateOf(false) }
+    var rightChevronBump by remember { mutableStateOf(false) }
+
+    LaunchedEffect(ratingsIndex) {
+        if (ratingsIndex < previousRatingsIndex) {
+            leftChevronBump = true
+            kotlinx.coroutines.delay(100)
+            leftChevronBump = false
+        } else if (ratingsIndex > previousRatingsIndex) {
+            rightChevronBump = true
+            kotlinx.coroutines.delay(100)
+            rightChevronBump = false
+        }
+        previousRatingsIndex = ratingsIndex
+    }
+
+    val leftOffset by androidx.compose.animation.core.animateDpAsState(
+        targetValue = if (leftChevronBump) (-8).dp else 0.dp,
+        animationSpec = androidx.compose.animation.core.tween(100)
+    )
+
+    val rightOffset by androidx.compose.animation.core.animateDpAsState(
+        targetValue = if (rightChevronBump) 8.dp else 0.dp,
+        animationSpec = androidx.compose.animation.core.tween(100)
+    )
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = if (isMobile) 16.dp else 0.dp)
+    ) {
+        if (isMobile) Spacer(modifier = Modifier.height(24.dp)) else Spacer(modifier = Modifier.height(4.dp))
+        
+        Text(
+            text = stringResource(R.string.ratings),
+            style = if (isMobile) ArvioSkin.typography.sectionTitle.copy(fontSize = 15.sp, fontWeight = FontWeight.Bold) 
+                    else ArvioSkin.typography.sectionTitle.copy(fontSize = 14.sp, fontWeight = FontWeight.Bold),
+            color = Color.White.copy(alpha = 0.9f),
+            modifier = Modifier.padding(
+                start = if (isMobile) 0.dp else contentStartPadding,
+                bottom = if (isMobile) 0.dp else 2.dp
+            )
+        )
+
+        if (!isMobile) {
+            val episodesLabel = stringResource(R.string.episodes).lowercase()
+            val textStr = if (totalSeasons > 1) {
+                val seasonLabel = "${stringResource(R.string.season_label)} $currentSeason"
+                "$seasonLabel • ${episodes.size} $episodesLabel"
+            } else {
+                "${episodes.size} $episodesLabel"
+            }
+            Text(
+                text = textStr,
+                style = ArvioSkin.typography.body.copy(fontSize = 12.sp, fontWeight = FontWeight.Normal),
+                color = Color.White.copy(alpha = 0.5f),
+                modifier = Modifier.padding(
+                    start = contentStartPadding,
+                    bottom = 10.dp
+                )
+            )
+        }
+        
+        if (isMobile) Spacer(modifier = Modifier.height(8.dp))
+
+        if (isMobile) {
+            LazyRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                contentPadding = PaddingValues(0.dp)
+            ) {
+                standardItemsIndexed(
+                    episodes,
+                    key = { index, ep -> "mob_rate_${ep.seasonNumber}_${ep.episodeNumber}_$index" }
+                ) { index, episode ->
+                    val ratingValue = episode.imdbRating.toFloatOrNull() ?: 0f
+                    val bgColor = getEpisodeRatingColor(ratingValue)
+                    val txtColor = getEpisodeRatingTextColor(ratingValue)
+                    val ratingText = formatEpisodeRating(episode.imdbRating)
+                    
+                    Box(
+                        modifier = Modifier
+                            .size(width = 48.dp, height = 48.dp)
+                            .background(bgColor, RoundedCornerShape(8.dp)),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.Center) {
+                            Text(
+                                text = "E${episode.episodeNumber}",
+                                color = txtColor.copy(alpha = 0.8f),
+                                style = ArvioSkin.typography.body.copy(fontWeight = FontWeight.Normal, fontSize = 10.sp)
+                            )
+                            Text(
+                                text = ratingText,
+                                color = txtColor,
+                                style = ArvioSkin.typography.body.copy(fontWeight = FontWeight.Bold, fontSize = 14.sp)
+                            )
+                        }
+                    }
+                }
+            }
+        } else {
+            val isRowFocused = focusSectionForUi == FocusSection.RATINGS
+            val adjustedStart = if (contentStartPadding > 36.dp) contentStartPadding - 36.dp else 0.dp
+            
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = adjustedStart, top = 12.dp, bottom = 12.dp)
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    val pageSize = 12
+                    val totalPages = (episodes.size + pageSize - 1) / pageSize
+                    val safePageIndex = ratingsIndex.coerceIn(0, maxOf(0, totalPages - 1))
+                    val startIndex = safePageIndex * pageSize
+                    val endIndex = minOf(startIndex + pageSize, episodes.size)
+                    val displayEpisodes = if (startIndex < episodes.size) episodes.subList(startIndex, endIndex) else emptyList()
+                    
+                    if (!isRowFocused) {
+                        Spacer(modifier = Modifier.width(24.dp))
+                    } else {
+                        if (safePageIndex > 0) {
+                            Icon(
+                                imageVector = Icons.Default.ChevronLeft,
+                                contentDescription = "Previous page",
+                                tint = Color.White,
+                                modifier = Modifier.size(24.dp).offset(x = leftOffset)
+                            )
+                        } else {
+                            Box(
+                                modifier = Modifier.size(24.dp),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Box(
+                                    modifier = Modifier
+                                        .size(6.dp)
+                                        .background(Color.White, CircleShape)
+                                )
+                            }
+                        }
+                    }
+                    
+                    val crossfadeTarget = Pair(displayEpisodes, safePageIndex == totalPages - 1 && isRowFocused)
+                    
+                    androidx.compose.animation.Crossfade(
+                        targetState = crossfadeTarget,
+                        label = "RatingsPagination",
+                        animationSpec = androidx.compose.animation.core.tween(durationMillis = 200)
+                    ) { (currentEpisodes, isLastPageFocused) ->
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(7.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            currentEpisodes.forEachIndexed { index, episode ->
+                                val ratingValue = episode.imdbRating.toFloatOrNull() ?: 0f
+                                val bgColor = getEpisodeRatingColor(ratingValue)
+                                val txtColor = getEpisodeRatingTextColor(ratingValue)
+                                val ratingText = formatEpisodeRating(episode.imdbRating)
+                                
+                                Box(
+                                    modifier = Modifier
+                                        .size(width = 64.dp, height = 64.dp)
+                                        .background(bgColor, RoundedCornerShape(8.dp)),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.Center) {
+                                        Text(
+                                            text = "E${episode.episodeNumber}",
+                                            color = txtColor.copy(alpha = 0.8f),
+                                            style = ArvioSkin.typography.body.copy(fontWeight = FontWeight.Normal, fontSize = 12.sp)
+                                        )
+                                        Text(
+                                            text = ratingText,
+                                            color = txtColor,
+                                            style = ArvioSkin.typography.body.copy(fontWeight = FontWeight.Bold, fontSize = 16.sp)
+                                        )
+                                    }
+                                }
+                            }
+                            
+                            if (isLastPageFocused) {
+                                Box(
+                                    modifier = Modifier.size(24.dp),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Box(
+                                        modifier = Modifier
+                                            .size(6.dp)
+                                            .background(Color.White, CircleShape)
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    
+                    if (!isRowFocused) {
+                        Spacer(modifier = Modifier.width(24.dp))
+                    } else if (safePageIndex < totalPages - 1) {
+                        Icon(
+                            imageVector = Icons.Default.ChevronRight,
+                            contentDescription = "Next page",
+                            tint = Color.White,
+                            modifier = Modifier.size(24.dp).offset(x = rightOffset)
+                        )
+                    }
+                }
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
@@ -77,6 +77,7 @@ data class DetailsUiState(
     val hasStreamingAddons: Boolean = true,
     val addonOrderedIds: List<String> = emptyList(),
     val isInWatchlist: Boolean = false,
+    val showEpisodeRatings: Boolean = true,
     // Toast
     val toastMessage: String? = null,
     val toastType: ToastType = ToastType.INFO,
@@ -222,6 +223,7 @@ class DetailsViewModel @Inject constructor(
     private fun autoPlaySingleSourceKey() = profileManager.profileBooleanKey("auto_play_single_source")
     private fun autoPlayMinQualityKey() = profileManager.profileStringKey("auto_play_min_quality")
     private fun showBudgetKey() = profileManager.profileBooleanKey("show_budget_on_home")
+    private fun showEpisodeRatingsKey() = profileManager.profileBooleanKey("show_episode_ratings")
 
     private fun isBlankRating(value: String): Boolean {
         return value.isBlank() || value == "0.0" || value == "0"
@@ -279,6 +281,7 @@ class DetailsViewModel @Inject constructor(
                 val autoPlaySingleSource = prefs[autoPlaySingleSourceKey()] ?: true
                 val autoPlayMinQuality = normalizeAutoPlayMinQuality(prefs[autoPlayMinQualityKey()])
                 val showBudget = prefs[showBudgetKey()] ?: true
+                val showEpisodeRatings = prefs[showEpisodeRatingsKey()] ?: true
 
                 val previousState = _uiState.value
                 val previousMatches = previousState.item?.id == mediaId &&
@@ -319,6 +322,7 @@ class DetailsViewModel @Inject constructor(
                     } else {
                         null
                     },
+                    showEpisodeRatings = showEpisodeRatings,
                     autoPlaySingleSource = autoPlaySingleSource,
                     autoPlayMinQuality = autoPlayMinQuality
                 )

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.material.icons.filled.LinkOff
 import androidx.compose.material.icons.filled.Movie
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Subtitles
@@ -219,7 +220,7 @@ private fun tvGeneralRowsForSection(section: String): List<Int> {
         "subtitles" -> listOf(1, 2, 38, 39, 4, 5, 6, 7, 8, 9)
         "ai_subtitles" -> listOf(28, 29, 30, 31, 32, 33)
         "playback" -> listOf(10, 11, 12, 13, 14, 37, 34, 16, 15, 40, 27)
-        "appearance" -> listOf(17, 18, 20, 21, 24, 23, 22, 36)
+        "appearance" -> listOf(17, 18, 20, 21, 24, 23, 22, 41, 36)
         "profiles" -> listOf(19)
         "network" -> listOf(25, 26, 35)
         else -> emptyList()
@@ -896,6 +897,7 @@ fun SettingsScreen(
                                                 20 -> viewModel.setOledBlackBackground(!uiState.oledBlackBackground)
                                                 21 -> viewModel.cycleClockFormat()
                                                 22 -> viewModel.setShowBudget(!uiState.showBudget)
+                                                41 -> viewModel.setShowEpisodeRatings(!uiState.showEpisodeRatings)
                                                  36 -> viewModel.setSmoothScrolling(!uiState.smoothScrolling)
                                                 23 -> viewModel.setSpoilerBlurEnabled(!uiState.spoilerBlurEnabled)
                                                 24 -> viewModel.cycleAccentColor()
@@ -1316,6 +1318,8 @@ fun SettingsScreen(
                             onOledBlackBackgroundToggle = { viewModel.setOledBlackBackground(it) },
                             onClockFormatClick = { viewModel.cycleClockFormat() },
                             onShowBudgetToggle = { viewModel.setShowBudget(it) },
+                            showEpisodeRatings = uiState.showEpisodeRatings,
+                            onShowEpisodeRatingsToggle = { viewModel.setShowEpisodeRatings(it) },
                             smoothScrolling = uiState.smoothScrolling,
                             onSmoothScrollingToggle = { viewModel.setSmoothScrolling(it) },
                             spoilerBlurEnabled = uiState.spoilerBlurEnabled,
@@ -3858,6 +3862,14 @@ private fun MobileSettingsSubPage(
                         onClick = { viewModel.setShowBudget(!uiState.showBudget) }
                     )
                     MobileSettingsRow(
+                        icon = Icons.Default.Star,
+                        title = stringResource(R.string.show_episode_ratings),
+                        value = if (uiState.showEpisodeRatings) "On" else "Off",
+                        isFocused = false,
+                        showDivider = true,
+                        onClick = { viewModel.setShowEpisodeRatings(!uiState.showEpisodeRatings) }
+                    )
+                    MobileSettingsRow(
                         icon = Icons.Default.VisibilityOff,
                         title = stringResource(R.string.spoiler_blur),
                         value = if (uiState.spoilerBlurEnabled) "On" else "Off",
@@ -4732,6 +4744,7 @@ private fun TvGeneralSettingsRows(
     oledBlackBackground: Boolean = false,
     clockFormat: String = "24h",
     showBudget: Boolean = true,
+    showEpisodeRatings: Boolean = true,
     smoothScrolling: Boolean = true,
     spoilerBlurEnabled: Boolean = false,
     accentColor: String = "White",
@@ -4752,6 +4765,7 @@ private fun TvGeneralSettingsRows(
     onOledBlackBackgroundToggle: (Boolean) -> Unit = {},
     onClockFormatClick: () -> Unit = {},
     onShowBudgetToggle: (Boolean) -> Unit = {},
+    onShowEpisodeRatingsToggle: (Boolean) -> Unit = {},
     onSmoothScrollingToggle: (Boolean) -> Unit = {},
     onSpoilerBlurToggle: (Boolean) -> Unit = {},
     onAccentColorClick: () -> Unit = {},
@@ -4868,6 +4882,7 @@ private fun TvGeneralSettingsRows(
                 20 -> SettingsToggleRow(stringResource(R.string.oled_black_background), stringResource(R.string.oled_black_background_desc), oledBlackBackground, focusedIndex == localIndex, onOledBlackBackgroundToggle, Modifier.settingsFocusSlot(localIndex))
                 21 -> SettingsRow(Icons.Default.Schedule, stringResource(R.string.clock_format), stringResource(R.string.clock_format_desc), if (clockFormat == "12h") "12-hour" else "24-hour", focusedIndex == localIndex, onClockFormatClick, Modifier.settingsFocusSlot(localIndex))
                 22 -> SettingsToggleRow(stringResource(R.string.show_budget), stringResource(R.string.show_budget_desc), showBudget, focusedIndex == localIndex, onShowBudgetToggle, Modifier.settingsFocusSlot(localIndex))
+                41 -> SettingsToggleRow(stringResource(R.string.show_episode_ratings), stringResource(R.string.show_episode_ratings_desc), showEpisodeRatings, focusedIndex == localIndex, onShowEpisodeRatingsToggle, Modifier.settingsFocusSlot(localIndex))
                 36 -> SettingsToggleRow(stringResource(R.string.smooth_scrolling), stringResource(R.string.smooth_scrolling_desc), smoothScrolling, focusedIndex == localIndex, onSmoothScrollingToggle, Modifier.settingsFocusSlot(localIndex))
                 23 -> SettingsToggleRow(stringResource(R.string.spoiler_blur), stringResource(R.string.spoiler_blur_desc), spoilerBlurEnabled, focusedIndex == localIndex, onSpoilerBlurToggle, Modifier.settingsFocusSlot(localIndex))
                 24 -> SettingsRow(Icons.Default.Palette, stringResource(R.string.accent_color), stringResource(R.string.accent_color_desc), accentColor, focusedIndex == localIndex, onAccentColorClick, Modifier.settingsFocusSlot(localIndex))
@@ -4933,6 +4948,7 @@ private fun GeneralSettings(
     oledBlackBackground: Boolean = false,
     clockFormat: String = "24h",
     showBudget: Boolean = true,
+    showEpisodeRatings: Boolean = true,
     spoilerBlurEnabled: Boolean = false,
     accentColor: String = "White",
     volumeBoostDb: Int = 0,
@@ -4952,6 +4968,7 @@ private fun GeneralSettings(
     onOledBlackBackgroundToggle: (Boolean) -> Unit = {},
     onClockFormatClick: () -> Unit = {},
     onShowBudgetToggle: (Boolean) -> Unit = {},
+    onShowEpisodeRatingsToggle: (Boolean) -> Unit = {},
     onSpoilerBlurToggle: (Boolean) -> Unit = {},
     onAccentColorClick: () -> Unit = {},
     showLoadingStats: Boolean = true,
@@ -5240,6 +5257,15 @@ private fun GeneralSettings(
             isFocused = focusedIndex == 22,
             onToggle = onShowBudgetToggle,
             modifier = Modifier.settingsFocusSlot(22)
+        )
+        Spacer(modifier = Modifier.height(10.dp))
+        SettingsToggleRow(
+            title = stringResource(R.string.show_episode_ratings),
+            subtitle = stringResource(R.string.show_episode_ratings_desc),
+            isEnabled = showEpisodeRatings,
+            isFocused = focusedIndex == 41,
+            onToggle = onShowEpisodeRatingsToggle,
+            modifier = Modifier.settingsFocusSlot(41)
         )
         Spacer(modifier = Modifier.height(10.dp))
         SettingsToggleRow(

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -113,6 +113,7 @@ data class SettingsUiState(
     val trailerDelaySeconds: Int = 2,
     val trailerInCards: Boolean = true,
     val showBudget: Boolean = true,
+    val showEpisodeRatings: Boolean = true,
     // Volume boost in decibels (0 = off, up to 15 dB). Applied via system LoudnessEnhancer
     // attached to the ExoPlayer audio session. Issue #88.
     val volumeBoostDb: Int = 0,
@@ -266,6 +267,7 @@ class SettingsViewModel @Inject constructor(
     private fun trailerDelayKey() = profileManager.profileStringKey("trailer_delay_seconds")
     private fun trailerInCardsKey() = profileManager.profileBooleanKey("trailer_in_cards")
     private fun showBudgetKey() = profileManager.profileBooleanKey("show_budget_on_home")
+    private fun showEpisodeRatingsKey() = profileManager.profileBooleanKey("show_episode_ratings")
     private fun clockFormatKey() = profileManager.profileStringKey("clock_format")
     private fun smoothScrollingKey() = profileManager.profileBooleanKey("smooth_scrolling")
     private fun spoilerBlurKey() = profileManager.profileBooleanKey("spoiler_blur")
@@ -451,6 +453,7 @@ class SettingsViewModel @Inject constructor(
             val trailerInCards = prefs[trailerInCardsKey()] ?: true
             val spoilerBlurEnabled = prefs[spoilerBlurKey()] ?: false
             val showBudget = prefs[showBudgetKey()] ?: true
+            val showEpisodeRatings = prefs[showEpisodeRatingsKey()] ?: true
             val clockFormat = prefs[clockFormatKey()] ?: "24h"
             // One-time migration: read old "focus_border_color" key if new "accent_color" is absent
             val OLD_FOCUS_BORDER_COLOR_KEY = stringPreferencesKey("focus_border_color")
@@ -538,6 +541,7 @@ class SettingsViewModel @Inject constructor(
                 trailerDelaySeconds = trailerDelaySeconds,
                 trailerInCards = trailerInCards,
                 showBudget = showBudget,
+                showEpisodeRatings = showEpisodeRatings,
                 volumeBoostDb = volumeBoostDb,
                 showLoadingStats = showLoadingStats,
 
@@ -1195,6 +1199,14 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             context.settingsDataStore.edit { it[showBudgetKey()] = enabled }
             _uiState.value = _uiState.value.copy(showBudget = enabled)
+            syncLocalStateToCloud(silent = true)
+        }
+    }
+
+    fun setShowEpisodeRatings(enabled: Boolean) {
+        viewModelScope.launch {
+            context.settingsDataStore.edit { it[showEpisodeRatingsKey()] = enabled }
+            _uiState.value = _uiState.value.copy(showEpisodeRatings = enabled)
             syncLocalStateToCloud(silent = true)
         }
     }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -61,4 +61,5 @@
     <string name="add_later">Añade películas y series para ver más tarde</string>
     <string name="sources_available">fuentes disponibles</string>
     <string name="ends_at">Termina a las</string>
+    <string name="ratings">Puntuaciones de Episodios</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1133,4 +1133,5 @@
     <string name="live_menu_move_down">Descendre</string>
     <string name="live_menu_hide_category">Masquer la catégorie</string>
     <string name="live_menu_unhide_category">Afficher la catégorie</string>
+    <string name="ratings">Notes des Épisodes</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -233,4 +233,5 @@
     <string name="ai_qr_scan_hint">סרוק עם הטלפון — בחר Groq או Gemini</string>
     <string name="plugin_prefix">Plugin: </string>
     <string name="plugins_loading">פלאגינים: %1$s</string>
+    <string name="ratings">דירוגי פרקים</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -61,4 +61,5 @@
     <string name="add_later">Adicione filmes e séries para assistir depois</string>
     <string name="sources_available">fontes disponíveis</string>
     <string name="ends_at">Termina às</string>
+    <string name="ratings">Notas dos Episódios</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -182,6 +182,8 @@
     <string name="oled_black_background_desc">Use pure black app backgrounds for OLED screens</string>
     <string name="clock_format_desc">Choose 12-hour or 24-hour time</string>
     <string name="show_budget_desc">Display the movie budget on the home hero banner</string>
+    <string name="show_episode_ratings">Show Episode Ratings</string>
+    <string name="show_episode_ratings_desc">Display episode ratings as a visual row below the episode list</string>
     <string name="spoiler_blur">Spoiler Blur</string>
     <string name="spoiler_blur_desc">Blur unwatched episode cards to avoid spoilers</string>
     <string name="accent_color">Accent Color</string>
@@ -1148,4 +1150,5 @@
     <string name="live_menu_move_down">Move down</string>
     <string name="live_menu_hide_category">Hide category</string>
     <string name="live_menu_unhide_category">Unhide category</string>
+    <string name="ratings">Episode Ratings</string>
 </resources>


### PR DESCRIPTION
### Description
This PR introduces a color-coded episode rating row to the TV and Mobile details screen. It provides a quick visual overview (heatmap) of a season's ratings, inspired by visualizations from TVChart and SeriesGraph.

### Changes
- **UI & Layout:** Added `DetailsEpisodeRatingsRail` below the episode list. Features a continuous scroll on Mobile and a paginated layout with animated indicators (Chevrons/Dots) on TV.
- **TV Navigation:** Added `FocusSection.RATINGS` to the focus router. The rail acts as a single, large focus target with left/right pagination to prevent D-pad focus traps.
- **Reactivity:** Updates when switching seasons and automatically calculates its starting page to align with the user's last-watched episode index (TV Layout).
- **Performance:** Renders alongside the episode list, consuming the existing TMDB payload without generating any additional network requests.
- **Settings & Config:** Added a `showEpisodeRatings` toggle in Appearance settings (default: true).
- **Cloud Sync:** Injected the `showEpisodeRatings` flag into `CloudSyncRepository`.
- **i18n:** Added string keys for EN, ES, FR, PT-BR, and IW.

### Visuals
**Android TV (Layout & Animation Demo):**
<img width="800" alt="tv_layout" src="https://github.com/user-attachments/assets/ca3c0a8c-49b8-4e2a-9f5b-6bfe4167d076" />

https://github.com/user-attachments/assets/4e162fe5-5d42-4ac9-bdf5-f26f380ebc1e

**Mobile:**
<img width="280" alt="mobile_layout" src="https://github.com/user-attachments/assets/516a2ca2-0aa4-4842-8016-b821dc7a95eb" />


### Checklist
- [x] Code follows the project's style conventions.
- [x] Tested on Android TV (D-pad focus behavior and pagination verified).
- [x] Tested on Mobile (Touch/Layout constraints and standard margins verified).
- [x] Cloud synchronization tested.