### PR TITLE
ci(web): deploy merged web changes automatically

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,77 @@
+name: Deploy Web App
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "web/**"
+      - ".github/workflows/deploy-web.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-web-production
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Build and deploy web.arvio.tv
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: web
+    env:
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      NETLIFY_SITE_ID: ${{ secrets.NETLIFY_WEB_SITE_ID }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Netlify bundle
+        run: npx --yes netlify-cli@25.6.0 build --context production
+
+      - name: Record expected build stamp
+        run: echo "EXPECTED_BUILD_STAMP=$(jq -r .v .netlify/static/version.json)" >> "$GITHUB_ENV"
+
+      # Deploy the generated function source so Netlify preserves its /* route.
+      - name: Deploy to production
+        run: >-
+          npx --yes netlify-cli@25.6.0 deploy
+          --prod
+          --no-build
+          --dir .netlify/static
+          --functions .netlify/functions-internal
+          --message "GitHub ${GITHUB_SHA}"
+          --timeout 900
+
+      - name: Verify production deployment
+        shell: bash
+        run: |
+          for attempt in {1..20}; do
+            status=$(curl --silent --show-error --output /dev/null --write-out "%{http_code}" https://web.arvio.tv/ || true)
+            live_stamp=$(curl --silent --show-error --fail https://web.arvio.tv/version.json | jq -r .v 2>/dev/null || true)
+            if [[ "$status" == "200" && "$live_stamp" == "$EXPECTED_BUILD_STAMP" ]]; then
+              echo "Production deployment verified: $live_stamp"
+              exit 0
+            fi
+            echo "Waiting for production: HTTP $status, stamp ${live_stamp:-missing} (attempt $attempt/20)"
+            sleep 6
+          done
+
+          echo "Production did not serve the expected build stamp $EXPECTED_BUILD_STAMP" >&2
+          exit 1


### PR DESCRIPTION
## What changed

- deploy `web/**` changes automatically when they land on `main`
- build using the Netlify production context
- upload the generated Next.js function source so its catch-all route is preserved
- verify both the live HTTP response and exact build stamp after deployment
- serialize production deploys and cancel superseded runs

## Validation

- `npx yaml-lint .github/workflows/deploy-web.yml`
- `npx netlify-cli@25.6.0 build --context production`
- verified the same static/function packaging against `web.arvio.tv`

The required Netlify token and web site ID are configured as encrypted repository secrets.