### PR TITLE
fix: expand disposable email domain blocklist

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/util/AuthEmailValidator.kt
+++ b/app/src/main/kotlin/com/arflix/tv/util/AuthEmailValidator.kt
@@ -21,7 +21,19 @@ object AuthEmailValidator {
         "10minutemail.com",
         "tempmail.com",
         "temp-mail.org",
-        "yopmail.com"
+        "yopmail.com",
+        "trashmail.com",
+        "trashmail.at",
+        "trashmail.io",
+        "sharklasers.com",
+        "throwam.com",
+        "dispostable.com",
+        "mailnull.com",
+        "spamgourmet.com",
+        "discard.email",
+        "fakeinbox.com",
+        "spamherelots.com",
+        "maildrop.cc"
     )
 
     fun normalize(email: String): String = email.trim().lowercase()

--- a/app/src/test/kotlin/com/arflix/tv/util/AuthEmailValidatorTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/util/AuthEmailValidatorTest.kt
@@ -1,0 +1,74 @@
+package com.arflix.tv.util
+
+import com.arflix.tv.R
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class AuthEmailValidatorTest {
+
+    @Test
+    fun `new disposable domains require a real email`() {
+        val domains = listOf(
+            "trashmail.com",
+            "trashmail.at",
+            "trashmail.io",
+            "sharklasers.com",
+            "throwam.com",
+            "dispostable.com",
+            "mailnull.com",
+            "spamgourmet.com",
+            "discard.email",
+            "fakeinbox.com",
+            "spamherelots.com",
+            "maildrop.cc"
+        )
+
+        domains.forEach { domain ->
+            assertEquals(
+                domain,
+                R.string.auth_email_real_required,
+                AuthEmailValidator.validate("user@$domain")
+            )
+        }
+    }
+
+    @Test
+    fun `normal public email domain is accepted`() {
+        assertNull(AuthEmailValidator.validate("user@gmail.com"))
+    }
+
+    @Test
+    fun `disposable domain matching normalizes case and whitespace`() {
+        assertEquals(
+            R.string.auth_email_real_required,
+            AuthEmailValidator.validate("  User@TrashMail.COM  ")
+        )
+    }
+
+    @Test
+    fun `existing disposable domain remains rejected`() {
+        assertEquals(
+            R.string.auth_email_real_required,
+            AuthEmailValidator.validate("user@mailinator.com")
+        )
+    }
+
+    @Test
+    fun `malformed email remains invalid`() {
+        assertEquals(
+            R.string.auth_email_invalid,
+            AuthEmailValidator.validate("not-an-email")
+        )
+    }
+
+    @Test
+    fun `disposable domain is accepted when rejection is disabled`() {
+        assertNull(
+            AuthEmailValidator.validate(
+                email = "user@trashmail.com",
+                rejectDisposable = false
+            )
+        )
+    }
+}


### PR DESCRIPTION
Extend the existing exact-match `blockedDomains` set with the disposable domains enumerated by the issue, preserving normalization, validation order, error resources, and the current suffix checks. Add a focused `AuthEmailValidatorTest` that exercises the expanded set through the public `validate` API instead of exposing or testing the private collection directly. `AuthEmailValidator` currently rejects only 12 reserved or disposable domains, so the widely used throwaway providers identified in issue #368 pass Android-side account-creation validation. The current `main` clone confirms that the reported domains are absent from `blockedDomains`.

Happy path: each newly added disposable domain in a syntactically valid email returns `R.string.auth_email_real_required` under the default account-creation behavior, while a normal public email domain remains accepted; Edge cases: mixed-case and surrounding-whitespace variants normalize to a newly blocked domain, and an existing blocked domain remains rejected so the expansion does not regress current coverage.

Fixes #368
