### PR TITLE
feat(android): add IPTV Provider Sort Order setting option

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/model/IptvModels.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/model/IptvModels.kt
@@ -79,6 +79,7 @@ data class IptvSnapshot(
     val favoriteChannels: List<String> = emptyList(),
     val hiddenGroups: List<String> = emptyList(),
     val groupOrder: List<String> = emptyList(),
+    val sortOrder: String = "provider",
     val epgWarning: String? = null,
     val loadedAt: Instant = Instant.now()
 )

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
@@ -156,7 +156,8 @@ data class IptvConfig(
     val epgUrl: String = "",
     val playlists: List<IptvPlaylistEntry> = emptyList(),
     val stalkerPortalUrl: String = "",
-    val stalkerMacAddress: String = ""
+    val stalkerMacAddress: String = "",
+    val sortOrder: String = "provider"
 )
 
 data class IptvPlaylistEntry(
@@ -455,7 +456,8 @@ class IptvRepository @Inject constructor(
                 epgUrl = primary?.epgUrl ?: legacyEpgUrls.firstOrNull().orEmpty(),
                 playlists = playlists,
                 stalkerPortalUrl = decryptConfigValue(prefs[stalkerPortalUrlKey()].orEmpty()),
-                stalkerMacAddress = prefs[stalkerMacAddressKey()].orEmpty()
+                stalkerMacAddress = prefs[stalkerMacAddressKey()].orEmpty(),
+                sortOrder = prefs[sortOrderKey()] ?: "provider"
             )
         }
 
@@ -610,6 +612,13 @@ class IptvRepository @Inject constructor(
         }
         invalidateCache()
         invalidationBus.markDirty(CloudSyncScope.IPTV, profileManager.getProfileIdSync(), "save stalker config")
+    }
+
+    suspend fun saveSortOrder(sortOrder: String) {
+        context.settingsDataStore.edit { prefs ->
+            prefs[sortOrderKey()] = sortOrder
+        }
+        invalidationBus.markDirty(CloudSyncScope.IPTV, profileManager.getProfileIdSync(), "save iptv sort order")
     }
 
     /**
@@ -2820,6 +2829,7 @@ class IptvRepository @Inject constructor(
     private fun playlistsKey(): Preferences.Key<String> = profileManager.profileStringKey("iptv_playlists_json")
     private fun stalkerPortalUrlKey(): Preferences.Key<String> = profileManager.profileStringKey("iptv_stalker_portal_url")
     private fun stalkerMacAddressKey(): Preferences.Key<String> = profileManager.profileStringKey("iptv_stalker_mac_address")
+    private fun sortOrderKey(): Preferences.Key<String> = profileManager.profileStringKey("iptv_sort_order")
     private fun epgUrlKeyFor(profileId: String): Preferences.Key<String> =
         profileManager.profileStringKeyFor(profileId, "iptv_epg_url")
     private fun favoriteGroupsKey(): Preferences.Key<String> = profileManager.profileStringKey("iptv_favorite_groups")

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
@@ -151,6 +151,12 @@ private object IptvIdSentinels {
 private const val LargeIptvListChannelCount = 10_000
 internal const val IPTV_GROUP_ORDER_SCHEMA = 3
 
+internal fun normalizeIptvSortOrder(value: String?): String = when (value?.trim()?.lowercase()) {
+    "number" -> "number"
+    "name" -> "name"
+    else -> "provider"
+}
+
 data class IptvConfig(
     val m3uUrl: String = "",
     val epgUrl: String = "",
@@ -182,6 +188,7 @@ data class IptvCloudProfileState(
     val hiddenGroups: List<String> = emptyList(),
     val groupOrder: List<String> = emptyList(),
     val groupOrderSchema: Int = 0,
+    val sortOrder: String = "provider",
     val playlists: List<IptvPlaylistEntry> = emptyList(),
     val tvSession: IptvTvSessionState = IptvTvSessionState()
 )
@@ -457,7 +464,7 @@ class IptvRepository @Inject constructor(
                 playlists = playlists,
                 stalkerPortalUrl = decryptConfigValue(prefs[stalkerPortalUrlKey()].orEmpty()),
                 stalkerMacAddress = prefs[stalkerMacAddressKey()].orEmpty(),
-                sortOrder = prefs[sortOrderKey()] ?: "provider"
+                sortOrder = normalizeIptvSortOrder(prefs[sortOrderKey()])
             )
         }
 
@@ -615,8 +622,9 @@ class IptvRepository @Inject constructor(
     }
 
     suspend fun saveSortOrder(sortOrder: String) {
+        val normalizedSortOrder = normalizeIptvSortOrder(sortOrder)
         context.settingsDataStore.edit { prefs ->
-            prefs[sortOrderKey()] = sortOrder
+            prefs[sortOrderKey()] = normalizedSortOrder
         }
         invalidationBus.markDirty(CloudSyncScope.IPTV, profileManager.getProfileIdSync(), "save iptv sort order")
     }
@@ -2830,6 +2838,8 @@ class IptvRepository @Inject constructor(
     private fun stalkerPortalUrlKey(): Preferences.Key<String> = profileManager.profileStringKey("iptv_stalker_portal_url")
     private fun stalkerMacAddressKey(): Preferences.Key<String> = profileManager.profileStringKey("iptv_stalker_mac_address")
     private fun sortOrderKey(): Preferences.Key<String> = profileManager.profileStringKey("iptv_sort_order")
+    private fun sortOrderKeyFor(profileId: String): Preferences.Key<String> =
+        profileManager.profileStringKeyFor(profileId, "iptv_sort_order")
     private fun epgUrlKeyFor(profileId: String): Preferences.Key<String> =
         profileManager.profileStringKeyFor(profileId, "iptv_epg_url")
     private fun favoriteGroupsKey(): Preferences.Key<String> = profileManager.profileStringKey("iptv_favorite_groups")
@@ -3031,6 +3041,7 @@ class IptvRepository @Inject constructor(
                 }.getOrDefault(emptyList())
             } else emptyList(),
             groupOrderSchema = IPTV_GROUP_ORDER_SCHEMA,
+            sortOrder = normalizeIptvSortOrder(prefs[sortOrderKeyFor(safeProfileId)]),
             playlists = playlists,
             tvSession = decodeTvSessionState(tvSessionRaw)
         )
@@ -3073,6 +3084,7 @@ class IptvRepository @Inject constructor(
             if (normalizedGroupOrder.isEmpty()) prefs.remove(groupOrderKeyFor(safeProfileId))
             else prefs[groupOrderKeyFor(safeProfileId)] = gson.toJson(normalizedGroupOrder)
             prefs[groupOrderSchemaKeyFor(safeProfileId)] = IPTV_GROUP_ORDER_SCHEMA.toString()
+            prefs[sortOrderKeyFor(safeProfileId)] = normalizeIptvSortOrder(state.sortOrder)
             if (effectivePlaylists.isEmpty()) prefs.remove(playlistsKeyFor(safeProfileId))
             else prefs[playlistsKeyFor(safeProfileId)] = gson.toJson(effectivePlaylists)
             if (state.tvSession != IptvTvSessionState()) {

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -447,7 +447,7 @@ fun SettingsScreen(
                     groupOrder = uiState.iptvGroupOrder
                 ).size // Reset row + category rows
             } else {
-                2 + uiState.iptvPlaylists.size // Add + rows + refresh + clear
+                3 + uiState.iptvPlaylists.size // Add + rows + order + refresh + clear
             }
             "home_server" -> uiState.homeServerConnections.size + 3
             "catalogs" -> uiState.catalogs.size + 1 // Add + Import + catalogs
@@ -1018,9 +1018,17 @@ fun SettingsScreen(
                                                     }
                                                 }
                                                 contentFocusIndex == uiState.iptvPlaylists.size + 1 -> {
-                                                    viewModel.refreshIptv(force = true)
+                                                    val next = when (uiState.iptvSortOrder) {
+                                                        "provider" -> "number"
+                                                        "number" -> "name"
+                                                        else -> "provider"
+                                                    }
+                                                    viewModel.setIptvSortOrder(next)
                                                 }
                                                 contentFocusIndex == uiState.iptvPlaylists.size + 2 -> {
+                                                    viewModel.refreshIptv(force = true)
+                                                }
+                                                contentFocusIndex == uiState.iptvPlaylists.size + 3 -> {
                                                     viewModel.clearIptvConfig()
                                                 }
                                             }
@@ -6279,16 +6287,16 @@ private fun IptvSettings(
                     }
                 }
             }
-            MobileSettingsCategory(title = "Options") {
+            MobileSettingsCategory(title = stringResource(R.string.settings_section_options)) {
                 val sortDisplayValue = when (sortOrder) {
-                    "number" -> "Channel Number"
-                    "name" -> "Alphabetical (A-Z)"
-                    else -> "Provider Order"
+                    "number" -> stringResource(R.string.settings_iptv_order_number)
+                    "name" -> stringResource(R.string.settings_iptv_order_name)
+                    else -> stringResource(R.string.settings_iptv_order_provider)
                 }
                 MobileSettingsRow(
                     icon = Icons.Default.List,
-                    title = "Sort order",
-                    subtitle = "Choose how live channels and groups are ordered in the list",
+                    title = stringResource(R.string.settings_iptv_channel_order),
+                    subtitle = stringResource(R.string.settings_iptv_channel_order_description),
                     value = sortDisplayValue,
                     isFocused = false,
                     onClick = {
@@ -6317,27 +6325,6 @@ private fun IptvSettings(
         // TV UI
         Column {
             SettingsRow(icon = Icons.Default.LiveTv, title = stringResource(R.string.add_playlist), subtitle = if (playlists.isEmpty()) stringResource(R.string.settings_add_iptv_lists_hint) else stringResource(R.string.settings_create_another_iptv), value = if (playlists.size >= 3) stringResource(R.string.settings_badge_full) else stringResource(R.string.settings_badge_add), isFocused = focusedIndex == 0, onClick = onConfigure, modifier = Modifier.settingsFocusSlot(0))
-            Spacer(modifier = Modifier.height(16.dp))
-            SettingsRow(
-                icon = Icons.Default.List,
-                title = "Sort order",
-                subtitle = "Choose how live channels and groups are ordered in the list",
-                value = when (sortOrder) {
-                    "number" -> "Channel Number"
-                    "name" -> "Alphabetical (A-Z)"
-                    else -> "Provider Order"
-                },
-                isFocused = focusedIndex == playlists.size + 3,
-                onClick = {
-                    val next = when (sortOrder) {
-                        "provider" -> "number"
-                        "number" -> "name"
-                        else -> "provider"
-                    }
-                    onSortOrderChange(next)
-                },
-                modifier = Modifier.settingsFocusSlot(playlists.size + 3)
-            )
             Spacer(modifier = Modifier.height(16.dp))
             playlists.forEachIndexed { index, playlist ->
                 val rowIndex = index + 1
@@ -6389,10 +6376,31 @@ private fun IptvSettings(
                 Spacer(modifier = Modifier.height(10.dp))
             }
             Spacer(modifier = Modifier.height(6.dp))
-            val refreshSubtitle = when { isLoading -> stringResource(R.string.settings_refreshing_channels_epg); error != null -> error; playlists.none { it.epgUrl.isNotBlank() || it.epgUrls.orEmpty().isNotEmpty() } -> stringResource(R.string.settings_reload_playlists_now); else -> stringResource(R.string.settings_reload_playlist_epg_now) }
-            SettingsRow(icon = Icons.Default.Link, title = stringResource(R.string.refresh_iptv), subtitle = refreshSubtitle, value = if (isLoading) stringResource(R.string.settings_badge_loading) else stringResource(R.string.settings_badge_refresh), isFocused = focusedIndex == playlists.size + 1, onClick = onRefresh, modifier = Modifier.settingsFocusSlot(playlists.size + 1))
+            SettingsRow(
+                icon = Icons.Default.List,
+                title = stringResource(R.string.settings_iptv_channel_order),
+                subtitle = stringResource(R.string.settings_iptv_channel_order_description),
+                value = when (sortOrder) {
+                    "number" -> stringResource(R.string.settings_iptv_order_number)
+                    "name" -> stringResource(R.string.settings_iptv_order_name)
+                    else -> stringResource(R.string.settings_iptv_order_provider)
+                },
+                isFocused = focusedIndex == playlists.size + 1,
+                onClick = {
+                    val next = when (sortOrder) {
+                        "provider" -> "number"
+                        "number" -> "name"
+                        else -> "provider"
+                    }
+                    onSortOrderChange(next)
+                },
+                modifier = Modifier.settingsFocusSlot(playlists.size + 1)
+            )
             Spacer(modifier = Modifier.height(16.dp))
-            SettingsRow(icon = Icons.Default.Delete, title = stringResource(R.string.delete_iptv), subtitle = if (playlists.isEmpty()) stringResource(R.string.settings_no_playlists_configured) else stringResource(R.string.settings_remove_playlists_epg), value = if (playlists.isEmpty()) stringResource(R.string.settings_badge_empty) else stringResource(R.string.settings_badge_delete), isFocused = focusedIndex == playlists.size + 2, onClick = onDelete, modifier = Modifier.settingsFocusSlot(playlists.size + 2))
+            val refreshSubtitle = when { isLoading -> stringResource(R.string.settings_refreshing_channels_epg); error != null -> error; playlists.none { it.epgUrl.isNotBlank() || it.epgUrls.orEmpty().isNotEmpty() } -> stringResource(R.string.settings_reload_playlists_now); else -> stringResource(R.string.settings_reload_playlist_epg_now) }
+            SettingsRow(icon = Icons.Default.Link, title = stringResource(R.string.refresh_iptv), subtitle = refreshSubtitle, value = if (isLoading) stringResource(R.string.settings_badge_loading) else stringResource(R.string.settings_badge_refresh), isFocused = focusedIndex == playlists.size + 2, onClick = onRefresh, modifier = Modifier.settingsFocusSlot(playlists.size + 2))
+            Spacer(modifier = Modifier.height(16.dp))
+            SettingsRow(icon = Icons.Default.Delete, title = stringResource(R.string.delete_iptv), subtitle = if (playlists.isEmpty()) stringResource(R.string.settings_no_playlists_configured) else stringResource(R.string.settings_remove_playlists_epg), value = if (playlists.isEmpty()) stringResource(R.string.settings_badge_empty) else stringResource(R.string.settings_badge_delete), isFocused = focusedIndex == playlists.size + 3, onClick = onDelete, modifier = Modifier.settingsFocusSlot(playlists.size + 3))
             if (isLoading && !progressText.isNullOrBlank()) {
                 Spacer(modifier = Modifier.height(12.dp))
                 Text(stringResource(R.string.settings_progress_format, progressText, progressPercent.coerceIn(0, 100)), style = ArflixTypography.caption, color = TextSecondary)

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -1521,7 +1521,9 @@ fun SettingsScreen(
                             },
                             onRefresh = { viewModel.refreshIptv() },
                             onDelete = { viewModel.clearIptvConfig() },
-                            onManageCategories = openIptvCategories
+                            onManageCategories = openIptvCategories,
+                            sortOrder = uiState.iptvSortOrder,
+                            onSortOrderChange = { viewModel.setIptvSortOrder(it) }
                         )
                         "TV" -> IptvSettings(
                             playlists = uiState.iptvPlaylists,
@@ -4173,7 +4175,9 @@ private fun MobileSettingsSubPage(
                     onManageCategories = { playlistId ->
                         viewModel.setIptvSelectedPlaylistId(playlistId)
                         onNavigate("IPTV_CATEGORIES")
-                    }
+                    },
+                    sortOrder = uiState.iptvSortOrder,
+                    onSortOrderChange = { viewModel.setIptvSortOrder(it) }
                 )
             }
             "IPTV_CATEGORIES" -> {
@@ -6192,7 +6196,9 @@ private fun IptvSettings(
     onDeletePlaylist: (Int) -> Unit,
     onRefresh: () -> Unit,
     onDelete: () -> Unit,
-    onManageCategories: (String) -> Unit = {}
+    onManageCategories: (String) -> Unit = {},
+    sortOrder: String = "provider",
+    onSortOrderChange: (String) -> Unit = {}
 ) {
     val isMobile = LocalDeviceType.current.isTouchDevice()
     var selectionMode by remember { mutableStateOf(false) }
@@ -6273,6 +6279,28 @@ private fun IptvSettings(
                     }
                 }
             }
+            MobileSettingsCategory(title = "Options") {
+                val sortDisplayValue = when (sortOrder) {
+                    "number" -> "Channel Number"
+                    "name" -> "Alphabetical (A-Z)"
+                    else -> "Provider Order"
+                }
+                MobileSettingsRow(
+                    icon = Icons.Default.List,
+                    title = "Sort order",
+                    subtitle = "Choose how live channels and groups are ordered in the list",
+                    value = sortDisplayValue,
+                    isFocused = false,
+                    onClick = {
+                        val next = when (sortOrder) {
+                            "provider" -> "number"
+                            "number" -> "name"
+                            else -> "provider"
+                        }
+                        onSortOrderChange(next)
+                    }
+                )
+            }
             MobileSettingsCategory(title = stringResource(R.string.settings_section_actions)) {
                 val refreshSubtitle = when { isLoading -> stringResource(R.string.settings_refreshing_channels_epg); error != null -> error; playlists.none { it.epgUrl.isNotBlank() || it.epgUrls.orEmpty().isNotEmpty() } -> stringResource(R.string.settings_reload_playlists_now); else -> stringResource(R.string.settings_reload_playlist_epg_now) }
                 MobileSettingsRow(icon = Icons.Default.Link, title = stringResource(R.string.refresh_iptv), subtitle = refreshSubtitle, value = if (isLoading) stringResource(R.string.loading_label) else "", isFocused = false, onClick = onRefresh)
@@ -6289,6 +6317,27 @@ private fun IptvSettings(
         // TV UI
         Column {
             SettingsRow(icon = Icons.Default.LiveTv, title = stringResource(R.string.add_playlist), subtitle = if (playlists.isEmpty()) stringResource(R.string.settings_add_iptv_lists_hint) else stringResource(R.string.settings_create_another_iptv), value = if (playlists.size >= 3) stringResource(R.string.settings_badge_full) else stringResource(R.string.settings_badge_add), isFocused = focusedIndex == 0, onClick = onConfigure, modifier = Modifier.settingsFocusSlot(0))
+            Spacer(modifier = Modifier.height(16.dp))
+            SettingsRow(
+                icon = Icons.Default.List,
+                title = "Sort order",
+                subtitle = "Choose how live channels and groups are ordered in the list",
+                value = when (sortOrder) {
+                    "number" -> "Channel Number"
+                    "name" -> "Alphabetical (A-Z)"
+                    else -> "Provider Order"
+                },
+                isFocused = focusedIndex == playlists.size + 3,
+                onClick = {
+                    val next = when (sortOrder) {
+                        "provider" -> "number"
+                        "number" -> "name"
+                        else -> "provider"
+                    }
+                    onSortOrderChange(next)
+                },
+                modifier = Modifier.settingsFocusSlot(playlists.size + 3)
+            )
             Spacer(modifier = Modifier.height(16.dp))
             playlists.forEachIndexed { index, playlist ->
                 val rowIndex = index + 1

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -151,6 +151,7 @@ data class SettingsUiState(
     val iptvPlaylists: List<IptvPlaylistEntry> = emptyList(),
     val iptvStalkerUrl: String = "",
     val iptvStalkerMac: String = "",
+    val iptvSortOrder: String = "provider",
     val iptvChannelCount: Int = 0,
     val isIptvLoading: Boolean = false,
     val iptvError: String? = null,
@@ -1721,7 +1722,8 @@ class SettingsViewModel @Inject constructor(
                         iptvEpgUrl = config.epgUrl,
                         iptvPlaylists = config.playlists,
                         iptvStalkerUrl = config.stalkerPortalUrl,
-                        iptvStalkerMac = config.stalkerMacAddress
+                        iptvStalkerMac = config.stalkerMacAddress,
+                        iptvSortOrder = config.sortOrder
                     )
                 }
                 if (!hasObservedIptvConfig) {
@@ -2220,6 +2222,12 @@ class SettingsViewModel @Inject constructor(
                     }
                 }
             }
+        }
+    }
+
+    fun setIptvSortOrder(mode: String) {
+        viewModelScope.launch {
+            iptvRepository.saveSortOrder(mode)
         }
     }
 

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/TvViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/TvViewModel.kt
@@ -257,7 +257,8 @@ class TvViewModel @Inject constructor(
                     favoriteGroups = favoriteGroups,
                     favoriteChannels = favoriteChannels,
                     hiddenGroups = hiddenGroups,
-                    groupOrder = groupOrder
+                    groupOrder = groupOrder,
+                    sortOrder = config.sortOrder
                 )
                 setUiState(
                     _uiState.value.copy(

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveCategory.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveCategory.kt
@@ -314,6 +314,26 @@ data class LiveCategory(
     val isGroup: Boolean get() = children.isNotEmpty()
 }
 
+internal fun sortChannelsByConfiguredOrder(
+    channels: List<EnrichedChannel>,
+    sortOrder: String,
+): List<EnrichedChannel> = when (sortOrder) {
+    "number" -> channels.sortedWith { first, second ->
+        val firstNumber = first.source.providerChannelNumber?.trim()?.toBigDecimalOrNull()
+        val secondNumber = second.source.providerChannelNumber?.trim()?.toBigDecimalOrNull()
+        when {
+            firstNumber != null && secondNumber != null -> firstNumber.compareTo(secondNumber)
+            firstNumber != null -> -1
+            secondNumber != null -> 1
+            else -> 0
+        }
+    }
+    "name" -> channels.sortedWith { first, second ->
+        first.name.compareTo(second.name, ignoreCase = true)
+    }
+    else -> channels
+}
+
 enum class CategoryIcon { Favorite, Recent, All, Grid, Sport, Movie, News, Kids, Docs, Music, Lock, Country, SubEntry }
 
 /**

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvScreen.kt
@@ -827,6 +827,7 @@ fun LiveTvScreen(
         favSet,
         recentsFilterKey,
         pagedLoadedLimit,
+        state.snapshot.sortOrder,
     ) {
         val tree = visibleEnrichedState.value.tree
         val categoryCount = tree.countForCategory(selectedCategoryId) ?: 0
@@ -912,13 +913,7 @@ fun LiveTvScreen(
             return@LaunchedEffect
         }
         filteredChannelsCategoryKey = selectedCategoryId
-        val sortMode = state.snapshot.sortOrder
-        val sortedResult = when (sortMode) {
-            "number" -> result.sortedWith(compareBy<EnrichedChannel> { it.number ?: Int.MAX_VALUE }.thenBy { it.name })
-            "name" -> result.sortedBy { it.name }
-            else -> result
-        }
-        filteredChannelsState.value = sortedResult
+        filteredChannelsState.value = sortChannelsByConfiguredOrder(result, state.snapshot.sortOrder)
     }
     val visibleChannels = visibleEnrichedState.value.all
     // Variant grouping + collapsing + index building are O(channels). Doing them

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvScreen.kt
@@ -912,7 +912,13 @@ fun LiveTvScreen(
             return@LaunchedEffect
         }
         filteredChannelsCategoryKey = selectedCategoryId
-        filteredChannelsState.value = result
+        val sortMode = state.snapshot.sortOrder
+        val sortedResult = when (sortMode) {
+            "number" -> result.sortedWith(compareBy<EnrichedChannel> { it.number ?: Int.MAX_VALUE }.thenBy { it.name })
+            "name" -> result.sortedBy { it.name }
+            else -> result
+        }
+        filteredChannelsState.value = sortedResult
     }
     val visibleChannels = visibleEnrichedState.value.all
     // Variant grouping + collapsing + index building are O(channels). Doing them

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -560,6 +560,12 @@
     <string name="settings_badge_delete">DELETE</string>
     <string name="settings_n_selected">%1$d selected</string>
     <string name="settings_section_playlists">PLAYLISTS</string>
+    <string name="settings_section_options">OPTIONS</string>
+    <string name="settings_iptv_channel_order">Channel order</string>
+    <string name="settings_iptv_channel_order_description">Choose how channels are ordered within each group</string>
+    <string name="settings_iptv_order_provider">Provider order</string>
+    <string name="settings_iptv_order_number">Channel number</string>
+    <string name="settings_iptv_order_name">Alphabetical (A-Z)</string>
     <string name="settings_add_tv_lists_hint">Add up to 3 M3U / Xtream TV lists</string>
     <string name="settings_create_another_tv">Create another TV list</string>
     <string name="settings_badge_full_short">Full</string>

--- a/app/src/test/kotlin/com/arflix/tv/data/repository/IptvProviderOrderTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/repository/IptvProviderOrderTest.kt
@@ -7,6 +7,14 @@ import org.junit.Test
 class IptvProviderOrderTest {
 
     @Test
+    fun iptvSortOrderRejectsUnknownCloudValues() {
+        assertThat(normalizeIptvSortOrder(" NUMBER ")).isEqualTo("number")
+        assertThat(normalizeIptvSortOrder("name")).isEqualTo("name")
+        assertThat(normalizeIptvSortOrder("unexpected")).isEqualTo("provider")
+        assertThat(normalizeIptvSortOrder(null)).isEqualTo("provider")
+    }
+
+    @Test
     fun xtreamCategoryEndpointDefinesGroupOrder() {
         val categorizedChannels = listOf(
             "sports" to apiChannel(301, "Sports One", "Sports"),

--- a/app/src/test/kotlin/com/arflix/tv/ui/screens/tv/live/LiveCategoryIndexTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/ui/screens/tv/live/LiveCategoryIndexTest.kt
@@ -133,6 +133,33 @@ class LiveCategoryIndexTest {
     }
 
     @Test
+    fun channelNumberSortUsesProviderNumbersAndKeepsTiesStable() {
+        val channels = listOf(
+            channel("list:20", "Twenty", "General").copy(providerChannelNumber = "20"),
+            channel("list:none", "No number", "General"),
+            channel("list:3a", "Three A", "General").copy(providerChannelNumber = "3"),
+            channel("list:invalid", "Invalid number", "General").copy(providerChannelNumber = "HD"),
+            channel("list:3b", "Three B", "General").copy(providerChannelNumber = "3.0"),
+        ).mapIndexed { index, channel -> channel.enrich(index + 100) }
+
+        val result = sortChannelsByConfiguredOrder(channels, "number")
+
+        assertThat(result.map { it.id })
+            .containsExactly("list:3a", "list:3b", "list:20", "list:none", "list:invalid")
+            .inOrder()
+    }
+
+    @Test
+    fun providerSortKeepsTheOriginalChannelList() {
+        val channels = listOf(
+            channel("list:z", "Zulu", "General"),
+            channel("list:a", "Alpha", "General"),
+        ).mapIndexed { index, channel -> channel.enrich(index + 1) }
+
+        assertThat(sortChannelsByConfiguredOrder(channels, "provider")).isSameInstanceAs(channels)
+    }
+
+    @Test
     fun configSignatureChangesWhenPlaylistOrderChanges() {
         val first = IptvPlaylistEntry("first", "First", "https://example.test/first.m3u")
         val second = IptvPlaylistEntry("second", "Second", "https://example.test/second.m3u")

--- a/web/lib/cloud.ts
+++ b/web/lib/cloud.ts
@@ -60,6 +60,7 @@ interface AndroidIptvProfileState {
   favoriteGroups?: string[];
   hiddenGroups?: string[];
   groupOrder?: string[];
+  sortOrder?: string;
 }
 
 function canUseBackendSync(auth: AuthClient) {
@@ -482,6 +483,7 @@ function iptvFromAndroid(value: unknown, root?: RawPayload): Partial<AppSettings
     favoriteGroupIds: stringArray(state.favoriteGroups).length ? stringArray(state.favoriteGroups) : stringArray(rootState.iptvFavoriteGroups),
     hiddenGroupIds: stringArray(state.hiddenGroups),
     groupOrder: stringArray(state.groupOrder),
+    iptvSortOrder: state.sortOrder === "number" || state.sortOrder === "name" ? state.sortOrder : "provider",
     iptvStalkerUrl: stringValue(state.stalkerPortalUrl ?? rootState.iptvStalkerUrl),
     iptvStalkerMac: stringValue(state.stalkerMacAddress ?? rootState.iptvStalkerMac)
   };
@@ -836,7 +838,8 @@ export async function saveCloudSettings(
         favoriteChannels: settings.favoriteChannelIds,
         favoriteGroups: settings.favoriteGroupIds,
         hiddenGroups: settings.hiddenGroupIds,
-        groupOrder: settings.groupOrder
+        groupOrder: settings.groupOrder,
+        sortOrder: settings.iptvSortOrder
       });
     }
   });

--- a/web/lib/cloud.ts
+++ b/web/lib/cloud.ts
@@ -839,7 +839,7 @@ export async function saveCloudSettings(
         favoriteGroups: settings.favoriteGroupIds,
         hiddenGroups: settings.hiddenGroupIds,
         groupOrder: settings.groupOrder,
-        sortOrder: settings.iptvSortOrder
+        sortOrder: settings.iptvSortOrder ?? "provider"
       });
     }
   });

--- a/web/lib/store.tsx
+++ b/web/lib/store.tsx
@@ -181,7 +181,8 @@ export const defaultSettings: AppSettings = {
   favoriteChannelIds: [],
   favoriteGroupIds: [],
   hiddenGroupIds: [],
-  groupOrder: []
+  groupOrder: [],
+  iptvSortOrder: "provider"
 };
 
 const emptyIptv: IptvSnapshot = {

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -467,5 +467,5 @@ export interface AppSettings {
   favoriteGroupIds: string[];
   hiddenGroupIds: string[];
   groupOrder: string[];
-  iptvSortOrder: "provider" | "number" | "name";
+  iptvSortOrder?: "provider" | "number" | "name";
 }

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -467,4 +467,5 @@ export interface AppSettings {
   favoriteGroupIds: string[];
   hiddenGroupIds: string[];
   groupOrder: string[];
+  iptvSortOrder: "provider" | "number" | "name";
 }


### PR DESCRIPTION
### Summary
This PR adds the IPTV Provider Sort Order setting option for Android (Mobile & TV), bringing feature parity with the Web platform (resolving Issue #420).

### Changes
- Added `sortOrder` DataStore persistence (`"provider" | "number" | "name"`) in `IptvRepository.kt`.
- Exposed `iptvSortOrder` state and `setIptvSortOrder` in `SettingsViewModel.kt` & `TvViewModel.kt`.
- Added Sort Order toggle row in Android Settings (`SettingsScreen.kt`) for both Mobile and TV form factors.
- Applied category and channel sort mode handling in `LiveTvScreen.kt`.