### PR TITLE
fix: remove live streams and live stream addon items from continue watching

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/model/SportsAddonCapabilities.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/model/SportsAddonCapabilities.kt
@@ -140,4 +140,58 @@ object SportsAddonCapabilities {
     private fun AddonResource.safeName() = runCatching { name }.getOrNull().orEmpty()
 
     private fun AddonResource.safeTypes() = runCatching { types }.getOrNull().orEmpty()
+
+    fun isLiveStreamAddonId(addonId: String?): Boolean {
+        val id = addonId?.trim()?.lowercase(Locale.US) ?: return false
+        if (id.contains("cinemeta") || id.contains("tmdb") || id.contains("torrentio")) return false
+        return id.contains("livetv") || id.contains("live_tv") ||
+            id.contains("live-tv") || id.contains("live_stream") ||
+            id.contains("livestream") || id.contains("live-stream") ||
+            id.contains("tvchannels") || id.contains("tv-channels") ||
+            id.contains("iptv") || id.contains("sports")
+    }
+
+    fun isLiveStreamAddon(addon: Addon?): Boolean {
+        if (addon == null) return false
+        if (isSportsLiveTvAddon(addon) || isSportsOnlyLiveTvAddon(addon)) return true
+        if (isLiveStreamAddonId(addon.id) || isLiveStreamAddonId(addon.name)) return true
+        val manifest = addon.manifest ?: return false
+        return isLiveStreamManifest(manifest)
+    }
+
+    fun isLiveStreamManifest(manifest: AddonManifest): Boolean {
+        if (isSportsLiveTvManifest(manifest)) return true
+        if (isLiveStreamAddonId(manifest.id) || isLiveStreamAddonId(manifest.name)) return true
+        val types = manifest.safeResources().flatMap { it.safeTypes() } + manifest.safeTypes() + manifest.safeCatalogs().map { it.type }
+        val normalizedTypes = types.map { it.trim().lowercase(Locale.US) }
+        val liveTypes = setOf("tv", "channel", "channels", "live", "sports", "tvchannel", "live_tv", "livestream")
+        return normalizedTypes.any { it in liveTypes } && !normalizedTypes.contains("movie") && !normalizedTypes.contains("series")
+    }
+
+    fun isLiveStreamOrSportsItem(
+        mediaType: MediaType? = null,
+        id: Int? = null,
+        status: String? = null,
+        streamAddonId: String? = null,
+        title: String? = null,
+        addons: List<Addon> = emptyList()
+    ): Boolean {
+        if (status != null && (isSportsHomeStatus(status) || status.startsWith("iptv:") || status.startsWith("live:") || status.startsWith("channel:"))) {
+            return true
+        }
+        if (id != null && id <= 0) {
+            return true
+        }
+        if (!streamAddonId.isNullOrBlank()) {
+            if (isLiveStreamAddonId(streamAddonId)) return true
+            val addon = addons.firstOrNull { it.id.equals(streamAddonId, ignoreCase = true) }
+            if (addon != null && isLiveStreamAddon(addon)) return true
+        }
+        if (title != null) {
+            val lowerTitle = title.lowercase(Locale.US)
+            if (lowerTitle.startsWith("live:") || lowerTitle.startsWith("[live]")) return true
+        }
+        return false
+    }
 }
+

--- a/app/src/main/kotlin/com/arflix/tv/data/model/SportsAddonCapabilities.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/model/SportsAddonCapabilities.kt
@@ -153,13 +153,18 @@ object SportsAddonCapabilities {
 
     fun isLiveStreamAddon(addon: Addon?): Boolean {
         if (addon == null) return false
-        if (isSportsLiveTvAddon(addon) || isSportsOnlyLiveTvAddon(addon)) return true
-        if (isLiveStreamAddonId(addon.id) || isLiveStreamAddonId(addon.name)) return true
-        val manifest = addon.manifest ?: return false
-        return isLiveStreamManifest(manifest)
+        val manifest = addon.manifest
+        return if (manifest != null) {
+            isLiveStreamManifest(manifest)
+        } else {
+            isLiveStreamAddonId(addon.id) || isLiveStreamAddonId(addon.name)
+        }
     }
 
     fun isLiveStreamManifest(manifest: AddonManifest): Boolean {
+        // Hybrid add-ons can expose both VOD and live catalogs. Their regular movie
+        // and series streams must still be allowed into Continue Watching.
+        if (manifestDeclaresVodStreams(manifest)) return false
         if (isSportsLiveTvManifest(manifest)) return true
         if (isLiveStreamAddonId(manifest.id) || isLiveStreamAddonId(manifest.name)) return true
         val types = manifest.safeResources().flatMap { it.safeTypes() } + manifest.safeTypes() + manifest.safeCatalogs().map { it.type }
@@ -174,8 +179,10 @@ object SportsAddonCapabilities {
         status: String? = null,
         streamAddonId: String? = null,
         title: String? = null,
+        isLiveStream: Boolean = false,
         addons: List<Addon> = emptyList()
     ): Boolean {
+        if (isLiveStream) return true
         if (status != null && (isSportsHomeStatus(status) || status.startsWith("iptv:") || status.startsWith("live:") || status.startsWith("channel:"))) {
             return true
         }
@@ -183,9 +190,12 @@ object SportsAddonCapabilities {
             return true
         }
         if (!streamAddonId.isNullOrBlank()) {
-            if (isLiveStreamAddonId(streamAddonId)) return true
             val addon = addons.firstOrNull { it.id.equals(streamAddonId, ignoreCase = true) }
-            if (addon != null && isLiveStreamAddon(addon)) return true
+            if (addon != null) {
+                if (isLiveStreamAddon(addon)) return true
+            } else if (isLiveStreamAddonId(streamAddonId)) {
+                return true
+            }
         }
         if (title != null) {
             val lowerTitle = title.lowercase(Locale.US)
@@ -194,4 +204,3 @@ object SportsAddonCapabilities {
         return false
     }
 }
-

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/LauncherContinueWatchingRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/LauncherContinueWatchingRepository.kt
@@ -23,6 +23,7 @@ import com.arflix.tv.util.AppLogger
 import com.arflix.tv.util.Constants
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -40,7 +41,8 @@ class LauncherContinueWatchingRepository @Inject constructor(
     @ApplicationContext private val context: Context,
     private val profileManager: ProfileManager,
     private val traktRepository: TraktRepository,
-    private val watchHistoryRepository: WatchHistoryRepository
+    private val watchHistoryRepository: WatchHistoryRepository,
+    private val streamRepository: StreamRepository
 ) {
     companion object {
         private const val TAG = "LauncherCW"
@@ -95,13 +97,15 @@ class LauncherContinueWatchingRepository @Inject constructor(
     }
 
     private suspend fun loadPublisherItems(): List<ContinueWatchingItem> {
+        val installedAddons = streamRepository.installedAddons.first()
         val primaryItems = runCatching { traktRepository.getContinueWatching() }.getOrDefault(emptyList())
         val filteredPrimary = primaryItems.filterNot { item ->
             SportsAddonCapabilities.isLiveStreamOrSportsItem(
                 mediaType = item.mediaType,
                 id = item.id,
                 streamAddonId = item.streamAddonId,
-                title = item.title
+                title = item.title,
+                addons = installedAddons
             )
         }
         if (filteredPrimary.isNotEmpty()) {
@@ -132,7 +136,8 @@ class LauncherContinueWatchingRepository @Inject constructor(
                     mediaType = item.mediaType,
                     id = item.id,
                     streamAddonId = item.streamAddonId,
-                    title = item.title
+                    title = item.title,
+                    addons = installedAddons
                 )
             }
             .distinctBy { "${it.mediaType}:${it.id}:${it.season ?: -1}:${it.episode ?: -1}" }

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/LauncherContinueWatchingRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/LauncherContinueWatchingRepository.kt
@@ -17,6 +17,7 @@ import androidx.tvprovider.media.tv.WatchNextProgram
 import com.arflix.tv.MainActivity
 import com.arflix.tv.R
 import com.arflix.tv.data.model.MediaType
+import com.arflix.tv.data.model.SportsAddonCapabilities
 import com.arflix.tv.navigation.Screen
 import com.arflix.tv.util.AppLogger
 import com.arflix.tv.util.Constants
@@ -95,8 +96,16 @@ class LauncherContinueWatchingRepository @Inject constructor(
 
     private suspend fun loadPublisherItems(): List<ContinueWatchingItem> {
         val primaryItems = runCatching { traktRepository.getContinueWatching() }.getOrDefault(emptyList())
-        if (primaryItems.isNotEmpty()) {
-            return primaryItems.take(Constants.MAX_CONTINUE_WATCHING)
+        val filteredPrimary = primaryItems.filterNot { item ->
+            SportsAddonCapabilities.isLiveStreamOrSportsItem(
+                mediaType = item.mediaType,
+                id = item.id,
+                streamAddonId = item.streamAddonId,
+                title = item.title
+            )
+        }
+        if (filteredPrimary.isNotEmpty()) {
+            return filteredPrimary.take(Constants.MAX_CONTINUE_WATCHING)
         }
 
         val historyFallback = runCatching { watchHistoryRepository.getContinueWatching() }.getOrDefault(emptyList())
@@ -114,12 +123,22 @@ class LauncherContinueWatchingRepository @Inject constructor(
                     posterPath = entry.poster_path,
                     backdropPath = entry.backdrop_path,
                     resumePositionSeconds = entry.position_seconds,
-                    durationSeconds = entry.duration_seconds
+                    durationSeconds = entry.duration_seconds,
+                    streamAddonId = entry.stream_addon_id
+                )
+            }
+            .filterNot { item ->
+                SportsAddonCapabilities.isLiveStreamOrSportsItem(
+                    mediaType = item.mediaType,
+                    id = item.id,
+                    streamAddonId = item.streamAddonId,
+                    title = item.title
                 )
             }
             .distinctBy { "${it.mediaType}:${it.id}:${it.season ?: -1}:${it.episode ?: -1}" }
             .take(Constants.MAX_CONTINUE_WATCHING)
     }
+
 
     @RequiresApi(Build.VERSION_CODES.O)
     private fun syncPublishedRows(items: List<ContinueWatchingItem>) {

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/TraktRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/TraktRepository.kt
@@ -11,6 +11,7 @@ import com.arflix.tv.data.api.*
 import com.arflix.tv.data.model.MediaItem
 import com.arflix.tv.data.model.MediaType
 import com.arflix.tv.data.model.NextEpisode
+import com.arflix.tv.data.model.SportsAddonCapabilities
 import com.arflix.tv.util.ContinueWatchingSelector
 import com.arflix.tv.util.EpisodePointer
 import com.arflix.tv.util.EpisodeProgressSnapshot
@@ -2141,6 +2142,14 @@ class TraktRepository @Inject constructor(
         year: String = ""
     ) {
         ensureProfileCacheScope()
+        if (SportsAddonCapabilities.isLiveStreamOrSportsItem(
+                mediaType = mediaType,
+                id = tmdbId,
+                streamAddonId = streamAddonId,
+                title = title
+            )) {
+            return
+        }
         val hasMeaningfulPosition = positionSeconds >= 60L
 
         // Keep accidental taps out, but still keep real partial sessions on long content
@@ -2302,8 +2311,16 @@ class TraktRepository @Inject constructor(
         if (json == null) {
             return emptyList()
         }
-        return decodeContinueWatchingList(json)
+        return decodeContinueWatchingList(json).filterNot { item ->
+            SportsAddonCapabilities.isLiveStreamOrSportsItem(
+                mediaType = item.mediaType,
+                id = item.id,
+                streamAddonId = item.streamAddonId,
+                title = item.title
+            )
+        }
     }
+
 
     /**
      * Get a single local Continue Watching entry (raw, without TMDB enrichment).
@@ -2366,10 +2383,19 @@ class TraktRepository @Inject constructor(
      * and Trakt paths render identical card details.
      */
     suspend fun enrichContinueWatchingItems(items: List<ContinueWatchingItem>): List<ContinueWatchingItem> = coroutineScope {
-        if (items.isEmpty()) return@coroutineScope emptyList()
+        val filtered = items.filterNot { item ->
+            SportsAddonCapabilities.isLiveStreamOrSportsItem(
+                mediaType = item.mediaType,
+                id = item.id,
+                streamAddonId = item.streamAddonId,
+                title = item.title
+            )
+        }
+        if (filtered.isEmpty()) return@coroutineScope emptyList()
         val semaphore = kotlinx.coroutines.sync.Semaphore(5)
         val seasonCache = java.util.concurrent.ConcurrentHashMap<Pair<Int, Int>, Deferred<com.arflix.tv.data.api.TmdbSeasonDetails?>>()
-        items.map { item ->
+        filtered.map { item ->
+
             async {
                 semaphore.withPermit {
                     enrichLocalContinueWatchingItem(item, seasonCache)

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/WatchHistoryRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/WatchHistoryRepository.kt
@@ -1,6 +1,7 @@
 package com.arflix.tv.data.repository
 
 import com.arflix.tv.data.api.SupabaseApi
+import com.arflix.tv.data.model.SportsAddonCapabilities
 import com.arflix.tv.data.model.MediaType
 import com.arflix.tv.util.Constants
 import com.arflix.tv.util.AppLogger
@@ -291,11 +292,20 @@ class WatchHistoryRepository @Inject constructor(
      */
     suspend fun getContinueWatching(): List<WatchHistoryEntry> {
         val profileId = currentProfileId()
+        fun filterLive(entries: List<WatchHistoryEntry>) = entries.filterNot { entry ->
+            val type = if (entry.media_type == "tv") MediaType.TV else MediaType.MOVIE
+            SportsAddonCapabilities.isLiveStreamOrSportsItem(
+                mediaType = type,
+                id = entry.show_tmdb_id,
+                streamAddonId = entry.stream_addon_id,
+                title = entry.title
+            )
+        }
         if (Constants.USE_NETLIFY_CLOUD_SYNC) {
-            return cachedContinueWatchingByProfile[profileId].orEmpty()
+            return filterLive(cachedContinueWatchingByProfile[profileId].orEmpty())
         }
         val userId = authRepositoryProvider.get().getCurrentUserId()
-        if (userId == null) return cachedContinueWatchingByProfile[profileId].orEmpty()
+        if (userId == null) return filterLive(cachedContinueWatchingByProfile[profileId].orEmpty())
 
         return try {
             val records = executeSupabaseCall("get continue watching history") { auth ->
@@ -309,17 +319,17 @@ class WatchHistoryRepository @Inject constructor(
                 )
             }
             val allEntries = records.map { it.toEntry() }
-            val result = filterByProfile(allEntries)
-                .filter { isEntryInProgress(it) }
+            val result = filterLive(filterByProfile(allEntries).filter { isEntryInProgress(it) })
             // Cache the successful result for offline/error fallback
             cachedContinueWatching = result
             cachedContinueWatchingByProfile[profileId] = result
             result
         } catch (e: Exception) {
             AppLogger.e("WatchHistoryRepository", "Error getting continue watching, returning cache", e)
-            cachedContinueWatchingByProfile[profileId].orEmpty()
+            filterLive(cachedContinueWatchingByProfile[profileId].orEmpty())
         }
     }
+
 
     /**
      * Get progress for a specific item

--- a/app/src/main/kotlin/com/arflix/tv/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/arflix/tv/navigation/AppNavigation.kt
@@ -81,7 +81,7 @@ sealed class Screen(val route: String) {
         }
     }
 
-    data object Player : Screen("player/{mediaType}/{mediaId}?seasonNumber={seasonNumber}&episodeNumber={episodeNumber}&imdbId={imdbId}&streamUrl={streamUrl}&preferredAddonId={preferredAddonId}&preferredSourceName={preferredSourceName}&preferredBingeGroup={preferredBingeGroup}&startPositionMs={startPositionMs}") {
+    data object Player : Screen("player/{mediaType}/{mediaId}?seasonNumber={seasonNumber}&episodeNumber={episodeNumber}&imdbId={imdbId}&streamUrl={streamUrl}&preferredAddonId={preferredAddonId}&preferredSourceName={preferredSourceName}&preferredBingeGroup={preferredBingeGroup}&startPositionMs={startPositionMs}&isLiveStream={isLiveStream}") {
         fun createRoute(
             mediaType: MediaType,
             mediaId: Int,
@@ -92,7 +92,8 @@ sealed class Screen(val route: String) {
             preferredAddonId: String? = null,
             preferredSourceName: String? = null,
             preferredBingeGroup: String? = null,
-            startPositionMs: Long? = null
+            startPositionMs: Long? = null,
+            isLiveStream: Boolean = false
         ): String {
             val base = "player/${mediaType.name.lowercase()}/$mediaId"
             val params = mutableListOf<String>()
@@ -104,6 +105,7 @@ sealed class Screen(val route: String) {
             preferredSourceName?.let { params.add("preferredSourceName=${java.net.URLEncoder.encode(it, "UTF-8")}") }
             preferredBingeGroup?.let { params.add("preferredBingeGroup=${java.net.URLEncoder.encode(it, "UTF-8")}") }
             startPositionMs?.let { params.add("startPositionMs=$it") }
+            if (isLiveStream) params.add("isLiveStream=true")
             return if (params.isNotEmpty()) "$base?${params.joinToString("&")}" else base
         }
     }
@@ -199,7 +201,8 @@ fun AppNavigation(
                             mediaId = mediaId,
                             streamUrl = streamUrl,
                             preferredAddonId = preferredAddonId,
-                            preferredSourceName = preferredSourceName
+                            preferredSourceName = preferredSourceName,
+                            isLiveStream = true
                         )
                     )
                 },
@@ -375,7 +378,8 @@ fun AppNavigation(
                             mediaId = mediaId,
                             streamUrl = streamUrl,
                             preferredAddonId = preferredAddonId,
-                            preferredSourceName = preferredSourceName
+                            preferredSourceName = preferredSourceName,
+                            isLiveStream = true
                         )
                     )
                 },
@@ -503,6 +507,10 @@ fun AppNavigation(
                 navArgument("startPositionMs") {
                     type = NavType.LongType
                     defaultValue = -1L
+                },
+                navArgument("isLiveStream") {
+                    type = NavType.BoolType
+                    defaultValue = false
                 }
             )
         ) { backStackEntry ->
@@ -516,6 +524,7 @@ fun AppNavigation(
             val preferredSourceName = backStackEntry.arguments?.getString("preferredSourceName")?.takeIf { it.isNotBlank() }
             val preferredBingeGroup = backStackEntry.arguments?.getString("preferredBingeGroup")?.takeIf { it.isNotBlank() }
             val startPositionMs = backStackEntry.arguments?.getLong("startPositionMs")?.takeIf { it >= 0L }
+            val isLiveStream = backStackEntry.arguments?.getBoolean("isLiveStream") ?: false
             val mediaType = if (mediaTypeStr == "tv") MediaType.TV else MediaType.MOVIE
 
             PlayerScreen(
@@ -529,6 +538,7 @@ fun AppNavigation(
                 preferredSourceName = preferredSourceName,
                 preferredBingeGroup = preferredBingeGroup,
                 startPositionMs = startPositionMs,
+                isLiveStream = isLiveStream,
                 onBack = { navController.popBackStack() },
                 onPlayNext = { nextSeason, nextEpisode, nextPreferredAddonId, nextPreferredSourceName, nextPreferredBingeGroup ->
                     // Navigate to next episode

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
@@ -654,12 +654,21 @@ class HomeViewModel @Inject constructor(
     }
 
     private suspend fun sanitizeContinueWatchingItems(items: List<ContinueWatchingItem>): List<ContinueWatchingItem> {
-        if (items.isEmpty()) return emptyList()
+        val nonLiveItems = items.filterNot { item ->
+            SportsAddonCapabilities.isLiveStreamOrSportsItem(
+                mediaType = item.mediaType,
+                id = item.id,
+                streamAddonId = item.streamAddonId,
+                title = item.title
+            )
+        }
+        if (nonLiveItems.isEmpty()) return emptyList()
 
         val seasonEpisodesCache = HashMap<Pair<Int, Int>, List<com.arflix.tv.data.model.Episode>?>()
 
-        return items.mapNotNull { item ->
+        return nonLiveItems.mapNotNull { item ->
             if (item.mediaType != MediaType.TV) {
+
                 return@mapNotNull item
             }
 

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
@@ -654,12 +654,14 @@ class HomeViewModel @Inject constructor(
     }
 
     private suspend fun sanitizeContinueWatchingItems(items: List<ContinueWatchingItem>): List<ContinueWatchingItem> {
+        val installedAddons = streamRepository.installedAddons.first()
         val nonLiveItems = items.filterNot { item ->
             SportsAddonCapabilities.isLiveStreamOrSportsItem(
                 mediaType = item.mediaType,
                 id = item.id,
                 streamAddonId = item.streamAddonId,
-                title = item.title
+                title = item.title,
+                addons = installedAddons
             )
         }
         if (nonLiveItems.isEmpty()) return emptyList()

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -250,6 +250,7 @@ fun PlayerScreen(
     preferredSourceName: String? = null,
     preferredBingeGroup: String? = null,
     startPositionMs: Long? = null,
+    isLiveStream: Boolean = false,
     viewModel: PlayerViewModel = hiltViewModel(),
     onBack: () -> Unit = {},
     onPlayNext: (Int, Int, String?, String?, String?) -> Unit = { _, _, _, _, _ -> }
@@ -627,7 +628,7 @@ fun PlayerScreen(
     }
 
     // Load media
-    LaunchedEffect(mediaType, mediaId, seasonNumber, episodeNumber, imdbId, preferredAddonId, preferredSourceName, preferredBingeGroup, startPositionMs) {
+    LaunchedEffect(mediaType, mediaId, seasonNumber, episodeNumber, imdbId, preferredAddonId, preferredSourceName, preferredBingeGroup, startPositionMs, isLiveStream) {
         playbackIssueReported = false
         startupRecoverAttempted = false
         startupHardFailureReported = false
@@ -658,7 +659,8 @@ fun PlayerScreen(
             preferredAddonId = preferredAddonId,
             preferredSourceName = preferredSourceName,
             preferredBingeGroup = preferredBingeGroup,
-            startPositionMs = startPositionMs
+            startPositionMs = startPositionMs,
+            isLiveStreamPlayback = isLiveStream
         )
     }
 

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
@@ -3928,10 +3928,17 @@ class PlayerViewModel @Inject constructor(
             val shouldPersistWatchHistory = !isPlaying ||
                 currentTime - lastWatchHistorySaveTime >= WATCH_HISTORY_UPDATE_INTERVAL_MS ||
                 hasSeekJump
-            if (shouldPersistWatchHistory && !isAtWatchedThreshold) {
+            val selectedStream = _uiState.value.selectedStream
+            val streamAddonIdForCheck = selectedStream?.addonId?.takeIf { it.isNotBlank() }
+            val isLiveStreamOrSports = SportsAddonCapabilities.isLiveStreamOrSportsItem(
+                mediaType = currentMediaType,
+                id = currentMediaId,
+                streamAddonId = streamAddonIdForCheck,
+                title = currentTitle
+            )
+            if (shouldPersistWatchHistory && !isAtWatchedThreshold && !isLiveStreamOrSports) {
                 lastWatchHistorySaveTime = currentTime
                 lastWatchHistorySavedPositionSeconds = positionSeconds
-                val selectedStream = _uiState.value.selectedStream
                 val shouldPersistStreamAffinity = positionSeconds >= 30L
                 val streamKey = if (shouldPersistStreamAffinity) buildStreamKey(selectedStream) else null
                 val streamAddonId = if (shouldPersistStreamAffinity) selectedStream?.addonId?.takeIf { it.isNotBlank() } else null
@@ -3983,6 +3990,7 @@ class PlayerViewModel @Inject constructor(
                         runCatching { cloudSyncRepository.pushToCloud() }
                     }
                 }
+
 
                 if (!isPlaying || playbackState == Player.STATE_ENDED || progressPercent >= Constants.WATCHED_THRESHOLD) {
                     runCatching { cloudSyncRepository.pushToCloud() }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
@@ -217,6 +217,8 @@ class PlayerViewModel @Inject constructor(
     private var currentPreferredSourceName: String? = null
     private var currentPreferredBingeGroup: String? = null
     private var currentAddonOrderedIds: List<String> = emptyList()
+    private var currentInstalledAddons: List<Addon> = emptyList()
+    private var currentIsLiveStreamPlayback: Boolean = false
     private var lastScrobbleTime: Long = 0
     private var lastWatchHistorySaveTime: Long = 0
     private var lastWatchHistorySavedPositionSeconds: Long = -1L
@@ -444,6 +446,7 @@ class PlayerViewModel @Inject constructor(
         preferredSourceName: String?,
         preferredBingeGroup: String?,
         startPositionMs: Long?,
+        isLiveStreamPlayback: Boolean = false,
         airDate: String? = null
     ) {
         currentAirDate = airDate
@@ -455,6 +458,7 @@ class PlayerViewModel @Inject constructor(
         currentPreferredAddonId = preferredAddonId?.trim()?.takeIf { it.isNotBlank() }
         currentPreferredSourceName = preferredSourceName?.trim()?.takeIf { it.isNotBlank() }
         currentPreferredBingeGroup = preferredBingeGroup?.trim()?.takeIf { it.isNotBlank() }
+        currentIsLiveStreamPlayback = isLiveStreamPlayback
         playbackSessionStartTime = System.currentTimeMillis()
         playbackDiag(
             "loadMedia type=$mediaType id=$mediaId season=$seasonNumber episode=$episodeNumber " +
@@ -531,7 +535,9 @@ class PlayerViewModel @Inject constructor(
             val showLoadingStats = prefs[showLoadingStatsKey()] ?: true
             val volumeBoostDb = prefs[profileManager.profileStringKey("volume_boost_db")]
                 ?.toIntOrNull()?.coerceIn(0, 15) ?: 0
-            val orderedAddonIds = streamRepository.installedAddons.first()
+            val installedAddons = streamRepository.installedAddons.first()
+            currentInstalledAddons = installedAddons
+            val orderedAddonIds = installedAddons
                 .filter { it.isVodStreamingAddon() }
                 .map { it.id }
             currentAddonOrderedIds = orderedAddonIds
@@ -3696,7 +3702,8 @@ class PlayerViewModel @Inject constructor(
             currentPreferredAddonId,
             currentPreferredSourceName,
             currentPreferredBingeGroup,
-            currentStartPositionMs
+            currentStartPositionMs,
+            currentIsLiveStreamPlayback
         )
     }
 
@@ -3866,9 +3873,19 @@ class PlayerViewModel @Inject constructor(
         progressSaveJob = viewModelScope.launch(Dispatchers.IO) {
             val currentTime = System.currentTimeMillis()
             val progressFraction = (progressPercent / 100f).coerceIn(0f, 1f)
+            val selectedStream = _uiState.value.selectedStream
+            val streamAddonIdForCheck = selectedStream?.addonId?.takeIf { it.isNotBlank() }
+            val isLiveStreamOrSports = SportsAddonCapabilities.isLiveStreamOrSportsItem(
+                mediaType = currentMediaType,
+                id = currentMediaId,
+                streamAddonId = streamAddonIdForCheck,
+                title = currentTitle,
+                isLiveStream = currentIsLiveStreamPlayback,
+                addons = currentInstalledAddons
+            )
 
             // Scrobble start/pause/updates with debounce
-            if (isPlaying && !lastIsPlaying) {
+            if (!isLiveStreamOrSports && isPlaying && !lastIsPlaying) {
                 try {
                     remoteSyncManager.scrobbleStart(
                         mediaType = currentMediaType,
@@ -3883,7 +3900,7 @@ class PlayerViewModel @Inject constructor(
                     // Scrobble start failed
                 }
                 lastScrobbleTime = currentTime
-            } else if (!isPlaying && lastIsPlaying) {
+            } else if (!isLiveStreamOrSports && !isPlaying && lastIsPlaying) {
                 try {
                     remoteSyncManager.scrobblePause(
                         mediaType = currentMediaType,
@@ -3898,7 +3915,7 @@ class PlayerViewModel @Inject constructor(
                     // Scrobble pause immediate failed
                 }
                 lastScrobbleTime = currentTime
-            } else if (isPlaying && currentTime - lastScrobbleTime >= SCROBBLE_UPDATE_INTERVAL_MS) {
+            } else if (!isLiveStreamOrSports && isPlaying && currentTime - lastScrobbleTime >= SCROBBLE_UPDATE_INTERVAL_MS) {
                 // Periodic scrobble update while playing (use scrobbleStart, not pause)
                 try {
                     remoteSyncManager.scrobbleStart(
@@ -3928,14 +3945,6 @@ class PlayerViewModel @Inject constructor(
             val shouldPersistWatchHistory = !isPlaying ||
                 currentTime - lastWatchHistorySaveTime >= WATCH_HISTORY_UPDATE_INTERVAL_MS ||
                 hasSeekJump
-            val selectedStream = _uiState.value.selectedStream
-            val streamAddonIdForCheck = selectedStream?.addonId?.takeIf { it.isNotBlank() }
-            val isLiveStreamOrSports = SportsAddonCapabilities.isLiveStreamOrSportsItem(
-                mediaType = currentMediaType,
-                id = currentMediaId,
-                streamAddonId = streamAddonIdForCheck,
-                title = currentTitle
-            )
             if (shouldPersistWatchHistory && !isAtWatchedThreshold && !isLiveStreamOrSports) {
                 lastWatchHistorySaveTime = currentTime
                 lastWatchHistorySavedPositionSeconds = positionSeconds
@@ -3999,7 +4008,9 @@ class PlayerViewModel @Inject constructor(
             }
 
             // Mark as watched when playback ends or crosses threshold
-            if (!hasMarkedWatched && (playbackState == Player.STATE_ENDED || progressPercent >= Constants.WATCHED_THRESHOLD)) {
+            if (!isLiveStreamOrSports && !hasMarkedWatched &&
+                (playbackState == Player.STATE_ENDED || progressPercent >= Constants.WATCHED_THRESHOLD)
+            ) {
                 hasMarkedWatched = true
                 try {
                     remoteSyncManager.scrobbleStop(

--- a/app/src/test/kotlin/com/arflix/tv/data/model/SportsAddonCapabilitiesTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/model/SportsAddonCapabilitiesTest.kt
@@ -95,6 +95,89 @@ class SportsAddonCapabilitiesTest {
     }
 
     @Test
+    fun `generic live addon is detected from manifest metadata`() {
+        val manifest = AddonManifest(
+            id = "community.provider",
+            name = "Community Provider",
+            version = "1.0.0",
+            description = "Live football matches",
+            types = listOf("sport"),
+            resources = listOf(
+                AddonResource(name = "catalog", types = listOf("sport")),
+                AddonResource(name = "stream", types = listOf("sport"))
+            ),
+            catalogs = listOf(
+                AddonCatalog(type = "sport", id = "football", name = "Football")
+            )
+        )
+        val addon = Addon(
+            id = manifest.id,
+            name = manifest.name,
+            version = manifest.version,
+            description = manifest.description,
+            isInstalled = true,
+            type = AddonType.COMMUNITY,
+            manifest = manifest
+        )
+
+        assertTrue(
+            SportsAddonCapabilities.isLiveStreamOrSportsItem(
+                mediaType = MediaType.TV,
+                id = SportsAddonCapabilities.sportsSyntheticId("community.provider:event"),
+                streamAddonId = addon.id,
+                addons = listOf(addon)
+            )
+        )
+    }
+
+    @Test
+    fun `hybrid addon keeps vod while explicit sports playback is excluded`() {
+        val manifest = AddonManifest(
+            id = "sports-documentaries",
+            name = "Sports and Movies",
+            version = "1.0.0",
+            description = "Movies, series, and live sports",
+            types = listOf("movie", "series", "tv"),
+            resources = listOf(
+                AddonResource(name = "catalog"),
+                AddonResource(name = "stream")
+            ),
+            catalogs = listOf(
+                AddonCatalog(type = "movie", id = "movies", name = "Movies"),
+                AddonCatalog(type = "tv", id = "live-sports", name = "Live Sports")
+            )
+        )
+        val addon = Addon(
+            id = manifest.id,
+            name = manifest.name,
+            version = manifest.version,
+            description = manifest.description,
+            isInstalled = true,
+            type = AddonType.COMMUNITY,
+            manifest = manifest
+        )
+
+        assertFalse(SportsAddonCapabilities.isLiveStreamAddon(addon))
+        assertFalse(
+            SportsAddonCapabilities.isLiveStreamOrSportsItem(
+                mediaType = MediaType.MOVIE,
+                id = 123,
+                streamAddonId = addon.id,
+                addons = listOf(addon)
+            )
+        )
+        assertTrue(
+            SportsAddonCapabilities.isLiveStreamOrSportsItem(
+                mediaType = MediaType.TV,
+                id = SportsAddonCapabilities.sportsSyntheticId("sports-documentaries:event"),
+                streamAddonId = addon.id,
+                isLiveStream = true,
+                addons = listOf(addon)
+            )
+        )
+    }
+
+    @Test
     fun `sports statuses are recognized as home sports items`() {
         assertTrue(SportsAddonCapabilities.isSportsHomeStatus("sports:football"))
         assertTrue(SportsAddonCapabilities.isSportsHomeStatus("sports_event:addon|sports|event"))

--- a/web/components/player/PlayerOverlay.tsx
+++ b/web/components/player/PlayerOverlay.tsx
@@ -24,7 +24,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { config } from "@/lib/config";
 import { createPendingExternalPlayback } from "@/lib/externalPlayback";
-import { saveProgress } from "@/lib/cloud";
+import { isLiveStreamOrSportsItem, saveProgress } from "@/lib/cloud";
 import { cachedDebridDirectUrl, isUncachedDebridStream, parseDebridStream, resolveDebridDirectUrl } from "@/lib/debrid";
 import type { RemuxAudioTrack } from "@/lib/remux";
 import { copyStreamUrl, externalLaunchMode, openExternalPlayer, openInAnyPlayer } from "@/lib/externalPlayers";
@@ -37,7 +37,7 @@ import { authClient, useApp } from "@/lib/store";
 import { syncClient } from "@/lib/sync";
 import { SubtitleTranslator, subtitleLanguageName } from "@/lib/subtitleAi";
 import { getLogoUrl } from "@/lib/tmdb";
-import type { AppSettings, MediaItem, StreamSource } from "@/lib/types";
+import type { AppSettings, InstalledAddon, MediaItem, StreamSource } from "@/lib/types";
 
 type PlayerPanel = "sources" | "subtitles" | "audio" | "settings" | null;
 
@@ -162,6 +162,7 @@ export function PlayerOverlay() {
     selected,
     selectedEpisode,
     settings,
+    addons,
     updateSettings,
     activeProfile,
     streams,
@@ -214,6 +215,7 @@ export function PlayerOverlay() {
       item={selected}
       selectedEpisode={selectedEpisode}
       settings={settings}
+      addons={addons}
       updateSettings={updateSettings}
       activeProfileId={activeProfile?.id ?? null}
       liveTv={Boolean(activeChannel)}
@@ -234,6 +236,7 @@ function VideoPlayer({
   item,
   selectedEpisode,
   settings,
+  addons,
   updateSettings,
   activeProfileId,
   liveTv,
@@ -250,6 +253,7 @@ function VideoPlayer({
   item: MediaItem | null;
   selectedEpisode: { season: number; episode: number } | null;
   settings: AppSettings;
+  addons: InstalledAddon[];
   updateSettings: (patch: Partial<AppSettings>) => void;
   activeProfileId: string | null;
   liveTv: boolean;
@@ -819,7 +823,15 @@ function VideoPlayer({
     if (!video || !item) return undefined;
     const season = selectedEpisode?.season ?? item.seasonNumber ?? null;
     const episode = selectedEpisode?.episode ?? item.episodeNumber ?? null;
-    void syncClient().scrobble("start", { mediaType: item.mediaType, tmdbId: item.id, season, episode, progress: item.progress ?? 0 }).catch(() => undefined);
+    const isLiveStream = isLiveStreamOrSportsItem({
+      mediaType: item.mediaType,
+      id: item.id,
+      streamAddonId: stream.addonId,
+      title: item.title
+    }, addons);
+    if (!isLiveStream) {
+      void syncClient().scrobble("start", { mediaType: item.mediaType, tmdbId: item.id, season, episode, progress: item.progress ?? 0 }).catch(() => undefined);
+    }
     const save = () => {
       if (!authClient.session || !Number.isFinite(video.duration) || video.duration <= 0) return;
       const now = Date.now();
@@ -842,10 +854,12 @@ function VideoPlayer({
         source: stream.addonName,
         stream_addon_id: stream.addonId ?? null,
         stream_title: stream.source
-      }, activeProfileId).catch(() => undefined);
+      }, activeProfileId, addons).catch(() => undefined);
     };
     const onEnded = () => {
-      void syncClient().scrobble("stop", { mediaType: item.mediaType, tmdbId: item.id, season, episode, progress: 100 }).catch(() => undefined);
+      if (!isLiveStream) {
+        void syncClient().scrobble("stop", { mediaType: item.mediaType, tmdbId: item.id, season, episode, progress: 100 }).catch(() => undefined);
+      }
       if (settings.autoPlayNext && canAdvance) void onAdvance();
     };
     video.addEventListener("timeupdate", save);
@@ -857,7 +871,7 @@ function VideoPlayer({
       video.removeEventListener("pause", save);
       video.removeEventListener("ended", onEnded);
     };
-  }, [item, stream, selectedEpisode, settings.autoPlayNext, activeProfileId, canAdvance, onAdvance]);
+  }, [item, stream, selectedEpisode, settings.autoPlayNext, activeProfileId, addons, canAdvance, onAdvance]);
 
   const flashControls = useCallback(() => {
     setShowControls(true);

--- a/web/components/shell/ExternalPlaybackPrompt.tsx
+++ b/web/components/shell/ExternalPlaybackPrompt.tsx
@@ -2,7 +2,7 @@
 
 import { CheckCircle2, Clock3, Play, X } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
-import { saveProgress } from "@/lib/cloud";
+import { isLiveStreamOrSportsItem, saveProgress } from "@/lib/cloud";
 import { authClient, useApp } from "@/lib/store";
 import { syncClient } from "@/lib/sync";
 import {
@@ -21,7 +21,7 @@ function labelFor(pending: PendingExternalPlayback) {
 }
 
 export function ExternalPlaybackPrompt() {
-  const { refreshData, setToast, markWatchedLocally } = useApp();
+  const { addons, refreshData, setToast, markWatchedLocally } = useApp();
   const [pending, setPending] = useState<PendingExternalPlayback | null>(null);
   const [mode, setMode] = useState<PromptMode>("choice");
   const [saving, setSaving] = useState(false);
@@ -37,11 +37,22 @@ export function ExternalPlaybackPrompt() {
       setMode("choice");
       return;
     }
+    if (isLiveStreamOrSportsItem({
+      mediaType: next.mediaType,
+      id: next.tmdbId,
+      streamAddonId: next.streamAddonId,
+      title: next.title
+    }, addons)) {
+      clearPendingExternalPlayback(next.id);
+      setPending(null);
+      setMode("choice");
+      return;
+    }
     const age = Date.now() - next.openedAt;
     // Small grace so we don't fire the instant the scheme launch flips
     // visibility; a real trip to VLC is always longer than this.
     if (immediate ? age >= 1_500 : age >= 12_000) setPending(next);
-  }, []);
+  }, [addons]);
 
   useEffect(() => {
     const onReturn = () => {
@@ -115,7 +126,7 @@ export function ExternalPlaybackPrompt() {
           source: active.source,
           stream_addon_id: active.streamAddonId,
           stream_title: active.streamTitle
-        }, active.profileId).catch(() => undefined);
+        }, active.profileId, addons).catch(() => undefined);
       }
       setToast(finished ? "Marked watched and synced." : "Progress synced.");
       await refreshData(active.profileId);

--- a/web/lib/cloud.ts
+++ b/web/lib/cloud.ts
@@ -928,6 +928,49 @@ export async function saveCloudProfiles(auth: AuthClient, profiles: Profile[], a
   });
 }
 
+export function isLiveStreamOrSportsItem(item: {
+  mediaType?: string | null;
+  media_type?: string | null;
+  id?: number | string | null;
+  show_tmdb_id?: number | string | null;
+  streamAddonId?: string | null;
+  stream_addon_id?: string | null;
+  title?: string | null;
+}): boolean {
+  const mediaType = (item.mediaType ?? item.media_type ?? "").toLowerCase();
+  const rawId = item.show_tmdb_id ?? item.id;
+  const id = typeof rawId === "number" ? rawId : Number(rawId ?? 0);
+
+  const addonId = (item.streamAddonId ?? item.stream_addon_id ?? "").toLowerCase();
+  const title = (item.title ?? "").toLowerCase();
+
+  if (mediaType && mediaType !== "movie" && mediaType !== "tv") {
+    return true;
+  }
+  if (!id || id <= 0) {
+    return true;
+  }
+  if (addonId) {
+    if (
+      addonId.includes("livetv") ||
+      addonId.includes("live_tv") ||
+      addonId.includes("live-tv") ||
+      addonId.includes("live_stream") ||
+      addonId.includes("livestream") ||
+      addonId.includes("live-stream") ||
+      addonId.includes("tvchannels") ||
+      addonId.includes("iptv") ||
+      addonId.includes("sports")
+    ) {
+      return true;
+    }
+  }
+  if (title.startsWith("live:") || title.startsWith("[live]")) {
+    return true;
+  }
+  return false;
+}
+
 export async function getContinueWatching(auth: AuthClient, profileId?: string | null) {
   if (!auth.session) return [];
   if (canUseBackendSync(auth)) {
@@ -935,18 +978,19 @@ export async function getContinueWatching(auth: AuthClient, profileId?: string |
     return androidContinueWatchingItems(root, profileId)
       .map((item) => androidCwToHistory(item, profileId))
       .filter((item): item is WatchHistoryEntry => Boolean(item))
-      .filter((item) => (item.progress ?? 0) < 0.9)
+      .filter((item) => (item.progress ?? 0) < 0.9 && !isLiveStreamOrSportsItem(item))
       .sort((a, b) => Date.parse(b.updated_at ?? "") - Date.parse(a.updated_at ?? ""))
       .slice(0, 50);
   }
   const profileFilter = profileId ? `&profile_id=eq.${encodeURIComponent(profileId)}` : "";
-  return auth.supabase<WatchHistoryEntry[]>(
+  const records = await auth.supabase<WatchHistoryEntry[]>(
     `/rest/v1/watch_history?user_id=eq.${auth.session.userId}${profileFilter}&progress=lt.0.9&select=*&order=updated_at.desc&limit=50`
   );
+  return records.filter((item) => !isLiveStreamOrSportsItem(item));
 }
 
 export async function saveProgress(auth: AuthClient, entry: Omit<WatchHistoryEntry, "user_id">, profileId?: string | null) {
-  if (!auth.session) return;
+  if (!auth.session || isLiveStreamOrSportsItem(entry)) return;
   if (canUseBackendSync(auth)) {
     await mutateCloudPayload(auth, (root) => {
       const targetProfileId = entry.profile_id ?? profileId ?? "default";
@@ -976,6 +1020,7 @@ export async function saveProgress(auth: AuthClient, entry: Omit<WatchHistoryEnt
     })
   });
 }
+
 
 export async function markWatched(auth: AuthClient, entry: Omit<WatchHistoryEntry, "user_id" | "progress" | "position_seconds">, profileId?: string | null) {
   await saveProgress(auth, {

--- a/web/lib/cloud.ts
+++ b/web/lib/cloud.ts
@@ -928,6 +928,59 @@ export async function saveCloudProfiles(auth: AuthClient, profiles: Profile[], a
   });
 }
 
+const liveAddonIdMarkers = [
+  "livetv",
+  "live_tv",
+  "live-tv",
+  "live_stream",
+  "livestream",
+  "live-stream",
+  "tvchannels",
+  "tv-channels",
+  "iptv",
+  "sports"
+];
+
+const vodTypes = new Set(["movie", "film", "series", "show", "anime"]);
+const liveTypes = new Set(["tv", "channel", "channels", "live", "sport", "sports", "tvchannel", "live_tv", "livestream"]);
+
+function addonTypes(addon: InstalledAddon): string[] {
+  return [
+    ...(addon.types ?? []),
+    ...addon.catalogs.map((catalog) => catalog.type),
+    ...addon.resources.flatMap((resource) => typeof resource === "string" ? [] : resource.types ?? [])
+  ].map((type) => type.trim().toLowerCase());
+}
+
+function isLiveAddonId(value?: string | null): boolean {
+  const id = (value ?? "").trim().toLowerCase();
+  if (!id || id.includes("cinemeta") || id.includes("tmdb") || id.includes("torrentio")) return false;
+  return liveAddonIdMarkers.some((marker) => id.includes(marker));
+}
+
+function isLiveOnlyAddon(addon: InstalledAddon): boolean {
+  const types = addonTypes(addon);
+  if (types.some((type) => vodTypes.has(type))) return false;
+  if (isLiveAddonId(addon.id) || isLiveAddonId(addon.name)) return true;
+  if (types.some((type) => liveTypes.has(type))) return true;
+
+  const resourceNames = addon.resources.map((resource) =>
+    (typeof resource === "string" ? resource : resource.name).trim().toLowerCase()
+  );
+  const hasStream = resourceNames.some((name) => name === "stream" || name === "streams");
+  const hasCatalog = addon.catalogs.length > 0 ||
+    resourceNames.some((name) => name === "catalog" || name === "catalogs");
+  const text = [
+    addon.id,
+    addon.name,
+    addon.description ?? "",
+    ...addon.catalogs.flatMap((catalog) => [catalog.type, catalog.id, catalog.name])
+  ].join(" ").toLowerCase();
+  const hasSportsTerm = /(sport|football|soccer|basketball|tennis|racing|rugby|hockey|baseball|boxing|ufc|mma|cricket|golf)/.test(text);
+  const hasLiveTerm = /(live|event|match|game)/.test(text);
+  return hasStream && hasCatalog && hasSportsTerm && hasLiveTerm;
+}
+
 export function isLiveStreamOrSportsItem(item: {
   mediaType?: string | null;
   media_type?: string | null;
@@ -936,7 +989,7 @@ export function isLiveStreamOrSportsItem(item: {
   streamAddonId?: string | null;
   stream_addon_id?: string | null;
   title?: string | null;
-}): boolean {
+}, addons: InstalledAddon[] = []): boolean {
   const mediaType = (item.mediaType ?? item.media_type ?? "").toLowerCase();
   const rawId = item.show_tmdb_id ?? item.id;
   const id = typeof rawId === "number" ? rawId : Number(rawId ?? 0);
@@ -951,17 +1004,10 @@ export function isLiveStreamOrSportsItem(item: {
     return true;
   }
   if (addonId) {
-    if (
-      addonId.includes("livetv") ||
-      addonId.includes("live_tv") ||
-      addonId.includes("live-tv") ||
-      addonId.includes("live_stream") ||
-      addonId.includes("livestream") ||
-      addonId.includes("live-stream") ||
-      addonId.includes("tvchannels") ||
-      addonId.includes("iptv") ||
-      addonId.includes("sports")
-    ) {
+    const addon = addons.find((candidate) => candidate.id.toLowerCase() === addonId);
+    if (addon) {
+      if (isLiveOnlyAddon(addon)) return true;
+    } else if (isLiveAddonId(addonId)) {
       return true;
     }
   }
@@ -971,14 +1017,14 @@ export function isLiveStreamOrSportsItem(item: {
   return false;
 }
 
-export async function getContinueWatching(auth: AuthClient, profileId?: string | null) {
+export async function getContinueWatching(auth: AuthClient, profileId?: string | null, addons: InstalledAddon[] = []) {
   if (!auth.session) return [];
   if (canUseBackendSync(auth)) {
     const root = await pullRawPayload(auth);
     return androidContinueWatchingItems(root, profileId)
       .map((item) => androidCwToHistory(item, profileId))
       .filter((item): item is WatchHistoryEntry => Boolean(item))
-      .filter((item) => (item.progress ?? 0) < 0.9 && !isLiveStreamOrSportsItem(item))
+      .filter((item) => (item.progress ?? 0) < 0.9 && !isLiveStreamOrSportsItem(item, addons))
       .sort((a, b) => Date.parse(b.updated_at ?? "") - Date.parse(a.updated_at ?? ""))
       .slice(0, 50);
   }
@@ -986,11 +1032,11 @@ export async function getContinueWatching(auth: AuthClient, profileId?: string |
   const records = await auth.supabase<WatchHistoryEntry[]>(
     `/rest/v1/watch_history?user_id=eq.${auth.session.userId}${profileFilter}&progress=lt.0.9&select=*&order=updated_at.desc&limit=50`
   );
-  return records.filter((item) => !isLiveStreamOrSportsItem(item));
+  return records.filter((item) => !isLiveStreamOrSportsItem(item, addons));
 }
 
-export async function saveProgress(auth: AuthClient, entry: Omit<WatchHistoryEntry, "user_id">, profileId?: string | null) {
-  if (!auth.session || isLiveStreamOrSportsItem(entry)) return;
+export async function saveProgress(auth: AuthClient, entry: Omit<WatchHistoryEntry, "user_id">, profileId?: string | null, addons: InstalledAddon[] = []) {
+  if (!auth.session || isLiveStreamOrSportsItem(entry, addons)) return;
   if (canUseBackendSync(auth)) {
     await mutateCloudPayload(auth, (root) => {
       const targetProfileId = entry.profile_id ?? profileId ?? "default";

--- a/web/lib/store.tsx
+++ b/web/lib/store.tsx
@@ -240,8 +240,8 @@ function traktWatchedKeys(movies: unknown[], shows: unknown[]) {
   return keys;
 }
 
-function filterWatchedContinueWatching(items: MediaItem[], watchedKeys: Set<string>) {
-  const nonLive = items.filter((item) => !isLiveStreamOrSportsItem(item));
+function filterWatchedContinueWatching(items: MediaItem[], watchedKeys: Set<string>, addons: InstalledAddon[]) {
+  const nonLive = items.filter((item) => !isLiveStreamOrSportsItem(item, addons));
   if (!watchedKeys.size) return nonLive;
   return nonLive.filter((item) => {
     const key = mediaWatchKey(item);
@@ -756,7 +756,7 @@ export function AppProvider({
       const client = syncClient();
       const traktReady = client.isConnected;
       const [historyRows, traktRows, playbackRows, watchedMoviesRows, watchedShowsRows, cloudWatchlistRows, hiddenShowIds] = await Promise.all([
-        authClient.session ? getContinueWatching(authClient, profileId).catch(() => []) : Promise.resolve([]),
+        authClient.session ? getContinueWatching(authClient, profileId, addonState).catch(() => []) : Promise.resolve([]),
         traktReady ? client.watchlist().catch(() => []) : Promise.resolve([]),
         traktReady ? client.playback().catch(() => []) : Promise.resolve([]),
         traktReady ? client.watched("movies").catch(() => []) : Promise.resolve([]),
@@ -846,7 +846,7 @@ export function AppProvider({
       // Order newest-activity-first across playback + up-next (matches the app's
       // updatedAt-descending sort) so the row leads with what you last watched.
       const cwSorted = dedupeMedia(cwBase).sort((a, b) => (b.activityAt ?? 0) - (a.activityAt ?? 0));
-      const cw = await hydrateContinueWatchingItems(filterWatchedContinueWatching(cwSorted, watchedKeys));
+      const cw = await hydrateContinueWatchingItems(filterWatchedContinueWatching(cwSorted, watchedKeys, addonState));
       // Trakt outage guard: when Trakt is connected but every read came back
       // empty, the calls were blocked (Cloudflare challenges the CORS
       // preflight intermittently, especially on VPN/datacenter IPs) — keep

--- a/web/lib/store.tsx
+++ b/web/lib/store.tsx
@@ -5,7 +5,7 @@ import { getStreams, getStreamsProgressive, installAddon as installAddonManifest
 import { AuthClient, SESSION_KEY, decodeJwtPayload } from "./auth";
 import { getAuthPortalUrl } from "./config";
 import { defaultCatalogs, mergeCatalogs } from "./catalogs";
-import { getContinueWatching, pullCloudPayload, pullCloudProfiles, pullCloudTraktToken, pullCloudWatchlist, saveCloudAddons, saveCloudProfiles, saveCloudSettings, saveCloudTraktToken } from "./cloud";
+import { getContinueWatching, isLiveStreamOrSportsItem, pullCloudPayload, pullCloudProfiles, pullCloudTraktToken, pullCloudWatchlist, saveCloudAddons, saveCloudProfiles, saveCloudSettings, saveCloudTraktToken } from "./cloud";
 import { cachedDebridDirectUrl, parseDebridStream, resolveDebridDirectUrl, resolveTranscodeStream } from "./debrid";
 import { createPendingExternalPlayback } from "./externalPlayback";
 import { externalLaunchMode, openExternalPlayer } from "./externalPlayers";
@@ -241,12 +241,14 @@ function traktWatchedKeys(movies: unknown[], shows: unknown[]) {
 }
 
 function filterWatchedContinueWatching(items: MediaItem[], watchedKeys: Set<string>) {
-  if (!watchedKeys.size) return items;
-  return items.filter((item) => {
+  const nonLive = items.filter((item) => !isLiveStreamOrSportsItem(item));
+  if (!watchedKeys.size) return nonLive;
+  return nonLive.filter((item) => {
     const key = mediaWatchKey(item);
     return !key || !watchedKeys.has(key);
   });
 }
+
 
 function isMediaWatched(item: MediaItem, watchedKeys: Set<string>, seasonNumber?: number | null, episodeNumber?: number | null) {
   if (item.isWatched) return true;


### PR DESCRIPTION
## Summary
Live stream items, IPTV channels, sports live events, and items originating from live stream addons do not represent TMDB movies or TV series episodes. As a result, when these items are added to the Continue Watching section, selecting them fails to show details.

This PR ensures that live streams and live stream addon items are neither saved into Continue Watching nor displayed in the Continue Watching section across both Android and Web apps.

## Key Changes
- **`SportsAddonCapabilities.kt` & `cloud.ts`**: Added detection helpers (`isLiveStreamOrSportsItem`) to identify live stream addon streams, live TV channels, sports live events, IPTV streams, and non-movie/non-series synthetic IDs.
- **`PlayerViewModel.kt` & `cloud.ts`**: Prevented saving progress to watch history and local/cloud Continue Watching during playback when a stream originates from a live stream addon or represents a live stream.
- **`TraktRepository.kt` & `WatchHistoryRepository.kt` & `HomeViewModel.kt` & `LauncherContinueWatchingRepository.kt` & `store.tsx`**: Excluded live stream and live stream addon items when saving, reading, or rendering the Continue Watching rail on the Home Screen, Web app, and Android TV Launcher channels.