### PR TITLE
fix profile selection

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/profile/ProfileSelectionScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/profile/ProfileSelectionScreen.kt
@@ -102,8 +102,15 @@ fun ProfileSelectionScreen(
         }
     }
 
-    // Navigate when activeProfile changes after user selection
-    LaunchedEffect(uiState.activeProfile?.id, uiState.isSwitchingProfile) {
+    // Navigate after the user picks a profile.
+    // `navigateTriggered` MUST be a key. Keying only on the uiState values meant the tap itself
+    // never re-evaluated this, so navigation depended on *observing* a change in one of them —
+    // and re-selecting the already-active profile changes neither: activeProfile.id stays put,
+    // and isSwitchingProfile goes true→false inside a single frame, which the StateFlow conflates
+    // away before Compose ever reads it. The effect then never restarted and the tap did nothing,
+    // until some unrelated hitch let a frame land mid-switch. (Re-selecting the active profile
+    // became fast enough to hit this when d9e49b10 dropped its setActiveProfile disk write.)
+    LaunchedEffect(navigateTriggered, uiState.activeProfile?.id, uiState.isSwitchingProfile) {
         if (
             navigateTriggered &&
             uiState.activeProfile != null &&


### PR DESCRIPTION
● fix(profile): tapping the active profile no longer does nothing                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                    
  Selecting a profile on "Who's watching" often did nothing until you tapped several times.                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                    
  The LaunchedEffect that navigates read navigateTriggered without it being one of its keys, so the tap never re-ran it — navigation relied on observing a change in activeProfile.id or isSwitchingProfile. Re-selecting the active profile changes neither: the id is unchanged, and isSwitchingProfile flips true
  → false within one frame, which the conflating StateFlow collapses before Compose reads it.                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                    
  Surfaced by d9e49b10, which skipped the setActiveProfile disk write for the same profile — the write had incidentally kept the flag observable for a frame.                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                    
  Fix: add navigateTriggered to the effect's keys. The !isSwitchingProfile guard is untouched, so real switches still defer until done.   