### PR TITLE
fix: add GitHub raw fallback & reduced timeout for Pastebin manifest

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/MediaRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/MediaRepository.kt
@@ -573,7 +573,8 @@ class MediaRepository @Inject constructor(
     fun getDefaultCatalogConfigs(): List<CatalogConfig> = buildPreinstalledDefaults()
 
     companion object {
-        const val STREAMING_COLLECTION_ADDON_URL = "https://pastebin.com/raw/P4gfd98n"
+        const val STREAMING_COLLECTION_ADDON_URL = "https://raw.githubusercontent.com/ProdigyV21/ARVIO/main/config/streaming_addon.txt"
+        const val PASTEBIN_STREAMING_ADDON_URL = "https://pastebin.com/raw/P4gfd98n"
         private val UPLOADED_COVER_BASE = "https://" + "nu" + "vioapp.space/uploads/covers/"
 
         /**

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
@@ -1268,24 +1268,47 @@ class StreamRepository @Inject constructor(
 
     private suspend fun resolveAddonInstallUrl(rawUrl: String): String {
         val normalized = normalizeAddonInputUrl(rawUrl)
-        if (!normalized.contains("pastebin.com/raw/", ignoreCase = true)) {
+        val isRawTextManifest = normalized.contains("pastebin.com/raw/", ignoreCase = true) ||
+            normalized.contains("raw.githubusercontent.com/", ignoreCase = true) ||
+            normalized.endsWith(".txt", ignoreCase = true)
+        if (!isRawTextManifest) {
             return normalized
         }
-        val request = Request.Builder().url(normalized).build()
-        val body = runCatching {
-            okHttpClient.newCall(request).execute().use { response ->
-                if (!response.isSuccessful) return normalized
-                response.body?.string().orEmpty()
-            }
-        }.getOrDefault("")
-        val link = body.lineSequence()
-            .map { it.trim() }
-            .firstOrNull { line ->
-                line.startsWith("stremio://", ignoreCase = true) ||
-                    line.startsWith("https://", ignoreCase = true) ||
-                    line.startsWith("http://", ignoreCase = true)
-            }
-        return if (link.isNullOrBlank()) normalized else normalizeAddonInputUrl(link)
+
+        val fastClient = okHttpClient.newBuilder()
+            .connectTimeout(3500, java.util.concurrent.TimeUnit.MILLISECONDS)
+            .readTimeout(3500, java.util.concurrent.TimeUnit.MILLISECONDS)
+            .build()
+
+        fun fetchManifestUrl(targetUrl: String): String? {
+            val request = Request.Builder().url(targetUrl).build()
+            val body = runCatching {
+                fastClient.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) return null
+                    response.body?.string().orEmpty()
+                }
+            }.getOrNull() ?: return null
+
+            val link = body.lineSequence()
+                .map { it.trim() }
+                .firstOrNull { line ->
+                    line.startsWith("stremio://", ignoreCase = true) ||
+                        line.startsWith("https://", ignoreCase = true) ||
+                        line.startsWith("http://", ignoreCase = true)
+                }
+            return link?.takeIf { it.isNotBlank() }?.let { normalizeAddonInputUrl(it) }
+        }
+
+        val primaryResult = fetchManifestUrl(normalized)
+        if (primaryResult != null) return primaryResult
+
+        val fallbackUrl = if (normalized.contains("pastebin.com", ignoreCase = true)) {
+            MediaRepository.STREAMING_COLLECTION_ADDON_URL
+        } else {
+            MediaRepository.PASTEBIN_STREAMING_ADDON_URL
+        }
+        val fallbackResult = fetchManifestUrl(fallbackUrl)
+        return fallbackResult ?: normalized
     }
 
     suspend fun getAddonCatalogPage(

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
@@ -2071,7 +2071,7 @@ class HomeViewModel @Inject constructor(
                     runCatching {
                         streamRepository.removeCustomAddonsByUrl(
                             CollectionTemplateManifest.autoInstalledAddonUrls() +
-                                listOf(MediaRepository.STREAMING_COLLECTION_ADDON_URL)
+                                listOf(MediaRepository.STREAMING_COLLECTION_ADDON_URL, MediaRepository.PASTEBIN_STREAMING_ADDON_URL)
                         )
                         val addons = streamRepository.installedAddons.first()
                         catalogRepository.syncAddonCatalogs(addons)

--- a/app/src/test/kotlin/com/arflix/tv/data/repository/StreamAddonFallbackTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/repository/StreamAddonFallbackTest.kt
@@ -1,0 +1,19 @@
+package com.arflix.tv.data.repository
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class StreamAddonFallbackTest {
+
+    @Test
+    fun constants_verifyPrimaryAndFallbackUrlsAreConfigured() {
+        assertEquals(
+            "https://raw.githubusercontent.com/ProdigyV21/ARVIO/main/config/streaming_addon.txt",
+            MediaRepository.STREAMING_COLLECTION_ADDON_URL
+        )
+        assertEquals(
+            "https://pastebin.com/raw/P4gfd98n",
+            MediaRepository.PASTEBIN_STREAMING_ADDON_URL
+        )
+    }
+}

--- a/config/streaming_addon.txt
+++ b/config/streaming_addon.txt
@@ -1,0 +1,1 @@
+https://7a82163c306e-stremio-netflix-catalog-addon.baby-beamup.club/bmZ4LGRucCxhbXAsYXRwLGhibSxwbXAscGNwLGhsdTo6OjE3NzU5MzEzMzkxNzU6MDowOg%3D%3D/manifest.json


### PR DESCRIPTION
## Summary
Fixes #537

Hardcoded Pastebin dependency (`https://pastebin.com/raw/P4gfd98n`) caused a ~14-second TCP connection timeout on startup for users in Turkey and regions where Pastebin is blocked.

### Changes
- **Config**: Added repository-hosted `config/streaming_addon.txt`.
- **MediaRepository**: Updated `STREAMING_COLLECTION_ADDON_URL` to GitHub raw URL and retained `PASTEBIN_STREAMING_ADDON_URL` as secondary fallback.
- **StreamRepository**: Updated `resolveAddonInstallUrl` to use a 3.5s fast timeout and automatic fallback chain between GitHub raw and Pastebin.
- **HomeViewModel**: Updated auto-installed addon cleanup list to handle both manifest URLs.
- **Unit Tests**: Added `StreamAddonFallbackTest`.