### PR TITLE
feat: add official anime season structure

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/model/Models.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/model/Models.kt
@@ -84,6 +84,29 @@ data class NextEpisode(
  * Episode details
  */
 @Immutable
+data class EpisodeIdentity(
+    val displaySeason: Int,
+    val displayEpisode: Int,
+    val tmdbSeason: Int,
+    val tmdbEpisode: Int,
+    val kitsuId: Int? = null,
+    val kitsuEpisode: Int? = null,
+    val armEpisodeId: Int? = null
+) : Serializable {
+    val kitsuQuery: String?
+        get() = kitsuId?.let { id -> kitsuEpisode?.let { episode -> "kitsu:$id:$episode" } }
+
+    companion object {
+        fun canonical(season: Int, episode: Int) = EpisodeIdentity(
+            displaySeason = season,
+            displayEpisode = episode,
+            tmdbSeason = season,
+            tmdbEpisode = episode
+        )
+    }
+}
+
+@Immutable
 data class Episode(
     val id: Int,
     val episodeNumber: Int,
@@ -96,13 +119,14 @@ data class Episode(
     val runtime: Int = 0,
     val airDate: String = "",
     val isWatched: Boolean = false,
-    /** Canonical TMDB coordinates used by Trakt, history, ratings and metadata lookups. */
-    val tmdbSeasonNumber: Int = seasonNumber,
-    val tmdbEpisodeNumber: Int = episodeNumber,
-    /** Provider identity used when the anime-facing structure differs from TMDB. */
-    val kitsuId: Int? = null,
-    val kitsuEpisodeNumber: Int? = null
-) : Serializable
+    /** Single source of truth for display, TMDB and anime-provider coordinates. */
+    val identity: EpisodeIdentity = EpisodeIdentity.canonical(seasonNumber, episodeNumber)
+) : Serializable {
+    val tmdbSeasonNumber: Int get() = identity.tmdbSeason
+    val tmdbEpisodeNumber: Int get() = identity.tmdbEpisode
+    val kitsuId: Int? get() = identity.kitsuId
+    val kitsuEpisodeNumber: Int? get() = identity.kitsuEpisode
+}
 
 /**
  * Cast member

--- a/app/src/main/kotlin/com/arflix/tv/data/model/Models.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/model/Models.kt
@@ -95,7 +95,13 @@ data class Episode(
     val imdbRating: String = "",
     val runtime: Int = 0,
     val airDate: String = "",
-    val isWatched: Boolean = false
+    val isWatched: Boolean = false,
+    /** Canonical TMDB coordinates used by Trakt, history, ratings and metadata lookups. */
+    val tmdbSeasonNumber: Int = seasonNumber,
+    val tmdbEpisodeNumber: Int = episodeNumber,
+    /** Provider identity used when the anime-facing structure differs from TMDB. */
+    val kitsuId: Int? = null,
+    val kitsuEpisodeNumber: Int? = null
 ) : Serializable
 
 /**

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/AddonRuntime.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/AddonRuntime.kt
@@ -19,7 +19,8 @@ data class EpisodeRuntimeRequest(
     val genreIds: List<Int>,
     val originalLanguage: String?,
     val title: String,
-    val airDate: String?
+    val airDate: String?,
+    val animeQueryOverride: String? = null
 )
 
 interface AddonRuntime {

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
@@ -1856,6 +1856,7 @@ class StreamRepository @Inject constructor(
         genreIds: List<Int> = emptyList(),
         originalLanguage: String? = null,
         title: String = "",
+        animeQueryOverride: String? = null,
         airDate: String? = null
     ): List<StreamSource> {
         val startedAt = System.currentTimeMillis()
@@ -1914,7 +1915,7 @@ class StreamRepository @Inject constructor(
                     ANIME_ID_LOOKUP_TIMEOUT_MS
                 }
                 val animeQuery = if (resolveAsAnime) {
-                    resolveAnimeQuery(animeLookupTimeoutMs)
+                    animeQueryOverride ?: resolveAnimeQuery(animeLookupTimeoutMs)
                 } else null
 
                 val seriesId = "$imdbId:$season:$episode"
@@ -2661,6 +2662,7 @@ class StreamRepository @Inject constructor(
         originalLanguage: String? = null,
         title: String = "",
         forceRefresh: Boolean = false,
+        animeQueryOverride: String? = null,
         airDate: String? = null
     ): Flow<ProgressiveStreamResult> = callbackFlow {
         repositoryScope.launch {
@@ -2795,6 +2797,7 @@ class StreamRepository @Inject constructor(
                             genreIds = genreIds,
                             originalLanguage = originalLanguage,
                             title = title,
+                            animeQueryOverride = animeQueryOverride,
                             airDate = airDate
                         )
                     } catch (e: Exception) {

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
@@ -358,6 +358,7 @@ class StreamRepository @Inject constructor(
                 genreIds = request.genreIds,
                 originalLanguage = request.originalLanguage,
                 title = request.title,
+                animeQueryOverride = request.animeQueryOverride,
                 airDate = request.airDate
             )
         }
@@ -1642,9 +1643,11 @@ class StreamRepository @Inject constructor(
         imdbId: String,
         season: Int? = null,
         episode: Int? = null,
+        providerEpisodeId: String? = null,
         addonRevision: String
     ): String {
-        return "$profileId|$type|$imdbId|${season ?: 0}|${episode ?: 0}|addons:$addonRevision"
+        val providerPart = providerEpisodeId?.let { "|provider:$it" }.orEmpty()
+        return "$profileId|$type|$imdbId|${season ?: 0}|${episode ?: 0}$providerPart|addons:$addonRevision"
     }
 
     private fun cacheTtlMsFor(result: StreamResult): Long {
@@ -2593,6 +2596,7 @@ class StreamRepository @Inject constructor(
         originalLanguage: String? = null,
         title: String = "",
         forceRefresh: Boolean = false,
+        animeQueryOverride: String? = null,
         airDate: String? = null
     ): StreamResult = withContext(Dispatchers.IO) {
         ensureAddonHealthLoaded()
@@ -2613,6 +2617,7 @@ class StreamRepository @Inject constructor(
             imdbId = imdbId,
             season = season,
             episode = episode,
+            providerEpisodeId = animeQueryOverride,
             addonRevision = streamAddonConfigurationRevision(streamAddons)
         )
         if (!forceRefresh) {
@@ -2634,7 +2639,8 @@ class StreamRepository @Inject constructor(
             genreIds = genreIds,
             originalLanguage = originalLanguage,
             title = title,
-            airDate = airDate
+            airDate = airDate,
+            animeQueryOverride = animeQueryOverride
         )
         val streams = addonRuntimeAggregator.resolveEpisodeStreams(
             stremioAddons = prioritizedAddons,
@@ -2683,6 +2689,7 @@ class StreamRepository @Inject constructor(
                 imdbId = imdbId,
                 season = season,
                 episode = episode,
+                providerEpisodeId = animeQueryOverride,
                 addonRevision = streamAddonConfigurationRevision(streamAddons)
             )
             if (!forceRefresh) {

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/TraktRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/TraktRepository.kt
@@ -2203,6 +2203,8 @@ class TraktRepository @Inject constructor(
         backdropPath: String?,
         season: Int?,
         episode: Int?,
+        displaySeason: Int? = season,
+        displayEpisode: Int? = episode,
         episodeTitle: String?,
         progress: Int, // 0-100
         positionSeconds: Long = 0L,
@@ -2242,6 +2244,8 @@ class TraktRepository @Inject constructor(
             durationSeconds = durationSeconds.coerceAtLeast(0L),
             season = season,
             episode = episode,
+            displaySeason = displaySeason,
+            displayEpisode = displayEpisode,
             episodeTitle = episodeTitle,
             backdropPath = backdropPath,
             posterPath = posterPath,
@@ -4363,6 +4367,8 @@ data class ContinueWatchingItem(
     val durationSeconds: Long = 0L,
     val season: Int? = null,
     val episode: Int? = null,
+    val displaySeason: Int? = season,
+    val displayEpisode: Int? = episode,
     val episodeTitle: String? = null,
     val backdropPath: String? = null,
     val posterPath: String? = null,
@@ -4396,8 +4402,10 @@ data class ContinueWatchingItem(
         val resumeLabel = resumeSeconds.takeIf { it > 0L }?.let { formatResumeClock(it) }
 
         val subtitle = if (mediaType == MediaType.TV && season != null && episode != null) {
-            val base = context?.getString(R.string.continue_season_episode, season, episode)
-                ?: "Continue S${season}E${episode}"
+            val shownSeason = displaySeason ?: season
+            val shownEpisode = displayEpisode ?: episode
+            val base = context?.getString(R.string.continue_season_episode, shownSeason, shownEpisode)
+                ?: "Continue S${shownSeason}E${shownEpisode}"
             if (!resumeLabel.isNullOrBlank()) {
                 context?.getString(R.string.continue_from, resumeLabel) ?: "$base from $resumeLabel"
             } else {

--- a/app/src/main/kotlin/com/arflix/tv/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/arflix/tv/navigation/AppNavigation.kt
@@ -81,12 +81,14 @@ sealed class Screen(val route: String) {
         }
     }
 
-    data object Player : Screen("player/{mediaType}/{mediaId}?seasonNumber={seasonNumber}&episodeNumber={episodeNumber}&imdbId={imdbId}&streamUrl={streamUrl}&preferredAddonId={preferredAddonId}&preferredSourceName={preferredSourceName}&preferredBingeGroup={preferredBingeGroup}&startPositionMs={startPositionMs}&isLiveStream={isLiveStream}") {
+    data object Player : Screen("player/{mediaType}/{mediaId}?seasonNumber={seasonNumber}&episodeNumber={episodeNumber}&tmdbSeasonNumber={tmdbSeasonNumber}&tmdbEpisodeNumber={tmdbEpisodeNumber}&imdbId={imdbId}&streamUrl={streamUrl}&preferredAddonId={preferredAddonId}&preferredSourceName={preferredSourceName}&preferredBingeGroup={preferredBingeGroup}&startPositionMs={startPositionMs}&isLiveStream={isLiveStream}") {
         fun createRoute(
             mediaType: MediaType,
             mediaId: Int,
             seasonNumber: Int? = null,
             episodeNumber: Int? = null,
+            tmdbSeasonNumber: Int? = seasonNumber,
+            tmdbEpisodeNumber: Int? = episodeNumber,
             imdbId: String? = null,
             streamUrl: String? = null,
             preferredAddonId: String? = null,
@@ -99,6 +101,8 @@ sealed class Screen(val route: String) {
             val params = mutableListOf<String>()
             seasonNumber?.let { params.add("seasonNumber=$it") }
             episodeNumber?.let { params.add("episodeNumber=$it") }
+            tmdbSeasonNumber?.let { params.add("tmdbSeasonNumber=$it") }
+            tmdbEpisodeNumber?.let { params.add("tmdbEpisodeNumber=$it") }
             imdbId?.let { params.add("imdbId=${java.net.URLEncoder.encode(it, "UTF-8")}") }
             streamUrl?.let { params.add("streamUrl=${java.net.URLEncoder.encode(it, "UTF-8")}") }
             preferredAddonId?.let { params.add("preferredAddonId=${java.net.URLEncoder.encode(it, "UTF-8")}") }
@@ -424,13 +428,15 @@ fun AppNavigation(
                 initialSeason = initialSeason,
                 initialEpisode = initialEpisode,
                 currentProfile = currentProfile,
-                onNavigateToPlayer = { type, id, season, episode, imdbId, url, preferredAddonId, preferredSourceName, startPositionMs ->
+                onNavigateToPlayer = { type, id, season, episode, tmdbSeason, tmdbEpisode, imdbId, url, preferredAddonId, preferredSourceName, startPositionMs ->
                     navController.navigate(
                         Screen.Player.createRoute(
                             mediaType = type,
                             mediaId = id,
                             seasonNumber = season,
                             episodeNumber = episode,
+                            tmdbSeasonNumber = tmdbSeason,
+                            tmdbEpisodeNumber = tmdbEpisode,
                             imdbId = imdbId,
                             streamUrl = url,
                             preferredAddonId = preferredAddonId,
@@ -484,6 +490,14 @@ fun AppNavigation(
                     type = NavType.IntType
                     defaultValue = -1
                 },
+                navArgument("tmdbSeasonNumber") {
+                    type = NavType.IntType
+                    defaultValue = -1
+                },
+                navArgument("tmdbEpisodeNumber") {
+                    type = NavType.IntType
+                    defaultValue = -1
+                },
                 navArgument("imdbId") {
                     type = NavType.StringType
                     defaultValue = ""
@@ -518,6 +532,10 @@ fun AppNavigation(
             val mediaId = backStackEntry.arguments?.getInt("mediaId") ?: 0
             val seasonNumber = backStackEntry.arguments?.getInt("seasonNumber")?.takeIf { it >= 0 }
             val episodeNumber = backStackEntry.arguments?.getInt("episodeNumber")?.takeIf { it >= 0 }
+            val tmdbSeasonNumber = backStackEntry.arguments?.getInt("tmdbSeasonNumber")?.takeIf { it >= 0 }
+                ?: seasonNumber
+            val tmdbEpisodeNumber = backStackEntry.arguments?.getInt("tmdbEpisodeNumber")?.takeIf { it >= 0 }
+                ?: episodeNumber
             val imdbId = backStackEntry.arguments?.getString("imdbId")?.takeIf { it.isNotBlank() }
             val streamUrl = backStackEntry.arguments?.getString("streamUrl")?.takeIf { it.isNotEmpty() }
             val preferredAddonId = backStackEntry.arguments?.getString("preferredAddonId")?.takeIf { it.isNotBlank() }
@@ -532,6 +550,8 @@ fun AppNavigation(
                 mediaId = mediaId,
                 seasonNumber = seasonNumber,
                 episodeNumber = episodeNumber,
+                tmdbSeasonNumber = tmdbSeasonNumber,
+                tmdbEpisodeNumber = tmdbEpisodeNumber,
                 imdbId = imdbId,
                 streamUrl = streamUrl,
                 preferredAddonId = preferredAddonId,
@@ -540,7 +560,7 @@ fun AppNavigation(
                 startPositionMs = startPositionMs,
                 isLiveStream = isLiveStream,
                 onBack = { navController.popBackStack() },
-                onPlayNext = { nextSeason, nextEpisode, nextPreferredAddonId, nextPreferredSourceName, nextPreferredBingeGroup ->
+                onPlayNext = { nextSeason, nextEpisode, nextTmdbSeason, nextTmdbEpisode, nextPreferredAddonId, nextPreferredSourceName, nextPreferredBingeGroup ->
                     // Navigate to next episode
                     navController.navigate(
                         Screen.Player.createRoute(
@@ -548,6 +568,8 @@ fun AppNavigation(
                             mediaId = mediaId,
                             seasonNumber = nextSeason,
                             episodeNumber = nextEpisode,
+                            tmdbSeasonNumber = nextTmdbSeason,
+                            tmdbEpisodeNumber = nextTmdbEpisode,
                             preferredAddonId = nextPreferredAddonId,
                             preferredSourceName = nextPreferredSourceName,
                             preferredBingeGroup = nextPreferredBingeGroup

--- a/app/src/main/kotlin/com/arflix/tv/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/arflix/tv/navigation/AppNavigation.kt
@@ -81,7 +81,7 @@ sealed class Screen(val route: String) {
         }
     }
 
-    data object Player : Screen("player/{mediaType}/{mediaId}?seasonNumber={seasonNumber}&episodeNumber={episodeNumber}&tmdbSeasonNumber={tmdbSeasonNumber}&tmdbEpisodeNumber={tmdbEpisodeNumber}&imdbId={imdbId}&streamUrl={streamUrl}&preferredAddonId={preferredAddonId}&preferredSourceName={preferredSourceName}&preferredBingeGroup={preferredBingeGroup}&startPositionMs={startPositionMs}&isLiveStream={isLiveStream}") {
+    data object Player : Screen("player/{mediaType}/{mediaId}?seasonNumber={seasonNumber}&episodeNumber={episodeNumber}&tmdbSeasonNumber={tmdbSeasonNumber}&tmdbEpisodeNumber={tmdbEpisodeNumber}&kitsuId={kitsuId}&kitsuEpisodeNumber={kitsuEpisodeNumber}&imdbId={imdbId}&streamUrl={streamUrl}&preferredAddonId={preferredAddonId}&preferredSourceName={preferredSourceName}&preferredBingeGroup={preferredBingeGroup}&startPositionMs={startPositionMs}&isLiveStream={isLiveStream}") {
         fun createRoute(
             mediaType: MediaType,
             mediaId: Int,
@@ -89,6 +89,8 @@ sealed class Screen(val route: String) {
             episodeNumber: Int? = null,
             tmdbSeasonNumber: Int? = seasonNumber,
             tmdbEpisodeNumber: Int? = episodeNumber,
+            kitsuId: Int? = null,
+            kitsuEpisodeNumber: Int? = null,
             imdbId: String? = null,
             streamUrl: String? = null,
             preferredAddonId: String? = null,
@@ -103,6 +105,8 @@ sealed class Screen(val route: String) {
             episodeNumber?.let { params.add("episodeNumber=$it") }
             tmdbSeasonNumber?.let { params.add("tmdbSeasonNumber=$it") }
             tmdbEpisodeNumber?.let { params.add("tmdbEpisodeNumber=$it") }
+            kitsuId?.let { params.add("kitsuId=$it") }
+            kitsuEpisodeNumber?.let { params.add("kitsuEpisodeNumber=$it") }
             imdbId?.let { params.add("imdbId=${java.net.URLEncoder.encode(it, "UTF-8")}") }
             streamUrl?.let { params.add("streamUrl=${java.net.URLEncoder.encode(it, "UTF-8")}") }
             preferredAddonId?.let { params.add("preferredAddonId=${java.net.URLEncoder.encode(it, "UTF-8")}") }
@@ -428,15 +432,17 @@ fun AppNavigation(
                 initialSeason = initialSeason,
                 initialEpisode = initialEpisode,
                 currentProfile = currentProfile,
-                onNavigateToPlayer = { type, id, season, episode, tmdbSeason, tmdbEpisode, imdbId, url, preferredAddonId, preferredSourceName, startPositionMs ->
+                onNavigateToPlayer = { type, id, identity, imdbId, url, preferredAddonId, preferredSourceName, startPositionMs ->
                     navController.navigate(
                         Screen.Player.createRoute(
                             mediaType = type,
                             mediaId = id,
-                            seasonNumber = season,
-                            episodeNumber = episode,
-                            tmdbSeasonNumber = tmdbSeason,
-                            tmdbEpisodeNumber = tmdbEpisode,
+                            seasonNumber = identity?.displaySeason,
+                            episodeNumber = identity?.displayEpisode,
+                            tmdbSeasonNumber = identity?.tmdbSeason,
+                            tmdbEpisodeNumber = identity?.tmdbEpisode,
+                            kitsuId = identity?.kitsuId,
+                            kitsuEpisodeNumber = identity?.kitsuEpisode,
                             imdbId = imdbId,
                             streamUrl = url,
                             preferredAddonId = preferredAddonId,
@@ -498,6 +504,14 @@ fun AppNavigation(
                     type = NavType.IntType
                     defaultValue = -1
                 },
+                navArgument("kitsuId") {
+                    type = NavType.IntType
+                    defaultValue = -1
+                },
+                navArgument("kitsuEpisodeNumber") {
+                    type = NavType.IntType
+                    defaultValue = -1
+                },
                 navArgument("imdbId") {
                     type = NavType.StringType
                     defaultValue = ""
@@ -536,6 +550,8 @@ fun AppNavigation(
                 ?: seasonNumber
             val tmdbEpisodeNumber = backStackEntry.arguments?.getInt("tmdbEpisodeNumber")?.takeIf { it >= 0 }
                 ?: episodeNumber
+            val kitsuId = backStackEntry.arguments?.getInt("kitsuId")?.takeIf { it > 0 }
+            val kitsuEpisodeNumber = backStackEntry.arguments?.getInt("kitsuEpisodeNumber")?.takeIf { it > 0 }
             val imdbId = backStackEntry.arguments?.getString("imdbId")?.takeIf { it.isNotBlank() }
             val streamUrl = backStackEntry.arguments?.getString("streamUrl")?.takeIf { it.isNotEmpty() }
             val preferredAddonId = backStackEntry.arguments?.getString("preferredAddonId")?.takeIf { it.isNotBlank() }
@@ -552,6 +568,8 @@ fun AppNavigation(
                 episodeNumber = episodeNumber,
                 tmdbSeasonNumber = tmdbSeasonNumber,
                 tmdbEpisodeNumber = tmdbEpisodeNumber,
+                kitsuId = kitsuId,
+                kitsuEpisodeNumber = kitsuEpisodeNumber,
                 imdbId = imdbId,
                 streamUrl = streamUrl,
                 preferredAddonId = preferredAddonId,
@@ -560,16 +578,18 @@ fun AppNavigation(
                 startPositionMs = startPositionMs,
                 isLiveStream = isLiveStream,
                 onBack = { navController.popBackStack() },
-                onPlayNext = { nextSeason, nextEpisode, nextTmdbSeason, nextTmdbEpisode, nextPreferredAddonId, nextPreferredSourceName, nextPreferredBingeGroup ->
+                onPlayNext = { nextIdentity, nextPreferredAddonId, nextPreferredSourceName, nextPreferredBingeGroup ->
                     // Navigate to next episode
                     navController.navigate(
                         Screen.Player.createRoute(
                             mediaType = mediaType,
                             mediaId = mediaId,
-                            seasonNumber = nextSeason,
-                            episodeNumber = nextEpisode,
-                            tmdbSeasonNumber = nextTmdbSeason,
-                            tmdbEpisodeNumber = nextTmdbEpisode,
+                            seasonNumber = nextIdentity.displaySeason,
+                            episodeNumber = nextIdentity.displayEpisode,
+                            tmdbSeasonNumber = nextIdentity.tmdbSeason,
+                            tmdbEpisodeNumber = nextIdentity.tmdbEpisode,
+                            kitsuId = nextIdentity.kitsuId,
+                            kitsuEpisodeNumber = nextIdentity.kitsuEpisode,
                             preferredAddonId = nextPreferredAddonId,
                             preferredSourceName = nextPreferredSourceName,
                             preferredBingeGroup = nextPreferredBingeGroup

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
@@ -204,7 +204,7 @@ fun DetailsScreen(
     initialEpisode: Int? = null,
     viewModel: DetailsViewModel = hiltViewModel(),
     currentProfile: com.arflix.tv.data.model.Profile? = null,
-    onNavigateToPlayer: (MediaType, Int, Int?, Int?, Int?, Int?, String?, String?, String?, String?, Long?) -> Unit,
+    onNavigateToPlayer: (MediaType, Int, EpisodeIdentity?, String?, String?, String?, String?, Long?) -> Unit,
     onNavigateToDetails: (MediaType, Int) -> Unit,
     onNavigateToCollection: (String) -> Unit = {},
     onNavigateToHome: () -> Unit = {},
@@ -266,16 +266,16 @@ fun DetailsScreen(
         showStreamSelector = false
         val identity = uiState.episodes.firstOrNull {
             it.seasonNumber == displaySeason && it.episodeNumber == displayEpisode
-        }?.identity ?: if (displaySeason != null && displayEpisode != null && tmdbSeason != null && tmdbEpisode != null) {
-            EpisodeIdentity(displaySeason, displayEpisode, tmdbSeason, tmdbEpisode)
-        } else null
-        viewModel.loadStreams(imdbId, identity)
-        autoPlayWaitTick = 0
-        pendingAutoPlayRequest = PendingAutoPlayRequest(
+        }?.identity ?: viewModel.resolveEpisodeIdentity(
             displaySeason = displaySeason,
             displayEpisode = displayEpisode,
             tmdbSeason = tmdbSeason,
-            tmdbEpisode = tmdbEpisode,
+            tmdbEpisode = tmdbEpisode
+        )
+        viewModel.loadStreams(imdbId, identity)
+        autoPlayWaitTick = 0
+        pendingAutoPlayRequest = PendingAutoPlayRequest(
+            identity = identity,
             startPositionMs = startPositionMs,
             requestedAtMs = SystemClock.elapsedRealtime()
         )
@@ -368,27 +368,12 @@ fun DetailsScreen(
 
         when {
             selectedStream != null && !shouldWaitForSources -> {
-                val identity = uiState.episodes.firstOrNull {
-                    it.seasonNumber == request.displaySeason && it.episodeNumber == request.displayEpisode
-                }?.identity ?: if (
-                    request.displaySeason != null && request.displayEpisode != null &&
-                    request.tmdbSeason != null && request.tmdbEpisode != null
-                ) {
-                    EpisodeIdentity(
-                        request.displaySeason,
-                        request.displayEpisode,
-                        request.tmdbSeason,
-                        request.tmdbEpisode
-                    )
-                } else null
+                val identity = request.identity
                 viewModel.recordPlayedEpisode(mediaId, identity)
                 onNavigateToPlayer(
                     mediaType,
                     mediaId,
-                    request.displaySeason,
-                    request.displayEpisode,
-                    request.tmdbSeason,
-                    request.tmdbEpisode,
+                    identity,
                     uiState.imdbId,
                     selectedStream.url?.takeIf { it.isNotBlank() },
                     selectedStream.addonId.takeIf { it.isNotBlank() },
@@ -1113,8 +1098,7 @@ fun DetailsScreen(
                 viewModel.recordPlayedEpisode(mediaId, ep?.identity)
                 onNavigateToPlayer(
                     mediaType, mediaId,
-                    ep?.seasonNumber, ep?.episodeNumber,
-                    ep?.tmdbSeasonNumber, ep?.tmdbEpisodeNumber,
+                    ep?.identity,
                     uiState.imdbId,
                     stream.url?.takeIf { it.isNotBlank() },
                     stream.addonId.takeIf { it.isNotBlank() },
@@ -1194,10 +1178,7 @@ private enum class FocusSection {
 }
 
 private data class PendingAutoPlayRequest(
-    val displaySeason: Int?,
-    val displayEpisode: Int?,
-    val tmdbSeason: Int?,
-    val tmdbEpisode: Int?,
+    val identity: EpisodeIdentity?,
     val startPositionMs: Long?,
     val requestedAtMs: Long
 )

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
@@ -203,7 +203,7 @@ fun DetailsScreen(
     initialEpisode: Int? = null,
     viewModel: DetailsViewModel = hiltViewModel(),
     currentProfile: com.arflix.tv.data.model.Profile? = null,
-    onNavigateToPlayer: (MediaType, Int, Int?, Int?, String?, String?, String?, String?, Long?) -> Unit,
+    onNavigateToPlayer: (MediaType, Int, Int?, Int?, Int?, Int?, String?, String?, String?, String?, Long?) -> Unit,
     onNavigateToDetails: (MediaType, Int) -> Unit,
     onNavigateToCollection: (String) -> Unit = {},
     onNavigateToHome: () -> Unit = {},
@@ -254,13 +254,22 @@ fun DetailsScreen(
     var seasonSelectDownAtMs by remember { mutableLongStateOf(0L) }
     var ignoreFirstResumeRefresh by remember(mediaType, mediaId, initialSeason, initialEpisode) { mutableStateOf(true) }
 
-    fun requestFastAutoPlay(imdbId: String?, season: Int?, episode: Int?, startPositionMs: Long?) {
+    fun requestFastAutoPlay(
+        imdbId: String?,
+        displaySeason: Int?,
+        displayEpisode: Int?,
+        startPositionMs: Long?,
+        tmdbSeason: Int? = displaySeason,
+        tmdbEpisode: Int? = displayEpisode
+    ) {
         showStreamSelector = false
-        viewModel.loadStreams(imdbId, season, episode)
+        viewModel.loadStreams(imdbId, tmdbSeason, tmdbEpisode)
         autoPlayWaitTick = 0
         pendingAutoPlayRequest = PendingAutoPlayRequest(
-            season = season,
-            episode = episode,
+            displaySeason = displaySeason,
+            displayEpisode = displayEpisode,
+            tmdbSeason = tmdbSeason,
+            tmdbEpisode = tmdbEpisode,
             startPositionMs = startPositionMs,
             requestedAtMs = SystemClock.elapsedRealtime()
         )
@@ -353,12 +362,14 @@ fun DetailsScreen(
 
         when {
             selectedStream != null && !shouldWaitForSources -> {
-                viewModel.recordPlayedEpisode(mediaId, request.season, request.episode)
+                viewModel.recordPlayedEpisode(mediaId, request.displaySeason, request.displayEpisode)
                 onNavigateToPlayer(
                     mediaType,
                     mediaId,
-                    request.season,
-                    request.episode,
+                    request.displaySeason,
+                    request.displayEpisode,
+                    request.tmdbSeason,
+                    request.tmdbEpisode,
                     uiState.imdbId,
                     selectedStream.url?.takeIf { it.isNotBlank() },
                     selectedStream.addonId.takeIf { it.isNotBlank() },
@@ -457,16 +468,24 @@ fun DetailsScreen(
                     if (!state.autoPlaySingleSource) {
                         // Autoplay OFF → open the source picker; never auto-play.
                         showStreamSelector = true
-                        viewModel.loadStreams(state.imdbId, season, episode)
+                        viewModel.loadStreams(
+                            state.imdbId,
+                            state.playTmdbSeason ?: season,
+                            state.playTmdbEpisode ?: episode
+                        )
                     } else {
                         // Autoplay ON → go straight to the player; PlayerScreen auto-picks.
-                        requestFastAutoPlay(state.imdbId, season, episode, startPositionMs)
+                        requestFastAutoPlay(
+                            state.imdbId, season, episode, startPositionMs,
+                            state.playTmdbSeason ?: season,
+                            state.playTmdbEpisode ?: episode
+                        )
                     }
                 }
                 1 -> { // Sources
                     showStreamSelector = true
                     val ep = state.episodes.getOrNull(currentEpIdx)
-                    viewModel.loadStreams(state.imdbId, ep?.seasonNumber, ep?.episodeNumber)
+                    viewModel.loadStreams(state.imdbId, ep?.tmdbSeasonNumber, ep?.tmdbEpisodeNumber)
                 }
                 2 -> { // Trailer
                     state.trailerKey?.let { showTrailerPlayer = true }
@@ -505,9 +524,12 @@ fun DetailsScreen(
                 episodeIndex = idx
                 if (isMobile || !state.autoPlaySingleSource) {
                     showStreamSelector = true
-                    viewModel.loadStreams(state.imdbId, ep.seasonNumber, ep.episodeNumber)
+                    viewModel.loadStreams(state.imdbId, ep.tmdbSeasonNumber, ep.tmdbEpisodeNumber)
                 } else {
-                    requestFastAutoPlay(state.imdbId, ep.seasonNumber, ep.episodeNumber, null)
+                    requestFastAutoPlay(
+                        state.imdbId, ep.seasonNumber, ep.episodeNumber, null,
+                        ep.tmdbSeasonNumber, ep.tmdbEpisodeNumber
+                    )
                 }
             }
         }
@@ -814,17 +836,25 @@ fun DetailsScreen(
                                             if (!uiState.autoPlaySingleSource) {
                                                 // Autoplay OFF → open the source picker; never auto-play.
                                                 showStreamSelector = true
-                                                viewModel.loadStreams(uiState.imdbId, season, episode)
+                                                viewModel.loadStreams(
+                                                    uiState.imdbId,
+                                                    uiState.playTmdbSeason ?: season,
+                                                    uiState.playTmdbEpisode ?: episode
+                                                )
                                             } else {
                                                 // Autoplay ON: pick a concrete stream first, then open PlayerScreen.
-                                                requestFastAutoPlay(uiState.imdbId, season, episode, startPositionMs)
+                                                requestFastAutoPlay(
+                                                    uiState.imdbId, season, episode, startPositionMs,
+                                                    uiState.playTmdbSeason ?: season,
+                                                    uiState.playTmdbEpisode ?: episode
+                                                )
                                             }
                                         }
                                         1 -> { // Sources - Show StreamSelector for manual selection
                                             showStreamSelector = true
                                             // Pass the currently focused episode for TV shows
                                             val ep = uiState.episodes.getOrNull(episodeIndex)
-                                            viewModel.loadStreams(uiState.imdbId, ep?.seasonNumber, ep?.episodeNumber)
+                                            viewModel.loadStreams(uiState.imdbId, ep?.tmdbSeasonNumber, ep?.tmdbEpisodeNumber)
                                         }
                                         2 -> { // Trailer
                                             uiState.trailerKey?.let {
@@ -844,9 +874,12 @@ fun DetailsScreen(
                                     if (ep != null) {
                                         if (!uiState.autoPlaySingleSource) {
                                             showStreamSelector = true
-                                            viewModel.loadStreams(uiState.imdbId, ep.seasonNumber, ep.episodeNumber)
+                                            viewModel.loadStreams(uiState.imdbId, ep.tmdbSeasonNumber, ep.tmdbEpisodeNumber)
                                         } else {
-                                            requestFastAutoPlay(uiState.imdbId, ep.seasonNumber, ep.episodeNumber, null)
+                                            requestFastAutoPlay(
+                                                uiState.imdbId, ep.seasonNumber, ep.episodeNumber, null,
+                                                ep.tmdbSeasonNumber, ep.tmdbEpisodeNumber
+                                            )
                                         }
                                     }
                                 }
@@ -1064,6 +1097,7 @@ fun DetailsScreen(
                 onNavigateToPlayer(
                     mediaType, mediaId,
                     ep?.seasonNumber, ep?.episodeNumber,
+                    ep?.tmdbSeasonNumber, ep?.tmdbEpisodeNumber,
                     uiState.imdbId,
                     stream.url?.takeIf { it.isNotBlank() },
                     stream.addonId.takeIf { it.isNotBlank() },
@@ -1083,12 +1117,15 @@ fun DetailsScreen(
                 isWatched = episode.isWatched,
                 onPlay = {
                     showEpisodeContextMenu = false
-                    requestFastAutoPlay(uiState.imdbId, episode.seasonNumber, episode.episodeNumber, null)
+                    requestFastAutoPlay(
+                        uiState.imdbId, episode.seasonNumber, episode.episodeNumber, null,
+                        episode.tmdbSeasonNumber, episode.tmdbEpisodeNumber
+                    )
                 },
                 onSelectSource = {
                     showEpisodeContextMenu = false
                     showStreamSelector = true
-                    viewModel.loadStreams(uiState.imdbId, episode.seasonNumber, episode.episodeNumber)
+                    viewModel.loadStreams(uiState.imdbId, episode.tmdbSeasonNumber, episode.tmdbEpisodeNumber)
                 },
                 onToggleWatched = {
                     viewModel.markEpisodeWatched(
@@ -1140,8 +1177,10 @@ private enum class FocusSection {
 }
 
 private data class PendingAutoPlayRequest(
-    val season: Int?,
-    val episode: Int?,
+    val displaySeason: Int?,
+    val displayEpisode: Int?,
+    val tmdbSeason: Int?,
+    val tmdbEpisode: Int?,
     val startPositionMs: Long?,
     val requestedAtMs: Long
 )

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
@@ -132,6 +132,7 @@ import coil.size.Precision
 import com.arflix.tv.R
 import com.arflix.tv.data.model.CastMember
 import com.arflix.tv.data.model.Episode
+import com.arflix.tv.data.model.EpisodeIdentity
 import com.arflix.tv.data.model.MediaItem
 import com.arflix.tv.data.model.MediaType
 import com.arflix.tv.data.model.Review
@@ -263,7 +264,12 @@ fun DetailsScreen(
         tmdbEpisode: Int? = displayEpisode
     ) {
         showStreamSelector = false
-        viewModel.loadStreams(imdbId, tmdbSeason, tmdbEpisode)
+        val identity = uiState.episodes.firstOrNull {
+            it.seasonNumber == displaySeason && it.episodeNumber == displayEpisode
+        }?.identity ?: if (displaySeason != null && displayEpisode != null && tmdbSeason != null && tmdbEpisode != null) {
+            EpisodeIdentity(displaySeason, displayEpisode, tmdbSeason, tmdbEpisode)
+        } else null
+        viewModel.loadStreams(imdbId, identity)
         autoPlayWaitTick = 0
         pendingAutoPlayRequest = PendingAutoPlayRequest(
             displaySeason = displaySeason,
@@ -362,7 +368,20 @@ fun DetailsScreen(
 
         when {
             selectedStream != null && !shouldWaitForSources -> {
-                viewModel.recordPlayedEpisode(mediaId, request.displaySeason, request.displayEpisode)
+                val identity = uiState.episodes.firstOrNull {
+                    it.seasonNumber == request.displaySeason && it.episodeNumber == request.displayEpisode
+                }?.identity ?: if (
+                    request.displaySeason != null && request.displayEpisode != null &&
+                    request.tmdbSeason != null && request.tmdbEpisode != null
+                ) {
+                    EpisodeIdentity(
+                        request.displaySeason,
+                        request.displayEpisode,
+                        request.tmdbSeason,
+                        request.tmdbEpisode
+                    )
+                } else null
+                viewModel.recordPlayedEpisode(mediaId, identity)
                 onNavigateToPlayer(
                     mediaType,
                     mediaId,
@@ -468,11 +487,10 @@ fun DetailsScreen(
                     if (!state.autoPlaySingleSource) {
                         // Autoplay OFF → open the source picker; never auto-play.
                         showStreamSelector = true
-                        viewModel.loadStreams(
-                            state.imdbId,
-                            state.playTmdbSeason ?: season,
-                            state.playTmdbEpisode ?: episode
-                        )
+                        val identity = state.episodes.firstOrNull {
+                            it.seasonNumber == season && it.episodeNumber == episode
+                        }?.identity
+                        viewModel.loadStreams(state.imdbId, identity)
                     } else {
                         // Autoplay ON → go straight to the player; PlayerScreen auto-picks.
                         requestFastAutoPlay(
@@ -485,7 +503,7 @@ fun DetailsScreen(
                 1 -> { // Sources
                     showStreamSelector = true
                     val ep = state.episodes.getOrNull(currentEpIdx)
-                    viewModel.loadStreams(state.imdbId, ep?.tmdbSeasonNumber, ep?.tmdbEpisodeNumber)
+                    viewModel.loadStreams(state.imdbId, ep?.identity)
                 }
                 2 -> { // Trailer
                     state.trailerKey?.let { showTrailerPlayer = true }
@@ -524,7 +542,7 @@ fun DetailsScreen(
                 episodeIndex = idx
                 if (isMobile || !state.autoPlaySingleSource) {
                     showStreamSelector = true
-                    viewModel.loadStreams(state.imdbId, ep.tmdbSeasonNumber, ep.tmdbEpisodeNumber)
+                    viewModel.loadStreams(state.imdbId, ep.identity)
                 } else {
                     requestFastAutoPlay(
                         state.imdbId, ep.seasonNumber, ep.episodeNumber, null,
@@ -836,11 +854,10 @@ fun DetailsScreen(
                                             if (!uiState.autoPlaySingleSource) {
                                                 // Autoplay OFF → open the source picker; never auto-play.
                                                 showStreamSelector = true
-                                                viewModel.loadStreams(
-                                                    uiState.imdbId,
-                                                    uiState.playTmdbSeason ?: season,
-                                                    uiState.playTmdbEpisode ?: episode
-                                                )
+                                                val identity = uiState.episodes.firstOrNull {
+                                                    it.seasonNumber == season && it.episodeNumber == episode
+                                                }?.identity
+                                                viewModel.loadStreams(uiState.imdbId, identity)
                                             } else {
                                                 // Autoplay ON: pick a concrete stream first, then open PlayerScreen.
                                                 requestFastAutoPlay(
@@ -854,7 +871,7 @@ fun DetailsScreen(
                                             showStreamSelector = true
                                             // Pass the currently focused episode for TV shows
                                             val ep = uiState.episodes.getOrNull(episodeIndex)
-                                            viewModel.loadStreams(uiState.imdbId, ep?.tmdbSeasonNumber, ep?.tmdbEpisodeNumber)
+                                            viewModel.loadStreams(uiState.imdbId, ep?.identity)
                                         }
                                         2 -> { // Trailer
                                             uiState.trailerKey?.let {
@@ -874,7 +891,7 @@ fun DetailsScreen(
                                     if (ep != null) {
                                         if (!uiState.autoPlaySingleSource) {
                                             showStreamSelector = true
-                                            viewModel.loadStreams(uiState.imdbId, ep.tmdbSeasonNumber, ep.tmdbEpisodeNumber)
+                                            viewModel.loadStreams(uiState.imdbId, ep.identity)
                                         } else {
                                             requestFastAutoPlay(
                                                 uiState.imdbId, ep.seasonNumber, ep.episodeNumber, null,
@@ -1093,7 +1110,7 @@ fun DetailsScreen(
                 }
                 showStreamSelector = false
                 val ep = uiState.episodes.getOrNull(episodeIndex)
-                viewModel.recordPlayedEpisode(mediaId, ep?.seasonNumber, ep?.episodeNumber)
+                viewModel.recordPlayedEpisode(mediaId, ep?.identity)
                 onNavigateToPlayer(
                     mediaType, mediaId,
                     ep?.seasonNumber, ep?.episodeNumber,
@@ -1125,7 +1142,7 @@ fun DetailsScreen(
                 onSelectSource = {
                     showEpisodeContextMenu = false
                     showStreamSelector = true
-                    viewModel.loadStreams(uiState.imdbId, episode.tmdbSeasonNumber, episode.tmdbEpisodeNumber)
+                    viewModel.loadStreams(uiState.imdbId, episode.identity)
                 },
                 onToggleWatched = {
                     viewModel.markEpisodeWatched(

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
@@ -9,6 +9,7 @@ import com.arflix.tv.data.model.Addon
 import com.arflix.tv.data.model.AddonType
 import com.arflix.tv.data.model.CastMember
 import com.arflix.tv.data.model.Episode
+import com.arflix.tv.data.model.EpisodeIdentity
 import com.arflix.tv.data.model.MediaItem
 import com.arflix.tv.data.model.MediaType
 import com.arflix.tv.data.model.PersonDetails
@@ -223,13 +224,11 @@ class DetailsViewModel @Inject constructor(
     // player (which recreates the details screen) points the Continue button at that episode even
     // when the play was too brief to record a resume point. Scoped to a media id.
     private var lastPlayedMediaId: Int = 0
-    private var lastPlayedSeason: Int? = null
-    private var lastPlayedEpisode: Int? = null
+    private var lastPlayedIdentity: EpisodeIdentity? = null
 
-    fun recordPlayedEpisode(mediaId: Int, season: Int?, episode: Int?) {
+    fun recordPlayedEpisode(mediaId: Int, identity: EpisodeIdentity?) {
         lastPlayedMediaId = mediaId
-        lastPlayedSeason = season
-        lastPlayedEpisode = episode
+        lastPlayedIdentity = identity
     }
     private var vodAppendJob: kotlinx.coroutines.Job? = null
     private var homeServerAppendJob: kotlinx.coroutines.Job? = null
@@ -317,8 +316,9 @@ class DetailsViewModel @Inject constructor(
                 // re-deriving from the viewed season. The season rail keeps whatever season the user
                 // was browsing (previousState.currentSeason).
                 val reentry = previousMatches && previousState.currentSeason > 0
-                val playedSeason = lastPlayedSeason?.takeIf { lastPlayedMediaId == mediaId }
-                val playedEpisode = lastPlayedEpisode?.takeIf { lastPlayedMediaId == mediaId }
+                val playedIdentity = lastPlayedIdentity?.takeIf { lastPlayedMediaId == mediaId }
+                val playedSeason = playedIdentity?.tmdbSeason
+                val playedEpisode = playedIdentity?.tmdbEpisode
                 val initialSeason = when {
                     reentry -> playedSeason
                     else -> initialSeason
@@ -988,8 +988,12 @@ class DetailsViewModel @Inject constructor(
                             episode.copy(
                                 episodeNumber = index + 1,
                                 seasonNumber = seasonNumber,
-                                tmdbSeasonNumber = episode.seasonNumber,
-                                tmdbEpisodeNumber = episode.episodeNumber
+                                identity = EpisodeIdentity(
+                                    displaySeason = seasonNumber,
+                                    displayEpisode = index + 1,
+                                    tmdbSeason = episode.seasonNumber,
+                                    tmdbEpisode = episode.episodeNumber
+                                )
                             )
                         }
                     } else {
@@ -1063,10 +1067,7 @@ class DetailsViewModel @Inject constructor(
                 ?.copy(
                     seasonNumber = identity.displaySeason,
                     episodeNumber = identity.displayEpisode,
-                    tmdbSeasonNumber = identity.tmdbSeason,
-                    tmdbEpisodeNumber = identity.tmdbEpisode,
-                    kitsuId = identity.kitsuId,
-                    kitsuEpisodeNumber = identity.displayEpisode
+                    identity = identity
                 )
         }
     }
@@ -1129,6 +1130,8 @@ class DetailsViewModel @Inject constructor(
                                 backdropPath = currentItem.backdrop,
                                 season = nextSeason,
                                 episode = nextEp,
+                                displaySeason = nextIdentity?.displaySeason ?: nextSeason,
+                                displayEpisode = nextIdentity?.displayEpisode ?: nextEp,
                                 episodeTitle = null,
                                 progress = 3,
                                 positionSeconds = 0L,
@@ -1550,7 +1553,7 @@ class DetailsViewModel @Inject constructor(
         }
     }
 
-    fun loadStreams(imdbId: String?, season: Int? = null, episode: Int? = null) {
+    fun loadStreams(imdbId: String?, identity: EpisodeIdentity? = null) {
         loadStreamsJob?.cancel()
         focusedStreamPrewarmJob?.cancel()
         streamListPrewarmJob?.cancel()
@@ -1627,18 +1630,9 @@ class DetailsViewModel @Inject constructor(
                 val item = _uiState.value.item
                 val genreIds = item?.genreIds ?: emptyList()
                 val originalLanguage = item?.originalLanguage
-                val selectedEpisode = if (requestMediaType == MediaType.TV) {
-                    _uiState.value.episodes.firstOrNull {
-                        it.seasonNumber == (season ?: 1) && it.episodeNumber == (episode ?: 1)
-                    }
-                } else null
-                val canonicalSeason = selectedEpisode?.tmdbSeasonNumber ?: season
-                val canonicalEpisode = selectedEpisode?.tmdbEpisodeNumber ?: episode
-                val animeQueryOverride = selectedEpisode?.kitsuId?.let { kitsuId ->
-                    selectedEpisode.kitsuEpisodeNumber?.let { kitsuEpisode ->
-                        "kitsu:$kitsuId:$kitsuEpisode"
-                    }
-                }
+                val canonicalSeason = identity?.tmdbSeason
+                val canonicalEpisode = identity?.tmdbEpisode
+                val animeQueryOverride = identity?.kitsuQuery
                 val hasHomeServerConnections = streamRepository.hasHomeServerConnections()
                 // Start VOD append in background - runs parallel to addon stream fetch
                 homeServerAppendJob = viewModelScope.launch {
@@ -1677,8 +1671,8 @@ class DetailsViewModel @Inject constructor(
                         pluginManager.executeScrapersStreaming(
                             tmdbId = tmdbIdStr,
                             mediaType = pluginMediaType,
-                            season = if (requestMediaType != MediaType.MOVIE) (season ?: 1) else null,
-                            episode = if (requestMediaType != MediaType.MOVIE) (episode ?: 1) else null
+                            season = if (requestMediaType != MediaType.MOVIE) (canonicalSeason ?: 1) else null,
+                            episode = if (requestMediaType != MediaType.MOVIE) (canonicalEpisode ?: 1) else null
                         ).collect { pair ->
                             val scraperInfo = pair.first
                             val results: List<LocalScraperResult>? = pair.second
@@ -1815,7 +1809,9 @@ class DetailsViewModel @Inject constructor(
                         return@launch
                     }
                     // Look up air date for daily show stream resolution fallback
-                    val episodeAirDate = selectedEpisode?.airDate?.takeIf { it.isNotBlank() }
+                    val episodeAirDate = identity?.let { requested ->
+                        _uiState.value.episodes.firstOrNull { it.identity == requested }?.airDate
+                    }?.takeIf { it.isNotBlank() }
 
                     streamRepository.resolveEpisodeStreamsProgressive(
                         imdbId = effectiveStreamId,
@@ -1894,6 +1890,8 @@ class DetailsViewModel @Inject constructor(
                                 backdropPath = item.backdrop,
                                 season = nextSeason,
                                 episode = nextEp,
+                                displaySeason = nextIdentity?.displaySeason ?: nextSeason,
+                                displayEpisode = nextIdentity?.displayEpisode ?: nextEp,
                                 episodeTitle = null,
                                 progress = 3,
                                 positionSeconds = 0L,
@@ -1945,7 +1943,8 @@ class DetailsViewModel @Inject constructor(
                 val seasonEpisodes = if (_uiState.value.currentSeason == season && _uiState.value.episodes.isNotEmpty()) {
                     _uiState.value.episodes
                 } else {
-                    mediaRepository.getSeasonEpisodes(currentMediaId, season)
+                    animeSeasonStructure?.let { loadAnimeDisplaySeason(currentMediaId, season, it) }
+                        ?: mediaRepository.getSeasonEpisodes(currentMediaId, season)
                 }
 
                 if (seasonEpisodes.isEmpty()) {
@@ -2025,6 +2024,7 @@ class DetailsViewModel @Inject constructor(
 
                 if (nextUnwatched != null) {
                     val (nextSeason, nextEpisode) = nextUnwatched
+                    val nextDisplayIdentity = animeSeasonStructure?.identityForTmdb(nextSeason, nextEpisode)
                     runCatching {
                         traktRepository.saveLocalContinueWatching(
                             mediaType = MediaType.TV,
@@ -2034,6 +2034,8 @@ class DetailsViewModel @Inject constructor(
                             backdropPath = currentItem.backdrop,
                             season = nextSeason,
                             episode = nextEpisode,
+                            displaySeason = nextDisplayIdentity?.displaySeason ?: nextSeason,
+                            displayEpisode = nextDisplayIdentity?.displayEpisode ?: nextEpisode,
                             episodeTitle = null,
                             progress = 3,
                             positionSeconds = 0L, // next episode: no resume position yet
@@ -2110,7 +2112,8 @@ class DetailsViewModel @Inject constructor(
                 val seasonEpisodes = if (_uiState.value.currentSeason == season && _uiState.value.episodes.isNotEmpty()) {
                     _uiState.value.episodes
                 } else {
-                    mediaRepository.getSeasonEpisodes(currentMediaId, season)
+                    animeSeasonStructure?.let { loadAnimeDisplaySeason(currentMediaId, season, it) }
+                        ?: mediaRepository.getSeasonEpisodes(currentMediaId, season)
                 }
 
                 if (seasonEpisodes.isEmpty()) {
@@ -2138,29 +2141,30 @@ class DetailsViewModel @Inject constructor(
                 )
 
                 // BATCH: Single Trakt API call to remove all episodes, then concurrent Supabase writes
-                val episodeNumbers = seasonEpisodes.map { it.episodeNumber }
-
-                // 1. Single batch Trakt API call to remove from history
-                val batchTraktRemoved = runCatching {
-                    traktRepository.removeSeasonFromHistory(currentMediaId, season, episodeNumbers)
-                }.getOrDefault(false)
-
-                // 2. Concurrent local/Supabase unwatch writes for each episode.
-                // If the batch Trakt removal failed, fall back to per-episode Trakt sync.
-                val episodeUnwatchResults = episodeNumbers.map { epNum ->
+                val canonicalGroups = seasonEpisodes.groupBy { it.identity.tmdbSeason }
+                val groupResults = canonicalGroups.map { (tmdbSeason, episodes) ->
                     async {
-                        runCatching {
-                            traktRepository.markEpisodeUnwatched(
-                                currentMediaId,
-                                season,
-                                epNum,
-                                syncTrakt = !batchTraktRemoved
-                            )
-                        }
+                        val tmdbEpisodes = episodes.map { it.identity.tmdbEpisode }
+                        val batchRemoved = runCatching {
+                            traktRepository.removeSeasonFromHistory(currentMediaId, tmdbSeason, tmdbEpisodes)
+                        }.getOrDefault(false)
+                        val perEpisode = episodes.map { ep ->
+                            async {
+                                runCatching {
+                                    traktRepository.markEpisodeUnwatched(
+                                        currentMediaId,
+                                        ep.identity.tmdbSeason,
+                                        ep.identity.tmdbEpisode,
+                                        syncTrakt = !batchRemoved
+                                    )
+                                }
+                            }
+                        }.map { it.await() }
+                        batchRemoved || perEpisode.all { it.isSuccess }
                     }
                 }.map { it.await() }
 
-                if (!batchTraktRemoved && episodeUnwatchResults.any { it.isFailure }) {
+                if (groupResults.any { !it }) {
                     _uiState.value = _uiState.value.copy(
                         episodes = updatedEpisodes,
                         seasonProgress = optimisticProgress,
@@ -2257,8 +2261,18 @@ class DetailsViewModel @Inject constructor(
                 }
             }
 
+            val watchedCoordinates = watchedKeys.mapNotNull { key ->
+                val parts = key.split(":")
+                val season = parts.getOrNull(2)?.toIntOrNull() ?: return@mapNotNull null
+                val episode = parts.getOrNull(3)?.toIntOrNull() ?: return@mapNotNull null
+                season to episode
+            }.toSet()
+            val displayProgress = animeSeasonStructure
+                ?.progressForCanonicalEpisodes(watchedCoordinates)
+                ?: progressMap
+
             SeasonProgressResult(
-                progress = progressMap,
+                progress = displayProgress,
                 hasWatched = watchedKeys.isNotEmpty() || progressMap.values.any { it.first > 0 },
                 nextUnwatched = nextUnwatched
             )

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
@@ -29,6 +29,8 @@ import com.arflix.tv.data.repository.TraktRepository
 import com.arflix.tv.data.repository.WatchHistoryRepository
 import com.arflix.tv.data.repository.WatchlistRepository
 import com.arflix.tv.util.AppLogger
+import com.arflix.tv.util.AnimeMapper
+import com.arflix.tv.util.AnimeSeasonStructure
 import com.arflix.tv.util.Constants
 import com.arflix.tv.util.settingsDataStore
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -99,6 +101,8 @@ data class DetailsUiState(
     val seasonProgress: Map<Int, Pair<Int, Int>> = emptyMap(),
     val playSeason: Int? = null,
     val playEpisode: Int? = null,
+    val playTmdbSeason: Int? = null,
+    val playTmdbEpisode: Int? = null,
     val playLabel: String? = null,
     val playPositionMs: Long? = null,
     val autoPlaySingleSource: Boolean = true,
@@ -193,6 +197,7 @@ class DetailsViewModel @Inject constructor(
     private val traktRepository: TraktRepository,
     private val remoteSyncManager: com.arflix.tv.data.repository.sync.RemoteSyncManager,
     private val streamRepository: StreamRepository,
+    private val animeMapper: AnimeMapper,
     private val tmdbApi: TmdbApi,
     private val watchHistoryRepository: WatchHistoryRepository,
     private val watchlistRepository: WatchlistRepository,
@@ -213,6 +218,7 @@ class DetailsViewModel @Inject constructor(
 
     private var currentMediaType: MediaType = MediaType.MOVIE
     private var currentMediaId: Int = 0
+    private var animeSeasonStructure: AnimeSeasonStructure? = null
     // The episode the user last started playing from this screen, kept so that returning from the
     // player (which recreates the details screen) points the Continue button at that episode even
     // when the play was too brief to record a resume point. Scoped to a media id.
@@ -285,6 +291,7 @@ class DetailsViewModel @Inject constructor(
     fun loadDetails(mediaType: MediaType, mediaId: Int, initialSeason: Int? = null, initialEpisode: Int? = null) {
         currentMediaType = mediaType
         currentMediaId = mediaId
+        animeSeasonStructure = null
         initialLoadComplete = false
         vodAppendJob?.cancel()
         homeServerAppendJob?.cancel()
@@ -354,6 +361,8 @@ class DetailsViewModel @Inject constructor(
                     totalSeasons = cachedTotalSeasons,
                     playSeason = initialSeason,
                     playEpisode = initialEpisode,
+                    playTmdbSeason = initialSeason,
+                    playTmdbEpisode = initialEpisode,
                     playLabel = if (mediaType == MediaType.TV && initialSeason != null && initialEpisode != null) {
                         context.getString(R.string.continue_season_episode, initialSeason, initialEpisode)
                     } else {
@@ -508,6 +517,56 @@ class DetailsViewModel @Inject constructor(
                     showStatus = showStatus
                 )
                 _uiState.value = baseState
+
+                // ARM/Kitsu may expose several anime seasons for a single TMDB season. Resolve this
+                // after the fast TMDB details path and only replace the UI when the mapping is
+                // complete; otherwise the existing TMDB structure remains untouched.
+                if (
+                    mediaType == MediaType.TV &&
+                    animeMapper.isAnimeContent(mediaId, mergedItem.genreIds, mergedItem.originalLanguage)
+                ) {
+                    launch {
+                        val structure = animeMapper.resolveAnimeSeasonStructure(mediaId)
+                            ?: return@launch
+                        if (!isCurrentRequest()) return@launch
+                        val currentState = _uiState.value
+                        val canonicalTargetSeason = currentState.playTmdbSeason
+                            ?: currentState.playSeason
+                            ?: seasonToLoad
+                        val canonicalTargetEpisode = currentState.playTmdbEpisode
+                            ?: currentState.playEpisode
+                            ?: initialEpisode
+                            ?: 1
+                        val displayTarget = structure.identityForTmdb(
+                            canonicalTargetSeason,
+                            canonicalTargetEpisode
+                        )
+                        val requestedDisplaySeason = displayTarget?.displaySeason
+                            ?: seasonToLoad.coerceIn(1, structure.seasonCount)
+                        val animeEpisodes = loadAnimeDisplaySeason(mediaId, requestedDisplaySeason, structure)
+                        if (animeEpisodes.isEmpty() || !isCurrentRequest()) return@launch
+                        animeSeasonStructure = structure
+                        updateState { state ->
+                            state.copy(
+                                totalSeasons = structure.seasonCount,
+                                currentSeason = requestedDisplaySeason,
+                                episodes = animeEpisodes,
+                                initialSeasonIndex = requestedDisplaySeason - 1,
+                                playSeason = displayTarget?.displaySeason ?: state.playSeason,
+                                playEpisode = displayTarget?.displayEpisode ?: state.playEpisode,
+                                playTmdbSeason = canonicalTargetSeason,
+                                playTmdbEpisode = canonicalTargetEpisode,
+                                playLabel = displayTarget?.let {
+                                    context.getString(
+                                        R.string.continue_season_episode,
+                                        it.displaySeason,
+                                        it.displayEpisode
+                                    )
+                                } ?: state.playLabel
+                            )
+                        }
+                    }
+                }
 
                 // Calculate initial season index (0-based)
                 val initialSeasonIndex = (seasonToLoad - 1).coerceAtLeast(0)
@@ -783,10 +842,18 @@ class DetailsViewModel @Inject constructor(
                             it.season == initialSeason && it.episode == initialEpisode
                         }
                         updateState { state ->
+                            val displayTarget = animeSeasonStructure?.identityForTmdb(
+                                initialSeason,
+                                initialEpisode
+                            )
                             state.copy(
-                                playSeason = initialSeason,
-                                playEpisode = initialEpisode,
-                                playLabel = matchedResume?.label ?: context.getString(R.string.continue_season_episode, initialSeason, initialEpisode),
+                                playSeason = displayTarget?.displaySeason ?: initialSeason,
+                                playEpisode = displayTarget?.displayEpisode ?: initialEpisode,
+                                playTmdbSeason = initialSeason,
+                                playTmdbEpisode = initialEpisode,
+                                playLabel = displayTarget?.let {
+                                    context.getString(R.string.continue_season_episode, it.displaySeason, it.displayEpisode)
+                                } ?: matchedResume?.label ?: context.getString(R.string.continue_season_episode, initialSeason, initialEpisode),
                                 playPositionMs = matchedResume?.positionMs
                             )
                         }
@@ -796,10 +863,19 @@ class DetailsViewModel @Inject constructor(
                         // Fast path: show Continue immediately from local history.
                         val playTarget = buildPlayTarget(mediaType, null, resumeInfo)
                         updateState { state ->
+                            val displayTarget = playTarget?.let { target ->
+                                val targetSeason = target.season ?: return@let null
+                                val targetEpisode = target.episode ?: return@let null
+                                animeSeasonStructure?.identityForTmdb(targetSeason, targetEpisode)
+                            }
                             state.copy(
-                                playSeason = playTarget?.season,
-                                playEpisode = playTarget?.episode,
-                                playLabel = playTarget?.label,
+                                playSeason = displayTarget?.displaySeason ?: playTarget?.season,
+                                playEpisode = displayTarget?.displayEpisode ?: playTarget?.episode,
+                                playTmdbSeason = playTarget?.season,
+                                playTmdbEpisode = playTarget?.episode,
+                                playLabel = displayTarget?.let {
+                                    context.getString(R.string.continue_season_episode, it.displaySeason, it.displayEpisode)
+                                } ?: playTarget?.label,
                                 playPositionMs = playTarget?.positionMs
                             )
                         }
@@ -807,10 +883,19 @@ class DetailsViewModel @Inject constructor(
                         val seasonProgressResult = runCatching { seasonProgressDeferred?.await() }.getOrNull()
                         val playTarget = buildPlayTarget(mediaType, seasonProgressResult, null)
                         updateState { state ->
+                            val displayTarget = playTarget?.let { target ->
+                                val targetSeason = target.season ?: return@let null
+                                val targetEpisode = target.episode ?: return@let null
+                                animeSeasonStructure?.identityForTmdb(targetSeason, targetEpisode)
+                            }
                             state.copy(
-                                playSeason = playTarget?.season,
-                                playEpisode = playTarget?.episode,
-                                playLabel = playTarget?.label,
+                                playSeason = displayTarget?.displaySeason ?: playTarget?.season,
+                                playEpisode = displayTarget?.displayEpisode ?: playTarget?.episode,
+                                playTmdbSeason = playTarget?.season,
+                                playTmdbEpisode = playTarget?.episode,
+                                playLabel = displayTarget?.let {
+                                    context.getString(R.string.continue_season_episode, it.displaySeason, it.displayEpisode)
+                                } ?: playTarget?.label,
                                 playPositionMs = playTarget?.positionMs
                             )
                         }
@@ -887,7 +972,30 @@ class DetailsViewModel @Inject constructor(
             val currentEpisodes = _uiState.value.episodes
 
             try {
-                val episodes = mediaRepository.getSeasonEpisodes(currentMediaId, seasonNumber)
+                val structure = animeSeasonStructure
+                val episodes = if (structure != null) {
+                    loadAnimeDisplaySeason(currentMediaId, seasonNumber, structure)
+                } else {
+                    val canonicalEpisodes = mediaRepository.getSeasonEpisodes(currentMediaId, seasonNumber)
+                    val item = _uiState.value.item
+                    val isAnime = animeMapper.isAnimeContent(
+                        currentMediaId,
+                        item?.genreIds.orEmpty(),
+                        item?.originalLanguage
+                    )
+                    if (isAnime && canonicalEpisodes.isNotEmpty() && canonicalEpisodes.first().episodeNumber != 1) {
+                        canonicalEpisodes.mapIndexed { index, episode ->
+                            episode.copy(
+                                episodeNumber = index + 1,
+                                seasonNumber = seasonNumber,
+                                tmdbSeasonNumber = episode.seasonNumber,
+                                tmdbEpisodeNumber = episode.episodeNumber
+                            )
+                        }
+                    } else {
+                        canonicalEpisodes
+                    }
+                }
                 // A newer request superseded this one while we were fetching — drop the stale result.
                 if (seasonLoadRequestedSeason != seasonNumber) return@launch
                 if (episodes.isNotEmpty()) {
@@ -897,7 +1005,7 @@ class DetailsViewModel @Inject constructor(
                     }.getOrDefault(emptySet())
                     val decoratedEpisodes = if (watchedKeys.isNotEmpty()) {
                         episodes.map { ep ->
-                            val key = "show_tmdb:$currentMediaId:${ep.seasonNumber}:${ep.episodeNumber}"
+                            val key = "show_tmdb:$currentMediaId:${ep.tmdbSeasonNumber}:${ep.tmdbEpisodeNumber}"
                             if (watchedKeys.contains(key)) ep.copy(isWatched = true) else ep
                         }
                     } else {
@@ -937,6 +1045,32 @@ class DetailsViewModel @Inject constructor(
         }
     }
 
+    private suspend fun loadAnimeDisplaySeason(
+        tmdbId: Int,
+        displaySeason: Int,
+        structure: AnimeSeasonStructure
+    ): List<Episode> {
+        val identities = structure.seasons[displaySeason] ?: return emptyList()
+        val canonicalBySeason = identities
+            .map { it.tmdbSeason }
+            .distinct()
+            .associateWith { season ->
+                mediaRepository.getSeasonEpisodes(tmdbId, season).associateBy { it.episodeNumber }
+            }
+        return identities.mapNotNull { identity ->
+            canonicalBySeason[identity.tmdbSeason]
+                ?.get(identity.tmdbEpisode)
+                ?.copy(
+                    seasonNumber = identity.displaySeason,
+                    episodeNumber = identity.displayEpisode,
+                    tmdbSeasonNumber = identity.tmdbSeason,
+                    tmdbEpisodeNumber = identity.tmdbEpisode,
+                    kitsuId = identity.kitsuId,
+                    kitsuEpisodeNumber = identity.displayEpisode
+                )
+        }
+    }
+
     fun toggleWatched(episodeIndex: Int? = null) {
         val currentItem = _uiState.value.item ?: return
 
@@ -970,25 +1104,30 @@ class DetailsViewModel @Inject constructor(
                     if (episodeWatched) {
                         traktRepository.markEpisodeWatched(
                             currentMediaId,
-                            targetEpisode.seasonNumber,
-                            targetEpisode.episodeNumber
+                            targetEpisode.tmdbSeasonNumber,
+                            targetEpisode.tmdbEpisodeNumber
                         )
                         watchHistoryRepository.removeFromHistory(
                             currentMediaId,
-                            targetEpisode.seasonNumber,
-                            targetEpisode.episodeNumber
+                            targetEpisode.tmdbSeasonNumber,
+                            targetEpisode.tmdbEpisodeNumber
                         )
 
                         // Save the NEXT episode to CW (local + cloud) so it appears on all devices
                         try {
-                            val nextEp = targetEpisode.episodeNumber + 1
+                            val nextIdentity = animeSeasonStructure?.nextAfterDisplay(
+                                targetEpisode.seasonNumber,
+                                targetEpisode.episodeNumber
+                            )
+                            val nextSeason = nextIdentity?.tmdbSeason ?: targetEpisode.tmdbSeasonNumber
+                            val nextEp = nextIdentity?.tmdbEpisode ?: targetEpisode.tmdbEpisodeNumber + 1
                             traktRepository.saveLocalContinueWatching(
                                 mediaType = MediaType.TV,
                                 tmdbId = currentMediaId,
                                 title = currentItem.title,
                                 posterPath = currentItem.image,
                                 backdropPath = currentItem.backdrop,
-                                season = targetEpisode.seasonNumber,
+                                season = nextSeason,
                                 episode = nextEp,
                                 episodeTitle = null,
                                 progress = 3,
@@ -1002,7 +1141,7 @@ class DetailsViewModel @Inject constructor(
                                 title = currentItem.title,
                                 poster = currentItem.image,
                                 backdrop = currentItem.backdrop,
-                                season = targetEpisode.seasonNumber,
+                                season = nextSeason,
                                 episode = nextEp,
                                 episodeTitle = null,
                                 progress = 0.01f,
@@ -1016,8 +1155,8 @@ class DetailsViewModel @Inject constructor(
                     } else {
                         traktRepository.markEpisodeUnwatched(
                             currentMediaId,
-                            targetEpisode.seasonNumber,
-                            targetEpisode.episodeNumber
+                            targetEpisode.tmdbSeasonNumber,
+                            targetEpisode.tmdbEpisodeNumber
                         )
                     }
 
@@ -1174,7 +1313,7 @@ class DetailsViewModel @Inject constructor(
                 val prefix = "show_tmdb:$tmdbId:"
                 if (watchedKeys.any { it.startsWith(prefix) }) {
                     updatedEpisodes = latestForEpisodes.episodes.map { ep ->
-                        val key = "show_tmdb:$tmdbId:${ep.seasonNumber}:${ep.episodeNumber}"
+                        val key = "show_tmdb:$tmdbId:${ep.tmdbSeasonNumber}:${ep.tmdbEpisodeNumber}"
                         ep.copy(isWatched = ep.isWatched || watchedKeys.contains(key))
                     }
                     val season = latestForEpisodes.currentSeason
@@ -1202,6 +1341,11 @@ class DetailsViewModel @Inject constructor(
 
             // Read latest state to avoid overwriting concurrent updates (e.g. seasonProgress)
             val latestState = _uiState.value
+            val displayPlayTarget = playTarget?.let { target ->
+                val season = target.season ?: return@let null
+                val episode = target.episode ?: return@let null
+                animeSeasonStructure?.identityForTmdb(season, episode)
+            }
             _uiState.value = latestState.copy(
                 item = updatedItem ?: latestState.item,
                 // Only overwrite episodes if we actually computed watched badges;
@@ -1209,9 +1353,13 @@ class DetailsViewModel @Inject constructor(
                 episodes = if (updatedEpisodes.isNotEmpty()) updatedEpisodes else latestState.episodes,
                 // Only update seasonProgress if we actually computed new data; preserve existing otherwise
                 seasonProgress = if (updatedProgress !== latestForEpisodes.seasonProgress) updatedProgress else latestState.seasonProgress,
-                playSeason = playTarget?.season ?: latestState.playSeason,
-                playEpisode = playTarget?.episode ?: latestState.playEpisode,
-                playLabel = playTarget?.label ?: latestState.playLabel,
+                playSeason = displayPlayTarget?.displaySeason ?: playTarget?.season ?: latestState.playSeason,
+                playEpisode = displayPlayTarget?.displayEpisode ?: playTarget?.episode ?: latestState.playEpisode,
+                playTmdbSeason = playTarget?.season ?: latestState.playTmdbSeason,
+                playTmdbEpisode = playTarget?.episode ?: latestState.playTmdbEpisode,
+                playLabel = displayPlayTarget?.let {
+                    context.getString(R.string.continue_season_episode, it.displaySeason, it.displayEpisode)
+                } ?: playTarget?.label ?: latestState.playLabel,
                 playPositionMs = playTarget?.positionMs ?: 0L
             )
         }
@@ -1479,13 +1627,25 @@ class DetailsViewModel @Inject constructor(
                 val item = _uiState.value.item
                 val genreIds = item?.genreIds ?: emptyList()
                 val originalLanguage = item?.originalLanguage
+                val selectedEpisode = if (requestMediaType == MediaType.TV) {
+                    _uiState.value.episodes.firstOrNull {
+                        it.seasonNumber == (season ?: 1) && it.episodeNumber == (episode ?: 1)
+                    }
+                } else null
+                val canonicalSeason = selectedEpisode?.tmdbSeasonNumber ?: season
+                val canonicalEpisode = selectedEpisode?.tmdbEpisodeNumber ?: episode
+                val animeQueryOverride = selectedEpisode?.kitsuId?.let { kitsuId ->
+                    selectedEpisode.kitsuEpisodeNumber?.let { kitsuEpisode ->
+                        "kitsu:$kitsuId:$kitsuEpisode"
+                    }
+                }
                 val hasHomeServerConnections = streamRepository.hasHomeServerConnections()
                 // Start VOD append in background - runs parallel to addon stream fetch
                 homeServerAppendJob = viewModelScope.launch {
                     appendHomeServerSourcesInBackground(
                         imdbId = resolvedImdbId,
-                        season = season,
-                        episode = episode,
+                        season = canonicalSeason,
+                        episode = canonicalEpisode,
                         timeoutMs = 5_000L,
                         requestId = requestId,
                         requestMediaType = requestMediaType,
@@ -1499,8 +1659,8 @@ class DetailsViewModel @Inject constructor(
                     val vodTimeout = if (currentMediaType == MediaType.MOVIE) 30_000L else 45_000L
                     appendVodSourceInBackground(
                         imdbId = resolvedImdbId,
-                        season = season,
-                        episode = episode,
+                        season = canonicalSeason,
+                        episode = canonicalEpisode,
                         timeoutMs = vodTimeout,
                         requestId = requestId,
                         requestMediaType = requestMediaType,
@@ -1655,19 +1815,18 @@ class DetailsViewModel @Inject constructor(
                         return@launch
                     }
                     // Look up air date for daily show stream resolution fallback
-                    val episodeAirDate = _uiState.value.episodes
-                        .firstOrNull { it.seasonNumber == (season ?: 1) && it.episodeNumber == (episode ?: 1) }
-                        ?.airDate?.takeIf { it.isNotBlank() }
+                    val episodeAirDate = selectedEpisode?.airDate?.takeIf { it.isNotBlank() }
 
                     streamRepository.resolveEpisodeStreamsProgressive(
                         imdbId = effectiveStreamId,
-                        season = season ?: 1,
-                        episode = episode ?: 1,
+                        season = canonicalSeason ?: 1,
+                        episode = canonicalEpisode ?: 1,
                         tmdbId = currentMediaId,
                         tvdbId = _uiState.value.tvdbId,
                         genreIds = genreIds,
                         originalLanguage = originalLanguage,
                         title = item?.title ?: "",
+                        animeQueryOverride = animeQueryOverride,
                         airDate = episodeAirDate
                     ).collect { progressive ->
                         if (!isCurrentRequest()) return@collect
@@ -1710,23 +1869,30 @@ class DetailsViewModel @Inject constructor(
     fun markEpisodeWatched(season: Int, episode: Int, watched: Boolean) {
         viewModelScope.launch {
             try {
+                val selectedEpisode = _uiState.value.episodes.firstOrNull {
+                    it.seasonNumber == season && it.episodeNumber == episode
+                }
+                val canonicalSeason = selectedEpisode?.tmdbSeasonNumber ?: season
+                val canonicalEpisode = selectedEpisode?.tmdbEpisodeNumber ?: episode
                 if (watched) {
-                    traktRepository.markEpisodeWatched(currentMediaId, season, episode)
+                    traktRepository.markEpisodeWatched(currentMediaId, canonicalSeason, canonicalEpisode)
                     // Also remove from Supabase watch_history (removes from Continue Watching)
-                    watchHistoryRepository.removeFromHistory(currentMediaId, season, episode)
+                    watchHistoryRepository.removeFromHistory(currentMediaId, canonicalSeason, canonicalEpisode)
 
                     // Save the NEXT episode to CW (local + cloud) so it appears on all devices
                     val item = _uiState.value.item
                     if (item != null) {
                         try {
-                            val nextEp = episode + 1
+                            val nextIdentity = animeSeasonStructure?.nextAfterDisplay(season, episode)
+                            val nextSeason = nextIdentity?.tmdbSeason ?: canonicalSeason
+                            val nextEp = nextIdentity?.tmdbEpisode ?: canonicalEpisode + 1
                             traktRepository.saveLocalContinueWatching(
                                 mediaType = MediaType.TV,
                                 tmdbId = currentMediaId,
                                 title = item.title,
                                 posterPath = item.image,
                                 backdropPath = item.backdrop,
-                                season = season,
+                                season = nextSeason,
                                 episode = nextEp,
                                 episodeTitle = null,
                                 progress = 3,
@@ -1740,7 +1906,7 @@ class DetailsViewModel @Inject constructor(
                                 title = item.title,
                                 poster = item.image,
                                 backdrop = item.backdrop,
-                                season = season,
+                                season = nextSeason,
                                 episode = nextEp,
                                 episodeTitle = null,
                                 progress = 0.01f,
@@ -1750,7 +1916,7 @@ class DetailsViewModel @Inject constructor(
                         } catch (_: Exception) {}
                     }
                 } else {
-                    traktRepository.markEpisodeUnwatched(currentMediaId, season, episode)
+                    traktRepository.markEpisodeUnwatched(currentMediaId, canonicalSeason, canonicalEpisode)
                 }
 
                 // Update local state
@@ -1809,29 +1975,50 @@ class DetailsViewModel @Inject constructor(
                 // BATCH: Use single Trakt API call for all episodes, then concurrent Supabase writes.
                 // Previously this looped sequentially calling markEpisodeWatched() per episode,
                 // each making its own Supabase + Trakt network call — taking ~5-12s for a full season.
-                val episodeNumbers = seasonEpisodes.map { it.episodeNumber }
+                val canonicalGroups = seasonEpisodes.groupBy { it.tmdbSeasonNumber }
 
-                // 1. Single batch Trakt API call (all episodes in one request)
-                runCatching {
-                    traktRepository.markSeasonWatched(currentMediaId, season, episodeNumbers)
-                }
-
-                // 2. Remove from watch history FIRST (synchronous), before Supabase writes.
-                //    This avoids a race condition where removeFromHistory deletes the
-                //    just-written watched records, causing watched status to be lost on re-entry.
-                runCatching {
-                    watchHistoryRepository.removeFromHistory(currentMediaId, season, null)
-                }
-
-                // 3. Concurrent Supabase writes for each episode (faster than sequential).
-                //    These run AFTER removeFromHistory to ensure the watched records are the final state.
-                episodeNumbers.map { epNum ->
-                    async {
-                        runCatching {
-                            traktRepository.markEpisodeWatchedWithoutTraktSync(currentMediaId, season, epNum)
-                        }
+                if (animeSeasonStructure == null) {
+                    // Preserve the existing single-season fast path for ordinary TV shows.
+                    val episodeNumbers = seasonEpisodes.map { it.episodeNumber }
+                    runCatching {
+                        traktRepository.markSeasonWatched(currentMediaId, season, episodeNumbers)
                     }
-                }.forEach { it.await() }
+                    runCatching {
+                        watchHistoryRepository.removeFromHistory(currentMediaId, season, null)
+                    }
+                    episodeNumbers.map { epNum ->
+                        async {
+                            runCatching {
+                                traktRepository.markEpisodeWatchedWithoutTraktSync(currentMediaId, season, epNum)
+                            }
+                        }
+                    }.forEach { it.await() }
+                } else {
+                    // A displayed anime season may be a cour inside a larger TMDB season. Never
+                    // clear or mark the rest of that canonical season by accident.
+                    canonicalGroups.forEach { (tmdbSeason, episodes) ->
+                        val tmdbEpisodes = episodes.map { it.tmdbEpisodeNumber }
+                        runCatching {
+                            traktRepository.markSeasonWatched(currentMediaId, tmdbSeason, tmdbEpisodes)
+                        }
+                        episodes.map { ep ->
+                            async {
+                                runCatching {
+                                    watchHistoryRepository.removeFromHistory(
+                                        currentMediaId,
+                                        ep.tmdbSeasonNumber,
+                                        ep.tmdbEpisodeNumber
+                                    )
+                                    traktRepository.markEpisodeWatchedWithoutTraktSync(
+                                        currentMediaId,
+                                        ep.tmdbSeasonNumber,
+                                        ep.tmdbEpisodeNumber
+                                    )
+                                }
+                            }
+                        }.forEach { it.await() }
+                    }
+                }
 
                 val refreshedProgress = runCatching { fetchSeasonProgress(currentMediaId) }.getOrNull()
                 val nextUnwatched = refreshedProgress?.nextUnwatched
@@ -1880,14 +2067,23 @@ class DetailsViewModel @Inject constructor(
                 }
 
                 val playTarget = buildPlayTarget(currentMediaType, refreshedProgress, null)
+                val displayPlayTarget = playTarget?.let { target ->
+                    val targetSeason = target.season ?: return@let null
+                    val targetEpisode = target.episode ?: return@let null
+                    animeSeasonStructure?.identityForTmdb(targetSeason, targetEpisode)
+                }
 
                 _uiState.value = _uiState.value.copy(
                     item = currentItem.copy(isWatched = nextUnwatched == null),
                     episodes = updatedEpisodes,
                     seasonProgress = refreshedProgress?.progress ?: optimisticProgress,
-                    playSeason = playTarget?.season ?: _uiState.value.playSeason,
-                    playEpisode = playTarget?.episode ?: _uiState.value.playEpisode,
-                    playLabel = playTarget?.label ?: _uiState.value.playLabel,
+                    playSeason = displayPlayTarget?.displaySeason ?: playTarget?.season ?: _uiState.value.playSeason,
+                    playEpisode = displayPlayTarget?.displayEpisode ?: playTarget?.episode ?: _uiState.value.playEpisode,
+                    playTmdbSeason = playTarget?.season ?: _uiState.value.playTmdbSeason,
+                    playTmdbEpisode = playTarget?.episode ?: _uiState.value.playTmdbEpisode,
+                    playLabel = displayPlayTarget?.let {
+                        context.getString(R.string.continue_season_episode, it.displaySeason, it.displayEpisode)
+                    } ?: playTarget?.label ?: _uiState.value.playLabel,
                     playPositionMs = playTarget?.positionMs ?: _uiState.value.playPositionMs,
                     toastMessage = context.getString(R.string.details_season_marked_watched, season),
                     toastType = ToastType.SUCCESS

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
@@ -441,12 +441,19 @@ class DetailsViewModel @Inject constructor(
                     launch {
                         val firstEpisodes = runCatching { episodesDeferred?.await() }.getOrNull()
                         if (!firstEpisodes.isNullOrEmpty()) {
+                            val episodeItem = runCatching { itemDeferred.await() }.getOrNull() ?: initialItem
+                            val displayedEpisodes = normalizeAnimeEpisodesForDisplay(
+                                tmdbId = mediaId,
+                                displaySeason = seasonToLoad,
+                                item = episodeItem,
+                                canonicalEpisodes = firstEpisodes
+                            )
                             updateState { state ->
-                                if (state.currentSeason == seasonToLoad && state.episodes == firstEpisodes) {
+                                if (state.currentSeason == seasonToLoad && state.episodes == displayedEpisodes) {
                                     state
                                 } else {
                                     state.copy(
-                                        episodes = firstEpisodes,
+                                        episodes = displayedEpisodes,
                                         currentSeason = seasonToLoad
                                     )
                                 }
@@ -564,6 +571,15 @@ class DetailsViewModel @Inject constructor(
                                     )
                                 } ?: state.playLabel
                             )
+                        }
+                        val displayProgress = runCatching { fetchSeasonProgress(mediaId) }.getOrNull()
+                        if (animeSeasonStructure === structure && isCurrentRequest()) {
+                            updateState { state ->
+                                state.copy(
+                                    seasonProgress = displayProgress?.progress ?: state.seasonProgress,
+                                    totalSeasons = structure.seasonCount
+                                )
+                            }
                         }
                     }
                 }
@@ -797,7 +813,12 @@ class DetailsViewModel @Inject constructor(
                 }
 
                 launch {
-                    val seasonProgressResult = runCatching { seasonProgressDeferred?.await() }.getOrNull()
+                    val structureAtRead = animeSeasonStructure
+                    val seasonProgressResult = if (structureAtRead == null) {
+                        runCatching { seasonProgressDeferred?.await() }.getOrNull()
+                    } else {
+                        runCatching { fetchSeasonProgress(mediaId) }.getOrNull()
+                    }
                     val baseSeasonProgress = seasonProgressResult?.progress ?: emptyMap()
                     val resumeTarget = runCatching { resumeDeferred.await() }.getOrNull()
                     val fallbackTargetSeason = initialSeason ?: resumeTarget?.season
@@ -828,10 +849,14 @@ class DetailsViewModel @Inject constructor(
                         baseState.totalSeasons
                     }
                     updateState { state ->
-                        state.copy(
-                            seasonProgress = seasonProgress,
-                            totalSeasons = resolvedTotalSeasons
-                        )
+                        if (structureAtRead == null && animeSeasonStructure != null) {
+                            state
+                        } else {
+                            state.copy(
+                                seasonProgress = seasonProgress,
+                                totalSeasons = resolvedTotalSeasons
+                            )
+                        }
                     }
                 }
 
@@ -977,28 +1002,12 @@ class DetailsViewModel @Inject constructor(
                     loadAnimeDisplaySeason(currentMediaId, seasonNumber, structure)
                 } else {
                     val canonicalEpisodes = mediaRepository.getSeasonEpisodes(currentMediaId, seasonNumber)
-                    val item = _uiState.value.item
-                    val isAnime = animeMapper.isAnimeContent(
-                        currentMediaId,
-                        item?.genreIds.orEmpty(),
-                        item?.originalLanguage
+                    normalizeAnimeEpisodesForDisplay(
+                        tmdbId = currentMediaId,
+                        displaySeason = seasonNumber,
+                        item = _uiState.value.item,
+                        canonicalEpisodes = canonicalEpisodes
                     )
-                    if (isAnime && canonicalEpisodes.isNotEmpty() && canonicalEpisodes.first().episodeNumber != 1) {
-                        canonicalEpisodes.mapIndexed { index, episode ->
-                            episode.copy(
-                                episodeNumber = index + 1,
-                                seasonNumber = seasonNumber,
-                                identity = EpisodeIdentity(
-                                    displaySeason = seasonNumber,
-                                    displayEpisode = index + 1,
-                                    tmdbSeason = episode.seasonNumber,
-                                    tmdbEpisode = episode.episodeNumber
-                                )
-                            )
-                        }
-                    } else {
-                        canonicalEpisodes
-                    }
                 }
                 // A newer request superseded this one while we were fetching — drop the stale result.
                 if (seasonLoadRequestedSeason != seasonNumber) return@launch
@@ -1069,6 +1078,44 @@ class DetailsViewModel @Inject constructor(
                     episodeNumber = identity.displayEpisode,
                     identity = identity
                 )
+        }
+    }
+
+    fun resolveEpisodeIdentity(
+        displaySeason: Int?,
+        displayEpisode: Int?,
+        tmdbSeason: Int?,
+        tmdbEpisode: Int?
+    ): EpisodeIdentity? {
+        if (displaySeason == null || displayEpisode == null || tmdbSeason == null || tmdbEpisode == null) {
+            return null
+        }
+        return animeSeasonStructure?.identityForDisplay(displaySeason, displayEpisode)
+            ?: animeSeasonStructure?.identityForTmdb(tmdbSeason, tmdbEpisode)
+            ?: EpisodeIdentity(displaySeason, displayEpisode, tmdbSeason, tmdbEpisode)
+    }
+
+    private fun normalizeAnimeEpisodesForDisplay(
+        tmdbId: Int,
+        displaySeason: Int,
+        item: MediaItem?,
+        canonicalEpisodes: List<Episode>
+    ): List<Episode> {
+        val usesAbsoluteNumbers = canonicalEpisodes.isNotEmpty() &&
+            canonicalEpisodes.first().episodeNumber != 1 &&
+            animeMapper.isAnimeContent(tmdbId, item?.genreIds.orEmpty(), item?.originalLanguage)
+        if (!usesAbsoluteNumbers) return canonicalEpisodes
+        return canonicalEpisodes.mapIndexed { index, episode ->
+            episode.copy(
+                episodeNumber = index + 1,
+                seasonNumber = displaySeason,
+                identity = EpisodeIdentity(
+                    displaySeason = displaySeason,
+                    displayEpisode = index + 1,
+                    tmdbSeason = episode.seasonNumber,
+                    tmdbEpisode = episode.episodeNumber
+                )
+            )
         }
     }
 

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -137,6 +137,7 @@ import coil.compose.AsyncImage
 import com.arflix.tv.ArflixApplication
 import com.arflix.tv.network.OkHttpProvider
 import com.arflix.tv.data.model.MediaType
+import com.arflix.tv.data.model.EpisodeIdentity
 import com.arflix.tv.data.model.StreamSource
 import com.arflix.tv.data.model.Subtitle
 import com.arflix.tv.ui.components.KeepScreenOn
@@ -409,6 +410,23 @@ fun PlayerScreen(
     var pendingNextAddonId by remember { mutableStateOf<String?>(null) }
     var pendingNextSourceName by remember { mutableStateOf<String?>(null) }
     var pendingNextBingeGroup by remember { mutableStateOf<String?>(null) }
+    var nextEpisodeIdentity by remember { mutableStateOf<EpisodeIdentity?>(null) }
+    var previousEpisodeIdentity by remember { mutableStateOf<EpisodeIdentity?>(null) }
+    LaunchedEffect(mediaId, seasonNumber, episodeNumber, tmdbSeasonNumber, tmdbEpisodeNumber) {
+        if (mediaType == MediaType.TV && seasonNumber != null && episodeNumber != null) {
+            val current = EpisodeIdentity(
+                displaySeason = seasonNumber,
+                displayEpisode = episodeNumber,
+                tmdbSeason = tmdbSeasonNumber ?: seasonNumber,
+                tmdbEpisode = tmdbEpisodeNumber ?: episodeNumber
+            )
+            nextEpisodeIdentity = viewModel.adjacentEpisodeIdentity(mediaId, current, forward = true)
+            previousEpisodeIdentity = viewModel.adjacentEpisodeIdentity(mediaId, current, forward = false)
+        } else {
+            nextEpisodeIdentity = null
+            previousEpisodeIdentity = null
+        }
+    }
     var nextEpisodePromptButton by remember { mutableIntStateOf(0) } // 0 = next, 1 = cancel
     val nextEpisodePromptGate = remember { NextEpisodePromptGate() }
     val playPendingNextEpisode: () -> Unit = {
@@ -675,6 +693,8 @@ fun PlayerScreen(
             mediaId = mediaId,
             seasonNumber = tmdbSeasonNumber,
             episodeNumber = tmdbEpisodeNumber,
+            displaySeasonNumber = seasonNumber,
+            displayEpisodeNumber = episodeNumber,
             providedImdbId = imdbId,
             providedStreamUrl = streamUrl,
             preferredAddonId = preferredAddonId,
@@ -2354,10 +2374,14 @@ fun PlayerScreen(
                 )
             ) {
                 val selected = uiState.selectedStream
-                pendingNextSeason = endedEpisodeKey.seasonNumber
-                pendingNextEpisode = endedEpisodeKey.episodeNumber + 1
-                pendingNextTmdbSeason = tmdbSeasonNumber ?: endedEpisodeKey.seasonNumber
-                pendingNextTmdbEpisode = (tmdbEpisodeNumber ?: endedEpisodeKey.episodeNumber) + 1
+                val next = nextEpisodeIdentity ?: EpisodeIdentity.canonical(
+                    tmdbSeasonNumber ?: endedEpisodeKey.seasonNumber,
+                    (tmdbEpisodeNumber ?: endedEpisodeKey.episodeNumber) + 1
+                )
+                pendingNextSeason = next.displaySeason
+                pendingNextEpisode = next.displayEpisode
+                pendingNextTmdbSeason = next.tmdbSeason
+                pendingNextTmdbEpisode = next.tmdbEpisode
                 pendingNextAddonId = selected?.addonId?.takeIf { it.isNotBlank() }
                 pendingNextSourceName = selected?.source?.takeIf { it.isNotBlank() }
                 pendingNextBingeGroup = selected?.behaviorHints?.bingeGroup?.takeIf { it.isNotBlank() }
@@ -2616,13 +2640,14 @@ fun PlayerScreen(
                         Key.MediaNext -> {
                             // Jump to next episode if this is a TV series and we have a
                             // current episode. No-op for movies (there is no next).
-                            if (mediaType == MediaType.TV && seasonNumber != null && episodeNumber != null) {
+                            if (mediaType == MediaType.TV && nextEpisodeIdentity != null) {
                                 val selected = uiState.selectedStream
+                                val next = nextEpisodeIdentity ?: return@onKeyEvent true
                                 onPlayNext(
-                                    seasonNumber,
-                                    episodeNumber + 1,
-                                    tmdbSeasonNumber ?: seasonNumber,
-                                    (tmdbEpisodeNumber ?: episodeNumber) + 1,
+                                    next.displaySeason,
+                                    next.displayEpisode,
+                                    next.tmdbSeason,
+                                    next.tmdbEpisode,
                                     selected?.addonId?.takeIf { it.isNotBlank() },
                                     selected?.source?.takeIf { it.isNotBlank() },
                                     selected?.behaviorHints?.bingeGroup?.takeIf { it.isNotBlank() }
@@ -2632,13 +2657,14 @@ fun PlayerScreen(
                         }
                         Key.MediaPrevious -> {
                             // Jump to previous episode for TV series. Movies: no-op.
-                            if (mediaType == MediaType.TV && seasonNumber != null && episodeNumber != null && episodeNumber > 1) {
+                            if (mediaType == MediaType.TV && previousEpisodeIdentity != null) {
                                 val selected = uiState.selectedStream
+                                val previous = previousEpisodeIdentity ?: return@onKeyEvent true
                                 onPlayNext(
-                                    seasonNumber,
-                                    episodeNumber - 1,
-                                    tmdbSeasonNumber ?: seasonNumber,
-                                    (tmdbEpisodeNumber ?: episodeNumber) - 1,
+                                    previous.displaySeason,
+                                    previous.displayEpisode,
+                                    previous.tmdbSeason,
+                                    previous.tmdbEpisode,
                                     selected?.addonId?.takeIf { it.isNotBlank() },
                                     selected?.source?.takeIf { it.isNotBlank() },
                                     selected?.behaviorHints?.bingeGroup?.takeIf { it.isNotBlank() }
@@ -3621,14 +3647,13 @@ fun PlayerScreen(
                                 focusRequester = nextEpisodeButtonFocusRequester, size = smallBtn, iconSize = smallIcon,
                                 onFocusChanged = {},
                                 onClick = {
-                                    val season = seasonNumber ?: return@PlayerIconButton
-                                    val episode = episodeNumber ?: return@PlayerIconButton
+                                    val next = nextEpisodeIdentity ?: return@PlayerIconButton
                                     val selected = uiState.selectedStream
                                     onPlayNext(
-                                        season,
-                                        episode + 1,
-                                        tmdbSeasonNumber ?: season,
-                                        (tmdbEpisodeNumber ?: episode) + 1,
+                                        next.displaySeason,
+                                        next.displayEpisode,
+                                        next.tmdbSeason,
+                                        next.tmdbEpisode,
                                         selected?.addonId?.takeIf { it.isNotBlank() },
                                         selected?.source?.takeIf { it.isNotBlank() },
                                         selected?.behaviorHints?.bingeGroup?.takeIf { it.isNotBlank() }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -246,6 +246,8 @@ fun PlayerScreen(
     episodeNumber: Int? = null,
     tmdbSeasonNumber: Int? = seasonNumber,
     tmdbEpisodeNumber: Int? = episodeNumber,
+    kitsuId: Int? = null,
+    kitsuEpisodeNumber: Int? = null,
     imdbId: String? = null,
     streamUrl: String? = null,
     preferredAddonId: String? = null,
@@ -255,7 +257,7 @@ fun PlayerScreen(
     isLiveStream: Boolean = false,
     viewModel: PlayerViewModel = hiltViewModel(),
     onBack: () -> Unit = {},
-    onPlayNext: (Int, Int, Int, Int, String?, String?, String?) -> Unit = { _, _, _, _, _, _, _ -> }
+    onPlayNext: (EpisodeIdentity, String?, String?, String?) -> Unit = { _, _, _, _ -> }
 ) {
     val playerAccent = LocalAccentColorOverride.current ?: Color.White
     val context = LocalContext.current
@@ -403,22 +405,21 @@ fun PlayerScreen(
     // advance to the next episode. Gated on the existing autoPlayNext profile setting —
     // when disabled we simply stay on the ended frame rather than advancing silently.
     var showNextEpisodePrompt by remember { mutableStateOf(false) }
-    var pendingNextSeason by remember { mutableIntStateOf(0) }
-    var pendingNextEpisode by remember { mutableIntStateOf(0) }
-    var pendingNextTmdbSeason by remember { mutableIntStateOf(0) }
-    var pendingNextTmdbEpisode by remember { mutableIntStateOf(0) }
+    var pendingNextIdentity by remember { mutableStateOf<EpisodeIdentity?>(null) }
     var pendingNextAddonId by remember { mutableStateOf<String?>(null) }
     var pendingNextSourceName by remember { mutableStateOf<String?>(null) }
     var pendingNextBingeGroup by remember { mutableStateOf<String?>(null) }
     var nextEpisodeIdentity by remember { mutableStateOf<EpisodeIdentity?>(null) }
     var previousEpisodeIdentity by remember { mutableStateOf<EpisodeIdentity?>(null) }
-    LaunchedEffect(mediaId, seasonNumber, episodeNumber, tmdbSeasonNumber, tmdbEpisodeNumber) {
+    LaunchedEffect(mediaId, seasonNumber, episodeNumber, tmdbSeasonNumber, tmdbEpisodeNumber, kitsuId, kitsuEpisodeNumber) {
         if (mediaType == MediaType.TV && seasonNumber != null && episodeNumber != null) {
             val current = EpisodeIdentity(
                 displaySeason = seasonNumber,
                 displayEpisode = episodeNumber,
                 tmdbSeason = tmdbSeasonNumber ?: seasonNumber,
-                tmdbEpisode = tmdbEpisodeNumber ?: episodeNumber
+                tmdbEpisode = tmdbEpisodeNumber ?: episodeNumber,
+                kitsuId = kitsuId,
+                kitsuEpisode = kitsuEpisodeNumber
             )
             nextEpisodeIdentity = viewModel.adjacentEpisodeIdentity(mediaId, current, forward = true)
             previousEpisodeIdentity = viewModel.adjacentEpisodeIdentity(mediaId, current, forward = false)
@@ -429,13 +430,11 @@ fun PlayerScreen(
     }
     var nextEpisodePromptButton by remember { mutableIntStateOf(0) } // 0 = next, 1 = cancel
     val nextEpisodePromptGate = remember { NextEpisodePromptGate() }
-    val playPendingNextEpisode: () -> Unit = {
+    val playPendingNextEpisode: () -> Unit = playNext@{
         showNextEpisodePrompt = false
+        val identity = pendingNextIdentity ?: return@playNext
         onPlayNext(
-            pendingNextSeason,
-            pendingNextEpisode,
-            pendingNextTmdbSeason,
-            pendingNextTmdbEpisode,
+            identity,
             pendingNextAddonId,
             pendingNextSourceName,
             pendingNextBingeGroup
@@ -667,7 +666,7 @@ fun PlayerScreen(
     }
 
     // Load media
-    LaunchedEffect(mediaType, mediaId, seasonNumber, episodeNumber, tmdbSeasonNumber, tmdbEpisodeNumber, imdbId, preferredAddonId, preferredSourceName, preferredBingeGroup, startPositionMs, isLiveStream) {
+    LaunchedEffect(mediaType, mediaId, seasonNumber, episodeNumber, tmdbSeasonNumber, tmdbEpisodeNumber, kitsuId, kitsuEpisodeNumber, imdbId, preferredAddonId, preferredSourceName, preferredBingeGroup, startPositionMs, isLiveStream) {
         playbackIssueReported = false
         startupRecoverAttempted = false
         startupHardFailureReported = false
@@ -695,6 +694,7 @@ fun PlayerScreen(
             episodeNumber = tmdbEpisodeNumber,
             displaySeasonNumber = seasonNumber,
             displayEpisodeNumber = episodeNumber,
+            animeQueryOverride = kitsuId?.let { id -> kitsuEpisodeNumber?.let { episode -> "kitsu:$id:$episode" } },
             providedImdbId = imdbId,
             providedStreamUrl = streamUrl,
             preferredAddonId = preferredAddonId,
@@ -2378,10 +2378,7 @@ fun PlayerScreen(
                     tmdbSeasonNumber ?: endedEpisodeKey.seasonNumber,
                     (tmdbEpisodeNumber ?: endedEpisodeKey.episodeNumber) + 1
                 )
-                pendingNextSeason = next.displaySeason
-                pendingNextEpisode = next.displayEpisode
-                pendingNextTmdbSeason = next.tmdbSeason
-                pendingNextTmdbEpisode = next.tmdbEpisode
+                pendingNextIdentity = next
                 pendingNextAddonId = selected?.addonId?.takeIf { it.isNotBlank() }
                 pendingNextSourceName = selected?.source?.takeIf { it.isNotBlank() }
                 pendingNextBingeGroup = selected?.behaviorHints?.bingeGroup?.takeIf { it.isNotBlank() }
@@ -2644,10 +2641,7 @@ fun PlayerScreen(
                                 val selected = uiState.selectedStream
                                 val next = nextEpisodeIdentity ?: return@onKeyEvent true
                                 onPlayNext(
-                                    next.displaySeason,
-                                    next.displayEpisode,
-                                    next.tmdbSeason,
-                                    next.tmdbEpisode,
+                                    next,
                                     selected?.addonId?.takeIf { it.isNotBlank() },
                                     selected?.source?.takeIf { it.isNotBlank() },
                                     selected?.behaviorHints?.bingeGroup?.takeIf { it.isNotBlank() }
@@ -2661,10 +2655,7 @@ fun PlayerScreen(
                                 val selected = uiState.selectedStream
                                 val previous = previousEpisodeIdentity ?: return@onKeyEvent true
                                 onPlayNext(
-                                    previous.displaySeason,
-                                    previous.displayEpisode,
-                                    previous.tmdbSeason,
-                                    previous.tmdbEpisode,
+                                    previous,
                                     selected?.addonId?.takeIf { it.isNotBlank() },
                                     selected?.source?.takeIf { it.isNotBlank() },
                                     selected?.behaviorHints?.bingeGroup?.takeIf { it.isNotBlank() }
@@ -3650,10 +3641,7 @@ fun PlayerScreen(
                                     val next = nextEpisodeIdentity ?: return@PlayerIconButton
                                     val selected = uiState.selectedStream
                                     onPlayNext(
-                                        next.displaySeason,
-                                        next.displayEpisode,
-                                        next.tmdbSeason,
-                                        next.tmdbEpisode,
+                                        next,
                                         selected?.addonId?.takeIf { it.isNotBlank() },
                                         selected?.source?.takeIf { it.isNotBlank() },
                                         selected?.behaviorHints?.bingeGroup?.takeIf { it.isNotBlank() }
@@ -3908,9 +3896,9 @@ fun PlayerScreen(
             // episode's metadata would require an extra TMDB round-trip during playback.
             // Fall back to a generic "Episode N" label — the show title, S/E number, and
             // backdrop image still give users enough context to decide Continue/Cancel.
-            episodeTitle = "Episode $pendingNextEpisode",
-            seasonNumber = pendingNextSeason,
-            episodeNumber = pendingNextEpisode,
+            episodeTitle = "Episode ${pendingNextIdentity?.displayEpisode ?: 0}",
+            seasonNumber = pendingNextIdentity?.displaySeason ?: 0,
+            episodeNumber = pendingNextIdentity?.displayEpisode ?: 0,
             episodeImage = uiState.backdropUrl,
             countdownSeconds = 10,
             focusedButtonOverride = nextEpisodePromptButton,

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -243,6 +243,8 @@ fun PlayerScreen(
     mediaId: Int,
     seasonNumber: Int? = null,
     episodeNumber: Int? = null,
+    tmdbSeasonNumber: Int? = seasonNumber,
+    tmdbEpisodeNumber: Int? = episodeNumber,
     imdbId: String? = null,
     streamUrl: String? = null,
     preferredAddonId: String? = null,
@@ -252,7 +254,7 @@ fun PlayerScreen(
     isLiveStream: Boolean = false,
     viewModel: PlayerViewModel = hiltViewModel(),
     onBack: () -> Unit = {},
-    onPlayNext: (Int, Int, String?, String?, String?) -> Unit = { _, _, _, _, _ -> }
+    onPlayNext: (Int, Int, Int, Int, String?, String?, String?) -> Unit = { _, _, _, _, _, _, _ -> }
 ) {
     val playerAccent = LocalAccentColorOverride.current ?: Color.White
     val context = LocalContext.current
@@ -402,6 +404,8 @@ fun PlayerScreen(
     var showNextEpisodePrompt by remember { mutableStateOf(false) }
     var pendingNextSeason by remember { mutableIntStateOf(0) }
     var pendingNextEpisode by remember { mutableIntStateOf(0) }
+    var pendingNextTmdbSeason by remember { mutableIntStateOf(0) }
+    var pendingNextTmdbEpisode by remember { mutableIntStateOf(0) }
     var pendingNextAddonId by remember { mutableStateOf<String?>(null) }
     var pendingNextSourceName by remember { mutableStateOf<String?>(null) }
     var pendingNextBingeGroup by remember { mutableStateOf<String?>(null) }
@@ -412,6 +416,8 @@ fun PlayerScreen(
         onPlayNext(
             pendingNextSeason,
             pendingNextEpisode,
+            pendingNextTmdbSeason,
+            pendingNextTmdbEpisode,
             pendingNextAddonId,
             pendingNextSourceName,
             pendingNextBingeGroup
@@ -643,7 +649,7 @@ fun PlayerScreen(
     }
 
     // Load media
-    LaunchedEffect(mediaType, mediaId, seasonNumber, episodeNumber, imdbId, preferredAddonId, preferredSourceName, preferredBingeGroup, startPositionMs, isLiveStream) {
+    LaunchedEffect(mediaType, mediaId, seasonNumber, episodeNumber, tmdbSeasonNumber, tmdbEpisodeNumber, imdbId, preferredAddonId, preferredSourceName, preferredBingeGroup, startPositionMs, isLiveStream) {
         playbackIssueReported = false
         startupRecoverAttempted = false
         startupHardFailureReported = false
@@ -667,8 +673,8 @@ fun PlayerScreen(
         viewModel.loadMedia(
             mediaType = mediaType,
             mediaId = mediaId,
-            seasonNumber = seasonNumber,
-            episodeNumber = episodeNumber,
+            seasonNumber = tmdbSeasonNumber,
+            episodeNumber = tmdbEpisodeNumber,
             providedImdbId = imdbId,
             providedStreamUrl = streamUrl,
             preferredAddonId = preferredAddonId,
@@ -2350,6 +2356,8 @@ fun PlayerScreen(
                 val selected = uiState.selectedStream
                 pendingNextSeason = endedEpisodeKey.seasonNumber
                 pendingNextEpisode = endedEpisodeKey.episodeNumber + 1
+                pendingNextTmdbSeason = tmdbSeasonNumber ?: endedEpisodeKey.seasonNumber
+                pendingNextTmdbEpisode = (tmdbEpisodeNumber ?: endedEpisodeKey.episodeNumber) + 1
                 pendingNextAddonId = selected?.addonId?.takeIf { it.isNotBlank() }
                 pendingNextSourceName = selected?.source?.takeIf { it.isNotBlank() }
                 pendingNextBingeGroup = selected?.behaviorHints?.bingeGroup?.takeIf { it.isNotBlank() }
@@ -2613,6 +2621,8 @@ fun PlayerScreen(
                                 onPlayNext(
                                     seasonNumber,
                                     episodeNumber + 1,
+                                    tmdbSeasonNumber ?: seasonNumber,
+                                    (tmdbEpisodeNumber ?: episodeNumber) + 1,
                                     selected?.addonId?.takeIf { it.isNotBlank() },
                                     selected?.source?.takeIf { it.isNotBlank() },
                                     selected?.behaviorHints?.bingeGroup?.takeIf { it.isNotBlank() }
@@ -2627,6 +2637,8 @@ fun PlayerScreen(
                                 onPlayNext(
                                     seasonNumber,
                                     episodeNumber - 1,
+                                    tmdbSeasonNumber ?: seasonNumber,
+                                    (tmdbEpisodeNumber ?: episodeNumber) - 1,
                                     selected?.addonId?.takeIf { it.isNotBlank() },
                                     selected?.source?.takeIf { it.isNotBlank() },
                                     selected?.behaviorHints?.bingeGroup?.takeIf { it.isNotBlank() }
@@ -3612,7 +3624,15 @@ fun PlayerScreen(
                                     val season = seasonNumber ?: return@PlayerIconButton
                                     val episode = episodeNumber ?: return@PlayerIconButton
                                     val selected = uiState.selectedStream
-                                    onPlayNext(season, episode + 1, selected?.addonId?.takeIf { it.isNotBlank() }, selected?.source?.takeIf { it.isNotBlank() }, selected?.behaviorHints?.bingeGroup?.takeIf { it.isNotBlank() })
+                                    onPlayNext(
+                                        season,
+                                        episode + 1,
+                                        tmdbSeasonNumber ?: season,
+                                        (tmdbEpisodeNumber ?: episode) + 1,
+                                        selected?.addonId?.takeIf { it.isNotBlank() },
+                                        selected?.source?.takeIf { it.isNotBlank() },
+                                        selected?.behaviorHints?.bingeGroup?.takeIf { it.isNotBlank() }
+                                    )
                                 },
                                 onLeftKey = { aspectButtonFocusRequester.requestFocus() },
                                 onRightKey = { subtitleButtonFocusRequester.requestFocus() },

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
@@ -34,6 +34,7 @@ import com.arflix.tv.data.repository.WatchHistoryRepository
 import com.arflix.tv.util.AnimeMapper
 import com.arflix.tv.util.AppLogger
 import com.arflix.tv.util.Constants
+import com.arflix.tv.util.fallbackAdjacentEpisodeIdentity
 import com.arflix.tv.util.settingsDataStore
 import com.arflix.tv.util.weightedSubtitleScore
 import androidx.datastore.preferences.core.booleanPreferencesKey
@@ -208,6 +209,7 @@ class PlayerViewModel @Inject constructor(
     private var currentEpisode: Int? = null
     private var currentDisplaySeason: Int? = null
     private var currentDisplayEpisode: Int? = null
+    private var currentAnimeQueryOverride: String? = null
     private var currentTitle: String = ""
     private var currentPoster: String? = null
     private var currentBackdrop: String? = null
@@ -254,10 +256,7 @@ class PlayerViewModel @Inject constructor(
                 structure.previousBeforeDisplay(current.displaySeason, current.displayEpisode)
             }
         }
-        val nextEpisode = current.tmdbEpisode + if (forward) 1 else -1
-        return nextEpisode.takeIf { it > 0 }?.let {
-            EpisodeIdentity.canonical(current.tmdbSeason, it)
-        }
+        return fallbackAdjacentEpisodeIdentity(current, forward)
     }
 
     // AI subtitle settings (read once per video load)
@@ -472,6 +471,7 @@ class PlayerViewModel @Inject constructor(
         episodeNumber: Int?,
         displaySeasonNumber: Int? = seasonNumber,
         displayEpisodeNumber: Int? = episodeNumber,
+        animeQueryOverride: String? = null,
         providedImdbId: String?,
         providedStreamUrl: String?,
         preferredAddonId: String?,
@@ -488,6 +488,7 @@ class PlayerViewModel @Inject constructor(
         currentEpisode = episodeNumber
         currentDisplaySeason = displaySeasonNumber
         currentDisplayEpisode = displayEpisodeNumber
+        currentAnimeQueryOverride = animeQueryOverride
         currentStartPositionMs = startPositionMs
         currentPreferredAddonId = preferredAddonId?.trim()?.takeIf { it.isNotBlank() }
         currentPreferredSourceName = preferredSourceName?.trim()?.takeIf { it.isNotBlank() }
@@ -966,6 +967,7 @@ class PlayerViewModel @Inject constructor(
                         genreIds = currentGenreIds,
                         originalLanguage = currentOriginalLanguage,
                         title = currentItemTitle,
+                        animeQueryOverride = animeQueryOverride,
                         airDate = currentAirDate
                     )
                 }
@@ -3778,6 +3780,7 @@ class PlayerViewModel @Inject constructor(
             episodeNumber = currentEpisode,
             displaySeasonNumber = currentDisplaySeason,
             displayEpisodeNumber = currentDisplayEpisode,
+            animeQueryOverride = currentAnimeQueryOverride,
             providedImdbId = currentImdbId,
             providedStreamUrl = null,
             preferredAddonId = currentPreferredAddonId,
@@ -4419,7 +4422,8 @@ class PlayerViewModel @Inject constructor(
                     tvdbId = currentTvdbId,
                     genreIds = currentGenreIds,
                     originalLanguage = currentOriginalLanguage,
-                    title = currentItemTitle
+                    title = currentItemTitle,
+                    animeQueryOverride = currentAnimeQueryOverride
                 )
             }
 

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
@@ -13,6 +13,7 @@ import com.arflix.tv.data.api.TmdbApi
 import com.arflix.tv.data.model.Addon
 import com.arflix.tv.data.model.AddonType
 import com.arflix.tv.data.model.MediaType
+import com.arflix.tv.data.model.EpisodeIdentity
 import com.arflix.tv.data.model.SportsAddonCapabilities
 import com.arflix.tv.data.model.StreamSource
 import com.arflix.tv.data.model.Subtitle
@@ -30,6 +31,7 @@ import com.arflix.tv.data.repository.LauncherContinueWatchingRepository
 import com.arflix.tv.data.repository.TraktRepository
 import com.arflix.tv.data.repository.WatchHistoryEntry
 import com.arflix.tv.data.repository.WatchHistoryRepository
+import com.arflix.tv.util.AnimeMapper
 import com.arflix.tv.util.AppLogger
 import com.arflix.tv.util.Constants
 import com.arflix.tv.util.settingsDataStore
@@ -191,6 +193,7 @@ class PlayerViewModel @Inject constructor(
     private val watchHistoryRepository: WatchHistoryRepository,
     private val cloudSyncRepository: CloudSyncRepository,
     private val launcherContinueWatchingRepository: LauncherContinueWatchingRepository,
+    private val animeMapper: AnimeMapper,
     private val tmdbApi: TmdbApi,
     private val skipIntroRepository: SkipIntroRepository,
     private val playbackTelemetryRepository: PlaybackTelemetryRepository
@@ -203,6 +206,8 @@ class PlayerViewModel @Inject constructor(
     private var currentMediaId: Int = 0
     private var currentSeason: Int? = null
     private var currentEpisode: Int? = null
+    private var currentDisplaySeason: Int? = null
+    private var currentDisplayEpisode: Int? = null
     private var currentTitle: String = ""
     private var currentPoster: String? = null
     private var currentBackdrop: String? = null
@@ -235,6 +240,25 @@ class PlayerViewModel @Inject constructor(
         currentMediaType == MediaType.TV &&
             currentOriginalLanguage.equals("ja", ignoreCase = true) &&
             currentGenreIds.contains(16)
+
+    suspend fun adjacentEpisodeIdentity(
+        tmdbId: Int,
+        current: EpisodeIdentity,
+        forward: Boolean
+    ): EpisodeIdentity? {
+        val structure = runCatching { animeMapper.resolveAnimeSeasonStructure(tmdbId) }.getOrNull()
+        if (structure != null) {
+            return if (forward) {
+                structure.nextAfterDisplay(current.displaySeason, current.displayEpisode)
+            } else {
+                structure.previousBeforeDisplay(current.displaySeason, current.displayEpisode)
+            }
+        }
+        val nextEpisode = current.tmdbEpisode + if (forward) 1 else -1
+        return nextEpisode.takeIf { it > 0 }?.let {
+            EpisodeIdentity.canonical(current.tmdbSeason, it)
+        }
+    }
 
     // AI subtitle settings (read once per video load)
     private var aiSubtitleEnabled = false
@@ -446,6 +470,8 @@ class PlayerViewModel @Inject constructor(
         mediaId: Int,
         seasonNumber: Int?,
         episodeNumber: Int?,
+        displaySeasonNumber: Int? = seasonNumber,
+        displayEpisodeNumber: Int? = episodeNumber,
         providedImdbId: String?,
         providedStreamUrl: String?,
         preferredAddonId: String?,
@@ -460,6 +486,8 @@ class PlayerViewModel @Inject constructor(
         currentMediaId = mediaId
         currentSeason = seasonNumber
         currentEpisode = episodeNumber
+        currentDisplaySeason = displaySeasonNumber
+        currentDisplayEpisode = displayEpisodeNumber
         currentStartPositionMs = startPositionMs
         currentPreferredAddonId = preferredAddonId?.trim()?.takeIf { it.isNotBlank() }
         currentPreferredSourceName = preferredSourceName?.trim()?.takeIf { it.isNotBlank() }
@@ -3744,17 +3772,19 @@ class PlayerViewModel @Inject constructor(
 
     fun retry() {
         loadMedia(
-            currentMediaType,
-            currentMediaId,
-            currentSeason,
-            currentEpisode,
-            currentImdbId,
-            null,
-            currentPreferredAddonId,
-            currentPreferredSourceName,
-            currentPreferredBingeGroup,
-            currentStartPositionMs,
-            currentIsLiveStreamPlayback
+            mediaType = currentMediaType,
+            mediaId = currentMediaId,
+            seasonNumber = currentSeason,
+            episodeNumber = currentEpisode,
+            displaySeasonNumber = currentDisplaySeason,
+            displayEpisodeNumber = currentDisplayEpisode,
+            providedImdbId = currentImdbId,
+            providedStreamUrl = null,
+            preferredAddonId = currentPreferredAddonId,
+            preferredSourceName = currentPreferredSourceName,
+            preferredBingeGroup = currentPreferredBingeGroup,
+            startPositionMs = currentStartPositionMs,
+            isLiveStreamPlayback = currentIsLiveStreamPlayback
         )
     }
 
@@ -4037,6 +4067,8 @@ class PlayerViewModel @Inject constructor(
                         backdropPath = currentBackdrop,
                         season = currentSeason,
                         episode = currentEpisode,
+                        displaySeason = currentDisplaySeason,
+                        displayEpisode = currentDisplayEpisode,
                         episodeTitle = currentEpisodeTitle,
                         progress = progressPercent,
                         positionSeconds = positionSeconds,
@@ -4130,15 +4162,25 @@ class PlayerViewModel @Inject constructor(
                 val cwEpisode = currentEpisode
                 if (currentMediaType == MediaType.TV && cwSeason != null && cwEpisode != null) {
                     try {
-                        val nextEpisode = cwEpisode + 1
+                        val nextIdentity = runCatching {
+                            animeMapper.resolveAnimeSeasonStructure(currentMediaId)
+                                ?.nextAfterDisplay(
+                                    currentDisplaySeason ?: cwSeason,
+                                    currentDisplayEpisode ?: cwEpisode
+                                )
+                        }.getOrNull()
+                        val nextSeason = nextIdentity?.tmdbSeason ?: cwSeason
+                        val nextEpisode = nextIdentity?.tmdbEpisode ?: (cwEpisode + 1)
                         traktRepository.saveLocalContinueWatching(
                             mediaType = currentMediaType,
                             tmdbId = currentMediaId,
                             title = currentItemTitle.ifEmpty { currentTitle },
                             posterPath = currentPoster,
                             backdropPath = currentBackdrop,
-                            season = cwSeason,
+                            season = nextSeason,
                             episode = nextEpisode,
+                            displaySeason = nextIdentity?.displaySeason ?: nextSeason,
+                            displayEpisode = nextIdentity?.displayEpisode ?: nextEpisode,
                             episodeTitle = null,
                             progress = 3, // meets MIN_PROGRESS_THRESHOLD to avoid filter
                             positionSeconds = 0L, // next episode: no resume position yet

--- a/app/src/main/kotlin/com/arflix/tv/util/AnimeMapper.kt
+++ b/app/src/main/kotlin/com/arflix/tv/util/AnimeMapper.kt
@@ -412,6 +412,34 @@ class AnimeMapper @Inject constructor(
     }
 
     /**
+     * Resolve the optional user-visible anime season structure for a TMDB show.
+     * Returns null unless ARM exposes multiple Kitsu entries with complete episode counts.
+     */
+    internal suspend fun resolveAnimeSeasonStructure(tmdbId: Int): AnimeSeasonStructure? = withContext(Dispatchers.IO) {
+        try {
+            val entries = cacheMutex.withLock { armTmdbCache[tmdbId] }
+                ?: fetchArmMapping(tmdbId)
+                ?: return@withContext null
+            val providerEntries = entries
+                .mapNotNull { entry ->
+                    val kitsuId = entry.kitsu ?: return@mapNotNull null
+                    val count = getKitsuEpisodeCount(kitsuId) ?: return@mapNotNull null
+                    AnimeProviderSeason(kitsuId, entry.themoviedbSeason, count)
+                }
+                .distinctBy { Triple(it.kitsuId, it.tmdbSeason, it.episodeCount) }
+            if (providerEntries.size < 2) return@withContext null
+
+            val details = tmdbApi.getTvDetails(tmdbId, Constants.TMDB_API_KEY)
+            val tmdbCounts = details.seasons
+                .filter { it.seasonNumber > 0 && it.episodeCount > 0 }
+                .associate { it.seasonNumber to it.episodeCount }
+            buildAnimeSeasonStructure(tmdbCounts, providerEntries)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /**
      * Main resolution function: resolves the correct Kitsu episode query string
      * for Stremio addons. Uses 5-tier fallback chain.
      *

--- a/app/src/main/kotlin/com/arflix/tv/util/AnimeSeasonStructure.kt
+++ b/app/src/main/kotlin/com/arflix/tv/util/AnimeSeasonStructure.kt
@@ -44,6 +44,22 @@ internal data class AnimeSeasonStructure(
     }
 }
 
+internal fun fallbackAdjacentEpisodeIdentity(
+    current: EpisodeIdentity,
+    forward: Boolean
+): EpisodeIdentity? {
+    val delta = if (forward) 1 else -1
+    val displayEpisode = current.displayEpisode + delta
+    val tmdbEpisode = current.tmdbEpisode + delta
+    if (displayEpisode <= 0 || tmdbEpisode <= 0) return null
+    return EpisodeIdentity(
+        displaySeason = current.displaySeason,
+        displayEpisode = displayEpisode,
+        tmdbSeason = current.tmdbSeason,
+        tmdbEpisode = tmdbEpisode
+    )
+}
+
 /**
  * Builds an anime-facing season structure without title-specific rules.
  *

--- a/app/src/main/kotlin/com/arflix/tv/util/AnimeSeasonStructure.kt
+++ b/app/src/main/kotlin/com/arflix/tv/util/AnimeSeasonStructure.kt
@@ -1,5 +1,7 @@
 package com.arflix.tv.util
 
+import com.arflix.tv.data.model.EpisodeIdentity
+
 /** A provider entry that can become one user-visible anime season. */
 internal data class AnimeProviderSeason(
     val kitsuId: Int,
@@ -7,31 +9,38 @@ internal data class AnimeProviderSeason(
     val episodeCount: Int
 )
 
-/** Maps one user-visible anime episode back to the canonical TMDB episode. */
-internal data class AnimeEpisodeIdentity(
-    val displaySeason: Int,
-    val displayEpisode: Int,
-    val tmdbSeason: Int,
-    val tmdbEpisode: Int,
-    val kitsuId: Int
-)
-
 internal data class AnimeSeasonStructure(
-    val seasons: Map<Int, List<AnimeEpisodeIdentity>>
+    val seasons: Map<Int, List<EpisodeIdentity>>
 ) {
     val seasonCount: Int get() = seasons.size
 
-    fun identityForDisplay(season: Int, episode: Int): AnimeEpisodeIdentity? =
+    fun identityForDisplay(season: Int, episode: Int): EpisodeIdentity? =
         seasons[season]?.firstOrNull { it.displayEpisode == episode }
 
-    fun identityForTmdb(season: Int, episode: Int): AnimeEpisodeIdentity? =
+    fun identityForTmdb(season: Int, episode: Int): EpisodeIdentity? =
         seasons.values.asSequence().flatten().firstOrNull {
             it.tmdbSeason == season && it.tmdbEpisode == episode
         }
 
-    fun nextAfterDisplay(season: Int, episode: Int): AnimeEpisodeIdentity? {
+    fun nextAfterDisplay(season: Int, episode: Int): EpisodeIdentity? {
         identityForDisplay(season, episode + 1)?.let { return it }
         return seasons[season + 1]?.firstOrNull()
+    }
+
+    fun previousBeforeDisplay(season: Int, episode: Int): EpisodeIdentity? {
+        identityForDisplay(season, episode - 1)?.let { return it }
+        return seasons[season - 1]?.lastOrNull()
+    }
+
+    fun canonicalEpisodesForDisplaySeason(season: Int): Map<Int, List<Int>> =
+        seasons[season].orEmpty()
+            .groupBy { it.tmdbSeason }
+            .mapValues { (_, identities) -> identities.map { it.tmdbEpisode } }
+
+    fun progressForCanonicalEpisodes(
+        watched: Set<Pair<Int, Int>>
+    ): Map<Int, Pair<Int, Int>> = seasons.mapValues { (_, identities) ->
+        identities.count { (it.tmdbSeason to it.tmdbEpisode) in watched } to identities.size
     }
 }
 
@@ -58,10 +67,11 @@ internal fun buildAnimeSeasonStructure(
         .filter { it.kitsuId > 0 && it.episodeCount > 0 }
         .distinctBy { Triple(it.kitsuId, it.tmdbSeason, it.episodeCount) }
     if (validProviders.size < 2) return null
+    if (validProviders.sumOf { it.episodeCount } != canonicalEpisodes.size) return null
 
     val explicitlyMapped = validProviders.all { it.tmdbSeason != null }
     if (explicitlyMapped) {
-        val result = linkedMapOf<Int, List<AnimeEpisodeIdentity>>()
+        val result = linkedMapOf<Int, List<EpisodeIdentity>>()
         var displaySeason = 1
         var explicitMappingValid = true
         validProviders.groupBy { it.tmdbSeason!! }.toSortedMap().forEach { (tmdbSeason, entries) ->
@@ -73,12 +83,13 @@ internal fun buildAnimeSeasonStructure(
             var tmdbEpisode = 1
             entries.forEach { provider ->
                 result[displaySeason] = (1..provider.episodeCount).map { displayEpisode ->
-                    AnimeEpisodeIdentity(
+                    EpisodeIdentity(
                         displaySeason = displaySeason,
                         displayEpisode = displayEpisode,
                         tmdbSeason = tmdbSeason,
                         tmdbEpisode = tmdbEpisode++,
-                        kitsuId = provider.kitsuId
+                        kitsuId = provider.kitsuId,
+                        kitsuEpisode = displayEpisode
                     )
                 }
                 displaySeason++
@@ -93,8 +104,7 @@ internal fun buildAnimeSeasonStructure(
     // though ARM labels each Kitsu entry with its official season. When the episode totals match
     // exactly, preserve TMDB identity by distributing the official seasons over the canonical
     // episode sequence. Any incomplete or contradictory provider data still falls back to TMDB.
-    if (validProviders.sumOf { it.episodeCount } != canonicalEpisodes.size) return null
-    val result = linkedMapOf<Int, List<AnimeEpisodeIdentity>>()
+    val result = linkedMapOf<Int, List<EpisodeIdentity>>()
     var canonicalIndex = 0
     validProviders.forEachIndexed { index, provider ->
         val remaining = canonicalEpisodes.size - canonicalIndex
@@ -103,12 +113,13 @@ internal fun buildAnimeSeasonStructure(
         val displaySeason = index + 1
         result[displaySeason] = (0 until take).map { offset ->
             val (tmdbSeason, tmdbEpisode) = canonicalEpisodes[canonicalIndex + offset]
-            AnimeEpisodeIdentity(
+            EpisodeIdentity(
                 displaySeason = displaySeason,
                 displayEpisode = offset + 1,
                 tmdbSeason = tmdbSeason,
                 tmdbEpisode = tmdbEpisode,
-                kitsuId = provider.kitsuId
+                kitsuId = provider.kitsuId,
+                kitsuEpisode = offset + 1
             )
         }
         canonicalIndex += take

--- a/app/src/main/kotlin/com/arflix/tv/util/AnimeSeasonStructure.kt
+++ b/app/src/main/kotlin/com/arflix/tv/util/AnimeSeasonStructure.kt
@@ -1,0 +1,119 @@
+package com.arflix.tv.util
+
+/** A provider entry that can become one user-visible anime season. */
+internal data class AnimeProviderSeason(
+    val kitsuId: Int,
+    val tmdbSeason: Int?,
+    val episodeCount: Int
+)
+
+/** Maps one user-visible anime episode back to the canonical TMDB episode. */
+internal data class AnimeEpisodeIdentity(
+    val displaySeason: Int,
+    val displayEpisode: Int,
+    val tmdbSeason: Int,
+    val tmdbEpisode: Int,
+    val kitsuId: Int
+)
+
+internal data class AnimeSeasonStructure(
+    val seasons: Map<Int, List<AnimeEpisodeIdentity>>
+) {
+    val seasonCount: Int get() = seasons.size
+
+    fun identityForDisplay(season: Int, episode: Int): AnimeEpisodeIdentity? =
+        seasons[season]?.firstOrNull { it.displayEpisode == episode }
+
+    fun identityForTmdb(season: Int, episode: Int): AnimeEpisodeIdentity? =
+        seasons.values.asSequence().flatten().firstOrNull {
+            it.tmdbSeason == season && it.tmdbEpisode == episode
+        }
+
+    fun nextAfterDisplay(season: Int, episode: Int): AnimeEpisodeIdentity? {
+        identityForDisplay(season, episode + 1)?.let { return it }
+        return seasons[season + 1]?.firstOrNull()
+    }
+}
+
+/**
+ * Builds an anime-facing season structure without title-specific rules.
+ *
+ * TMDB remains the canonical identity used by Trakt/history. ARM/Kitsu only controls how those
+ * canonical episodes are grouped and numbered for display and addon lookup. If the provider data
+ * is incomplete or contradictory, null is returned so callers safely keep the normal TMDB view.
+ */
+internal fun buildAnimeSeasonStructure(
+    tmdbSeasonEpisodeCounts: Map<Int, Int>,
+    providerSeasons: List<AnimeProviderSeason>
+): AnimeSeasonStructure? {
+    val canonicalEpisodes = tmdbSeasonEpisodeCounts
+        .filterKeys { it > 0 }
+        .toSortedMap()
+        .flatMap { (season, count) ->
+            (1..count.coerceAtLeast(0)).map { episode -> season to episode }
+        }
+    if (canonicalEpisodes.isEmpty()) return null
+
+    val validProviders = providerSeasons
+        .filter { it.kitsuId > 0 && it.episodeCount > 0 }
+        .distinctBy { Triple(it.kitsuId, it.tmdbSeason, it.episodeCount) }
+    if (validProviders.size < 2) return null
+
+    val explicitlyMapped = validProviders.all { it.tmdbSeason != null }
+    if (explicitlyMapped) {
+        val result = linkedMapOf<Int, List<AnimeEpisodeIdentity>>()
+        var displaySeason = 1
+        var explicitMappingValid = true
+        validProviders.groupBy { it.tmdbSeason!! }.toSortedMap().forEach { (tmdbSeason, entries) ->
+            val available = tmdbSeasonEpisodeCounts[tmdbSeason]
+            if (available == null || entries.sumOf { it.episodeCount } > available) {
+                explicitMappingValid = false
+                return@forEach
+            }
+            var tmdbEpisode = 1
+            entries.forEach { provider ->
+                result[displaySeason] = (1..provider.episodeCount).map { displayEpisode ->
+                    AnimeEpisodeIdentity(
+                        displaySeason = displaySeason,
+                        displayEpisode = displayEpisode,
+                        tmdbSeason = tmdbSeason,
+                        tmdbEpisode = tmdbEpisode++,
+                        kitsuId = provider.kitsuId
+                    )
+                }
+                displaySeason++
+            }
+        }
+        if (explicitMappingValid) {
+            return AnimeSeasonStructure(result).takeIf { it.seasonCount > 1 }
+        }
+    }
+
+    // Some TMDB records merge multiple official anime seasons into one canonical season even
+    // though ARM labels each Kitsu entry with its official season. When the episode totals match
+    // exactly, preserve TMDB identity by distributing the official seasons over the canonical
+    // episode sequence. Any incomplete or contradictory provider data still falls back to TMDB.
+    if (validProviders.sumOf { it.episodeCount } != canonicalEpisodes.size) return null
+    val result = linkedMapOf<Int, List<AnimeEpisodeIdentity>>()
+    var canonicalIndex = 0
+    validProviders.forEachIndexed { index, provider ->
+        val remaining = canonicalEpisodes.size - canonicalIndex
+        val take = provider.episodeCount
+        if (take <= 0 || (index != validProviders.lastIndex && take > remaining)) return null
+        val displaySeason = index + 1
+        result[displaySeason] = (0 until take).map { offset ->
+            val (tmdbSeason, tmdbEpisode) = canonicalEpisodes[canonicalIndex + offset]
+            AnimeEpisodeIdentity(
+                displaySeason = displaySeason,
+                displayEpisode = offset + 1,
+                tmdbSeason = tmdbSeason,
+                tmdbEpisode = tmdbEpisode,
+                kitsuId = provider.kitsuId
+            )
+        }
+        canonicalIndex += take
+    }
+    if (canonicalIndex != canonicalEpisodes.size) return null
+
+    return AnimeSeasonStructure(result).takeIf { it.seasonCount > 1 }
+}

--- a/app/src/test/kotlin/com/arflix/tv/util/AnimeSeasonStructureTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/util/AnimeSeasonStructureTest.kt
@@ -132,4 +132,68 @@ class AnimeSeasonStructureTest {
         assertEquals(1, next.tmdbSeason)
         assertEquals(13, next.tmdbEpisode)
     }
+
+    @Test
+    fun `previous display episode crosses back to the prior official season`() {
+        val result = buildAnimeSeasonStructure(
+            mapOf(1 to 24),
+            listOf(AnimeProviderSeason(1, null, 12), AnimeProviderSeason(2, null, 12))
+        )!!
+
+        val previous = result.previousBeforeDisplay(2, 1)!!
+        assertEquals(1, previous.displaySeason)
+        assertEquals(12, previous.displayEpisode)
+        assertEquals(1, previous.tmdbSeason)
+        assertEquals(12, previous.tmdbEpisode)
+    }
+
+    @Test
+    fun `stream identity retains exact Kitsu override after TMDB conversion`() {
+        val result = buildAnimeSeasonStructure(
+            mapOf(1 to 24),
+            listOf(AnimeProviderSeason(101, null, 12), AnimeProviderSeason(202, null, 12))
+        )!!
+
+        val identity = result.identityForDisplay(2, 8)!!
+        assertEquals(1, identity.tmdbSeason)
+        assertEquals(20, identity.tmdbEpisode)
+        assertEquals("kitsu:202:8", identity.kitsuQuery)
+    }
+
+    @Test
+    fun `season progress is calculated on displayed anime seasons`() {
+        val result = buildAnimeSeasonStructure(
+            mapOf(1 to 24),
+            listOf(AnimeProviderSeason(1, null, 12), AnimeProviderSeason(2, null, 12))
+        )!!
+
+        val progress = result.progressForCanonicalEpisodes(
+            ((1..12).map { 1 to it } + listOf(1 to 13, 1 to 14)).toSet()
+        )
+        assertEquals(12 to 12, progress[1])
+        assertEquals(2 to 12, progress[2])
+    }
+
+    @Test
+    fun `Trakt grouping always returns canonical coordinates`() {
+        val result = buildAnimeSeasonStructure(
+            mapOf(1 to 24),
+            listOf(AnimeProviderSeason(1, null, 12), AnimeProviderSeason(2, null, 12))
+        )!!
+
+        assertEquals(mapOf(1 to (13..24).toList()), result.canonicalEpisodesForDisplaySeason(2))
+    }
+
+    @Test
+    fun `partial explicit ARM mapping falls back instead of hiding episodes`() {
+        assertNull(
+            buildAnimeSeasonStructure(
+                mapOf(1 to 24),
+                listOf(
+                    AnimeProviderSeason(100, 1, 6),
+                    AnimeProviderSeason(200, 1, 6)
+                )
+            )
+        )
+    }
 }

--- a/app/src/test/kotlin/com/arflix/tv/util/AnimeSeasonStructureTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/util/AnimeSeasonStructureTest.kt
@@ -1,0 +1,135 @@
+package com.arflix.tv.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AnimeSeasonStructureTest {
+
+    @Test
+    fun `My Dress-Up Darling splits one TMDB season into two anime seasons`() {
+        val result = buildAnimeSeasonStructure(
+            tmdbSeasonEpisodeCounts = mapOf(1 to 24),
+            providerSeasons = listOf(
+                AnimeProviderSeason(kitsuId = 44382, tmdbSeason = 1, episodeCount = 12),
+                AnimeProviderSeason(kitsuId = 46492, tmdbSeason = 2, episodeCount = 12)
+            )
+        )!!
+
+        assertEquals(2, result.seasonCount)
+        assertEquals(12, result.seasons.getValue(1).size)
+        assertEquals(12, result.seasons.getValue(2).size)
+        val seasonTwoFirst = result.seasons.getValue(2).first()
+        assertEquals(1, seasonTwoFirst.displayEpisode)
+        assertEquals(1, seasonTwoFirst.tmdbSeason)
+        assertEquals(13, seasonTwoFirst.tmdbEpisode)
+    }
+
+    @Test
+    fun `Rent-a-Girlfriend creates one display season per provider entry`() {
+        val result = buildAnimeSeasonStructure(
+            tmdbSeasonEpisodeCounts = mapOf(1 to 48),
+            providerSeasons = listOf(
+                AnimeProviderSeason(43019, null, 12),
+                AnimeProviderSeason(45588, null, 12),
+                AnimeProviderSeason(47194, null, 12),
+                AnimeProviderSeason(48817, null, 12)
+            )
+        )!!
+
+        assertEquals(4, result.seasonCount)
+        assertTrue(result.seasons.values.all { it.size == 12 })
+        assertEquals(37, result.seasons.getValue(4).first().tmdbEpisode)
+    }
+
+    @Test
+    fun `explicit ARM TMDB season entries preserve canonical tracking identity`() {
+        val result = buildAnimeSeasonStructure(
+            tmdbSeasonEpisodeCounts = mapOf(1 to 12, 2 to 24),
+            providerSeasons = listOf(
+                AnimeProviderSeason(100, 1, 12),
+                AnimeProviderSeason(200, 2, 12),
+                AnimeProviderSeason(201, 2, 12)
+            )
+        )!!
+
+        assertEquals(3, result.seasonCount)
+        assertEquals(2, result.seasons.getValue(3).first().tmdbSeason)
+        assertEquals(13, result.seasons.getValue(3).first().tmdbEpisode)
+    }
+
+    @Test
+    fun `Mushoku Tensei cours can split one canonical season without losing TMDB identity`() {
+        val result = buildAnimeSeasonStructure(
+            tmdbSeasonEpisodeCounts = mapOf(1 to 23),
+            providerSeasons = listOf(
+                AnimeProviderSeason(1, null, 11),
+                AnimeProviderSeason(2, null, 12)
+            )
+        )!!
+
+        assertEquals(2, result.seasonCount)
+        assertEquals(12, result.seasons.getValue(2).size)
+        assertEquals(12, result.seasons.getValue(2).first().tmdbEpisode)
+        assertEquals(23, result.seasons.getValue(2).last().tmdbEpisode)
+    }
+
+    @Test
+    fun `incomplete provider data safely falls back to TMDB`() {
+        assertNull(
+            buildAnimeSeasonStructure(
+                tmdbSeasonEpisodeCounts = mapOf(1 to 24),
+                providerSeasons = listOf(
+                    AnimeProviderSeason(100, null, 12),
+                    AnimeProviderSeason(200, null, 20)
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `single long-running provider entry does not invent seasons`() {
+        assertNull(
+            buildAnimeSeasonStructure(
+                tmdbSeasonEpisodeCounts = mapOf(1 to 61, 2 to 16),
+                providerSeasons = listOf(AnimeProviderSeason(12, null, 77))
+            )
+        )
+    }
+
+    @Test
+    fun `Naruto style long series remains on its TMDB structure`() {
+        assertNull(
+            buildAnimeSeasonStructure(
+                tmdbSeasonEpisodeCounts = mapOf(1 to 35, 2 to 65, 3 to 41, 4 to 42, 5 to 37),
+                providerSeasons = listOf(AnimeProviderSeason(11, null, 220))
+            )
+        )
+    }
+
+    @Test
+    fun `classic series without anime provider seasons are unchanged`() {
+        listOf(
+            mapOf(1 to 7, 2 to 13, 3 to 13, 4 to 13, 5 to 16), // Breaking Bad
+            mapOf(1 to 9, 2 to 7),                              // The Last of Us
+            mapOf(1 to 10, 2 to 10, 3 to 10, 4 to 10, 5 to 10, 6 to 10, 7 to 7, 8 to 6)
+        ).forEach { tmdbSeasons ->
+            assertNull(buildAnimeSeasonStructure(tmdbSeasons, emptyList()))
+        }
+    }
+
+    @Test
+    fun `next display episode resolves to canonical Trakt coordinates across a cour boundary`() {
+        val result = buildAnimeSeasonStructure(
+            mapOf(1 to 24),
+            listOf(AnimeProviderSeason(1, null, 12), AnimeProviderSeason(2, null, 12))
+        )!!
+
+        val next = result.nextAfterDisplay(1, 12)!!
+        assertEquals(2, next.displaySeason)
+        assertEquals(1, next.displayEpisode)
+        assertEquals(1, next.tmdbSeason)
+        assertEquals(13, next.tmdbEpisode)
+    }
+}

--- a/app/src/test/kotlin/com/arflix/tv/util/AnimeSeasonStructureTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/util/AnimeSeasonStructureTest.kt
@@ -1,5 +1,6 @@
 package com.arflix.tv.util
 
+import com.arflix.tv.data.model.EpisodeIdentity
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -195,5 +196,39 @@ class AnimeSeasonStructureTest {
                 )
             )
         )
+    }
+
+    @Test
+    fun `fallback next keeps local display numbering for absolute TMDB episodes`() {
+        val next = fallbackAdjacentEpisodeIdentity(
+            current = EpisodeIdentity(
+                displaySeason = 22,
+                displayEpisode = 1,
+                tmdbSeason = 22,
+                tmdbEpisode = 1089
+            ),
+            forward = true
+        )!!
+
+        assertEquals(22, next.displaySeason)
+        assertEquals(2, next.displayEpisode)
+        assertEquals(22, next.tmdbSeason)
+        assertEquals(1090, next.tmdbEpisode)
+    }
+
+    @Test
+    fun `fallback previous keeps local display numbering for absolute TMDB episodes`() {
+        val previous = fallbackAdjacentEpisodeIdentity(
+            current = EpisodeIdentity(
+                displaySeason = 22,
+                displayEpisode = 2,
+                tmdbSeason = 22,
+                tmdbEpisode = 1090
+            ),
+            forward = false
+        )!!
+
+        assertEquals(1, previous.displayEpisode)
+        assertEquals(1089, previous.tmdbEpisode)
     }
 }


### PR DESCRIPTION
# ARVIO-ANIME-001 — Official Anime Season Structure

## Summary

This change separates an anime episode's user-facing identity from its canonical identity. The UI can display official ARM/Kitsu seasons without changing the coordinates used by TMDB, Trakt, and watch history.

Each episode can carry:

- display season and episode numbers;
- canonical TMDB season and episode numbers;
- Kitsu ID and episode number for anime source lookup.

Movies and non-anime TV shows keep their existing behavior.

## Behavior

- Uses the existing anime detection: Japanese animation or a known anime mapping.
- Resolves TMDB shows to Kitsu entries through ARM.
- Retrieves Kitsu episode counts dynamically.
- Builds official seasons only when provider data is complete and consistent.
- Sequentially distributes episodes when TMDB merges several official anime seasons into one container and the episode totals match exactly.
- Falls back immediately to the existing TMDB structure when ARM/Kitsu fails or returns contradictory data.
- Displays season-local episode numbers for long-running anime whose TMDB seasons use absolute episode numbering.
- Uses the exact Kitsu identity for anime addon source lookup when available.
- Keeps playback tracking, history, progress, and Trakt operations on the canonical TMDB identity.

## Why not simply replace season and episode numbers?

A global number replacement would break the identifiers expected by Trakt, TMDB, resume handling, and some addons. The dual-identity model lets every subsystem use the appropriate coordinates: official season numbering for the user, canonical TMDB coordinates for tracking, and Kitsu coordinates for anime addons.

## Files changed

- `app/src/main/kotlin/com/arflix/tv/util/AnimeSeasonStructure.kt`
- `app/src/main/kotlin/com/arflix/tv/util/AnimeMapper.kt`
- `app/src/main/kotlin/com/arflix/tv/data/model/Models.kt`
- `app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt`
- `app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt`
- `app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt`
- `app/src/main/kotlin/com/arflix/tv/navigation/AppNavigation.kt`
- `app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt`
- `app/src/test/kotlin/com/arflix/tv/util/AnimeSeasonStructureTest.kt`

## Validation completed

- `testPlayDebugUnitTest`: 308 tests, 0 failures, 0 errors, 1 skipped.
- `assemblePlayDebug`: successful.
- `assembleSideloadDebug`: successful.
- `git diff --check`: successful.
- Manual Android Pixel test: Rent-a-Girlfriend and My Dress-Up Darling season splitting validated; source lookup and playback validated after the exact Kitsu identity fix.
- Automated My Dress-Up Darling coverage: a merged 24-episode structure becomes two 12-episode display seasons, and `S2E08` retains the Season 2 Kitsu identity.
- Automated long-running anime handling: absolute canonical episode coordinates remain available while season-local numbering is used for display.

## Validation still required from the maintainer

- Android TV navigation, resume, playback, and season switching.
- Manual One Piece verification after the season-local display-numbering change.
- Live Trakt integration: Continue Watching, history, mark as watched, progress, and next episode.
- ARVIO Cloud authentication and synchronization.

The last two items require the official project's private Trakt and Cloud credentials. Those credentials are not present in the public repository, so these integrations cannot be tested properly from a fork build.

## Regression scenarios covered

- My Dress-Up Darling
- Rent-a-Girlfriend
- Mushoku Tensei
- One Piece and other absolute-numbered shows
- Naruto and other long-running shows represented by a single anime entry
- Breaking Bad
- The Last of Us
- Game of Thrones
- TMDB fallback when ARM/Kitsu data is incomplete
- next-episode resolution across an official season/cour boundary
