### PR TITLE
fix(stream): make PenguPlay timeout handling safe

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
@@ -112,6 +112,13 @@ internal fun buildTmdbEpisodeIdCandidate(
     return "tmdb:$tmdbId:$season:$episode"
 }
 
+internal fun buildEpisodeAddonLookupIds(imdbId: String, tmdbId: Int?): List<String> {
+    return buildList {
+        add(imdbId)
+        if (tmdbId != null) add("tmdb:$tmdbId")
+    }.distinct()
+}
+
 internal fun buildNativeAnimeRetryCandidates(
     seriesId: String,
     animeQuery: String?,
@@ -1575,12 +1582,9 @@ class StreamRepository @Inject constructor(
         genreIds: List<Int>,
         originalLanguage: String?
     ): List<Addon> {
-        val seriesAddons = buildList {
-            addAll(getStreamAddons(addons, "series", imdbId))
-            if (tmdbId != null) {
-                addAll(getStreamAddons(addons, "series", "tmdb:$tmdbId"))
-            }
-        }.distinctBy { it.id }
+        val seriesAddons = buildEpisodeAddonLookupIds(imdbId, tmdbId)
+            .flatMap { id -> getStreamAddons(addons, "series", id) }
+            .distinctBy { it.id }
         val hasNativeAnimeAddon = addons.any(::shouldPreferNativeAnimeIds)
         val shouldIncludeAnimeAddons = isAnime ||
             shouldTryNativeAnimeFallback(
@@ -1603,7 +1607,7 @@ class StreamRepository @Inject constructor(
     // debrid-backed addons (Torrentio, MediaFusion, etc.) that resolve remotely.
     private val ADDON_TIMEOUT_MS = 6_000L
     private val ADDON_EPISODE_TIMEOUT_MS = 10_000L
-    private val ADDON_SINGLE_STREAM_REQUEST_TIMEOUT_MS = 8_000L
+    private val ADDON_SINGLE_STREAM_REQUEST_TIMEOUT_MS = 4_000L
     private val ADDON_NATIVE_ANIME_EPISODE_TIMEOUT_MS = 24_000L
     private val ADDON_NATIVE_ANIME_SINGLE_STREAM_REQUEST_TIMEOUT_MS = 12_000L
     private val ANIME_ID_LOOKUP_TIMEOUT_MS = 3_000L
@@ -1612,7 +1616,7 @@ class StreamRepository @Inject constructor(
     private val ADDON_EXTENDED_TIMEOUT_MS = 30_000L
     private val ADDON_EXTENDED_EPISODE_TIMEOUT_MS = 45_000L
     private val ADDON_EXTENDED_SINGLE_STREAM_REQUEST_TIMEOUT_MS = 35_000L
-    // Aggregators (AIOStreams/Comet/MediaFusion/HdHub) can take well over the default timeout
+    // Aggregators (AIOStreams/Comet/MediaFusion/HdHub/PenguPlay) can take well over the default timeout
     // on a cold request. Progressive fetch keeps them from blocking faster addon results.
     private val ADDON_AGGREGATOR_TIMEOUT_MS = 20_000L
     private val ADDON_AGGREGATOR_EPISODE_TIMEOUT_MS = 25_000L

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
@@ -198,7 +198,8 @@ internal fun usesSlowAggregatorTimeout(addon: Addon): Boolean {
         haystack.contains("aio-streams") ||
         haystack.contains("comet") ||
         haystack.contains("mediafusion") ||
-        haystack.contains("hdhub")
+        haystack.contains("hdhub") ||
+        haystack.contains("pengu")
 }
 
 // --- HubCloud/HubDrive URL classification (pure, unit-tested) --------------------
@@ -1574,7 +1575,12 @@ class StreamRepository @Inject constructor(
         genreIds: List<Int>,
         originalLanguage: String?
     ): List<Addon> {
-        val seriesAddons = getStreamAddons(addons, "series", imdbId)
+        val seriesAddons = buildList {
+            addAll(getStreamAddons(addons, "series", imdbId))
+            if (tmdbId != null) {
+                addAll(getStreamAddons(addons, "series", "tmdb:$tmdbId"))
+            }
+        }.distinctBy { it.id }
         val hasNativeAnimeAddon = addons.any(::shouldPreferNativeAnimeIds)
         val shouldIncludeAnimeAddons = isAnime ||
             shouldTryNativeAnimeFallback(
@@ -1597,7 +1603,7 @@ class StreamRepository @Inject constructor(
     // debrid-backed addons (Torrentio, MediaFusion, etc.) that resolve remotely.
     private val ADDON_TIMEOUT_MS = 6_000L
     private val ADDON_EPISODE_TIMEOUT_MS = 10_000L
-    private val ADDON_SINGLE_STREAM_REQUEST_TIMEOUT_MS = 4_000L
+    private val ADDON_SINGLE_STREAM_REQUEST_TIMEOUT_MS = 8_000L
     private val ADDON_NATIVE_ANIME_EPISODE_TIMEOUT_MS = 24_000L
     private val ADDON_NATIVE_ANIME_SINGLE_STREAM_REQUEST_TIMEOUT_MS = 12_000L
     private val ANIME_ID_LOOKUP_TIMEOUT_MS = 3_000L

--- a/app/src/test/kotlin/com/arflix/tv/data/repository/StreamAddonTimeoutPolicyTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/repository/StreamAddonTimeoutPolicyTest.kt
@@ -9,6 +9,17 @@ import org.junit.Test
 
 class StreamAddonTimeoutPolicyTest {
     @Test
+    fun `penguplay configured instances use the slow aggregator timeout`() {
+        val addon = addon(
+            id = "com.penguplay.configured",
+            name = "PenguPlay",
+            manifestId = "com.penguplay"
+        )
+
+        assertTrue(usesSlowAggregatorTimeout(addon))
+    }
+
+    @Test
     fun `hdhub configured instances use the slow aggregator timeout`() {
         val addon = addon(
             id = "com.stremio.HdHub_configured",

--- a/app/src/test/kotlin/com/arflix/tv/data/repository/StreamEpisodeRequestPlannerTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/repository/StreamEpisodeRequestPlannerTest.kt
@@ -38,6 +38,22 @@ class StreamEpisodeRequestPlannerTest {
     }
 
     @Test
+    fun `generic series without anime query includes tmdb episode candidate`() {
+        val candidates = buildEpisodeIdCandidates(
+            seriesId = "tt9054364:1:2",
+            animeQuery = null,
+            tmdbEpisodeId = "tmdb:82684:1:2",
+            preferNativeAnimeIds = false
+        )
+
+        assertEquals(
+            listOf("tt9054364:1:2", "tmdb:82684:1:2"),
+            candidates.map { it.contentId }
+        )
+        assertEquals(listOf("imdb", "tmdb"), candidates.map { it.label })
+    }
+
+    @Test
     fun `native anime addons can skip ambiguous tmdb episode ids`() {
         val candidates = buildEpisodeIdCandidates(
             seriesId = "tt9054364:3:1",

--- a/app/src/test/kotlin/com/arflix/tv/data/repository/StreamEpisodeRequestPlannerTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/repository/StreamEpisodeRequestPlannerTest.kt
@@ -38,19 +38,15 @@ class StreamEpisodeRequestPlannerTest {
     }
 
     @Test
-    fun `generic series without anime query includes tmdb episode candidate`() {
-        val candidates = buildEpisodeIdCandidates(
-            seriesId = "tt9054364:1:2",
-            animeQuery = null,
-            tmdbEpisodeId = "tmdb:82684:1:2",
-            preferNativeAnimeIds = false
-        )
-
+    fun `episode addon lookup includes imdb and tmdb ids`() {
         assertEquals(
-            listOf("tt9054364:1:2", "tmdb:82684:1:2"),
-            candidates.map { it.contentId }
+            listOf("tt9054364", "tmdb:82684"),
+            buildEpisodeAddonLookupIds(imdbId = "tt9054364", tmdbId = 82684)
         )
-        assertEquals(listOf("imdb", "tmdb"), candidates.map { it.label })
+        assertEquals(
+            listOf("tt9054364"),
+            buildEpisodeAddonLookupIds(imdbId = "tt9054364", tmdbId = null)
+        )
     }
 
     @Test


### PR DESCRIPTION
Replacement for #526 because the contributor fork does not allow maintainer edits and the original PR was stacked on #525. The feature commit remains authored by @Himanth-reddy.\n\nThis keeps the normal per-request timeout at 4 seconds, classifies PenguPlay under the existing slow-aggregator policy, discovers TMDB-only series addons without losing custom addons, and adds focused regression tests.\n\nLocal verification:\n- :app:compilePlayDebugKotlin\n- :app:testSideloadDebugUnitTest\n- focused PenguPlay timeout and episode lookup tests\n\nSupersedes #526.