### PR TITLE
fix(auth): add client-side email format & required field validation

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -1691,13 +1691,16 @@ fun SettingsScreen(
 
         // Custom Addon Input Modal
         if (showCustomAddonInput) {
+            val isValidAddonUrl = customAddonUrl.isNotBlank() &&
+                (customAddonUrl.trim().startsWith("http://", ignoreCase = true) || customAddonUrl.trim().startsWith("https://", ignoreCase = true))
             InputModal(
                 title = stringResource(R.string.add_addon),
                 fields = listOf(
                     InputField(label = stringResource(R.string.settings_label_url), value = customAddonUrl, onValueChange = { customAddonUrl = it })
                 ),
+                isConfirmEnabled = isValidAddonUrl,
                 onConfirm = {
-                    if (customAddonUrl.isNotBlank()) {
+                    if (isValidAddonUrl) {
                         viewModel.addCustomAddon(customAddonUrl.trim())
                         customAddonUrl = ""
                         showCustomAddonInput = false
@@ -8691,6 +8694,7 @@ private fun InputModal(
     title: String,
     supportingText: String? = null,
     fields: List<InputField>,
+    isConfirmEnabled: Boolean = true,
     onConfirm: () -> Unit,
     onDismiss: () -> Unit
 ) {
@@ -8860,8 +8864,10 @@ private fun InputModal(
                                             true
                                         }
                                         focusedIndex == fields.size + 2 -> {
-                                            hideKeyboardAll()
-                                            onConfirm()
+                                            if (isConfirmEnabled) {
+                                                hideKeyboardAll()
+                                                onConfirm()
+                                            }
                                             true
                                         }
                                         else -> false
@@ -9163,25 +9169,26 @@ private fun InputModal(
                             .weight(1f)
                             .clip(RoundedCornerShape(10.dp))
                             .background(
-                                color = if (isConfirmFocused) Color.White else Color.Black.copy(alpha = 0.82f),
+                                color = if (isConfirmFocused && isConfirmEnabled) Color.White else Color.Black.copy(alpha = 0.82f),
                                 shape = RoundedCornerShape(10.dp)
                             )
                             .border(
                                 width = 1.dp,
-                                color = if (isConfirmFocused) Color.White else Color.White.copy(alpha = 0.14f),
+                                color = if (isConfirmFocused && isConfirmEnabled) Color.White else Color.White.copy(alpha = 0.14f),
                                 shape = RoundedCornerShape(10.dp)
                             )
-                            .clickable {
+                            .clickable(enabled = isConfirmEnabled) {
                                 hideKeyboardAll()
                                 onConfirm()
                             }
-                            .padding(vertical = 12.dp),
+                            .padding(vertical = 12.dp)
+                            .graphicsLayer { alpha = if (isConfirmEnabled) 1f else 0.45f },
                         contentAlignment = Alignment.Center
                     ) {
                         Text(
                             text = tr("Confirm"),
                             style = ArflixTypography.button,
-                            color = if (isConfirmFocused) Color.Black else Color.White
+                            color = if (isConfirmFocused && isConfirmEnabled) Color.Black else Color.White
                         )
                     }
                 }

--- a/netlify-auth-site/index.html
+++ b/netlify-auth-site/index.html
@@ -860,7 +860,23 @@
       throw new Error("This password link is no longer valid. Request a new reset email.");
     }
 
+    function validateFormInputs() {
+      const emailVal = emailEl.value.trim();
+      const passVal = passEl.value;
+      if (!emailVal || !passVal) {
+        return "Email and password are required.";
+      }
+      const emailErr = validateEmail(emailVal, false);
+      if (emailErr) return emailErr;
+      return null;
+    }
+
     signInBtn.onclick = async () => {
+      const validationError = validateFormInputs();
+      if (validationError) {
+        setStatus(validationError, "error");
+        return;
+      }
       try {
         setBusy(true);
         setStatus("Signing in...");
@@ -886,6 +902,11 @@
     };
 
     signUpBtn.onclick = async () => {
+      const validationError = validateFormInputs();
+      if (validationError) {
+        setStatus(validationError, "error");
+        return;
+      }
       try {
         setBusy(true);
         const email = requireValidEmail(emailEl.value);

--- a/web/components/settings/SettingsScreen.tsx
+++ b/web/components/settings/SettingsScreen.tsx
@@ -2177,7 +2177,7 @@ function AddonsSection() {
         <button
           type="button"
           className="primary"
-          disabled={installing}
+          disabled={installing || !addonUrl.trim()}
           onClick={() => void install()}
         >
           <Plus size={18} /> {installing ? "Installing..." : "Install"}


### PR DESCRIPTION
## Summary
Fixes #531, #532, and #533.

Previously, auth forms and addon URL inputs accepted blank fields or invalid email formats without client-side validation, causing unnecessary backend auth calls and unresponsive submission feedback.

### Changes
- **Auth Site**: Added `validateFormInputs()` in `index.html` to validate non-empty fields and email regex before sending requests.
- **Web Settings**: Disabled Addon Install button when input is blank.
- **Android TV Settings**: Added `isConfirmEnabled` property to `InputModal` to disable Confirm button and D-pad Enter when input is blank or not a valid `http(s)://` URL.
