### PR TITLE
docs: Add standardized Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,55 @@
+## Description
+
+<!-- Briefly describe what changed and why. -->
+
+## Related Issue
+
+<!-- Link the related issue, if applicable. Example: Closes #123 -->
+
+Closes #
+
+## Type of Change
+
+<!-- Select all that apply. -->
+
+* [ ] Bug fix
+* [ ] New feature
+* [ ] UI/UX improvement
+* [ ] Refactor / performance improvement
+* [ ] Documentation
+* [ ] Build / CI / tooling
+
+## Key Changes
+
+<!-- Summarize the main implementation changes. -->
+
+*
+
+## Testing
+
+<!-- Select the checks that apply and briefly mention any additional verification performed. -->
+
+* [ ] Android TV / Fire TV (D-pad / remote navigation)
+* [ ] Mobile / Tablet (touch UI)
+* [ ] iOS
+* [ ] `./gradlew assembleSideloadDebug` completed successfully
+* [ ] Manual testing performed on a target device or emulator
+* [ ] Not applicable
+
+<!-- Add any relevant testing details, devices, or configurations here. -->
+
+## Screenshots / Demo
+
+<!-- For UI/UX changes, add before/after screenshots or a short recording. Remove this section if not applicable. -->
+
+|        Before        |         After        |
+| :------------------: | :------------------: |
+| <!-- Image / GIF --> | <!-- Image / GIF --> |
+
+## Checklist
+
+* [ ] My changes follow the repository's existing code style and conventions.
+* [ ] I have reviewed my own changes.
+* [ ] My changes do not include credentials, private keys, or prohibited third-party media links as defined by the `README.md` Content Policy.
+* [ ] I have updated relevant documentation where needed.
+* [ ] I have kept this PR focused and avoided unrelated changes.


### PR DESCRIPTION
## Description

Introduces a standardized GitHub Pull Request template (`.github/PULL_REQUEST_TEMPLATE.md`) to guide contributors when submitting changes to Arvio.

## Related Issue

Closes #482 

## Type of Change

* [ ] Bug fix
* [ ] New feature
* [ ] UI/UX improvement
* [ ] Refactor / performance improvement
* [x] Documentation
* [x] Build / CI / tooling

## Key Changes

* Created `.github/PULL_REQUEST_TEMPLATE.md` to establish a clear structure for incoming PRs.
* Added prompts for issue linking (`Closes #`), change categorization, and implementation highlights.
* Included target platform verification options (Android TV, Mobile/Tablet, iOS) and Gradle build checks (`./gradlew assembleSideloadDebug`).
* Added explicit checklist verification for compliance with Arvio's `README.md` Content Policy.

## Testing

* [ ] Android TV / Fire TV (D-pad / remote navigation)
* [ ] Mobile / Tablet (touch UI)
* [ ] iOS
* [x] `./gradlew assembleSideloadDebug` completed successfully
* [x] Manual testing performed on a target device or emulator
* [ ] Not applicable

Verified markdown rendering and structure of the template file locally.

## Screenshots / Demo

N/A (Non-UI documentation update)

## Checklist

* [x] My changes follow the repository's existing code style and conventions.
* [x] I have reviewed my own changes.
* [x] My changes do not include credentials, private keys, or prohibited third-party media links as defined by the `README.md` Content Policy.
* [x] I have updated relevant documentation where needed.
* [x] I have kept this PR focused and avoided unrelated changes.
