### PR TITLE
fix(home): correct RTL navigation and refresh localized content

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/MainActivity.kt
+++ b/app/src/main/kotlin/com/arflix/tv/MainActivity.kt
@@ -302,7 +302,7 @@ class MainActivity : ComponentActivity() {
                 }
             }.collectAsStateWithLifecycle(initialValue = "en-US")
             LaunchedEffect(appLanguage) {
-                mediaRepository.get().contentLanguage = if (appLanguage == "en-US") null else appLanguage
+                mediaRepository.get().contentLanguage = appLanguage
             }
             val deviceType = when (deviceModeOverride) {
                 "tv" -> DeviceType.TV

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/MediaRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/MediaRepository.kt
@@ -103,9 +103,9 @@ class MediaRepository @Inject constructor(
 
     /** TMDB content language (e.g. "en-US", "fr-FR", "nl-NL"). Null = TMDB default (English). */
     @Volatile
-    var contentLanguage: String? = null
+    var contentLanguage: String = "en-US"
         set(value) {
-            field = value?.replace("iw", "he")?.replace('_', '-')
+            field = value.ifBlank { "en-US" }.replace("iw", "he").replace('_', '-')
         }
 
     // === IN-MEMORY CACHE FOR PERFORMANCE ===
@@ -117,6 +117,18 @@ class MediaRepository @Inject constructor(
         private set
     @Volatile private var homeCategoriesFetchedAt = 0L
     private val HOME_CATEGORIES_CACHE_MS = 120_000L // 2 minutes
+
+    fun clearMediaCache() {
+        cachedHomeCategories = emptyList()
+        homeCategoriesFetchedAt = 0L
+        synchronized(detailsCache) { detailsCache.clear() }
+        synchronized(fullDetailsCacheKeys) { fullDetailsCacheKeys.clear() }
+        synchronized(castCache) { castCache.clear() }
+        synchronized(similarCache) { similarCache.clear() }
+        synchronized(logoCache) { logoCache.clear() }
+        synchronized(reviewsCache) { reviewsCache.clear() }
+        synchronized(seasonEpisodesCache) { seasonEpisodesCache.clear() }
+    }
 
     private val detailsCache = mutableMapOf<String, CacheEntry<MediaItem>>()
     private val fullDetailsCacheKeys = mutableSetOf<String>()
@@ -3638,7 +3650,11 @@ private fun TmdbMediaItem.toMediaItem(defaultType: MediaType): MediaItem {
 
     return MediaItem(
         id = id,
-        title = title ?: name ?: "Unknown",
+        title = title?.takeIf { it.isNotBlank() }
+            ?: name?.takeIf { it.isNotBlank() }
+            ?: originalTitle?.takeIf { it.isNotBlank() }
+            ?: originalName?.takeIf { it.isNotBlank() }
+            ?: "Unknown",
         subtitle = if (type == MediaType.MOVIE) "Movie" else "TV Series",
         overview = overview ?: "",
         year = year,
@@ -3665,7 +3681,9 @@ private fun TmdbMovieDetails.toMediaItem(): MediaItem {
 
     return MediaItem(
         id = id,
-        title = title,
+        title = title.takeIf { it.isNotBlank() }
+            ?: originalTitle?.takeIf { it.isNotBlank() }
+            ?: "Unknown",
         subtitle = "Movie",
         overview = overview ?: "",
         year = year,
@@ -3700,7 +3718,9 @@ private fun TmdbTvDetails.toMediaItem(): MediaItem {
 
     return MediaItem(
         id = id,
-        title = name,
+        title = name.takeIf { it.isNotBlank() }
+            ?: originalName?.takeIf { it.isNotBlank() }
+            ?: "Unknown",
         subtitle = "TV Series",
         overview = overview ?: "",
         year = year,

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/MediaRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/MediaRepository.kt
@@ -101,7 +101,7 @@ class MediaRepository @Inject constructor(
     private val apiKey = Constants.TMDB_API_KEY
     private val gson = Gson()
 
-    /** TMDB content language (e.g. "en-US", "fr-FR", "nl-NL"). Null = TMDB default (English). */
+    /** TMDB content language (e.g. "en-US", "fr-FR", "nl-NL"). */
     @Volatile
     var contentLanguage: String = "en-US"
         set(value) {
@@ -3052,7 +3052,10 @@ class MediaRepository @Inject constructor(
             val videos = tmdbApi.getVideos(type, mediaId, apiKey, language = contentLanguage)
             var results = videos.results
             // If language-specific request returned no YouTube videos, fall back to English
-            if (results.none { it.site == "YouTube" } && !contentLanguage.isNullOrBlank()) {
+            if (
+                results.none { it.site == "YouTube" } &&
+                !contentLanguage.equals("en-US", ignoreCase = true)
+            ) {
                 results = tmdbApi.getVideos(type, mediaId, apiKey, language = null).results
             }
             val trailer = results.find { it.type == "Trailer" && it.site == "YouTube" && it.official }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeProfilePreferences.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeProfilePreferences.kt
@@ -14,7 +14,8 @@ internal data class HomeProfilePreferences(
     val trailerInCards: Boolean,
     val showBudget: Boolean,
     val clockFormat: String,
-    val smoothScrolling: Boolean
+    val smoothScrolling: Boolean,
+    val contentLanguage: String
 )
 
 internal fun readHomeProfilePreferences(
@@ -22,6 +23,8 @@ internal fun readHomeProfilePreferences(
     profileId: String
 ): HomeProfilePreferences {
     val prefix = "profile_${profileId}_"
+    val fallbackLanguage = preferences[stringPreferencesKey("last_app_language")] ?: "en-US"
+    val contentLang = preferences[stringPreferencesKey("${prefix}content_language")] ?: fallbackLanguage
     return HomeProfilePreferences(
         trailerAutoPlay = preferences[booleanPreferencesKey("${prefix}trailer_auto_play")] ?: false,
         trailerSoundEnabled = preferences[booleanPreferencesKey("${prefix}trailer_sound_enabled")] ?: false,
@@ -30,7 +33,8 @@ internal fun readHomeProfilePreferences(
         trailerInCards = preferences[booleanPreferencesKey("${prefix}trailer_in_cards")] ?: true,
         showBudget = preferences[booleanPreferencesKey("${prefix}show_budget_on_home")] ?: true,
         clockFormat = preferences[stringPreferencesKey("${prefix}clock_format")] ?: "24h",
-        smoothScrolling = preferences[booleanPreferencesKey("${prefix}smooth_scrolling")] ?: false
+        smoothScrolling = preferences[booleanPreferencesKey("${prefix}smooth_scrolling")] ?: false,
+        contentLanguage = contentLang
     )
 }
 

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
@@ -1769,7 +1769,6 @@ private fun HomeHeroLayer(
         val buttonsBottomPadding = contentRowTopPadding - 10.dp
         val heroBottomPadding = buttonsBottomPadding + if (configuration.screenHeightDp < 720) 34.dp else 34.dp
 
-        val isRtl = androidx.compose.ui.platform.LocalLayoutDirection.current == androidx.compose.ui.unit.LayoutDirection.Rtl
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -1784,10 +1783,10 @@ private fun HomeHeroLayer(
                         overviewOverride = heroOverviewOverride,
                         showBudget = showBudget,
                         modifier = Modifier
-                            .align(if (isRtl) Alignment.BottomEnd else Alignment.BottomStart)
+                            .align(Alignment.BottomStart)
                             .padding(
-                                start = if (isRtl) 400.dp else contentStartPadding,
-                                end = if (isRtl) contentStartPadding else 400.dp
+                                start = contentStartPadding,
+                                end = 400.dp
                             )
                             .offset(y = -heroBottomPadding)
                     )

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
@@ -294,8 +294,8 @@ private fun localizedCategoryTitle(category: Category): String = when (category.
     "collection_row_franchise" -> stringResource(R.string.franchises)
     "collection_row_network"   -> stringResource(R.string.networks)
     "collection_row_featured"  -> stringResource(R.string.featured)
-    "top10_movies_today"       -> if (androidx.compose.ui.platform.LocalLayoutDirection.current == androidx.compose.ui.unit.LayoutDirection.Rtl) "10 הסרטים הנצפים היום" else stringResource(R.string.home_top10_movies_today)
-    "top10_shows_today"        -> if (androidx.compose.ui.platform.LocalLayoutDirection.current == androidx.compose.ui.unit.LayoutDirection.Rtl) "10 הסדרות הנצפות היום" else stringResource(R.string.home_top10_shows_today)
+    "top10_movies_today"       -> stringResource(R.string.home_top10_movies_today)
+    "top10_shows_today"        -> stringResource(R.string.home_top10_shows_today)
     else                       -> category.title
 }
 
@@ -423,14 +423,16 @@ private fun createHomeHeroPlaybackHandles(context: Context): HomeHeroPlaybackHan
 
 private suspend fun androidx.compose.foundation.lazy.LazyListState.animateHomeScrollDelta(
     deltaPx: Float,
-    durationMillis: Int
+    durationMillis: Int,
+    isRtl: Boolean = false
 ) {
-    if (abs(deltaPx) <= 1f) return
+    val targetDelta = if (isRtl) -deltaPx else deltaPx
+    if (abs(targetDelta) <= 1f) return
     scroll(scrollPriority = MutatePriority.PreventUserInput) {
         var previousValue = 0f
         animate(
             initialValue = 0f,
-            targetValue = deltaPx,
+            targetValue = targetDelta,
             animationSpec = spring(
                 dampingRatio = 0.85f,
                 stiffness = 200f
@@ -1767,28 +1769,28 @@ private fun HomeHeroLayer(
         val buttonsBottomPadding = contentRowTopPadding - 10.dp
         val heroBottomPadding = buttonsBottomPadding + if (configuration.screenHeightDp < 720) 34.dp else 34.dp
 
-        androidx.compose.runtime.CompositionLocalProvider(
-            androidx.compose.ui.platform.LocalLayoutDirection provides androidx.compose.ui.unit.LayoutDirection.Ltr
+        val isRtl = androidx.compose.ui.platform.LocalLayoutDirection.current == androidx.compose.ui.unit.LayoutDirection.Rtl
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(top = AppTopBarContentTopInset)
+                .zIndex(3f)
         ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(top = AppTopBarContentTopInset)
-                    .zIndex(3f)
-            ) {
-                heroItem?.let { item ->
-                    if (!item.status.orEmpty().startsWith("collection:")) {
-                        HeroSection(
-                            item = item,
-                            logoUrl = heroLogoUrl,
-                            overviewOverride = heroOverviewOverride,
-                            showBudget = showBudget,
-                            modifier = Modifier
-                                .align(Alignment.BottomStart)
-                                .padding(start = contentStartPadding, end = 400.dp)
-                                .offset(y = -heroBottomPadding)
-                        )
-                    }
+            heroItem?.let { item ->
+                if (!item.status.orEmpty().startsWith("collection:")) {
+                    HeroSection(
+                        item = item,
+                        logoUrl = heroLogoUrl,
+                        overviewOverride = heroOverviewOverride,
+                        showBudget = showBudget,
+                        modifier = Modifier
+                            .align(if (isRtl) Alignment.BottomEnd else Alignment.BottomStart)
+                            .padding(
+                                start = if (isRtl) 400.dp else contentStartPadding,
+                                end = if (isRtl) contentStartPadding else 400.dp
+                            )
+                            .offset(y = -heroBottomPadding)
+                    )
                 }
             }
         }
@@ -3406,6 +3408,7 @@ private fun ContentRow(
             category.items
         }
     }
+    val isRtlLayout = androidx.compose.ui.platform.LocalLayoutDirection.current == androidx.compose.ui.unit.LayoutDirection.Rtl
     val totalItems = itemsToRender.size
     val maxFirstIndex = remember(totalItems) {
         (totalItems - 1).coerceAtLeast(0)
@@ -3521,7 +3524,8 @@ private fun ContentRow(
                         isFastScrolling -> 115
                         jumpDistance >= 3 -> 180
                         else -> 150
-                    }
+                    },
+                    isRtl = isRtlLayout
                 )
                 if (
                     !isFastScrolling && (

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
@@ -953,7 +953,7 @@ class HomeViewModel @Inject constructor(
         val fallbackLanguage = prefs[LAST_APP_LANGUAGE_KEY] ?: "en-US"
         val language = prefs[profileManager.profileStringKeyFor(profileId, "content_language")]
             ?: fallbackLanguage
-        mediaRepository.contentLanguage = if (language == "en-US") null else language
+        mediaRepository.contentLanguage = language
         return language
     }
 
@@ -981,7 +981,20 @@ class HomeViewModel @Inject constructor(
                 .getParameterized(MutableList::class.java, Category::class.java)
                 .type
             val parsed: List<Category> = gson.fromJson(json, type) ?: emptyList()
-            parsed.filter { it.items.isNotEmpty() }
+            var hadBlankTitles = false
+            val sanitized = parsed.map { cat ->
+                val cleanItems = cat.items.filter { item ->
+                    val isValid = item.title.isNotBlank() && item.title != "Unknown"
+                    if (!isValid) hadBlankTitles = true
+                    isValid
+                }
+                cat.copy(items = cleanItems)
+            }.filter { it.items.isNotEmpty() }
+
+            if (hadBlankTitles) {
+                file.delete()
+            }
+            sanitized
         }.getOrDefault(emptyList())
     }
     // IO concurrency for network requests (logo fetches, catalog loads, etc.)
@@ -1408,6 +1421,9 @@ class HomeViewModel @Inject constructor(
                 ).collect { preferences ->
                     val previousState = _uiState.value
                     val autoplayJustEnabled = !previousState.trailerAutoPlay && preferences.trailerAutoPlay
+                    val langChanged = mediaRepository.contentLanguage != preferences.contentLanguage
+                    mediaRepository.contentLanguage = preferences.contentLanguage
+
                     _uiState.value = previousState.copy(
                         trailerAutoPlay = preferences.trailerAutoPlay,
                         trailerSoundEnabled = preferences.trailerSoundEnabled,
@@ -1418,7 +1434,13 @@ class HomeViewModel @Inject constructor(
                         smoothScrolling = preferences.smoothScrolling
                     )
 
-                    if (autoplayJustEnabled) {
+                    if (langChanged) {
+                        mediaRepository.clearMediaCache()
+                        runCatching {
+                            context.cacheDir.listFiles()?.filter { it.name.startsWith("home_categories_cache_") }?.forEach { it.delete() }
+                        }
+                        loadHomeData()
+                    } else if (autoplayJustEnabled) {
                         _uiState.value.heroItem?.let(::hydrateHeroDetailsIfNeeded)
                     }
                 }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
@@ -942,7 +942,7 @@ class HomeViewModel @Inject constructor(
         val profileId = profileManager.getProfileIdSync()
             .ifBlank { "default" }
             .replace(HomeVMRegexes.ALPHANUMERIC_REGEX, "_")
-        val language = (mediaRepository.contentLanguage ?: "en-US")
+        val language = mediaRepository.contentLanguage
             .replace(HomeVMRegexes.ALPHANUMERIC_REGEX, "_")
         return java.io.File(context.cacheDir, "home_categories_cache_${profileId}_$language.json")
     }
@@ -1035,6 +1035,7 @@ class HomeViewModel @Inject constructor(
     private var watchedBadgesJob: Job? = null
     private var loadHomeRequestId: Long = 0L
     private var activeRuntimeProfileId: String? = null
+    private var observedContentLanguage: String? = null
     private val HERO_DEBOUNCE_MS = 80L // Short debounce; focus idle is handled in HomeScreen
     private val startupCreatedAtMs = SystemClock.elapsedRealtime()
     private val startupSettleMs = if (isLowRamDevice) 5_000L else 4_000L
@@ -1386,6 +1387,21 @@ class HomeViewModel @Inject constructor(
         }
     }
 
+    private fun invalidateContentLanguageCaches() {
+        heroUpdateJob?.cancel()
+        heroDetailsJob?.cancel()
+        prefetchJob?.cancel()
+        heroDetailsCache.clear()
+        heroDetailsFetchInFlight.clear()
+        lastResolvedBaseCategories = emptyList()
+        mediaRepository.clearMediaCache()
+        _uiState.value = _uiState.value.copy(
+            heroOverviewOverride = null,
+            heroTrailerKey = null,
+            isHeroTransitioning = false
+        )
+    }
+
     init {
         viewModelScope.launch {
             streamRepository.installedAddons.collectLatest { addons ->
@@ -1421,8 +1437,10 @@ class HomeViewModel @Inject constructor(
                 ).collect { preferences ->
                     val previousState = _uiState.value
                     val autoplayJustEnabled = !previousState.trailerAutoPlay && preferences.trailerAutoPlay
-                    val langChanged = mediaRepository.contentLanguage != preferences.contentLanguage
                     mediaRepository.contentLanguage = preferences.contentLanguage
+                    val normalizedLanguage = mediaRepository.contentLanguage
+                    val langChanged = observedContentLanguage?.let { it != normalizedLanguage } ?: false
+                    observedContentLanguage = normalizedLanguage
 
                     _uiState.value = previousState.copy(
                         trailerAutoPlay = preferences.trailerAutoPlay,
@@ -1435,10 +1453,7 @@ class HomeViewModel @Inject constructor(
                     )
 
                     if (langChanged) {
-                        mediaRepository.clearMediaCache()
-                        runCatching {
-                            context.cacheDir.listFiles()?.filter { it.name.startsWith("home_categories_cache_") }?.forEach { it.delete() }
-                        }
+                        invalidateContentLanguageCaches()
                         loadHomeData()
                     } else if (autoplayJustEnabled) {
                         _uiState.value.heroItem?.let(::hydrateHeroDetailsIfNeeded)

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -1107,9 +1107,6 @@ class SettingsViewModel @Inject constructor(
                 .edit().putString("locale_tag", lang).apply()
             mediaRepository.contentLanguage = lang
             _uiState.value = _uiState.value.copy(contentLanguage = lang)
-            runCatching {
-                context.cacheDir.listFiles()?.filter { it.name.startsWith("home_categories_cache_") }?.forEach { it.delete() }
-            }
             syncLocalStateToCloud(silent = true)
         }
     }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -445,7 +445,7 @@ class SettingsViewModel @Inject constructor(
             val oledBlackBackground = prefs[com.arflix.tv.util.OLED_BLACK_BACKGROUND_KEY] ?: false
             val contentLang = prefs[contentLanguageKey()] ?: "en-US"
             // Apply content language to MediaRepository immediately
-            mediaRepository.contentLanguage = if (contentLang == "en-US") null else contentLang
+            mediaRepository.contentLanguage = contentLang
             var autoPlay = prefs[autoPlayNextKey()] ?: true
             var autoPlaySingleSource = prefs[autoPlaySingleSourceKey()] ?: true
             // Ensure defaults are persisted on first launch so they're never ambiguous
@@ -1090,8 +1090,11 @@ class SettingsViewModel @Inject constructor(
             // Mirror to SharedPreferences so attachBaseContext can read it synchronously on next launch
             context.getSharedPreferences("app_locale", android.content.Context.MODE_PRIVATE)
                 .edit().putString("locale_tag", lang).apply()
-            mediaRepository.contentLanguage = if (lang == "en-US") null else lang
+            mediaRepository.contentLanguage = lang
             _uiState.value = _uiState.value.copy(contentLanguage = lang)
+            runCatching {
+                context.cacheDir.listFiles()?.filter { it.name.startsWith("home_categories_cache_") }?.forEach { it.delete() }
+            }
             syncLocalStateToCloud(silent = true)
         }
     }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -61,4 +61,6 @@
     <string name="add_later">أضف أفلاما ومسلسلات للمشاهدة لاحقا</string>
     <string name="sources_available">مصادر متاحة</string>
     <string name="ends_at">ينتهي في</string>
+    <string name="home_top10_movies_today">أفضل 10 أفلام اليوم</string>
+    <string name="home_top10_shows_today">أفضل 10 مسلسلات اليوم</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -240,4 +240,6 @@
     <string name="settings_trakt_desc">סנכרון היסטוריית צפייה, התקדמות ורשימת צפייה</string>
     <string name="mdblist_key_help">השג את מפתח ה-API שלך מ-mdblist.com/preferences</string>
     <string name="settings_telegram_desc">חפש קובצי וידאו בערוצים ובקבוצות שלך</string>
+    <string name="home_top10_movies_today">10 הסרטים הנצפים היום</string>
+    <string name="home_top10_shows_today">10 הסדרות הנצפות היום</string>
 </resources>

--- a/app/src/test/kotlin/com/arflix/tv/ui/screens/home/HomeProfilePreferencesTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/ui/screens/home/HomeProfilePreferencesTest.kt
@@ -66,5 +66,31 @@ class HomeProfilePreferencesTest {
         assertThat(settings.showBudget).isTrue()
         assertThat(settings.clockFormat).isEqualTo("24h")
         assertThat(settings.smoothScrolling).isFalse()
+        assertThat(settings.contentLanguage).isEqualTo("en-US")
+    }
+
+    @Test
+    fun `missing profile language uses last app language`() {
+        val settings = readHomeProfilePreferences(
+            mutablePreferencesOf(
+                stringPreferencesKey("last_app_language") to "ar-SA"
+            ),
+            "primary"
+        )
+
+        assertThat(settings.contentLanguage).isEqualTo("ar-SA")
+    }
+
+    @Test
+    fun `profile language overrides last app language`() {
+        val settings = readHomeProfilePreferences(
+            mutablePreferencesOf(
+                stringPreferencesKey("last_app_language") to "ar-SA",
+                stringPreferencesKey("profile_primary_content_language") to "iw-IL"
+            ),
+            "primary"
+        )
+
+        assertThat(settings.contentLanguage).isEqualTo("iw-IL")
     }
 }


### PR DESCRIPTION
## Summary

Fixes #327 and makes Home react correctly when the active profile's content language changes.

- Correct the custom smooth-scroll direction for RTL Home rails.
- Let Compose mirror the TV hero through logical `Start`/`End` positioning exactly once.
- Localize the Top 10 row titles, including Arabic and Hebrew resources.
- Send an explicit normalized TMDB content language and fall back to original titles when a translation is blank.
- Invalidate localized media and Home hero state when the observed profile language changes, then reload Home.
- Keep disk Home caches scoped by profile and language instead of deleting every profile's cache.
- Avoid duplicate English trailer fallback requests.

Third-party/addon catalog titles remain controlled by their providers and cannot always be translated by ARVIO.

## Verification

- `:app:compilePlayDebugKotlin`
- `:app:compileSideloadDebugKotlin`
- `:app:testPlayDebugUnitTest --tests com.arflix.tv.ui.screens.home.HomeProfilePreferencesTest`
- `git diff --check`
