### PR TITLE
fix(sync): enforce single tracking integration connection at a time

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/simkl/SimklAuthManager.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/simkl/SimklAuthManager.kt
@@ -43,6 +43,7 @@ class SimklAuthManager @Inject constructor(
         val response = simklApi.pollPinToken(userCode, effectiveClientId)
         if (response.result.equals("OK", ignoreCase = true) && !response.accessToken.isNullOrBlank()) {
             syncProviderStore.setSimklAccessToken(response.accessToken)
+            syncProviderStore.setMdbListApiKey(null)
             syncProviderStore.setProvider(SyncProvider.SIMKL)
             return true
         }

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/sync/SyncProviderStore.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/sync/SyncProviderStore.kt
@@ -69,7 +69,10 @@ class SyncProviderStore @Inject constructor(
                 SyncProvider.SIMKL -> {
                     prefs.remove(mdbListKey())
                 }
-                SyncProvider.NONE -> {}
+                SyncProvider.NONE -> {
+                    prefs.remove(mdbListKey())
+                    prefs.remove(simklAccessTokenKey())
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/sync/SyncProviderStore.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/sync/SyncProviderStore.kt
@@ -57,6 +57,21 @@ class SyncProviderStore @Inject constructor(
                 prefs[providerKey()] = provider.toStorage()
             }
         }
+        context.traktDataStore.edit { prefs ->
+            when (provider) {
+                SyncProvider.TRAKT -> {
+                    prefs.remove(mdbListKey())
+                    prefs.remove(simklAccessTokenKey())
+                }
+                SyncProvider.MDBLIST -> {
+                    prefs.remove(simklAccessTokenKey())
+                }
+                SyncProvider.SIMKL -> {
+                    prefs.remove(mdbListKey())
+                }
+                SyncProvider.NONE -> {}
+            }
+        }
     }
 
     private fun simklAccessTokenKey() = profileManager.profileStringKey("simkl_access_token")
@@ -137,13 +152,13 @@ class SyncProviderStore @Inject constructor(
         }
         context.traktDataStore.edit { prefs ->
             values.forEach { (profileId, selection) ->
-                val key = selection.mdbListApiKey?.trim().orEmpty()
+                val key = if (selection.provider == SyncProvider.MDBLIST) selection.mdbListApiKey?.trim().orEmpty() else ""
                 if (key.isEmpty()) {
                     prefs.remove(mdbListKeyFor(profileId))
                 } else {
                     prefs[mdbListKeyFor(profileId)] = key
                 }
-                val simklToken = selection.simklAccessToken?.trim().orEmpty()
+                val simklToken = if (selection.provider == SyncProvider.SIMKL) selection.simklAccessToken?.trim().orEmpty() else ""
                 if (simklToken.isEmpty()) {
                     prefs.remove(simklAccessTokenKeyFor(profileId))
                 } else {

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -3737,6 +3737,8 @@ class SettingsViewModel @Inject constructor(
                             isMdbListConnected = false,
                             isSimklConnected = true
                         )
+                        syncLocalStateToCloud(silent = true, force = true)
+                        runCatching { launcherContinueWatchingRepository.refreshForCurrentProfile() }
                         return@launch
                     }
                 } catch (e: Exception) {
@@ -3756,7 +3758,8 @@ class SettingsViewModel @Inject constructor(
 
     fun pollSimklAuth() {
         val userCode = _uiState.value.simklUserCode ?: return
-        viewModelScope.launch {
+        simklPollingJob?.cancel()
+        simklPollingJob = viewModelScope.launch {
             runCatching {
                 val success = simklAuthManager.pollPinAuth(userCode)
                 if (success) {
@@ -3783,6 +3786,8 @@ class SettingsViewModel @Inject constructor(
                         isMdbListConnected = false,
                         isSimklConnected = true
                     )
+                    syncLocalStateToCloud(silent = true, force = true)
+                    runCatching { launcherContinueWatchingRepository.refreshForCurrentProfile() }
                 }
             }
         }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -3486,7 +3486,10 @@ class SettingsViewModel @Inject constructor(
                     val expirationDate = traktRepository.getTokenExpirationDate()
 
                     // Success!
-                    // Mutual exclusion: selecting Trakt disconnects MDBList for this profile.
+                    // Mutual exclusion: selecting Trakt disconnects MDBList and Simkl for this profile.
+                    simklPollingJob?.cancel()
+                    simklPollingJob = null
+                    runCatching { simklAuthManager.disconnect() }
                     syncProviderStore.setProvider(com.arflix.tv.data.repository.sync.SyncProvider.TRAKT)
                     syncProviderStore.setMdbListApiKey(null)
                     _uiState.value = _uiState.value.copy(
@@ -3494,6 +3497,11 @@ class SettingsViewModel @Inject constructor(
                         traktUsername = null,
                         isMdbListConnected = false,
                         mdbListUsername = null,
+                        isSimklConnected = false,
+                        simklUsername = null,
+                        isSimklPolling = false,
+                        simklUserCode = null,
+                        simklVerificationUrl = null,
                         traktCode = null,
                         isTraktAuthStarting = false,
                         isTraktPolling = false,
@@ -3504,7 +3512,8 @@ class SettingsViewModel @Inject constructor(
                     refreshIntegrationUsernames(
                         profileManager.getProfileIdSync(),
                         isTraktConnected = true,
-                        isMdbListConnected = false
+                        isMdbListConnected = false,
+                        isSimklConnected = false
                     )
                     traktRepository.clearContinueWatchingCache()
                     runCatching { traktRepository.getContinueWatching() }
@@ -3613,9 +3622,12 @@ class SettingsViewModel @Inject constructor(
                 )
                 return@launch
             }
-            // Mutual exclusion: drop Trakt for this profile.
+            // Mutual exclusion: drop Trakt and Simkl for this profile.
             cancelTraktAuth()
             runCatching { traktRepository.logout() }
+            simklPollingJob?.cancel()
+            simklPollingJob = null
+            runCatching { simklAuthManager.disconnect() }
             syncProviderStore.setMdbListApiKey(trimmed)
             syncProviderStore.setProvider(com.arflix.tv.data.repository.sync.SyncProvider.MDBLIST)
             _uiState.value = _uiState.value.copy(
@@ -3625,6 +3637,11 @@ class SettingsViewModel @Inject constructor(
                 isTraktAuthenticated = false,
                 traktUsername = null,
                 traktExpiration = null,
+                isSimklConnected = false,
+                simklUsername = null,
+                isSimklPolling = false,
+                simklUserCode = null,
+                simklVerificationUrl = null,
                 lastSyncTime = null,
                 syncedMovies = 0,
                 syncedEpisodes = 0,
@@ -3634,7 +3651,8 @@ class SettingsViewModel @Inject constructor(
             refreshIntegrationUsernames(
                 profileManager.getProfileIdSync(),
                 isTraktConnected = false,
-                isMdbListConnected = true
+                isMdbListConnected = true,
+                isSimklConnected = false
             )
             // The MDBList watchlist is pulled when the Watchlist screen next loads.
             syncLocalStateToCloud(silent = true, force = true)
@@ -3696,19 +3714,27 @@ class SettingsViewModel @Inject constructor(
                 try {
                     val success = simklAuthManager.pollPinAuth(userCode)
                     if (success) {
+                        cancelTraktAuth()
+                        runCatching { traktRepository.logout() }
+                        syncProviderStore.setMdbListApiKey(null)
                         syncProviderStore.setProvider(com.arflix.tv.data.repository.sync.SyncProvider.SIMKL)
                         _uiState.value = _uiState.value.copy(
                             isSimklPolling = false,
                             isSimklConnected = true,
                             simklUserCode = null,
                             simklVerificationUrl = null,
+                            isTraktAuthenticated = false,
+                            traktUsername = null,
+                            traktExpiration = null,
+                            isMdbListConnected = false,
+                            mdbListUsername = null,
                             toastMessage = "Connected to Simkl!",
                             toastType = ToastType.SUCCESS
                         )
                         refreshIntegrationUsernames(
                             profileManager.getProfileIdSync(),
-                            isTraktConnected = _uiState.value.isTraktAuthenticated,
-                            isMdbListConnected = _uiState.value.isMdbListConnected,
+                            isTraktConnected = false,
+                            isMdbListConnected = false,
                             isSimklConnected = true
                         )
                         return@launch
@@ -3734,19 +3760,27 @@ class SettingsViewModel @Inject constructor(
             runCatching {
                 val success = simklAuthManager.pollPinAuth(userCode)
                 if (success) {
+                    cancelTraktAuth()
+                    runCatching { traktRepository.logout() }
+                    syncProviderStore.setMdbListApiKey(null)
                     syncProviderStore.setProvider(com.arflix.tv.data.repository.sync.SyncProvider.SIMKL)
                     _uiState.value = _uiState.value.copy(
                         isSimklPolling = false,
                         isSimklConnected = true,
                         simklUserCode = null,
                         simklVerificationUrl = null,
+                        isTraktAuthenticated = false,
+                        traktUsername = null,
+                        traktExpiration = null,
+                        isMdbListConnected = false,
+                        mdbListUsername = null,
                         toastMessage = "Connected to Simkl!",
                         toastType = ToastType.SUCCESS
                     )
                     refreshIntegrationUsernames(
                         profileManager.getProfileIdSync(),
-                        isTraktConnected = _uiState.value.isTraktAuthenticated,
-                        isMdbListConnected = _uiState.value.isMdbListConnected,
+                        isTraktConnected = false,
+                        isMdbListConnected = false,
                         isSimklConnected = true
                     )
                 }

--- a/app/src/test/kotlin/com/arflix/tv/data/repository/simkl/SimklIntegrationTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/repository/simkl/SimklIntegrationTest.kt
@@ -63,6 +63,7 @@ class SimklIntegrationTest {
         val success = authManager.pollPinAuth("SIMKL-123")
         assertTrue(success)
         coVerify { syncProviderStore.setSimklAccessToken("token_abc123") }
+        coVerify { syncProviderStore.setMdbListApiKey(null) }
     }
 
     @Test

--- a/web/lib/cloud.ts
+++ b/web/lib/cloud.ts
@@ -865,8 +865,28 @@ export async function pullCloudProfiles(auth: AuthClient): Promise<CloudProfiles
   };
 }
 
-export async function pullCloudTraktToken(auth: AuthClient, profileId?: string | null): Promise<TraktToken | null> {
-  const root = await pullRawPayload(auth);
+export type CloudTrackingProvider = "NONE" | "TRAKT" | "MDBLIST" | "SIMKL";
+
+export interface CloudTrackingSelection {
+  provider: CloudTrackingProvider;
+  traktToken: TraktToken | null;
+  mdbListApiKey: string | null;
+  simklToken: SimklToken | null;
+}
+
+export interface CloudTrackingSnapshot extends CloudTrackingSelection {
+  hasCloudState: boolean;
+  needsCleanup: boolean;
+}
+
+function normalizeCloudTrackingProvider(value: unknown): CloudTrackingProvider | null {
+  const normalized = typeof value === "string" ? value.trim().toUpperCase() : "";
+  return normalized === "NONE" || normalized === "TRAKT" || normalized === "MDBLIST" || normalized === "SIMKL"
+    ? normalized
+    : null;
+}
+
+function readCloudTraktToken(root: RawPayload, profileId: string): TraktToken | null {
   const tokensByProfile = objectRecord<{
     accessToken?: string;
     refreshToken?: string;
@@ -875,7 +895,7 @@ export async function pullCloudTraktToken(auth: AuthClient, profileId?: string |
     refresh_token?: string;
     expires_at?: number;
   }>(root.traktTokens);
-  const token = profileId ? tokensByProfile?.[profileId] : undefined;
+  const token = tokensByProfile[profileId];
   const accessToken = token?.accessToken ?? token?.access_token;
   const refreshToken = token?.refreshToken ?? token?.refresh_token;
   const rawExpiresAt = token?.expiresAt ?? token?.expires_at ?? 0;
@@ -888,32 +908,7 @@ export async function pullCloudTraktToken(auth: AuthClient, profileId?: string |
   };
 }
 
-export async function saveCloudTraktToken(auth: AuthClient, token: TraktToken | null, profileId?: string | null) {
-  if (!profileId) return;
-  await mutateCloudPayload(auth, (root) => {
-    const tokens = objectRecord<unknown>(root.traktTokens) ?? {};
-    if (token) {
-      tokens[profileId] = {
-        accessToken: token.access_token,
-        refreshToken: token.refresh_token,
-        expiresAt: token.expires_at,
-        access_token: token.access_token,
-        refresh_token: token.refresh_token,
-        expires_at: token.expires_at
-      };
-      root.traktTokens = tokens;
-      root.traktLinked = true;
-    } else {
-      delete tokens[profileId];
-      root.traktTokens = tokens;
-      if (Object.keys(tokens).length === 0) root.traktLinked = false;
-    }
-  });
-}
-
-export async function pullCloudSimklToken(auth: AuthClient, profileId?: string | null): Promise<SimklToken | null> {
-  if (!profileId) return null;
-  const root = await pullRawPayload(auth);
+function readCloudSimklToken(root: RawPayload, profileId: string): SimklToken | null {
   const directTokens = objectRecord<{ access_token?: string; accessToken?: string }>(root.simklTokens);
   const selections = objectRecord<{ provider?: string; simklAccessToken?: string }>(root.mdbListSyncByProfile);
   const direct = directTokens[profileId];
@@ -922,35 +917,108 @@ export async function pullCloudSimklToken(auth: AuthClient, profileId?: string |
   return accessToken ? { access_token: accessToken } : null;
 }
 
-export async function saveCloudSimklToken(
+export async function pullCloudTrackingSelection(
   auth: AuthClient,
-  token: SimklToken | null,
   profileId?: string | null
+): Promise<CloudTrackingSnapshot> {
+  if (!profileId) {
+    return {
+      provider: "NONE",
+      traktToken: null,
+      mdbListApiKey: null,
+      simklToken: null,
+      hasCloudState: false,
+      needsCleanup: false
+    };
+  }
+  const root = await pullRawPayload(auth);
+  const selections = objectRecord<Record<string, unknown>>(root.mdbListSyncByProfile);
+  const selection = selections[profileId] ?? {};
+  const traktToken = readCloudTraktToken(root, profileId);
+  const simklToken = readCloudSimklToken(root, profileId);
+  const rawMdbListKey = selection.mdbListApiKey ?? selection.mdblistApiKey;
+  const mdbListApiKey = typeof rawMdbListKey === "string" ? rawMdbListKey.trim() || null : null;
+  const explicitProvider = normalizeCloudTrackingProvider(selection.provider);
+  const inferredProvider: CloudTrackingProvider = traktToken
+    ? "TRAKT"
+    : simklToken
+      ? "SIMKL"
+      : mdbListApiKey
+        ? "MDBLIST"
+        : "NONE";
+  const requestedProvider = explicitProvider ?? inferredProvider;
+  const provider: CloudTrackingProvider = requestedProvider === "TRAKT" && traktToken
+    ? "TRAKT"
+    : requestedProvider === "SIMKL" && simklToken
+      ? "SIMKL"
+      : requestedProvider === "MDBLIST" && mdbListApiKey
+        ? "MDBLIST"
+        : "NONE";
+  const storedProviderCount = Number(Boolean(traktToken)) + Number(Boolean(simklToken)) + Number(Boolean(mdbListApiKey));
+  const hasCloudState = explicitProvider !== null || storedProviderCount > 0;
+  const needsCleanup = !hasCloudState
+    ? false
+    : explicitProvider === null
+    ? storedProviderCount > 0
+    : explicitProvider !== provider || storedProviderCount !== (provider === "NONE" ? 0 : 1);
+
+  return {
+    provider,
+    traktToken: provider === "TRAKT" ? traktToken : null,
+    mdbListApiKey: provider === "MDBLIST" ? mdbListApiKey : null,
+    simklToken: provider === "SIMKL" ? simklToken : null,
+    hasCloudState,
+    needsCleanup
+  };
+}
+
+export async function saveCloudTrackingSelection(
+  auth: AuthClient,
+  profileId: string | null | undefined,
+  selection: CloudTrackingSelection
 ) {
   if (!profileId) return;
   await mutateCloudPayload(auth, (root) => {
-    const directTokens = objectRecord<unknown>(root.simklTokens) ?? {};
-    const selections = objectRecord<Record<string, unknown>>(root.mdbListSyncByProfile) ?? {};
-    const currentSelection = selections[profileId] ?? {};
-    if (token?.access_token) {
-      directTokens[profileId] = {
+    const traktTokens = objectRecord<unknown>(root.traktTokens);
+    const simklTokens = objectRecord<unknown>(root.simklTokens);
+    const selections = objectRecord<Record<string, unknown>>(root.mdbListSyncByProfile);
+
+    delete traktTokens[profileId];
+    delete simklTokens[profileId];
+
+    if (selection.provider === "TRAKT" && selection.traktToken) {
+      const token = selection.traktToken;
+      traktTokens[profileId] = {
+        accessToken: token.access_token,
+        refreshToken: token.refresh_token,
+        expiresAt: token.expires_at,
+        access_token: token.access_token,
+        refresh_token: token.refresh_token,
+        expires_at: token.expires_at
+      };
+      selections[profileId] = { provider: "TRAKT" };
+    } else if (selection.provider === "MDBLIST" && selection.mdbListApiKey?.trim()) {
+      selections[profileId] = {
+        provider: "MDBLIST",
+        mdbListApiKey: selection.mdbListApiKey.trim()
+      };
+    } else if (selection.provider === "SIMKL" && selection.simklToken?.access_token) {
+      const token = selection.simklToken;
+      simklTokens[profileId] = {
         access_token: token.access_token,
         accessToken: token.access_token
       };
       selections[profileId] = {
-        ...currentSelection,
         provider: "SIMKL",
         simklAccessToken: token.access_token
       };
     } else {
-      delete directTokens[profileId];
-      const { simklAccessToken: _removed, ...remaining } = currentSelection;
-      selections[profileId] = {
-        ...remaining,
-        provider: String(currentSelection.provider ?? "").toLowerCase() === "simkl" ? "NONE" : currentSelection.provider
-      };
+      selections[profileId] = { provider: "NONE" };
     }
-    root.simklTokens = directTokens;
+
+    root.traktTokens = traktTokens;
+    root.traktLinked = Object.keys(traktTokens).length > 0;
+    root.simklTokens = simklTokens;
     root.mdbListSyncByProfile = selections;
   });
 }

--- a/web/lib/cloud.ts
+++ b/web/lib/cloud.ts
@@ -888,21 +888,26 @@ export async function pullCloudTraktToken(auth: AuthClient, profileId?: string |
   };
 }
 
-export async function saveCloudTraktToken(auth: AuthClient, token: TraktToken, profileId?: string | null) {
+export async function saveCloudTraktToken(auth: AuthClient, token: TraktToken | null, profileId?: string | null) {
   if (!profileId) return;
   await mutateCloudPayload(auth, (root) => {
     const tokens = objectRecord<unknown>(root.traktTokens) ?? {};
-    // Write both key styles so the Android app and web read it either way.
-    tokens[profileId] = {
-      accessToken: token.access_token,
-      refreshToken: token.refresh_token,
-      expiresAt: token.expires_at,
-      access_token: token.access_token,
-      refresh_token: token.refresh_token,
-      expires_at: token.expires_at
-    };
-    root.traktTokens = tokens;
-    root.traktLinked = true;
+    if (token) {
+      tokens[profileId] = {
+        accessToken: token.access_token,
+        refreshToken: token.refresh_token,
+        expiresAt: token.expires_at,
+        access_token: token.access_token,
+        refresh_token: token.refresh_token,
+        expires_at: token.expires_at
+      };
+      root.traktTokens = tokens;
+      root.traktLinked = true;
+    } else {
+      delete tokens[profileId];
+      root.traktTokens = tokens;
+      if (Object.keys(tokens).length === 0) root.traktLinked = false;
+    }
   });
 }
 

--- a/web/lib/mdblist.ts
+++ b/web/lib/mdblist.ts
@@ -1,7 +1,7 @@
 import { jsonRequest } from "./http";
 import { loadStored, removeStored, saveStored } from "./storage";
 
-const MDBLIST_KEY_STORAGE = "arvio.web.mdblist.key";
+const LEGACY_MDBLIST_KEY_STORAGE = "arvio.web.mdblist.key";
 
 export interface MdbMediaRef {
   mediaType: "movie" | "tv";
@@ -20,18 +20,46 @@ export interface MdbMediaRef {
  * work unchanged regardless of the active provider.
  */
 export class MdbListClient {
-  key = loadStored<string | null>(MDBLIST_KEY_STORAGE, null);
+  key: string | null = null;
+  private profileId: string | null = null;
 
   get isConnected() {
     return Boolean(this.key);
+  }
+
+  private keyStorage(profileId: string) {
+    return `arvio.web.mdblist.key:${profileId}`;
+  }
+
+  setProfile(profileId: string | null) {
+    const normalized = profileId?.trim() || null;
+    if (normalized === this.profileId) return;
+    this.profileId = normalized;
+    this.watchedCache = null;
+    if (!normalized) {
+      this.key = null;
+      return;
+    }
+
+    let stored = loadStored<string | null>(this.keyStorage(normalized), null)?.trim() || null;
+    if (!stored) {
+      const legacy = loadStored<string | null>(LEGACY_MDBLIST_KEY_STORAGE, null)?.trim() || null;
+      if (legacy) {
+        stored = legacy;
+        saveStored(this.keyStorage(normalized), legacy);
+        removeStored(LEGACY_MDBLIST_KEY_STORAGE);
+      }
+    }
+    this.key = stored;
   }
 
   setKey(key: string | null) {
     const trimmed = key?.trim();
     this.key = trimmed ? trimmed : null;
     this.watchedCache = null; // don't serve a previous key's watched history
-    if (this.key) saveStored(MDBLIST_KEY_STORAGE, this.key);
-    else removeStored(MDBLIST_KEY_STORAGE);
+    if (!this.profileId) return;
+    if (this.key) saveStored(this.keyStorage(this.profileId), this.key);
+    else removeStored(this.keyStorage(this.profileId));
   }
 
   disconnect() {
@@ -128,19 +156,22 @@ export class MdbListClient {
     if (this.watchedCache && Date.now() - this.watchedCache.at < 30_000) {
       return this.watchedCache.data;
     }
-    const data = this.loadAllWatched();
+    const data = this.loadAllWatched(this.key);
     this.watchedCache = { at: Date.now(), data };
     return data;
   }
 
-  private async loadAllWatched() {
+  private async loadAllWatched(key: string | null) {
     const movies: MdbWatchedMovieRow[] = [];
     const episodes: MdbWatchedEpisodeRow[] = [];
+    if (!key) return { movies, episodes };
     const limit = 1000;
     // Hard page cap: never loop indefinitely on a bad has_more, even if it costs
     // a truncated tail (20k movies / 20k episodes is far beyond any real library).
     for (let page = 0; page < 20; page += 1) {
-      const resp = await this.request<MdbWatchedResponse>(`sync/watched?limit=${limit}&offset=${page * limit}`, {}).catch(() => null);
+      const resp = await this.request<MdbWatchedResponse>(`sync/watched?limit=${limit}&offset=${page * limit}`, {
+        headers: { "x-mdblist-key": key }
+      }).catch(() => null);
       if (!resp) break;
       if (resp.movies) movies.push(...resp.movies);
       if (resp.episodes) episodes.push(...resp.episodes);

--- a/web/lib/simkl.ts
+++ b/web/lib/simkl.ts
@@ -121,12 +121,12 @@ export class SimklClient implements SyncClient {
     this.setToken(null);
   }
 
-  private async simkl<T>(path: string, options: RequestInit = {}): Promise<T> {
+  private async simkl<T>(path: string, options: RequestInit = {}, accessToken = this.token?.access_token): Promise<T> {
     const headers: Record<string, string> = {
       "content-type": "application/json",
       ...(options.headers as Record<string, string>)
     };
-    if (this.token?.access_token) headers["x-user-token"] = this.token.access_token;
+    if (accessToken) headers["x-user-token"] = accessToken;
     return jsonRequest<T>(`/api/simkl${path}`, { ...options, headers });
   }
 
@@ -151,12 +151,13 @@ export class SimklClient implements SyncClient {
       return { scope: this.scope(), activity: null, checkedAt: Date.now(), movies: [], shows: [], anime: [] };
     }
     const scope = this.scope();
+    const accessToken = this.token?.access_token;
     const cached = this.snapshot?.scope === scope ? this.snapshot : null;
     if (cached && Date.now() - cached.checkedAt < SNAPSHOT_TTL_MS) return cached;
     if (this.snapshotPromise) return this.snapshotPromise;
 
     const request = (async () => {
-      const activities = await this.simkl<unknown>("/sync/activities").catch(() => null);
+      const activities = await this.simkl<unknown>("/sync/activities", {}, accessToken).catch(() => null);
       const marker = activityMarker(activities);
       if (cached && marker && marker === cached.activity) {
         return { ...cached, checkedAt: Date.now() };
@@ -164,9 +165,9 @@ export class SimklClient implements SyncClient {
 
       const query = "?extended=full&episode_watched_at=yes&include_all_episodes=original";
       const [moviesRes, showsRes, animeRes] = await Promise.all([
-        this.simkl<unknown>(`/sync/all-items/movies/all${query}`),
-        this.simkl<unknown>(`/sync/all-items/shows/all${query}`),
-        this.simkl<unknown>(`/sync/all-items/anime/all${query}`)
+        this.simkl<unknown>(`/sync/all-items/movies/all${query}`, {}, accessToken),
+        this.simkl<unknown>(`/sync/all-items/shows/all${query}`, {}, accessToken),
+        this.simkl<unknown>(`/sync/all-items/anime/all${query}`, {}, accessToken)
       ]);
       return {
         scope,
@@ -192,14 +193,13 @@ export class SimklClient implements SyncClient {
     return this.simkl<SimklPinCode>("/oauth/pin");
   }
 
-  async pollPinToken(userCode: string): Promise<boolean> {
+  async pollPinToken(userCode: string): Promise<SimklToken | null> {
     type PollRes = { result: string; access_token?: string };
     const res = await this.simkl<PollRes>(`/oauth/pin/${encodeURIComponent(userCode)}`);
     if (res.result === "OK" && res.access_token) {
-      this.setToken({ access_token: res.access_token });
-      return true;
+      return { access_token: res.access_token };
     }
-    return false;
+    return null;
   }
 
   async watchlist(): Promise<unknown[]> {

--- a/web/lib/store.tsx
+++ b/web/lib/store.tsx
@@ -5,7 +5,7 @@ import { getStreams, getStreamsProgressive, installAddon as installAddonManifest
 import { AuthClient, SESSION_KEY, decodeJwtPayload } from "./auth";
 import { getAuthPortalUrl } from "./config";
 import { defaultCatalogs, mergeCatalogs } from "./catalogs";
-import { getContinueWatching, isLiveStreamOrSportsItem, pullCloudPayload, pullCloudProfiles, pullCloudSimklToken, pullCloudTraktToken, pullCloudWatchlist, removeContinueWatchingProgress, saveCloudAddons, saveCloudProfiles, saveCloudSettings, saveCloudSimklToken, saveCloudTraktToken, saveProgress } from "./cloud";
+import { getContinueWatching, isLiveStreamOrSportsItem, pullCloudPayload, pullCloudProfiles, pullCloudTrackingSelection, pullCloudWatchlist, removeContinueWatchingProgress, saveCloudAddons, saveCloudProfiles, saveCloudSettings, saveCloudTrackingSelection, saveProgress } from "./cloud";
 import { cachedDebridDirectUrl, parseDebridStream, resolveDebridDirectUrl, resolveTranscodeStream } from "./debrid";
 import { createPendingExternalPlayback } from "./externalPlayback";
 import { externalLaunchMode, openExternalPlayer } from "./externalPlayers";
@@ -728,7 +728,11 @@ export function AppProvider({
     refreshKeyRef.current = key;
     const existing = refreshInFlightRef.current;
     if (existing?.key === key) return existing.promise;
+    traktClient.setProfile(profileId);
+    mdblistClient.setProfile(profileId);
     simklClient.setProfile(profileId);
+    setTraktConnected(traktClient.isConnected);
+    setMdblistConnected(mdblistClient.isConnected);
     setSimklConnected(simklClient.isConnected);
     const run = (async () => {
       const currentSettings = settingsRef.current;
@@ -762,33 +766,48 @@ export function AppProvider({
       const cloud = authClient.session ? await pullCloudPayload(authClient, profileId).catch(() => null) : null;
       let effectiveSettings = currentSettings;
       if (authClient.session && profileId) {
-        const [cloudTraktToken, cloudSimklToken] = await Promise.all([
-          pullCloudTraktToken(authClient, profileId).catch(() => null),
-          pullCloudSimklToken(authClient, profileId).catch(() => null)
-        ]);
+        const cloudTracking = await pullCloudTrackingSelection(authClient, profileId).catch(() => null);
         if (refreshKeyRef.current !== key) return;
-        if (cloudTraktToken) {
-          traktClient.setToken(cloudTraktToken);
-          setTraktConnected(true);
-          simklClient.disconnect();
-          setSimklConnected(false);
-          mdblistClient.disconnect();
-          setMdblistConnected(false);
-          if (cloudSimklToken) {
-            void saveCloudSimklToken(authClient, null, profileId).catch(() => undefined);
+        if (cloudTracking) {
+          if (!cloudTracking.hasCloudState) {
+            const localTracking = traktClient.token
+              ? { provider: "TRAKT" as const, traktToken: traktClient.token, mdbListApiKey: null, simklToken: null }
+              : simklClient.token
+                ? { provider: "SIMKL" as const, traktToken: null, mdbListApiKey: null, simklToken: simklClient.token }
+                : mdblistClient.key
+                  ? { provider: "MDBLIST" as const, traktToken: null, mdbListApiKey: mdblistClient.key, simklToken: null }
+                  : null;
+            if (localTracking) {
+              if (localTracking.provider !== "TRAKT") traktClient.disconnect();
+              if (localTracking.provider !== "SIMKL") simklClient.disconnect();
+              if (localTracking.provider !== "MDBLIST") mdblistClient.disconnect();
+              await saveCloudTrackingSelection(authClient, profileId, localTracking).catch(() => undefined);
+              if (refreshKeyRef.current !== key) return;
+            }
+          } else if (cloudTracking.provider === "TRAKT" && cloudTracking.traktToken) {
+            traktClient.setToken(cloudTracking.traktToken);
+            simklClient.disconnect();
+            mdblistClient.disconnect();
+          } else if (cloudTracking.provider === "SIMKL" && cloudTracking.simklToken) {
+            simklClient.setToken(cloudTracking.simklToken);
+            traktClient.disconnect();
+            mdblistClient.disconnect();
+          } else if (cloudTracking.provider === "MDBLIST" && cloudTracking.mdbListApiKey) {
+            mdblistClient.setKey(cloudTracking.mdbListApiKey);
+            traktClient.disconnect();
+            simklClient.disconnect();
+          } else {
+            traktClient.disconnect();
+            simklClient.disconnect();
+            mdblistClient.disconnect();
           }
-        } else if (cloudSimklToken) {
-          simklClient.setToken(cloudSimklToken);
-          setSimklConnected(true);
-          traktClient.disconnect();
-          setTraktConnected(false);
-          mdblistClient.disconnect();
-          setMdblistConnected(false);
-        } else if (!mdblistClient.isConnected) {
-          traktClient.disconnect();
-          setTraktConnected(false);
-          simklClient.disconnect();
-          setSimklConnected(false);
+          setTraktConnected(traktClient.isConnected);
+          setSimklConnected(simklClient.isConnected);
+          setMdblistConnected(mdblistClient.isConnected);
+          if (cloudTracking.hasCloudState && cloudTracking.needsCleanup) {
+            await saveCloudTrackingSelection(authClient, profileId, cloudTracking).catch(() => undefined);
+            if (refreshKeyRef.current !== key) return;
+          }
         }
       }
       if (cloud?.settings) {
@@ -1678,6 +1697,7 @@ export function AppProvider({
   }, []);
 
   const beginTrakt = useCallback(async () => {
+    traktClient.setProfile(activeProfileIdRef.current);
     setDeviceCode(await traktClient.beginDeviceLink());
   }, []);
 
@@ -1685,8 +1705,12 @@ export function AppProvider({
     const targetProfileId = activeProfileIdRef.current;
     const code = deviceCodeRef.current;
     if (!code) return;
-    await traktClient.pollDeviceToken(code.device_code);
+    const token = await traktClient.pollDeviceToken(code.device_code);
     if (activeProfileIdRef.current !== targetProfileId) return;
+    traktClient.setProfile(targetProfileId);
+    mdblistClient.setProfile(targetProfileId);
+    simklClient.setProfile(targetProfileId);
+    traktClient.setToken(token);
     setTraktConnected(true);
     setDeviceCode(null);
     // Mutual exclusion: connecting Trakt drops MDBList and Simkl for this profile.
@@ -1695,25 +1719,33 @@ export function AppProvider({
     simklClient.disconnect();
     setSimklConnected(false);
     if (targetProfileId) {
-      await saveCloudSimklToken(authClient, null, targetProfileId).catch(() => undefined);
-      if (traktClient.token) {
-        await saveCloudTraktToken(authClient, traktClient.token, targetProfileId).catch(() => undefined);
-      }
+      await saveCloudTrackingSelection(authClient, targetProfileId, {
+        provider: "TRAKT",
+        traktToken: token,
+        mdbListApiKey: null,
+        simklToken: null
+      }).catch(() => undefined);
     }
     if (activeProfileIdRef.current === targetProfileId) {
-      await refreshData();
+      await refreshData(targetProfileId);
     }
   }, [refreshData]);
 
   const disconnectTrakt = useCallback(async () => {
     const targetProfileId = activeProfileIdRef.current;
+    traktClient.setProfile(targetProfileId);
     traktClient.disconnect();
     setTraktConnected(false);
     if (targetProfileId) {
-      await saveCloudTraktToken(authClient, null, targetProfileId).catch(() => undefined);
+      await saveCloudTrackingSelection(authClient, targetProfileId, {
+        provider: "NONE",
+        traktToken: null,
+        mdbListApiKey: null,
+        simklToken: null
+      }).catch(() => undefined);
     }
     if (activeProfileIdRef.current === targetProfileId) {
-      await refreshData();
+      await refreshData(targetProfileId);
     }
   }, [refreshData]);
 
@@ -1722,6 +1754,9 @@ export function AppProvider({
     const ok = await mdblistClient.validateKey(key);
     if (!ok) throw new Error("Invalid MDBList API key");
     if (activeProfileIdRef.current !== targetProfileId) return;
+    traktClient.setProfile(targetProfileId);
+    mdblistClient.setProfile(targetProfileId);
+    simklClient.setProfile(targetProfileId);
     mdblistClient.setKey(key);
     setMdblistConnected(true);
     // Mutual exclusion: connecting MDBList drops Trakt and Simkl for this profile.
@@ -1730,36 +1765,54 @@ export function AppProvider({
     simklClient.disconnect();
     setSimklConnected(false);
     if (targetProfileId) {
-      await Promise.all([
-        saveCloudTraktToken(authClient, null, targetProfileId).catch(() => undefined),
-        saveCloudSimklToken(authClient, null, targetProfileId).catch(() => undefined)
-      ]);
+      await saveCloudTrackingSelection(authClient, targetProfileId, {
+        provider: "MDBLIST",
+        traktToken: null,
+        mdbListApiKey: key,
+        simklToken: null
+      }).catch(() => undefined);
     }
     if (activeProfileIdRef.current === targetProfileId) {
-      await refreshData();
+      await refreshData(targetProfileId);
     }
   }, [refreshData]);
 
-  const disconnectMdblist = useCallback(() => {
+  const disconnectMdblist = useCallback(async () => {
+    const targetProfileId = activeProfileIdRef.current;
+    mdblistClient.setProfile(targetProfileId);
     mdblistClient.disconnect();
     setMdblistConnected(false);
-    void refreshData();
+    if (targetProfileId) {
+      await saveCloudTrackingSelection(authClient, targetProfileId, {
+        provider: "NONE",
+        traktToken: null,
+        mdbListApiKey: null,
+        simklToken: null
+      }).catch(() => undefined);
+    }
+    if (activeProfileIdRef.current === targetProfileId) {
+      await refreshData(targetProfileId);
+    }
   }, [refreshData]);
 
   const beginSimkl = useCallback(async () => {
-    simklClient.setProfile(activeProfileId);
+    simklClient.setProfile(activeProfileIdRef.current);
     setSimklDeviceCode(await simklClient.beginPinAuth());
-  }, [activeProfileId]);
+  }, []);
 
   const pollSimkl = useCallback(async () => {
     const targetProfileId = activeProfileIdRef.current;
     const code = simklDeviceCodeRef.current;
     if (!code) return;
-    const ok = await simklClient.pollPinToken(code.user_code);
-    if (!ok) {
+    const token = await simklClient.pollPinToken(code.user_code);
+    if (!token) {
       throw new Error("Simkl has not approved this PIN yet. Please approve the code on Simkl.");
     }
     if (activeProfileIdRef.current !== targetProfileId) return;
+    traktClient.setProfile(targetProfileId);
+    mdblistClient.setProfile(targetProfileId);
+    simklClient.setProfile(targetProfileId);
+    simklClient.setToken(token);
     setSimklConnected(true);
     setSimklDeviceCode(null);
     // Mutual exclusion: connecting Simkl drops Trakt & MDBList for this profile.
@@ -1768,25 +1821,33 @@ export function AppProvider({
     mdblistClient.disconnect();
     setMdblistConnected(false);
     if (targetProfileId) {
-      await saveCloudTraktToken(authClient, null, targetProfileId).catch(() => undefined);
-      if (simklClient.token) {
-        await saveCloudSimklToken(authClient, simklClient.token, targetProfileId).catch(() => undefined);
-      }
+      await saveCloudTrackingSelection(authClient, targetProfileId, {
+        provider: "SIMKL",
+        traktToken: null,
+        mdbListApiKey: null,
+        simklToken: token
+      }).catch(() => undefined);
     }
     if (activeProfileIdRef.current === targetProfileId) {
-      await refreshData();
+      await refreshData(targetProfileId);
     }
   }, [refreshData]);
 
   const disconnectSimkl = useCallback(async () => {
     const targetProfileId = activeProfileIdRef.current;
+    simklClient.setProfile(targetProfileId);
     simklClient.disconnect();
     setSimklConnected(false);
     if (targetProfileId) {
-      await saveCloudSimklToken(authClient, null, targetProfileId).catch(() => undefined);
+      await saveCloudTrackingSelection(authClient, targetProfileId, {
+        provider: "NONE",
+        traktToken: null,
+        mdbListApiKey: null,
+        simklToken: null
+      }).catch(() => undefined);
     }
     if (activeProfileIdRef.current === targetProfileId) {
-      await refreshData();
+      await refreshData(targetProfileId);
     }
   }, [refreshData]);
 
@@ -1845,6 +1906,7 @@ export function AppProvider({
   }, [fetchTraktListItems]);
 
   const persistProfiles = useCallback((next: Profile[], activeId: string | null) => {
+    activeProfileIdRef.current = activeId;
     setProfiles(next);
     setActiveProfileId(activeId);
     saveStored(PROFILES_KEY, next);
@@ -1856,10 +1918,16 @@ export function AppProvider({
     const updated = profiles.map((p) => (p.id === profile.id ? { ...p, lastUsedAt: Date.now() } : p));
     const switching = profile.id !== activeProfileId;
     persistProfiles(updated, profile.id);
+    traktClient.setProfile(profile.id);
+    mdblistClient.setProfile(profile.id);
     simklClient.setProfile(profile.id);
+    setTraktConnected(traktClient.isConnected);
+    setMdblistConnected(mdblistClient.isConnected);
     setSimklConnected(simklClient.isConnected);
     setManageMode(false);
     if (switching) {
+      setDeviceCode(null);
+      setSimklDeviceCode(null);
       // Drop the previous profile's rows and seed from the new profile's cache
       // so its Continue Watching paints instantly. refreshKeyRef (updated by the
       // refreshData call below) invalidates any in-flight refresh for the old

--- a/web/lib/store.tsx
+++ b/web/lib/store.tsx
@@ -767,10 +767,13 @@ export function AppProvider({
         if (cloudTraktToken) {
           traktClient.setToken(cloudTraktToken);
           setTraktConnected(true);
-        }
-        if (cloudSimklToken) {
+          simklClient.disconnect();
+          setSimklConnected(false);
+        } else if (cloudSimklToken) {
           simklClient.setToken(cloudSimklToken);
           setSimklConnected(true);
+          traktClient.disconnect();
+          setTraktConnected(false);
         }
       }
       if (cloud?.settings) {
@@ -1686,7 +1689,8 @@ export function AppProvider({
   const disconnectTrakt = useCallback(() => {
     traktClient.disconnect();
     setTraktConnected(false);
-  }, []);
+    if (activeProfileId) void saveCloudTraktToken(authClient, null, activeProfileId).catch(() => undefined);
+  }, [activeProfileId]);
 
   const connectMdblist = useCallback(async (key: string) => {
     const ok = await mdblistClient.validateKey(key);
@@ -1698,7 +1702,10 @@ export function AppProvider({
     setTraktConnected(false);
     simklClient.disconnect();
     setSimklConnected(false);
-    if (activeProfileId) void saveCloudSimklToken(authClient, null, activeProfileId).catch(() => undefined);
+    if (activeProfileId) {
+      void saveCloudTraktToken(authClient, null, activeProfileId).catch(() => undefined);
+      void saveCloudSimklToken(authClient, null, activeProfileId).catch(() => undefined);
+    }
     await refreshData();
   }, [refreshData, activeProfileId]);
 
@@ -1727,6 +1734,9 @@ export function AppProvider({
     setTraktConnected(false);
     mdblistClient.disconnect();
     setMdblistConnected(false);
+    if (activeProfileId) {
+      void saveCloudTraktToken(authClient, null, activeProfileId).catch(() => undefined);
+    }
     if (simklClient.token && activeProfileId) {
       await saveCloudSimklToken(authClient, simklClient.token, activeProfileId).catch(() => undefined);
     }

--- a/web/lib/store.tsx
+++ b/web/lib/store.tsx
@@ -645,6 +645,8 @@ export function AppProvider({
   const [activeProfileId, setActiveProfileId] = useState<string | null>(() =>
     localProfilesMatchAccount() ? loadStored<string | null>(ACTIVE_PROFILE_KEY, null) : null
   );
+  const activeProfileIdRef = useRef(activeProfileId);
+  activeProfileIdRef.current = activeProfileId;
   // Hydrate cached custom-avatar images synchronously so profile tiles paint the
   // real avatar on first render instead of flashing the letter fallback.
   const [avatarImages, setAvatarImagesState] = useState<Record<string, string>>(() => loadStored<Record<string, string>>(AVATAR_IMAGES_KEY, {}));
@@ -764,16 +766,29 @@ export function AppProvider({
           pullCloudTraktToken(authClient, profileId).catch(() => null),
           pullCloudSimklToken(authClient, profileId).catch(() => null)
         ]);
+        if (refreshKeyRef.current !== key) return;
         if (cloudTraktToken) {
           traktClient.setToken(cloudTraktToken);
           setTraktConnected(true);
           simklClient.disconnect();
           setSimklConnected(false);
+          mdblistClient.disconnect();
+          setMdblistConnected(false);
+          if (cloudSimklToken) {
+            void saveCloudSimklToken(authClient, null, profileId).catch(() => undefined);
+          }
         } else if (cloudSimklToken) {
           simklClient.setToken(cloudSimklToken);
           setSimklConnected(true);
           traktClient.disconnect();
           setTraktConnected(false);
+          mdblistClient.disconnect();
+          setMdblistConnected(false);
+        } else if (!mdblistClient.isConnected) {
+          traktClient.disconnect();
+          setTraktConnected(false);
+          simklClient.disconnect();
+          setSimklConnected(false);
         }
       }
       if (cloud?.settings) {
@@ -1667,9 +1682,11 @@ export function AppProvider({
   }, []);
 
   const pollTrakt = useCallback(async () => {
+    const targetProfileId = activeProfileIdRef.current;
     const code = deviceCodeRef.current;
     if (!code) return;
     await traktClient.pollDeviceToken(code.device_code);
+    if (activeProfileIdRef.current !== targetProfileId) return;
     setTraktConnected(true);
     setDeviceCode(null);
     // Mutual exclusion: connecting Trakt drops MDBList and Simkl for this profile.
@@ -1677,24 +1694,34 @@ export function AppProvider({
     setMdblistConnected(false);
     simklClient.disconnect();
     setSimklConnected(false);
-    if (activeProfileId) void saveCloudSimklToken(authClient, null, activeProfileId).catch(() => undefined);
-    // Persist the token to cloud so other devices (and future sessions) see the
-    // connection — parity with the Android app's traktTokens payload.
-    if (traktClient.token && activeProfileId) {
-      void saveCloudTraktToken(authClient, traktClient.token, activeProfileId).catch(() => undefined);
+    if (targetProfileId) {
+      await saveCloudSimklToken(authClient, null, targetProfileId).catch(() => undefined);
+      if (traktClient.token) {
+        await saveCloudTraktToken(authClient, traktClient.token, targetProfileId).catch(() => undefined);
+      }
     }
-    await refreshData();
-  }, [refreshData, activeProfileId]);
+    if (activeProfileIdRef.current === targetProfileId) {
+      await refreshData();
+    }
+  }, [refreshData]);
 
-  const disconnectTrakt = useCallback(() => {
+  const disconnectTrakt = useCallback(async () => {
+    const targetProfileId = activeProfileIdRef.current;
     traktClient.disconnect();
     setTraktConnected(false);
-    if (activeProfileId) void saveCloudTraktToken(authClient, null, activeProfileId).catch(() => undefined);
-  }, [activeProfileId]);
+    if (targetProfileId) {
+      await saveCloudTraktToken(authClient, null, targetProfileId).catch(() => undefined);
+    }
+    if (activeProfileIdRef.current === targetProfileId) {
+      await refreshData();
+    }
+  }, [refreshData]);
 
   const connectMdblist = useCallback(async (key: string) => {
+    const targetProfileId = activeProfileIdRef.current;
     const ok = await mdblistClient.validateKey(key);
     if (!ok) throw new Error("Invalid MDBList API key");
+    if (activeProfileIdRef.current !== targetProfileId) return;
     mdblistClient.setKey(key);
     setMdblistConnected(true);
     // Mutual exclusion: connecting MDBList drops Trakt and Simkl for this profile.
@@ -1702,12 +1729,16 @@ export function AppProvider({
     setTraktConnected(false);
     simklClient.disconnect();
     setSimklConnected(false);
-    if (activeProfileId) {
-      void saveCloudTraktToken(authClient, null, activeProfileId).catch(() => undefined);
-      void saveCloudSimklToken(authClient, null, activeProfileId).catch(() => undefined);
+    if (targetProfileId) {
+      await Promise.all([
+        saveCloudTraktToken(authClient, null, targetProfileId).catch(() => undefined),
+        saveCloudSimklToken(authClient, null, targetProfileId).catch(() => undefined)
+      ]);
     }
-    await refreshData();
-  }, [refreshData, activeProfileId]);
+    if (activeProfileIdRef.current === targetProfileId) {
+      await refreshData();
+    }
+  }, [refreshData]);
 
   const disconnectMdblist = useCallback(() => {
     mdblistClient.disconnect();
@@ -1721,12 +1752,14 @@ export function AppProvider({
   }, [activeProfileId]);
 
   const pollSimkl = useCallback(async () => {
+    const targetProfileId = activeProfileIdRef.current;
     const code = simklDeviceCodeRef.current;
     if (!code) return;
     const ok = await simklClient.pollPinToken(code.user_code);
     if (!ok) {
       throw new Error("Simkl has not approved this PIN yet. Please approve the code on Simkl.");
     }
+    if (activeProfileIdRef.current !== targetProfileId) return;
     setSimklConnected(true);
     setSimklDeviceCode(null);
     // Mutual exclusion: connecting Simkl drops Trakt & MDBList for this profile.
@@ -1734,21 +1767,28 @@ export function AppProvider({
     setTraktConnected(false);
     mdblistClient.disconnect();
     setMdblistConnected(false);
-    if (activeProfileId) {
-      void saveCloudTraktToken(authClient, null, activeProfileId).catch(() => undefined);
+    if (targetProfileId) {
+      await saveCloudTraktToken(authClient, null, targetProfileId).catch(() => undefined);
+      if (simklClient.token) {
+        await saveCloudSimklToken(authClient, simklClient.token, targetProfileId).catch(() => undefined);
+      }
     }
-    if (simklClient.token && activeProfileId) {
-      await saveCloudSimklToken(authClient, simklClient.token, activeProfileId).catch(() => undefined);
+    if (activeProfileIdRef.current === targetProfileId) {
+      await refreshData();
     }
-    await refreshData();
-  }, [refreshData, activeProfileId]);
+  }, [refreshData]);
 
-  const disconnectSimkl = useCallback(() => {
+  const disconnectSimkl = useCallback(async () => {
+    const targetProfileId = activeProfileIdRef.current;
     simklClient.disconnect();
     setSimklConnected(false);
-    if (activeProfileId) void saveCloudSimklToken(authClient, null, activeProfileId).catch(() => undefined);
-    void refreshData();
-  }, [refreshData, activeProfileId]);
+    if (targetProfileId) {
+      await saveCloudSimklToken(authClient, null, targetProfileId).catch(() => undefined);
+    }
+    if (activeProfileIdRef.current === targetProfileId) {
+      await refreshData();
+    }
+  }, [refreshData]);
 
   // Watchlist list-source switcher. Returns the user's custom Trakt lists to
   // populate the dropdown (built-in Watchlist/Collection are added by the UI).

--- a/web/lib/trakt.ts
+++ b/web/lib/trakt.ts
@@ -2,7 +2,7 @@ import { config, hasTraktConfig } from "./config";
 import { HttpError, jsonRequest } from "./http";
 import { loadStored, removeStored, saveStored } from "./storage";
 
-const TRAKT_TOKEN_KEY = "arvio.web.trakt.token";
+const LEGACY_TRAKT_TOKEN_KEY = "arvio.web.trakt.token";
 // v2: v1 stored FULL progress payloads (every season/episode — ~740KB across a
 // library) and helped exhaust the localStorage quota; v2 entries are slimmed
 // to the four fields Continue Watching reads.
@@ -33,16 +33,43 @@ function normalizeToken(token: TraktToken | null): TraktToken | null {
 }
 
 export class TraktClient {
-  token = normalizeToken(loadStored<TraktToken | null>(TRAKT_TOKEN_KEY, null));
+  token: TraktToken | null = null;
+  private profileId: string | null = null;
 
   get isConnected() {
     return Boolean(this.token?.access_token);
   }
 
+  private tokenKey(profileId: string) {
+    return `arvio.web.trakt.token:${profileId}`;
+  }
+
+  setProfile(profileId: string | null) {
+    const normalized = profileId?.trim() || null;
+    if (normalized === this.profileId) return;
+    this.profileId = normalized;
+    if (!normalized) {
+      this.token = null;
+      return;
+    }
+
+    let stored = normalizeToken(loadStored<TraktToken | null>(this.tokenKey(normalized), null));
+    if (!stored) {
+      const legacy = normalizeToken(loadStored<TraktToken | null>(LEGACY_TRAKT_TOKEN_KEY, null));
+      if (legacy) {
+        stored = legacy;
+        saveStored(this.tokenKey(normalized), legacy);
+        removeStored(LEGACY_TRAKT_TOKEN_KEY);
+      }
+    }
+    this.token = stored;
+  }
+
   setToken(token: TraktToken | null) {
     this.token = normalizeToken(token);
-    if (this.token) saveStored(TRAKT_TOKEN_KEY, this.token);
-    else removeStored(TRAKT_TOKEN_KEY);
+    if (!this.profileId) return;
+    if (this.token) saveStored(this.tokenKey(this.profileId), this.token);
+    else removeStored(this.tokenKey(this.profileId));
   }
 
   async beginDeviceLink() {
@@ -53,14 +80,13 @@ export class TraktClient {
     });
   }
 
-  async pollDeviceToken(code: string) {
+  async pollDeviceToken(code: string): Promise<TraktToken> {
     const response = await this.exchangeDeviceToken(code);
-    this.token = {
+    return {
       access_token: response.access_token,
       refresh_token: response.refresh_token,
       expires_at: Date.now() + response.expires_in * 1000
     };
-    this.setToken(this.token);
   }
 
   private async exchangeDeviceToken(code: string) {
@@ -87,51 +113,51 @@ export class TraktClient {
   }
 
   async watchlist() {
-    if (!this.token) return [];
-    await this.refreshIfNeeded();
+    const token = await this.refreshIfNeeded();
+    if (!token) return [];
     return this.trakt<unknown[]>("/sync/watchlist", {
-      headers: { "x-user-token": this.token.access_token }
+      headers: { "x-user-token": token.access_token }
     });
   }
 
   // The user's personal collection (owned/available items).
   async collection(type: "movies" | "shows") {
-    if (!this.token) return [];
-    await this.refreshIfNeeded();
+    const token = await this.refreshIfNeeded();
+    if (!token) return [];
     return this.trakt<unknown[]>(`/sync/collection/${type}`, {
-      headers: { "x-user-token": this.token.access_token }
+      headers: { "x-user-token": token.access_token }
     });
   }
 
   // Custom Trakt lists owned by the user: [{ ids: { trakt, slug }, name, ... }].
   async userLists() {
-    if (!this.token) return [];
-    await this.refreshIfNeeded();
+    const token = await this.refreshIfNeeded();
+    if (!token) return [];
     return this.trakt<unknown[]>("/users/me/lists", {
-      headers: { "x-user-token": this.token.access_token }
+      headers: { "x-user-token": token.access_token }
     });
   }
 
   // Items in a specific custom list (movies + shows).
   async listItems(listId: string | number) {
-    if (!this.token) return [];
-    await this.refreshIfNeeded();
+    const token = await this.refreshIfNeeded();
+    if (!token) return [];
     return this.trakt<unknown[]>(`/users/me/lists/${listId}/items/movies,shows`, {
-      headers: { "x-user-token": this.token.access_token }
+      headers: { "x-user-token": token.access_token }
     });
   }
 
   async playback() {
-    if (!this.token) return [];
-    await this.refreshIfNeeded();
+    const token = await this.refreshIfNeeded();
+    if (!token) return [];
     return this.trakt<unknown[]>("/sync/playback", {
-      headers: { "x-user-token": this.token.access_token }
+      headers: { "x-user-token": token.access_token }
     });
   }
 
   async watched(type: "movies" | "shows") {
-    if (!this.token) return [];
-    await this.refreshIfNeeded();
+    const token = await this.refreshIfNeeded();
+    if (!token) return [];
     const all: unknown[] = [];
     let page = 1;
     // Trakt's July 2026 API update (trakt-api discussion #775): extended=
@@ -149,7 +175,7 @@ export class TraktClient {
       // it is also the heavy variant, hence the page ceiling.
       if (type === "shows") query.set("extended", "progress");
       const rows = await this.trakt<unknown[]>(`/sync/watched/${type}?${query.toString()}`, {
-        headers: { "x-user-token": this.token.access_token }
+        headers: { "x-user-token": token.access_token }
       });
       if (!rows.length) break;
       all.push(...rows);
@@ -164,13 +190,13 @@ export class TraktClient {
   // Trakt itself omits these from Up Next, so Continue Watching must too —
   // otherwise a dropped show reappears here forever. Returns trakt show ids.
   async hiddenProgressShowIds(): Promise<Set<number>> {
-    if (!this.token) return new Set();
-    await this.refreshIfNeeded();
+    const token = await this.refreshIfNeeded();
+    if (!token) return new Set();
     const sections = ["progress_watched", "progress_watched_reset"];
     const ids = new Set<number>();
     const pages = await Promise.all(sections.map((section) =>
       this.trakt<unknown[]>(`/users/hidden/${section}?type=show&limit=100`, {
-        headers: { "x-user-token": this.token!.access_token }
+        headers: { "x-user-token": token.access_token }
       }).catch(() => [] as unknown[])
     ));
     pages.flat().forEach((raw) => {
@@ -185,9 +211,9 @@ export class TraktClient {
   // so entries stay valid for days instead of the blanket 15-minute TTL — a
   // repeat app boot then costs ~zero progress calls instead of ~120.
   async showProgress(traktShowId: number, includeSpecials = false, activityKey?: string | number) {
-    if (!this.token) return null;
-    await this.refreshIfNeeded();
-    const cached = readProgressCache(this.token.access_token, traktShowId, includeSpecials, activityKey);
+    const token = await this.refreshIfNeeded();
+    if (!token) return null;
+    const cached = readProgressCache(token.access_token, traktShowId, includeSpecials, activityKey);
     if (cached !== undefined) return cached;
     const query = new URLSearchParams({
       hidden: "false",
@@ -195,27 +221,27 @@ export class TraktClient {
       count_specials: String(includeSpecials)
     });
     const progress = await this.trakt<unknown>(`/shows/${traktShowId}/progress/watched?${query.toString()}`, {
-      headers: { "x-user-token": this.token.access_token }
+      headers: { "x-user-token": token.access_token }
     });
-    writeProgressCache(this.token.access_token, traktShowId, includeSpecials, progress, activityKey);
+    writeProgressCache(token.access_token, traktShowId, includeSpecials, progress, activityKey);
     return progress;
   }
 
   async history(type?: "movies" | "shows" | "episodes") {
-    if (!this.token) return [];
-    await this.refreshIfNeeded();
+    const token = await this.refreshIfNeeded();
+    if (!token) return [];
     const path = type ? `/sync/history/${type}` : "/sync/history";
     return this.trakt<unknown[]>(path, {
-      headers: { "x-user-token": this.token.access_token }
+      headers: { "x-user-token": token.access_token }
     });
   }
 
   async addToWatchlist(item: TraktMediaRef) {
-    if (!this.token) return;
-    await this.refreshIfNeeded();
+    const token = await this.refreshIfNeeded();
+    if (!token) return;
     await this.trakt("/sync/watchlist", {
       method: "POST",
-      headers: { "x-user-token": this.token.access_token },
+      headers: { "x-user-token": token.access_token },
       body: JSON.stringify(this.mediaBody(item))
     });
   }
@@ -223,30 +249,32 @@ export class TraktClient {
   // Mark watched on Trakt (registers in the user's history, same as the app's
   // "Mark watched"). A full-show ref (no season/episode) marks the whole show.
   async addToHistory(item: TraktMediaRef) {
-    if (!this.token) return;
-    await this.refreshIfNeeded();
+    const token = await this.refreshIfNeeded();
+    if (!token) return;
     await this.trakt("/sync/history", {
       method: "POST",
-      headers: { "x-user-token": this.token.access_token },
+      headers: { "x-user-token": token.access_token },
       body: JSON.stringify(this.mediaBody(item))
     });
   }
 
   async removeFromHistory(item: TraktMediaRef) {
-    if (!this.token) return;
-    await this.refreshIfNeeded();
+    const token = await this.refreshIfNeeded();
+    if (!token) return;
     await this.trakt("/sync/history/remove", {
       method: "POST",
-      headers: { "x-user-token": this.token.access_token },
+      headers: { "x-user-token": token.access_token },
       body: JSON.stringify(this.mediaBody(item))
     });
   }
 
   async dismissFromContinueWatching(item: TraktMediaRef) {
-    if (!this.token) return;
-    await this.refreshIfNeeded();
+    const token = await this.refreshIfNeeded();
+    if (!token) return;
 
-    const playbackRows = await this.playback();
+    const playbackRows = await this.trakt<unknown[]>("/sync/playback", {
+      headers: { "x-user-token": token.access_token }
+    });
     const matchingPlaybackIds = playbackRows.flatMap((raw) => {
       const row = raw as {
         id?: number;
@@ -265,34 +293,34 @@ export class TraktClient {
 
     await Promise.all(matchingPlaybackIds.map((id) => this.trakt(`/sync/playback/${id}`, {
       method: "DELETE",
-      headers: { "x-user-token": this.token!.access_token }
+      headers: { "x-user-token": token.access_token }
     })));
 
     if (item.mediaType === "tv") {
       await this.trakt("/users/hidden/progress_watched", {
         method: "POST",
-        headers: { "x-user-token": this.token.access_token },
+        headers: { "x-user-token": token.access_token },
         body: JSON.stringify({ shows: [{ ids: { tmdb: item.tmdbId } }] })
       });
     }
   }
 
   async removeFromWatchlist(item: TraktMediaRef) {
-    if (!this.token) return;
-    await this.refreshIfNeeded();
+    const token = await this.refreshIfNeeded();
+    if (!token) return;
     await this.trakt("/sync/watchlist/remove", {
       method: "POST",
-      headers: { "x-user-token": this.token.access_token },
+      headers: { "x-user-token": token.access_token },
       body: JSON.stringify(this.mediaBody(item))
     });
   }
 
   async scrobble(action: "start" | "pause" | "stop", item: TraktMediaRef & { progress: number }) {
-    if (!this.token) return;
-    await this.refreshIfNeeded();
+    const token = await this.refreshIfNeeded();
+    if (!token) return;
     await this.trakt(`/scrobble/${action}`, {
       method: "POST",
-      headers: { "x-user-token": this.token.access_token },
+      headers: { "x-user-token": token.access_token },
       body: JSON.stringify({ ...this.mediaBody(item), progress: Math.round(item.progress) })
     });
   }
@@ -302,6 +330,11 @@ export class TraktClient {
   }
 
   private async trakt<T>(path: string, init: RequestInit = {}) {
+    const requestProfileId = this.profileId;
+    const originalHeaders = new Headers(init.headers ?? {});
+    const originalAccessToken = originalHeaders.get("x-user-token")
+      ?? originalHeaders.get("Authorization")?.replace(/^Bearer\s+/i, "")
+      ?? null;
     const url = new URL(`/api/trakt/${path.replace(/^\/+/, "")}`, window.location.origin);
     const request = {
       ...init,
@@ -355,7 +388,11 @@ export class TraktClient {
       // blocks our server egress.
       const status = (error as { status?: number }).status;
       if (status !== 401 || path.replace(/^\/+/, "").startsWith("oauth/")) throw error;
-      const refreshed = await this.forceRefresh();
+      if (this.profileId !== requestProfileId) throw error;
+      const currentAccessToken = this.token?.access_token ?? null;
+      const refreshed = originalAccessToken && currentAccessToken && originalAccessToken !== currentAccessToken
+        ? currentAccessToken
+        : await this.forceRefresh();
       if (!refreshed) throw error;
       const retryHeaders = new Headers(request.headers as HeadersInit);
       if (retryHeaders.has("x-user-token")) retryHeaders.set("x-user-token", refreshed);
@@ -368,17 +405,20 @@ export class TraktClient {
 
   /** Refresh regardless of the stored expiry. Returns the new access token. */
   private async forceRefresh(): Promise<string | null> {
-    if (!this.token?.refresh_token) return null;
-    const previous = this.token.access_token;
+    const profileId = this.profileId;
+    const token = this.token;
+    if (!token?.refresh_token) return null;
+    const previous = token.access_token;
     try {
       // Reuse the normal refresh by pretending the token is already stale.
-      this.token = { ...this.token, expires_at: 0 };
-      await this.refreshIfNeeded();
+      this.token = { ...token, expires_at: 0 };
+      const refreshed = await this.refreshIfNeeded();
+      if (this.profileId !== profileId) return null;
+      const next = refreshed?.access_token ?? null;
+      return next && next !== previous ? next : null;
     } catch {
       return null;
     }
-    const next = this.token?.access_token ?? null;
-    return next && next !== previous ? next : null;
   }
 
   private canUseDirectFallback(path: string, init: RequestInit) {
@@ -423,12 +463,14 @@ export class TraktClient {
     return (await response.json()) as T;
   }
 
-  private async refreshIfNeeded() {
-    if (!this.token?.refresh_token) return;
-    if (this.token.expires_at && this.token.expires_at - Date.now() > 300000) return;
+  private async refreshIfNeeded(): Promise<TraktToken | null> {
+    const profileId = this.profileId;
+    const token = this.token;
+    if (!token?.refresh_token) return null;
+    if (token.expires_at && token.expires_at - Date.now() > 300000) return token;
     const body = {
       grant_type: "refresh_token",
-      refresh_token: this.token.refresh_token,
+      refresh_token: token.refresh_token,
       client_id: config.traktClientId,
       client_secret: config.traktClientSecret,
       redirect_uri: "urn:ietf:wg:oauth:2.0:oob"
@@ -444,19 +486,21 @@ export class TraktClient {
         body: JSON.stringify(body)
       }).catch(() => this.trakt<RefreshResponse>("/oauth/token", {
         method: "POST",
-        body: JSON.stringify({ grant_type: "refresh_token", refresh_token: this.token!.refresh_token })
+        body: JSON.stringify({ grant_type: "refresh_token", refresh_token: token.refresh_token })
       }));
     } else {
       response = await this.trakt<RefreshResponse>("/oauth/token", {
         method: "POST",
-        body: JSON.stringify({ grant_type: "refresh_token", refresh_token: this.token.refresh_token })
+        body: JSON.stringify({ grant_type: "refresh_token", refresh_token: token.refresh_token })
       });
     }
+    if (this.profileId !== profileId || this.token?.refresh_token !== token.refresh_token) return null;
     this.setToken({
       access_token: response.access_token,
-      refresh_token: response.refresh_token ?? this.token.refresh_token,
+      refresh_token: response.refresh_token ?? token.refresh_token,
       expires_at: Date.now() + response.expires_in * 1000
     });
+    return this.token;
   }
 
   private mediaBody(item: TraktMediaRef) {


### PR DESCRIPTION
### Overview
Enforces strict single tracking integration connection (Trakt, MDBList, or Simkl) at a time per profile across Android TV/Mobile and Web, preventing multi-provider conflicts and stale credential persistence.

### Key Fixes & Changes
- **Mutual Exclusion on Auth Flow**:
  - Connecting Trakt disconnects MDBList and Simkl, clearing tokens and canceling pending auth jobs.
  - Connecting MDBList logs out Trakt and disconnects Simkl.
  - Connecting Simkl logs out Trakt, cancels pending Trakt auth, and clears MDBList credentials.
  - Selecting `NONE` in `SyncProviderStore` clears both MDBList API key and Simkl access token from storage.
- **Cloud Sync & State Persistence**:
  - Added `syncLocalStateToCloud` and launcher continue watching refresh on successful Simkl connection paths for parity with Trakt and MDBList.
  - Serialized and awaited cloud token revocation/saves before data refresh.
  - Updated cloud hydration to prune conflicting/losing provider tokens from cloud storage when multiple tokens are present.
- **Race Condition & Cancellation Protection**:
  - Tracked manual Simkl polling coroutine in `simklPollingJob` to ensure proper cancellation on provider transitions.
  - Added active profile verification (`activeProfileIdRef`) across async web auth flows to prevent cross-profile token leaks.
- **Tests**:
  - Updated `SimklIntegrationTest` to verify mutual exclusion key clearing. All unit tests and web production builds passed.