### PR TITLE
feat(web): enable GPU-accelerated shimmer and poster loading skeletons

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -2253,22 +2253,57 @@ a.login-submit {
 .rail-skeleton {
   min-height: clamp(220px, 28vh, 320px);
 }
-.card-skeleton {
-  width: clamp(280px, 22.1vw, 424px);
-  aspect-ratio: 16 / 9;
-  border-radius: clamp(12px, 0.94vw, 18px);
-  background: linear-gradient(100deg, var(--bg-card) 30%, var(--bg-elevated) 50%, var(--bg-card) 70%);
-  background-size: 200% 100%;
-  animation: arvio-shimmer 1.4s ease-in-out infinite;
+.card-skeleton,
+.card-skeleton-title,
+.card-skeleton-meta {
+  position: relative;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.06);
 }
 
+.card-skeleton::after,
+.card-skeleton-title::after,
+.card-skeleton-meta::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.14), transparent);
+  transform: translateX(-100%);
+  animation: arvio-shimmer-gpu 1.5s infinite;
+  will-change: transform;
+}
+
+.card-skeleton {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: clamp(12px, 0.94vw, 18px);
+}
+
+.rail.is-poster .card-skeleton,
 .rail-skeleton.is-poster .card-skeleton {
-  width: clamp(150px, 12vw, 210px);
   aspect-ratio: 2 / 3;
 }
-@keyframes arvio-shimmer {
-  0% { background-position: 200% 0; }
-  100% { background-position: -200% 0; }
+
+.card-skeleton-title {
+  width: 75%;
+  height: 14px;
+  border-radius: 4px;
+  margin-top: 4px;
+}
+
+.card-skeleton-meta {
+  width: 45%;
+  height: 11px;
+  border-radius: 4px;
+}
+
+@keyframes arvio-shimmer-gpu {
+  100% {
+    transform: translateX(100%);
+  }
 }
 
 /* ============================================================

--- a/web/components/media/LazyRail.tsx
+++ b/web/components/media/LazyRail.tsx
@@ -21,11 +21,11 @@ export function LazyRail({ catalog, eager = false, posterMode, onOpen, onFocus, 
   onLoaded?: (category: Category) => void;
 }) {
   const { loadCatalogRow, settings } = useApp();
-  const effectivePosterMode = posterMode ?? (catalog.layout ? catalog.layout === "poster" : settings.cardLayoutMode === "poster");
   const cacheKey = catalogCacheKey(catalog, settings.language);
   const ref = useRef<HTMLDivElement | null>(null);
   const startedRef = useRef(false);
   const [category, setCategory] = useState<Category | null>(() => readCachedCatalog(cacheKey));
+  const effectivePosterMode = catalog.layout === "poster" || category?.layout === "poster" || (posterMode ?? (settings.cardLayoutMode === "poster"));
   const [loading, setLoading] = useState(false);
   const [done, setDone] = useState(false);
 


### PR DESCRIPTION
### Summary
This PR upgrades loading shimmers and skeleton placeholders on the Web platform to GPU-accelerated compositor animations.

### Changes
- Replaced background gradient position animations with hardware-accelerated `transform: translateX()` compositor animations (`will-change: transform`).
- Fixed skeleton layout mode calculation for poster rails in `LazyRail.tsx`.