### PR TITLE
docs(github) : Add githubissue templates for bugs, features, and docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,54 @@
+---
+name: Bug Report
+about: Report a reproducible bug or unexpected behavior across Arvio platforms
+title: '[Bug]: '
+labels: bug
+assignees: ''
+---
+
+## Bug Description
+<!-- A clear and concise description of what the bug is. -->
+
+## Affected Component / Platform
+<!-- Indicate the primary area where the issue occurs:
+- Android App (TV / Fire TV)
+- Android App (Mobile / Tablet)
+- Web App (web.arvio.tv / Desktop / Browser)
+- iOS App
+- Supabase / Edge Functions (Auth, Cloud Sync, Proxies)
+- Resolver Worker (Cloudflare Worker)
+- IPTV / EPG Parsing & Playlists
+- Player Engine (ExoPlayer / Media3 / Web Player)
+- Other / Not sure
+-->
+
+## Environment & Build Variant
+<!-- Provide relevant environment details below: -->
+- **Arvio Version / Variant:** <!-- e.g., v1.9.91 sideload APK / Play Store release / web.arvio.tv -->
+- **OS & Version:** <!-- e.g., Android TV 11, Android 14, iOS 17, macOS Sonoma -->
+- **Device Model / Browser:** <!-- e.g., Nvidia Shield TV, Firestick 4K, Pixel 8, Chrome 124 -->
+
+## Steps to Reproduce
+<!-- Step-by-step instructions to reproduce the issue -->
+1. 
+2. 
+3. 
+
+## Expected Behavior
+<!-- What you expected to happen -->
+
+## Actual Behavior
+<!-- What actually happened -->
+
+## Relevant Logs / Diagnostic Output
+<!-- Paste stack traces, ADB logcat logs, browser console output, or error messages inside the code fence below -->
+```shell
+
+```
+
+## Screenshots / Recordings
+<!-- Drag and drop screenshots, screen recordings, or visual evidence here -->
+
+## Pre-submission Checklist
+- [ ] I have searched existing issues to ensure this bug is not already reported.
+- [ ] I confirm this issue does not contain copyrighted media links, IPTV credentials, private keys, access tokens, or links to unauthorized content (complying with Arvio's Content & Source Policy).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Arvio Documentation & Content Policy
+    url: https://github.com/ProdigyV21/ARVIO/blob/main/README.md
+    about: Read local setup requirements, build instructions, and Content & Source Policy rules.
+

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,20 @@
+---
+name: Documentation Issue
+about: Report errors, outdated instructions, or missing details in READMEs or technical docs
+title: '[Docs]: '
+labels: documentation
+assignees: ''
+---
+
+## Affected Documentation
+<!-- Provide the path, file name, or documentation section requiring an update (e.g., README.md, web/README.md, docs/subtitle-auto-match.md). -->
+
+## Issue Description
+<!-- Describe what is inaccurate, unclear, or missing in the documentation. -->
+
+## Proposed Correction / Addition
+<!-- If possible, describe the correction or provide updated text, commands, examples, or other relevant information. -->
+
+## Pre-submission Checklist
+- [ ] I have searched existing issues to ensure this documentation issue is not already reported.
+- [ ] I confirm this issue complies with Arvio's Content & Source Policy.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,32 @@
+---
+name: Feature Request
+about: Propose a new feature, integration, or functional enhancement for Arvio
+title: '[Feature]: '
+labels: enhancement
+assignees: ''
+---
+
+## Problem Statement
+<!-- Is your feature request related to a problem or limitation? Describe it clearly. -->
+
+## Target Area / Subsystem
+<!-- Indicate the primary area this feature targets:
+- Android App (TV / Mobile UI)
+- Web App (web.arvio.tv)
+- Player Engine & Media Controls
+- IPTV / EPG & Playlist Management
+- Cloud Sync & Profiles
+- Home-Server Integrations (Jellyfin/Emby/Plex)
+- Addon & Resolver Ecosystem
+- Subtitle & Audio Tools
+-->
+
+## Proposed Solution
+<!-- Describe clearly and concisely how you envision the feature working. -->
+
+## Alternatives Considered
+<!-- Describe any alternative solutions or workarounds you have considered. -->
+
+## Pre-submission Checklist
+- [ ] I have searched existing issues to ensure this feature is not already proposed.
+- [ ] I confirm this feature request complies with Arvio's Content & Source Policy and does not ask for bundling, hosting, or providing access to copyrighted media or illegal IPTV services.


### PR DESCRIPTION
## Summary

This PR adds standardized, classic Markdown issue templates under `.github/ISSUE_TEMPLATE/` to streamline issue reporting, feature proposals, UI/UX feedback, and documentation fixes across the Arvio repository.

By using classic `.md` templates instead of structured forms, contributors can report issues directly inside GitHub's standard Markdown editor with pre-populated headings, code fences, and helpful guidance comments.

## Changes Introduced

Added `.github/ISSUE_TEMPLATE/`:

- **`bug_report.md`**: Pre-filled Markdown template for reproducible bug reports across Arvio platforms (Android TV/Mobile, Web, iOS, Supabase, Resolver Worker, IPTV, Player Engine). Includes version/device placeholders, a shell code block for logs, screenshot sections, and Content & Source Policy verification.

- **`feature_request.md`**: Structured template for functional enhancements, integrations, and subsystem improvements.

- **`documentation.md`**: Template for reporting documentation errors or proposing updates to READMEs and setup guides.

- **`config.yml`**: Configures template intake with `blank_issues_enabled: true` and includes links to repository documentation and policy guidelines.

## Benefits

- **Better Contributor Experience**: Opens GitHub's standard single-field Markdown editor with pre-populated structures and non-rendering `<!-- HTML guidance comments -->`.
- **Faster Triage**: Prompts contributors to specify their environment, device class (Android TV D-pad vs. Mobile Touch vs. Web), build variant (`play` vs `sideload`), and diagnostic logs upfront.
- **Policy Enforcement**: Includes pre-submission checkboxes to ensure issue reports adhere to Arvio's Content & Source Policy.

## Verification

- [x] Verified YAML frontmatter validity (`name`, `about`, `title`, `labels`, `assignees`).
- [x] Verified Markdown code fences and HTML comment syntax.
- [x] Verified `.github/ISSUE_TEMPLATE/` directory structure and `config.yml` settings.


### Closes #484 
