### PR TITLE
fix(di): add @JvmStatic to AppModule @Provides methods for sideload flavor build

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/di/AppModule.kt
+++ b/app/src/main/kotlin/com/arflix/tv/di/AppModule.kt
@@ -27,12 +27,14 @@ object AppModule {
 
     @Provides
     @Singleton
+    @JvmStatic
     fun provideOkHttpClient(): OkHttpClient {
         return OkHttpProvider.client
     }
 
     @Provides
     @Singleton
+    @JvmStatic
     fun provideTmdbApi(okHttpClient: OkHttpClient, @dagger.hilt.android.qualifiers.ApplicationContext context: android.content.Context): TmdbApi {
         val tmdbClient = okHttpClient.newBuilder()
             .addInterceptor { chain ->
@@ -64,6 +66,7 @@ object AppModule {
 
     @Provides
     @Singleton
+    @JvmStatic
     fun provideTraktApi(okHttpClient: OkHttpClient): TraktApi {
         return Retrofit.Builder()
             .baseUrl(Constants.TRAKT_API_URL)
@@ -75,6 +78,7 @@ object AppModule {
 
     @Provides
     @Singleton
+    @JvmStatic
     fun provideMdbListApi(okHttpClient: OkHttpClient): com.arflix.tv.data.api.MdbListApi {
         return Retrofit.Builder()
             .baseUrl(Constants.MDBLIST_API_URL)
@@ -86,6 +90,7 @@ object AppModule {
 
     @Provides
     @Singleton
+    @JvmStatic
     fun provideSupabaseApi(okHttpClient: OkHttpClient): SupabaseApi {
         // Supabase API client without disk cache to prevent OkHttp from returning
         // cached responses for POST/upsert operations (which silently drops writes)
@@ -102,6 +107,7 @@ object AppModule {
 
     @Provides
     @Singleton
+    @JvmStatic
     fun provideStreamApi(okHttpClient: OkHttpClient): StreamApi {
         // Base URL doesn't matter for dynamic URLs
         return Retrofit.Builder()
@@ -116,6 +122,7 @@ object AppModule {
 
     @Provides
     @Singleton
+    @JvmStatic
     @Named("introDb")
     fun provideIntroDbRetrofit(okHttpClient: OkHttpClient): Retrofit {
         return Retrofit.Builder()
@@ -127,12 +134,14 @@ object AppModule {
 
     @Provides
     @Singleton
+    @JvmStatic
     fun provideIntroDbApi(@Named("introDb") retrofit: Retrofit): IntroDbApi {
         return retrofit.create(IntroDbApi::class.java)
     }
 
     @Provides
     @Singleton
+    @JvmStatic
     @Named("aniSkip")
     fun provideAniSkipRetrofit(okHttpClient: OkHttpClient): Retrofit {
         return Retrofit.Builder()
@@ -144,12 +153,14 @@ object AppModule {
 
     @Provides
     @Singleton
+    @JvmStatic
     fun provideAniSkipApi(@Named("aniSkip") retrofit: Retrofit): AniSkipApi {
         return retrofit.create(AniSkipApi::class.java)
     }
 
     @Provides
     @Singleton
+    @JvmStatic
     @Named("arm")
     fun provideArmRetrofit(okHttpClient: OkHttpClient): Retrofit {
         return Retrofit.Builder()
@@ -161,12 +172,14 @@ object AppModule {
 
     @Provides
     @Singleton
+    @JvmStatic
     fun provideArmApi(@Named("arm") retrofit: Retrofit): ArmApi {
         return retrofit.create(ArmApi::class.java)
     }
 
     @Provides
     @Singleton
+    @JvmStatic
     @Named("jikan")
     fun provideJikanRetrofit(okHttpClient: OkHttpClient): Retrofit {
         return Retrofit.Builder()
@@ -178,11 +191,14 @@ object AppModule {
 
     @Provides
     @Singleton
+    @JvmStatic
     fun provideJikanApi(@Named("jikan") retrofit: Retrofit): com.arflix.tv.data.api.JikanApi {
         return retrofit.create(com.arflix.tv.data.api.JikanApi::class.java)
     }
+
     @Provides
     @Singleton
+    @JvmStatic
     fun provideMoshi(): com.squareup.moshi.Moshi {
         return com.squareup.moshi.Moshi.Builder()
             .add(com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory())


### PR DESCRIPTION
### Summary
Adds @JvmStatic to @Provides methods inside AppModule object.

### Problem
When compiling variant-specific builds like sideloadDebug, Dagger Hilt fails with missing binding errors because Kotlin object methods without @JvmStatic generate instance methods on AppModule.INSTANCE rather than static providers.

### Solution
Adding @JvmStatic to all @Provides functions in AppModule ensures static provider methods are emitted into Java bytecode, allowing Hilt Dagger annotation processing to resolve all bindings across all build variants.