### PR TITLE
fix(web): eliminate /login redirect loop and update auth redirect URI

### DIFF
--- a/netlify-arvio-tv-site/index.html
+++ b/netlify-arvio-tv-site/index.html
@@ -2244,7 +2244,7 @@
         <svg id="theme-icon-dark" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display: none;"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
       </button>
       <a class="nav-web" href="/web/">Dashboard</a>
-      <a class="nav-web" href="https://web.arvio.tv/login">Web app</a>
+      <a class="nav-web" href="https://web.arvio.tv">Web app</a>
       <a class="nav-cta" href="https://play.google.com/store/apps/details?id=com.arvio.tv" target="_blank" rel="noopener">Get ARVIO
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 5l7 7-7 7"></path></svg>
       </a>
@@ -2731,7 +2731,7 @@
     <div class="guide-warning reveal" data-delay="2" style="margin-top:22px">Browsers only decode a limited set of formats — true for every web streamer. Most sources play directly (use the "Browser playable" filter); heavy 4K HEVC, Dolby Vision and REMUX releases, lossless audio and some Live TV providers don't. That's what the one‑tap "Open in VLC" button is for: it hands the stream to VLC on iPhone, iPad, Android, macOS and Windows (one‑time one‑click setup), which plays everything. The app has none of these limits — its native player decodes it all.</div>
 
     <div class="reveal" data-delay="3" style="display:flex;gap:10px;flex-wrap:wrap;margin-top:24px">
-      <a class="btn btn-ghost" href="https://web.arvio.tv/login">Open ARVIO Web</a>
+      <a class="btn btn-ghost" href="https://web.arvio.tv">Open ARVIO Web</a>
       <a class="btn btn-ghost" href="https://ko-fi.com/arvio/tiers" target="_blank" rel="noopener">Ko‑fi membership</a>
       <a class="btn btn-ghost" href="https://github.com/ProdigyV21/ARVIO">Source on GitHub</a>
     </div>
@@ -2806,7 +2806,7 @@
         <div class="guide-actions">
           <a class="guide-link" href="https://stremio-addons.net/" target="_blank" rel="noopener">Browse compatible source directory</a>
           <a class="guide-link secondary" href="/web/">Manage settings and addons</a>
-          <a class="guide-link secondary" href="https://web.arvio.tv/login">Open web app</a>
+          <a class="guide-link secondary" href="https://web.arvio.tv">Open web app</a>
         </div>
       </div>
 

--- a/netlify-arvio-tv-site/netlify.toml
+++ b/netlify-arvio-tv-site/netlify.toml
@@ -3,7 +3,7 @@
 
 [[redirects]]
   from = "/app"
-  to = "https://web.arvio.tv/login"
+  to = "https://web.arvio.tv"
   status = 302
   force = true
 

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -1,10 +1,5 @@
-import { AppShell } from "@/components/shell/AppShell";
-import { AppProvider } from "@/lib/store";
+import { redirect } from "next/navigation";
 
 export default function LoginPage() {
-  return (
-    <AppProvider initialView="login" cloudLoginRequired>
-      <AppShell />
-    </AppProvider>
-  );
+  redirect("/");
 }

--- a/web/components/login/LoginScreen.tsx
+++ b/web/components/login/LoginScreen.tsx
@@ -12,7 +12,7 @@ export function LoginScreen() {
 
   const redirectToAuthPortal = () => {
     if (typeof window === "undefined") return;
-    const redirectUri = window.location.origin + "/login";
+    const redirectUri = window.location.origin + "/";
     const portalUrl = getAuthPortalUrl();
     window.location.href = `${portalUrl}?redirect_uri=${encodeURIComponent(redirectUri)}`;
   };

--- a/web/components/settings/SettingsScreen.tsx
+++ b/web/components/settings/SettingsScreen.tsx
@@ -1010,7 +1010,7 @@ function AccountsSection() {
   const cloudConfigured = hasNetlifyBackendConfig() || hasSupabaseConfig();
 
   const redirectToAuthPortal = () => {
-    const redirectUri = window.location.origin + "/login";
+    const redirectUri = window.location.origin + "/";
     window.location.href = `${getAuthPortalUrl()}?redirect_uri=${encodeURIComponent(redirectUri)}`;
   };
 

--- a/web/lib/store.tsx
+++ b/web/lib/store.tsx
@@ -3,6 +3,7 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { getStreams, getStreamsProgressive, installAddon as installAddonManifest, loadLocalAddons, normalizeAddons, saveLocalAddons } from "./addons";
 import { AuthClient, SESSION_KEY, decodeJwtPayload } from "./auth";
+import { getAuthPortalUrl } from "./config";
 import { defaultCatalogs, mergeCatalogs } from "./catalogs";
 import { getContinueWatching, pullCloudPayload, pullCloudProfiles, pullCloudTraktToken, pullCloudWatchlist, saveCloudAddons, saveCloudProfiles, saveCloudSettings, saveCloudTraktToken } from "./cloud";
 import { cachedDebridDirectUrl, parseDebridStream, resolveDebridDirectUrl, resolveTranscodeStream } from "./debrid";
@@ -1540,7 +1541,13 @@ export function AppProvider({
     setView("profiles");
   }, []);
 
-  const goToLogin = useCallback(() => setView("login"), []);
+  const goToLogin = useCallback(() => {
+    if (typeof window !== "undefined") {
+      const redirectUri = window.location.origin + "/";
+      const portalUrl = getAuthPortalUrl();
+      window.location.href = `${portalUrl}?redirect_uri=${encodeURIComponent(redirectUri)}`;
+    }
+  }, []);
   const backToProfiles = useCallback(() => setView("profiles"), []);
 
   const value = useMemo<AppStore>(() => ({


### PR DESCRIPTION
## Summary
Fixes an issue where navigating to `arvio.tv/app` or reloading the web app redirected users into a `/login` authentication loop.

## Changes
- **Redirection**: Updated `netlify-arvio-tv-site/netlify.toml` so `/app` redirects directly to `https://web.arvio.tv` instead of `https://web.arvio.tv/login`.
- **Auth Redirect URI**: Updated OAuth `redirect_uri` in `LoginScreen.tsx`, `SettingsScreen.tsx`, and `store.tsx` to target root (`https://web.arvio.tv/`).
- **` /login` Route**: Configured Next.js `/login` route (`web/app/login/page.tsx`) to redirect to `/` to ensure `/login` never lingers in the address bar or causes loop reloads.