### PR TITLE
docs: add root SECURITY.md for responsible vulnerability disclosure

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -77,7 +77,7 @@ We may update this policy occasionally. Changes will be posted here with an upda
 
 ## Contact
 
-For privacy questions, open an issue on GitHub or use the account deletion page above.
+For privacy questions, open an issue on GitHub or use the account deletion page above. For security vulnerability reporting, see [SECURITY.md](SECURITY.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -156,9 +156,9 @@ Before publishing a build, run:
 
 Smoke-test startup, profile switching, playback, stream fallback, subtitle/audio switching, IPTV/EPG loading, addon add/remove, search, settings navigation, background sync, and repeated player open/close on the supported device classes.
 
-## Privacy
+## Privacy And Security
 
-See [PRIVACY.md](PRIVACY.md) for the privacy policy. Cloud account and synced data deletion is available at [auth.arvio.tv/delete](https://auth.arvio.tv/delete).
+See [PRIVACY.md](PRIVACY.md) for the privacy policy and [SECURITY.md](SECURITY.md) for responsible security vulnerability reporting. Cloud account and synced data deletion is available at [auth.arvio.tv/delete](https://auth.arvio.tv/delete).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+This document outlines the policy for reporting security vulnerabilities in ARVIO. Maintainers encourage coordinated disclosure to ensure potential security issues can be investigated and remediated before public discussion.
+
+## Supported Versions
+
+Active application development takes place on the `main` branch.
+
+| Version / Branch | Status |
+| --- | --- |
+| `main` (latest source) | Active development |
+
+Support for tagged releases and previous builds is determined by the maintainers.
+
+## Reporting a Vulnerability
+
+Do **not** report security vulnerabilities through public channels, including:
+
+- Public GitHub issues
+- Public Discord channels
+- Public forums or social media
+
+To disclose a security vulnerability privately, maintainers are establishing a dedicated private reporting channel. Until a private channel (such as GitHub Private Vulnerability Reporting or a designated security contact) is configured for this repository, please refrain from publicly posting technical details, proof-of-concept exploits, or reproduction steps.
+
+## Information to Include
+
+When submitting a security report, include relevant technical context where possible:
+
+- Affected component or platform (e.g., Android application, Web UI, Netlify auth functions, Supabase Edge Functions, or integrations such as Jellyfin, Emby, Plex, Trakt, or IPTV)
+- Version, build number, or git commit hash where the issue was observed
+- Technical description of the vulnerability and its potential security impact
+- Step-by-step reproduction instructions or proof of concept
+- Relevant environment or setup details
+
+Do not include live production credentials, tokens, session keys, or private API keys in a security report.
+
+## Coordinated Disclosure
+
+Maintainers request that security researchers allow reasonable time to investigate, reproduce, and resolve reported findings before technical details are published or disclosed publicly.


### PR DESCRIPTION
### Summary

This PR introduces a production-quality, root-level `SECURITY.md` file to establish clear vulnerability reporting guidance and document ARVIO's security policy. It also adds minimal references to the security policy in `README.md` and `PRIVACY.md`.

### Proposed Changes

- **[NEW] `SECURITY.md`**: Added a dedicated repository Security Policy covering:
  - Active development status on `main` and release support scope.
  - Strict prohibition of public disclosure through GitHub issues, Discord, or public forums.
  - Neutral private vulnerability reporting guidance while private channels are established.
  - Practical technical context to include in reports (specifying ARVIO components such as Android, Web UI, Netlify auth functions, Supabase Edge Functions, and integrations).
  - Explicit warning against including live production credentials, session keys, or API tokens in reports.
  - Coordinated disclosure expectations.
- **`README.md`**: Updated Privacy section heading to **Privacy And Security** with a minimal link to `SECURITY.md`.
- **`PRIVACY.md`**: Added a minimal reference to `SECURITY.md` in the **Contact** section for security-sensitive inquiries.

### Maintainer Follow-up

> **Maintainer follow-up:** No verified private vulnerability-reporting mechanism is currently exposed by the repository. The policy therefore avoids assuming that GitHub Private Vulnerability Reporting is enabled or inventing a security contact. Maintainers can update the reporting section after enabling Private Vulnerability Reporting or designating an official private security contact.

### Verification

- Verified Markdown structure, link resolution, and formatting.
- Verified that all listed components match existing repository architecture.
- Ensured no fabricated email addresses, response SLAs, remediation deadlines, or unsupported security guarantees were introduced.

### Closes #486 
