### PR TITLE
feat(settings): add "Refresh Addons" to sync latest changes (#404)

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
@@ -626,87 +626,95 @@ class StreamRepository @Inject constructor(
         return true
     }
 
+    private suspend fun hydrateCustomAddon(url: String, customName: String? = null): Addon {
+        val normalizedUrl = resolveAddonInstallUrl(url)
+        if (normalizedUrl.isBlank()) {
+            throw IllegalArgumentException(context.getString(R.string.addon_error_url_empty))
+        }
+
+        httpLocalScraperRuntime.fetchInstallCandidate(
+            url = normalizedUrl,
+            customName = customName
+        )?.let { candidate ->
+            val addonId = buildAddonInstanceId(candidate.manifest.id, normalizedUrl)
+            return Addon(
+                id = addonId,
+                name = candidate.name,
+                version = candidate.version,
+                description = candidate.description,
+                isInstalled = true,
+                isEnabled = true,
+                type = AddonType.CUSTOM,
+                url = normalizedUrl,
+                logo = candidate.logo,
+                manifest = candidate.manifest,
+                transportUrl = candidate.transportUrl
+            )
+        }
+
+        val manifestUrl = getManifestUrl(normalizedUrl)
+
+        val manifest = try {
+            streamApi.getAddonManifest(manifestUrl)
+        } catch (manifestError: Exception) {
+            val candidate = httpLocalScraperRuntime.fetchInstallCandidate(
+                url = normalizedUrl,
+                customName = customName
+            ) ?: throw manifestError
+            val addonId = buildAddonInstanceId(candidate.manifest.id, normalizedUrl)
+            return Addon(
+                id = addonId,
+                name = candidate.name,
+                version = candidate.version,
+                description = candidate.description,
+                isInstalled = true,
+                isEnabled = true,
+                type = AddonType.CUSTOM,
+                url = normalizedUrl,
+                logo = candidate.logo,
+                manifest = candidate.manifest,
+                transportUrl = candidate.transportUrl
+            )
+        }
+
+        val transportUrl = getTransportUrl(normalizedUrl)
+        val addonManifest = convertToAddonManifest(manifest)
+        val resolvedName = customName?.trim()?.takeIf { it.isNotBlank() } ?: manifest.name
+        val addonId = buildAddonInstanceId(manifest.id, normalizedUrl)
+
+        val resourceNames = addonManifest.resources.map { it.name }.toSet()
+        val hasSubtitles = "subtitles" in resourceNames
+        val hasStream = "stream" in resourceNames
+        val addonType = when {
+            hasSubtitles && !hasStream -> AddonType.SUBTITLE
+            else -> AddonType.CUSTOM
+        }
+
+        return Addon(
+            id = addonId,
+            name = resolvedName,
+            version = manifest.version,
+            description = manifest.description ?: "",
+            isInstalled = true,
+            isEnabled = true,
+            type = addonType,
+            url = normalizedUrl,
+            logo = manifest.logo,
+            manifest = addonManifest,
+            transportUrl = transportUrl
+        )
+    }
+
     /**
      * Add a custom Stremio addon from URL -
      * Fetches manifest and stores addon info
      */
     suspend fun addCustomAddon(url: String, customName: String? = null): Result<Addon> = withContext(Dispatchers.IO) {
         try {
-            val normalizedUrl = resolveAddonInstallUrl(url)
-            if (normalizedUrl.isBlank()) {
-                return@withContext Result.failure(IllegalArgumentException(context.getString(R.string.addon_error_url_empty)))
-            }
-
-            httpLocalScraperRuntime.fetchInstallCandidate(
-                url = normalizedUrl,
-                customName = customName
-            )?.let { httpCandidate ->
-                return@withContext Result.success(
-                    installHttpLocalScraperCandidate(
-                        normalizedUrl = normalizedUrl,
-                        candidate = httpCandidate
-                    )
-                )
-            }
-
-            val manifestUrl = getManifestUrl(normalizedUrl)
-
-            val manifest = try {
-                streamApi.getAddonManifest(manifestUrl)
-            } catch (manifestError: Exception) {
-                val httpCandidate = httpLocalScraperRuntime.fetchInstallCandidate(
-                    url = normalizedUrl,
-                    customName = customName
-                ) ?: throw manifestError
-                return@withContext Result.success(
-                    installHttpLocalScraperCandidate(
-                        normalizedUrl = normalizedUrl,
-                        candidate = httpCandidate
-                    )
-                )
-            }
-
-            val transportUrl = getTransportUrl(normalizedUrl)
-            val addonManifest = convertToAddonManifest(manifest)
-            val resolvedName = customName?.trim()?.takeIf { it.isNotBlank() } ?: manifest.name
-            val addonId = buildAddonInstanceId(manifest.id, normalizedUrl)
-
-            // Classify the addon based on the resources its manifest declares.
-            // - If it declares `subtitles` but NOT `stream`, it's a pure subtitle addon
-            //   (e.g. Wizdom, Ktuvit) and gets AddonType.SUBTITLE so the subtitle fetcher
-            //   picks it up and the stream resolver correctly ignores it.
-            // - If it declares `stream` (with or without subtitles), keep it as CUSTOM so
-            //   the stream resolver queries it. The subtitle fetcher has been updated
-            //   separately to also include CUSTOM addons whose manifest declares a
-            //   subtitles resource, so hybrid addons still get queried for both.
-            // - Everything else stays CUSTOM, matching the previous default.
-            // Fixes issue #80 where Wizdom/Ktuvit were installed but never queried because
-            // every user-added addon was hardcoded to CUSTOM regardless of its manifest.
-            val resourceNames = addonManifest.resources.map { it.name }.toSet()
-            val hasSubtitles = "subtitles" in resourceNames
-            val hasStream = "stream" in resourceNames
-            val addonType = when {
-                hasSubtitles && !hasStream -> AddonType.SUBTITLE
-                else -> AddonType.CUSTOM
-            }
-
-            val newAddon = Addon(
-                id = addonId,
-                name = resolvedName,
-                version = manifest.version,
-                description = manifest.description ?: "",
-                isInstalled = true,
-                isEnabled = true,
-                type = addonType,
-                url = normalizedUrl,
-                logo = manifest.logo,
-                manifest = addonManifest,
-                transportUrl = transportUrl
-            )
-
+            val newAddon = hydrateCustomAddon(url, customName)
             val addons = installedAddons.first().toMutableList()
             // Remove existing addon with same ID if present
-            addons.removeAll { it.id == addonId }
+            addons.removeAll { it.id == newAddon.id }
             addons.add(newAddon)
             saveAddons(addons)
 
@@ -716,6 +724,57 @@ class StreamRepository @Inject constructor(
 
             Result.failure(e)
         }
+    }
+
+    /**
+     * Refresh all installed custom addons by re-fetching manifests, invalidating stream caches,
+     * and returning a refresh report.
+     */
+    suspend fun refreshInstalledAddons(): AddonRefreshReport = withContext(Dispatchers.IO) {
+        val currentAddons = installedAddons.first()
+        var refreshedCount = 0
+        var failedCount = 0
+
+        val updatedAddons = currentAddons.map { oldAddon ->
+            val addonUrl = oldAddon.url?.takeIf { it.isNotBlank() }
+            if (addonUrl == null) {
+                oldAddon
+            } else {
+                try {
+                    val hydrated = hydrateCustomAddon(url = addonUrl, customName = oldAddon.name)
+                    refreshedCount++
+                    hydrated.copy(
+                        id = oldAddon.id,
+                        isEnabled = oldAddon.isEnabled,
+                        isInstalled = oldAddon.isInstalled
+                    )
+                } catch (e: Exception) {
+                    if (e is kotlinx.coroutines.CancellationException) throw e
+                    Log.w(TAG, "[AddonRefresh] Failed to refresh addon ${oldAddon.id} from $addonUrl", e)
+                    failedCount++
+                    oldAddon
+                }
+            }
+        }
+
+        saveAddons(updatedAddons)
+
+        synchronized(streamResultCache) { streamResultCache.clear() }
+        resolvedStreamCache.clear()
+        synchronized(streamAddonsCache) {
+            streamAddonsCache.clear()
+            cachedStreamAddonsFingerprint = null
+        }
+
+        runCatching {
+            val activeProfileId = profileManager.getProfileIdSync()
+            val bundleKey = streamResultCacheBundleKey(activeProfileId)
+            context.streamDataStore.edit { prefs ->
+                prefs.remove(bundleKey)
+            }
+        }
+
+        AddonRefreshReport(refreshed = refreshedCount, failed = failedCount)
     }
 
     private suspend fun installHttpLocalScraperCandidate(
@@ -4021,4 +4080,9 @@ data class ProgressiveStreamResult(
     val completedAddons: Int,
     val totalAddons: Int,
     val isFinal: Boolean
+)
+
+data class AddonRefreshReport(
+    val refreshed: Int = 0,
+    val failed: Int = 0
 )

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
@@ -808,7 +808,10 @@ class StreamRepository @Inject constructor(
         var failedCount = 0
 
         val updatedAddons = currentAddons.map { oldAddon ->
-            val addonUrl = oldAddon.url?.takeIf { it.isNotBlank() }
+            val isRefreshable = oldAddon.isInstalled &&
+                oldAddon.runtimeKind == RuntimeKind.STREMIO &&
+                defaultAddons.none { it.id == oldAddon.id }
+            val addonUrl = oldAddon.url?.takeIf { isRefreshable && it.isNotBlank() }
             if (addonUrl == null) {
                 oldAddon
             } else {
@@ -818,7 +821,9 @@ class StreamRepository @Inject constructor(
                     hydrated.copy(
                         id = oldAddon.id,
                         isEnabled = oldAddon.isEnabled,
-                        isInstalled = oldAddon.isInstalled
+                        isInstalled = oldAddon.isInstalled,
+                        runtimeKind = oldAddon.runtimeKind,
+                        installSource = oldAddon.installSource
                     )
                 } catch (e: Exception) {
                     if (e is kotlinx.coroutines.CancellationException) throw e

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -92,6 +92,14 @@ import androidx.compose.material.icons.filled.Unarchive
 import androidx.compose.material.icons.filled.Archive
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.tv.material3.ClickableSurfaceDefaults
 import androidx.tv.material3.Surface
 import androidx.compose.foundation.layout.PaddingValues
@@ -108,6 +116,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.compositionLocalOf
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateMapOf
@@ -451,7 +460,7 @@ fun SettingsScreen(
             }
             "home_server" -> uiState.homeServerConnections.size + 3
             "catalogs" -> uiState.catalogs.size + 1 // Add + Import + catalogs
-            "stremio" -> stremioAddons.size // rows + add button
+            "stremio" -> stremioAddons.size + 1 // rows + refresh + add button
             "plugins" -> pluginsMaxIndex
             "accounts" -> 6 // Cloud + Trakt + Telegram + Force Sync + App Update + Privacy/Data + MDBList
             else -> 0
@@ -1109,6 +1118,9 @@ fun SettingsScreen(
                                                         else -> viewModel.toggleAddon(addon.id)
                                                     }
                                                 }
+                                                contentFocusIndex == stremioAddons.size -> {
+                                                    viewModel.refreshAddons()
+                                                }
                                                 else -> {
                                                     showCustomAddonInput = true
                                                 }
@@ -1621,13 +1633,15 @@ fun SettingsScreen(
                         )
                         "stremio" -> StremioAddonsSettings(
                             addons = stremioAddons,
+                            isRefreshingAddons = uiState.isRefreshingAddons,
                             focusedIndex = if (activeZone == Zone.CONTENT) contentFocusIndex else -1,
                             focusedActionIndex = addonActionIndex,
                             onToggleAddon = { viewModel.toggleAddon(it) },
                             onMoveAddonUp = { viewModel.moveAddonUp(it) },
                             onMoveAddonDown = { viewModel.moveAddonDown(it) },
                             onDeleteAddon = { viewModel.removeAddon(it) },
-                            onAddCustomAddon = { showCustomAddonInput = true }
+                            onAddCustomAddon = { showCustomAddonInput = true },
+                            onRefreshAddons = { viewModel.refreshAddons() }
                         )
                         "plugins" -> {
                             com.arflix.tv.ui.screens.plugin.PluginScreen(
@@ -4092,13 +4106,15 @@ private fun MobileSettingsSubPage(
             "Addons" -> {
                 StremioAddonsSettings(
                     addons = stremioAddons,
+                    isRefreshingAddons = uiState.isRefreshingAddons,
                     focusedIndex = -1,
                     focusedActionIndex = 0,
                     onToggleAddon = { viewModel.toggleAddon(it) },
                     onMoveAddonUp = { viewModel.moveAddonUp(it) },
                     onMoveAddonDown = { viewModel.moveAddonDown(it) },
                     onDeleteAddon = { viewModel.removeAddon(it) },
-                    onAddCustomAddon = onAddCustomAddonClick
+                    onAddCustomAddon = onAddCustomAddonClick,
+                    onRefreshAddons = { viewModel.refreshAddons() }
                 )
             }
             "Plugins & Extensions" -> {
@@ -7543,20 +7559,86 @@ private fun CatalogActionChip(
 @Composable
 private fun StremioAddonsSettings(
     addons: List<com.arflix.tv.data.model.Addon> = emptyList(),
+    isRefreshingAddons: Boolean = false,
     focusedIndex: Int = -1,
     focusedActionIndex: Int = 0,
     onToggleAddon: (String) -> Unit = {},
     onMoveAddonUp: (String) -> Unit = {},
     onMoveAddonDown: (String) -> Unit = {},
     onDeleteAddon: (String) -> Unit = {},
-    onAddCustomAddon: () -> Unit = {}
+    onAddCustomAddon: () -> Unit = {},
+    onRefreshAddons: () -> Unit = {}
 ) {
     val isMobile = LocalDeviceType.current.isTouchDevice()
 
     if (isMobile) {
-        Column(verticalArrangement = Arrangement.spacedBy(24.dp)) {
+        var pullOffsetY by remember { mutableFloatStateOf(0f) }
+        val density = LocalDensity.current
+        val refreshThreshold = remember(density) { with(density) { 90.dp.toPx() } }
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .pointerInput(isRefreshingAddons) {
+                    detectVerticalDragGestures(
+                        onVerticalDrag = { change, dragAmount ->
+                            if (dragAmount > 0 || pullOffsetY > 0f) {
+                                change.consume()
+                                pullOffsetY = (pullOffsetY + dragAmount * 0.5f).coerceAtLeast(0f)
+                            }
+                        },
+                        onDragEnd = {
+                            if (pullOffsetY >= refreshThreshold && !isRefreshingAddons) {
+                                onRefreshAddons()
+                            }
+                            pullOffsetY = 0f
+                        },
+                        onDragCancel = {
+                            pullOffsetY = 0f
+                        }
+                    )
+                },
+            verticalArrangement = Arrangement.spacedBy(24.dp)
+        ) {
+            AnimatedVisibility(
+                visible = isRefreshingAddons || pullOffsetY > 0f,
+                enter = fadeIn() + expandVertically(),
+                exit = fadeOut() + shrinkVertically()
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 14.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp),
+                        color = Pink,
+                        strokeWidth = 2.5.dp
+                    )
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Text(
+                        text = stringResource(R.string.settings_pulling_latest_addon),
+                        style = ArflixTypography.caption.copy(
+                            fontSize = 12.sp,
+                            fontStyle = FontStyle.Italic
+                        ),
+                        color = TextSecondary
+                    )
+                }
+            }
+
             MobileSettingsCategory(title = stringResource(R.string.settings_section_add_addon)) {
-                MobileSettingsRow(icon = Icons.Default.Add, title = stringResource(R.string.add_addon), subtitle = stringResource(R.string.settings_install_custom_addon), value = "", isFocused = false, showDivider = false, onClick = onAddCustomAddon)
+                MobileSettingsRow(
+                    icon = Icons.Default.Add,
+                    title = stringResource(R.string.add_addon),
+                    subtitle = stringResource(R.string.settings_install_custom_addon),
+                    value = "",
+                    isFocused = false,
+                    showDivider = false,
+                    onClick = onAddCustomAddon
+                )
             }
             MobileSettingsCategory(title = stringResource(R.string.settings_section_my_addons)) {
                 if (addons.isEmpty()) {
@@ -7649,7 +7731,33 @@ private fun StremioAddonsSettings(
                 }
             }
             Spacer(modifier = Modifier.height(24.dp))
-            Row(modifier = Modifier.settingsFocusSlot(addons.size).fillMaxWidth().clickable(onClick = onAddCustomAddon).background(if (focusedIndex == addons.size) Color.White.copy(alpha = 0.12f) else Color.White.copy(alpha = 0.05f), RoundedCornerShape(12.dp)).border(width = if (focusedIndex == addons.size) 2.dp else 0.dp, color = if (focusedIndex == addons.size) Pink else Color.Transparent, shape = RoundedCornerShape(12.dp)).padding(horizontal = 16.dp, vertical = 14.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.Center) {
+            Row(
+                modifier = Modifier
+                    .settingsFocusSlot(addons.size)
+                    .fillMaxWidth()
+                    .clickable(onClick = onRefreshAddons)
+                    .background(if (focusedIndex == addons.size) Color.White.copy(alpha = 0.12f) else Color.White.copy(alpha = 0.05f), RoundedCornerShape(12.dp))
+                    .border(width = if (focusedIndex == addons.size) 2.dp else 0.dp, color = if (focusedIndex == addons.size) Pink else Color.Transparent, shape = RoundedCornerShape(12.dp))
+                    .padding(horizontal = 16.dp, vertical = 14.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center
+            ) {
+                Icon(Icons.Default.Refresh, contentDescription = null, tint = Pink, modifier = Modifier.size(20.dp))
+                Spacer(modifier = Modifier.width(12.dp))
+                Text(stringResource(R.string.refresh_addons), style = ArflixTypography.button, color = Pink)
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(
+                modifier = Modifier
+                    .settingsFocusSlot(addons.size + 1)
+                    .fillMaxWidth()
+                    .clickable(onClick = onAddCustomAddon)
+                    .background(if (focusedIndex == addons.size + 1) Color.White.copy(alpha = 0.12f) else Color.White.copy(alpha = 0.05f), RoundedCornerShape(12.dp))
+                    .border(width = if (focusedIndex == addons.size + 1) 2.dp else 0.dp, color = if (focusedIndex == addons.size + 1) Pink else Color.Transparent, shape = RoundedCornerShape(12.dp))
+                    .padding(horizontal = 16.dp, vertical = 14.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center
+            ) {
                 Icon(Icons.Default.Widgets, contentDescription = null, tint = Pink, modifier = Modifier.size(20.dp))
                 Spacer(modifier = Modifier.width(12.dp))
                 Text(stringResource(R.string.add_addon), style = ArflixTypography.button, color = Pink)

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -92,14 +92,6 @@ import androidx.compose.material.icons.filled.Unarchive
 import androidx.compose.material.icons.filled.Archive
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.font.FontStyle
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.shrinkVertically
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.tv.material3.ClickableSurfaceDefaults
 import androidx.tv.material3.Surface
 import androidx.compose.foundation.layout.PaddingValues
@@ -118,7 +110,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.compositionLocalOf
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateMapOf
@@ -7459,64 +7450,25 @@ private fun StremioAddonsSettings(
     val isMobile = LocalDeviceType.current.isTouchDevice()
 
     if (isMobile) {
-        var pullOffsetY by remember { mutableFloatStateOf(0f) }
-        val density = LocalDensity.current
-        val refreshThreshold = remember(density) { with(density) { 90.dp.toPx() } }
-
         Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .pointerInput(isRefreshingAddons) {
-                    detectVerticalDragGestures(
-                        onVerticalDrag = { change, dragAmount ->
-                            if (dragAmount > 0 || pullOffsetY > 0f) {
-                                change.consume()
-                                pullOffsetY = (pullOffsetY + dragAmount * 0.5f).coerceAtLeast(0f)
-                            }
-                        },
-                        onDragEnd = {
-                            if (pullOffsetY >= refreshThreshold && !isRefreshingAddons) {
-                                onRefreshAddons()
-                            }
-                            pullOffsetY = 0f
-                        },
-                        onDragCancel = {
-                            pullOffsetY = 0f
-                        }
-                    )
-                },
+            modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(24.dp)
         ) {
-            AnimatedVisibility(
-                visible = isRefreshingAddons || pullOffsetY > 0f,
-                enter = fadeIn() + expandVertically(),
-                exit = fadeOut() + shrinkVertically()
-            ) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 14.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Center
-                ) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(24.dp),
-                        color = Pink,
-                        strokeWidth = 2.5.dp
-                    )
-                    Spacer(modifier = Modifier.height(6.dp))
-                    Text(
-                        text = stringResource(R.string.settings_pulling_latest_addon),
-                        style = ArflixTypography.caption.copy(
-                            fontSize = 12.sp,
-                            fontStyle = FontStyle.Italic
-                        ),
-                        color = TextSecondary
-                    )
-                }
-            }
-
             MobileSettingsCategory(title = stringResource(R.string.settings_section_add_addon)) {
+                MobileSettingsRow(
+                    icon = Icons.Default.Refresh,
+                    title = stringResource(R.string.refresh_addons),
+                    subtitle = stringResource(R.string.settings_refresh_addons_desc),
+                    value = if (isRefreshingAddons) {
+                        stringResource(R.string.settings_pulling_latest_addon)
+                    } else {
+                        ""
+                    },
+                    isFocused = false,
+                    onClick = {
+                        if (!isRefreshingAddons) onRefreshAddons()
+                    }
+                )
                 MobileSettingsRow(
                     icon = Icons.Default.Add,
                     title = stringResource(R.string.add_addon),
@@ -7622,7 +7574,7 @@ private fun StremioAddonsSettings(
                 modifier = Modifier
                     .settingsFocusSlot(addons.size)
                     .fillMaxWidth()
-                    .clickable(onClick = onRefreshAddons)
+                    .clickable(enabled = !isRefreshingAddons, onClick = onRefreshAddons)
                     .background(if (focusedIndex == addons.size) Color.White.copy(alpha = 0.12f) else Color.White.copy(alpha = 0.05f), RoundedCornerShape(12.dp))
                     .border(width = if (focusedIndex == addons.size) 2.dp else 0.dp, color = if (focusedIndex == addons.size) Pink else Color.Transparent, shape = RoundedCornerShape(12.dp))
                     .padding(horizontal = 16.dp, vertical = 14.dp),
@@ -7631,7 +7583,17 @@ private fun StremioAddonsSettings(
             ) {
                 Icon(Icons.Default.Refresh, contentDescription = null, tint = Pink, modifier = Modifier.size(20.dp))
                 Spacer(modifier = Modifier.width(12.dp))
-                Text(stringResource(R.string.refresh_addons), style = ArflixTypography.button, color = Pink)
+                Text(
+                    text = stringResource(
+                        if (isRefreshingAddons) {
+                            R.string.settings_pulling_latest_addon
+                        } else {
+                            R.string.refresh_addons
+                        }
+                    ),
+                    style = ArflixTypography.button,
+                    color = Pink
+                )
             }
             Spacer(modifier = Modifier.height(12.dp))
             Row(

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -179,6 +179,7 @@ data class SettingsUiState(
     val packError: String? = null,
     // Addons
     val addons: List<Addon> = emptyList(),
+    val isRefreshingAddons: Boolean = false,
     val torrServerBaseUrl: String = "",
     val homeServerConnection: HomeServerConnection? = null,
     val homeServerConnections: List<HomeServerConnection> = emptyList(),
@@ -1671,6 +1672,41 @@ class SettingsViewModel @Inject constructor(
             }.onFailure { error ->
                 _uiState.value = _uiState.value.copy(
                     toastMessage = error.message?.takeIf { it.isNotBlank() } ?: context.getString(R.string.addon_failed_add),
+                    toastType = ToastType.ERROR
+                )
+            }
+        }
+    }
+
+    fun refreshAddons() {
+        if (_uiState.value.isRefreshingAddons) return
+        _uiState.value = _uiState.value.copy(isRefreshingAddons = true)
+        viewModelScope.launch {
+            try {
+                if (authRepository.hasValidCloudSyncSession()) {
+                    restoreCloudStateToLocalInternal(
+                        silent = true,
+                        pushPendingLocalFirst = false
+                    )
+                }
+                val report = streamRepository.refreshInstalledAddons()
+                val updatedAddons = streamRepository.installedAddons.first()
+                runCatching {
+                    catalogRepository.syncAddonCatalogs(updatedAddons)
+                }
+                val toast = "${report.refreshed} addons refreshed, ${report.failed} failed"
+                _uiState.value = _uiState.value.copy(
+                    addons = updatedAddons,
+                    isRefreshingAddons = false,
+                    toastMessage = toast,
+                    toastType = if (report.failed == 0) ToastType.SUCCESS else ToastType.INFO
+                )
+                syncLocalStateToCloud(silent = true)
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                _uiState.value = _uiState.value.copy(
+                    isRefreshingAddons = false,
+                    toastMessage = "Failed to refresh addons",
                     toastType = ToastType.ERROR
                 )
             }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -1698,10 +1698,18 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             try {
                 if (authRepository.hasValidCloudSyncSession()) {
-                    restoreCloudStateToLocalInternal(
+                    val restoreResult = restoreCloudStateToLocalInternal(
                         silent = true,
                         pushPendingLocalFirst = false
                     )
+                    if (restoreResult == CloudRestoreResult.FAILED) {
+                        _uiState.value = _uiState.value.copy(
+                            isRefreshingAddons = false,
+                            toastMessage = "Cloud restore failed; addons were not changed",
+                            toastType = ToastType.ERROR
+                        )
+                        return@launch
+                    }
                 }
                 val report = streamRepository.refreshInstalledAddons()
                 val updatedAddons = streamRepository.installedAddons.first()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -597,6 +597,9 @@
     <string name="settings_from_source">From %1$s</string>
     <string name="settings_from_home_server">From Home Server</string>
     <string name="settings_custom_catalog">Custom catalog</string>
+    <string name="refresh_addons">Refresh Addons</string>
+    <string name="settings_refresh_addons_desc">Pull latest addon changes for current profile</string>
+    <string name="settings_pulling_latest_addon">Pulling latest addons</string>
     <string name="settings_section_add_addon">ADD ADDON</string>
     <string name="settings_install_custom_addon">Install a custom Stremio addon by URL</string>
     <string name="settings_section_my_addons">MY ADDONS</string>


### PR DESCRIPTION
Fixes #404

## Summary
Adds a "Refresh Addons" feature to allow users to sync latest addon changes for their active profile without restarting the application or profile.

## Key Changes
- **StreamRepository**:
  - `refreshInstalledAddons()` re-fetches and hydrates manifests for all installed custom Stremio addons.
  - Preserves user properties (`isEnabled`, `isInstalled`, `id`, ordering).
  - Invalidates in-memory caches (`streamResultCache`, `resolvedStreamCache`, `streamAddonsCache`) and removes the active profile's persisted disk cache bundle.
  - Returns `AddonRefreshReport(refreshed, failed)`.
- **SettingsViewModel**:
  - `refreshAddons()` pulls remote cloud profile snapshot (`pushPendingLocalFirst = false`) when signed in.
  - Refreshes installed addons and resyncs catalogs via `catalogRepository.syncAddonCatalogs()`.
  - Posts toast feedback with refreshed and failed counts.
- **UI Layer**:
  - **Mobile**: Gesture-driven Pull-to-Refresh on the Addons screen featuring a stock circular progress loader and small italic *"Pulling latest addon"* text.
  - **TV**: Focusable "Refresh Addons" button row before "Add Addon" with D-Pad navigation.

## Verification
- Verified compilation with `./gradlew assembleSideloadDebug` (BUILD SUCCESSFUL).
- Installed and tested on Android emulator (`127.0.0.1:6555`).