### PR TITLE
fix(iptv): reload EPG during manual playlist refresh

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -85,6 +85,19 @@ enum class ToastType {
     SUCCESS, ERROR, INFO
 }
 
+internal data class SettingsIptvRefreshPolicy(
+    val forcePlaylistReload: Boolean,
+    val forceEpgReload: Boolean,
+    val allowNetworkEpgFetch: Boolean,
+)
+
+internal fun settingsIptvRefreshPolicy(force: Boolean): SettingsIptvRefreshPolicy =
+    SettingsIptvRefreshPolicy(
+        forcePlaylistReload = force,
+        forceEpgReload = force,
+        allowNetworkEpgFetch = force,
+    )
+
 data class AiKeyServerState(
     val isActive: Boolean = false,
     val serverUrl: String? = null,
@@ -2400,9 +2413,11 @@ class SettingsViewModel @Inject constructor(
                 runCatching { iptvRepository.purgeAllIptvSourceCaches() }
             }
             runCatching {
+                val refreshPolicy = settingsIptvRefreshPolicy(force)
                 val snapshot = iptvRepository.loadSnapshot(
-                    forcePlaylistReload = force,
-                    forceEpgReload = false,
+                    forcePlaylistReload = refreshPolicy.forcePlaylistReload,
+                    forceEpgReload = refreshPolicy.forceEpgReload,
+                    allowNetworkEpgFetch = refreshPolicy.allowNetworkEpgFetch,
                     onProgress = { progress ->
                         _uiState.value = _uiState.value.copy(
                             isIptvLoading = true,

--- a/app/src/test/kotlin/com/arflix/tv/ui/screens/settings/IptvRefreshPolicyTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/ui/screens/settings/IptvRefreshPolicyTest.kt
@@ -1,0 +1,26 @@
+package com.arflix.tv.ui.screens.settings
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class IptvRefreshPolicyTest {
+
+    @Test
+    fun manualRefreshReloadsPlaylistAndEpgFromNetwork() {
+        val policy = settingsIptvRefreshPolicy(force = true)
+
+        assertTrue(policy.forcePlaylistReload)
+        assertTrue(policy.forceEpgReload)
+        assertTrue(policy.allowNetworkEpgFetch)
+    }
+
+    @Test
+    fun automaticConfigLoadKeepsNetworkEpgDeferred() {
+        val policy = settingsIptvRefreshPolicy(force = false)
+
+        assertFalse(policy.forcePlaylistReload)
+        assertFalse(policy.forceEpgReload)
+        assertFalse(policy.allowNetworkEpgFetch)
+    }
+}


### PR DESCRIPTION
## Summary
- Makes Settings → Refresh IPTV force both playlist and EPG network reloads.
- Allows EPG source discovery/network fetch during an explicit refresh instead of purging guide data and then performing a cache-only load.
- Keeps automatic/non-forced settings loads cache-friendly and defers broad network EPG work.

## Why
The refresh action could finish very quickly while leaving the guide empty or stuck on “Guide pending”, because it forced the playlist but explicitly disabled EPG reload/network fetching.

## Testing
- `IptvRefreshPolicyTest`
  - manual refresh forces playlist, EPG, and network EPG flags
  - automatic load keeps those flags disabled
- `./gradlew :app:compileSideloadDebugKotlin`
- `./gradlew :app:testSideloadDebugUnitTest`
- `git diff --check`
- Manual phone verification on the fork build: EPG populated noticeably faster after refresh.

## Behavior note
An explicit manual refresh may take longer than before because it now performs the EPG work the UI promises. Normal startup remains cache-first.

## Scope
Android Settings IPTV refresh orchestration only. No startup cache policy, backend, player interaction, catalog, or app version changes.
