### PR TITLE
feat(web): add IPTV Provider Sort Order setting option

### DIFF
--- a/web/components/livetv/LiveTvScreen.tsx
+++ b/web/components/livetv/LiveTvScreen.tsx
@@ -101,6 +101,7 @@ export function LiveTvScreen() {
       const keyed = items[0] ? groupKey(items[0]) : group;
       return orderMap.get(keyed) ?? orderMap.get(group) ?? Number.MAX_SAFE_INTEGER;
     };
+    const sortMode = settings.iptvSortOrder ?? "provider";
     const groupRows = Object.entries(groups)
       .map(([group, items]) => ({
         id: `group:${group}`,
@@ -111,13 +112,19 @@ export function LiveTvScreen() {
         rank: groupRank(group, items)
       }))
       .filter((group) => !group.hidden)
-      .sort((a, b) => Number(b.favorite) - Number(a.favorite) || a.rank - b.rank || b.count - a.count || a.label.localeCompare(b.label));
+      .sort((a, b) => {
+        if (Number(b.favorite) !== Number(a.favorite)) return Number(b.favorite) - Number(a.favorite);
+        if (a.rank !== b.rank) return a.rank - b.rank;
+        if (sortMode === "name") return a.label.localeCompare(b.label);
+        if (sortMode === "number") return b.count - a.count || a.label.localeCompare(b.label);
+        return 0;
+      });
     return [
       { id: "all", label: "All Channels", count: channels.length, favorite: false, hidden: false },
       { id: "favorites", label: "Favorites", count: favoriteChannels.length, favorite: true, hidden: false },
       ...groupRows
     ];
-  }, [channels.length, favoriteChannels.length, favoriteGroups, groups, hiddenGroups, iptvSnapshot.groupOrder]);
+  }, [channels.length, favoriteChannels.length, favoriteGroups, groups, hiddenGroups, iptvSnapshot.groupOrder, settings.iptvSortOrder]);
 
   const visibleChannels = useMemo(() => {
     const base = activeCategory === "favorites"
@@ -126,14 +133,27 @@ export function LiveTvScreen() {
         ? groups[activeCategory.slice(6)] ?? []
         : channels;
     const needle = query.trim().toLowerCase();
-    return needle
+    const filtered = needle
       ? base.filter((channel) =>
           channel.name.toLowerCase().includes(needle) ||
           channel.group.toLowerCase().includes(needle) ||
           channel.tvgId?.toLowerCase().includes(needle)
         )
       : base;
-  }, [activeCategory, channels, favoriteChannels, groups, query]);
+    const sortMode = settings.iptvSortOrder ?? "provider";
+    if (sortMode === "number") {
+      return [...filtered].sort((a, b) => {
+        const numA = a.number ? parseInt(a.number, 10) : Number.MAX_SAFE_INTEGER;
+        const numB = b.number ? parseInt(b.number, 10) : Number.MAX_SAFE_INTEGER;
+        if (numA !== numB) return numA - numB;
+        return a.name.localeCompare(b.name);
+      });
+    }
+    if (sortMode === "name") {
+      return [...filtered].sort((a, b) => a.name.localeCompare(b.name));
+    }
+    return filtered;
+  }, [activeCategory, channels, favoriteChannels, groups, query, settings.iptvSortOrder]);
 
   useEffect(() => {
     setVisibleCount(CHANNEL_PAGE_SIZE);

--- a/web/components/settings/SettingsScreen.tsx
+++ b/web/components/settings/SettingsScreen.tsx
@@ -1845,6 +1845,17 @@ function TvSettingsSection() {
 
   return (
     <Panel title="TV (IPTV)">
+      <Row label="Sort order" hint="Choose how live channels and groups are ordered in the list">
+        <Select
+          value={settings.iptvSortOrder ?? "provider"}
+          onChange={(v) => updateSettings({ iptvSortOrder: v as "provider" | "number" | "name" })}
+          options={[
+            ["provider", "Provider Order (Default)"],
+            ["number", "Channel Number"],
+            ["name", "Alphabetical (A-Z)"]
+          ]}
+        />
+      </Row>
       <p className="empty">
         {playlists.length} playlist(s) configured. These are cloud-saved and
         used by the TV page.

--- a/web/lib/store.tsx
+++ b/web/lib/store.tsx
@@ -181,7 +181,8 @@ export const defaultSettings: AppSettings = {
   favoriteChannelIds: [],
   favoriteGroupIds: [],
   hiddenGroupIds: [],
-  groupOrder: []
+  groupOrder: [],
+  iptvSortOrder: "provider"
 };
 
 const emptyIptv: IptvSnapshot = {

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -467,4 +467,5 @@ export interface AppSettings {
   favoriteGroupIds: string[];
   hiddenGroupIds: string[];
   groupOrder: string[];
+  iptvSortOrder?: "provider" | "number" | "name";
 }


### PR DESCRIPTION
### Summary
This PR adds the IPTV Provider Sort Order setting option on the Web platform (resolving Issue #420).

### Changes
- Added `iptvSortOrder` setting property (`"provider" | "number" | "name"`) in `types.ts` & `store.tsx`.
- Added Sort Order dropdown in `SettingsScreen.tsx` under TV (IPTV) settings.
- Applied sort mode handling to channel categories and visible channel sorting in `LiveTvScreen.tsx`.