### PR TITLE
fix(player): stop autoplay before unaired episodes

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/NextEpisodeAirDateResolver.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/NextEpisodeAirDateResolver.kt
@@ -1,0 +1,79 @@
+package com.arflix.tv.ui.screens.player
+
+import com.arflix.tv.data.api.TmdbSeasonDetails
+import com.arflix.tv.data.model.EpisodeIdentity
+import kotlinx.coroutines.CancellationException
+import java.time.Clock
+import java.time.LocalDate
+import java.time.format.DateTimeParseException
+
+internal enum class NextEpisodeAirDateBlockReason {
+    FutureAirDate,
+    MissingEpisode,
+    MissingAirDate,
+    MalformedAirDate,
+    MetadataUnavailable,
+}
+
+internal sealed interface NextEpisodeAirDateResolution {
+    data object Pending : NextEpisodeAirDateResolution
+    data object Allowed : NextEpisodeAirDateResolution
+    data class Blocked(
+        val reason: NextEpisodeAirDateBlockReason,
+    ) : NextEpisodeAirDateResolution
+}
+
+/**
+ * Resolves whether an autoplay target has aired according to TMDB metadata.
+ *
+ * The caller owns the [Pending] state while this suspend operation is running. Failures are
+ * fail-closed so metadata problems can never autoplay an unavailable episode.
+ */
+internal class NextEpisodeAirDateResolver(
+    private val loadSeason: suspend (tmdbId: Int, seasonNumber: Int) -> TmdbSeasonDetails,
+    private val clock: Clock,
+) {
+    suspend fun resolve(
+        tmdbId: Int,
+        target: EpisodeIdentity,
+    ): NextEpisodeAirDateResolution {
+        val season = try {
+            loadSeason(tmdbId, target.tmdbSeason)
+        } catch (cancellation: CancellationException) {
+            throw cancellation
+        } catch (_: Exception) {
+            return NextEpisodeAirDateResolution.Blocked(
+                NextEpisodeAirDateBlockReason.MetadataUnavailable,
+            )
+        }
+
+        val episode = season.episodes.firstOrNull {
+            it.seasonNumber == target.tmdbSeason && it.episodeNumber == target.tmdbEpisode
+        } ?: return NextEpisodeAirDateResolution.Blocked(
+            NextEpisodeAirDateBlockReason.MissingEpisode,
+        )
+
+        val rawAirDate = episode.airDate?.trim().orEmpty()
+        if (rawAirDate.isEmpty()) {
+            return NextEpisodeAirDateResolution.Blocked(
+                NextEpisodeAirDateBlockReason.MissingAirDate,
+            )
+        }
+
+        val airDate = try {
+            LocalDate.parse(rawAirDate)
+        } catch (_: DateTimeParseException) {
+            return NextEpisodeAirDateResolution.Blocked(
+                NextEpisodeAirDateBlockReason.MalformedAirDate,
+            )
+        }
+
+        return if (airDate.isAfter(LocalDate.now(clock))) {
+            NextEpisodeAirDateResolution.Blocked(
+                NextEpisodeAirDateBlockReason.FutureAirDate,
+            )
+        } else {
+            NextEpisodeAirDateResolution.Allowed
+        }
+    }
+}

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/NextEpisodePromptGate.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/NextEpisodePromptGate.kt
@@ -4,6 +4,10 @@ internal data class PlaybackEpisodeKey(
     val mediaId: Int,
     val seasonNumber: Int,
     val episodeNumber: Int,
+    val tmdbSeasonNumber: Int = seasonNumber,
+    val tmdbEpisodeNumber: Int = episodeNumber,
+    val kitsuId: Int? = null,
+    val kitsuEpisodeNumber: Int? = null,
 )
 
 /**
@@ -18,8 +22,16 @@ internal class NextEpisodePromptGate {
     fun tryOpen(
         episode: PlaybackEpisodeKey?,
         eligible: Boolean,
+        airDateResolution: NextEpisodeAirDateResolution,
     ): Boolean {
-        if (!eligible || episode == null || handledEpisode == episode) return false
+        if (
+            !eligible ||
+            episode == null ||
+            handledEpisode == episode ||
+            airDateResolution != NextEpisodeAirDateResolution.Allowed
+        ) {
+            return false
+        }
         handledEpisode = episode
         return true
     }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -419,8 +419,29 @@ fun PlayerScreen(
     var pendingNextSourceName by remember { mutableStateOf<String?>(null) }
     var pendingNextBingeGroup by remember { mutableStateOf<String?>(null) }
     var nextEpisodeIdentity by remember { mutableStateOf<EpisodeIdentity?>(null) }
+    var nextEpisodeAirDateSource by remember { mutableStateOf<PlaybackEpisodeKey?>(null) }
+    var nextEpisodeAirDateResolution by remember {
+        mutableStateOf<NextEpisodeAirDateResolution>(NextEpisodeAirDateResolution.Pending)
+    }
     var previousEpisodeIdentity by remember { mutableStateOf<EpisodeIdentity?>(null) }
-    LaunchedEffect(mediaId, seasonNumber, episodeNumber, tmdbSeasonNumber, tmdbEpisodeNumber, kitsuId, kitsuEpisodeNumber) {
+    LaunchedEffect(mediaType, mediaId, seasonNumber, episodeNumber, tmdbSeasonNumber, tmdbEpisodeNumber, kitsuId, kitsuEpisodeNumber) {
+        nextEpisodeIdentity = null
+        nextEpisodeAirDateSource = if (
+            mediaType == MediaType.TV && seasonNumber != null && episodeNumber != null
+        ) {
+            PlaybackEpisodeKey(
+                mediaId = mediaId,
+                seasonNumber = seasonNumber,
+                episodeNumber = episodeNumber,
+                tmdbSeasonNumber = tmdbSeasonNumber ?: seasonNumber,
+                tmdbEpisodeNumber = tmdbEpisodeNumber ?: episodeNumber,
+                kitsuId = kitsuId,
+                kitsuEpisodeNumber = kitsuEpisodeNumber,
+            )
+        } else {
+            null
+        }
+        nextEpisodeAirDateResolution = NextEpisodeAirDateResolution.Pending
         if (mediaType == MediaType.TV && seasonNumber != null && episodeNumber != null) {
             val current = EpisodeIdentity(
                 displaySeason = seasonNumber,
@@ -430,10 +451,20 @@ fun PlayerScreen(
                 kitsuId = kitsuId,
                 kitsuEpisode = kitsuEpisodeNumber
             )
-            nextEpisodeIdentity = viewModel.adjacentEpisodeIdentity(mediaId, current, forward = true)
+            val next = viewModel.adjacentEpisodeIdentity(mediaId, current, forward = true)
+            nextEpisodeIdentity = next
             previousEpisodeIdentity = viewModel.adjacentEpisodeIdentity(mediaId, current, forward = false)
+            nextEpisodeAirDateResolution = if (next == null) {
+                NextEpisodeAirDateResolution.Blocked(
+                    NextEpisodeAirDateBlockReason.MissingEpisode,
+                )
+            } else {
+                viewModel.resolveNextEpisodeAirDate(mediaId, next)
+            }
         } else {
-            nextEpisodeIdentity = null
+            nextEpisodeAirDateResolution = NextEpisodeAirDateResolution.Blocked(
+                NextEpisodeAirDateBlockReason.MissingEpisode,
+            )
             previousEpisodeIdentity = null
         }
     }
@@ -2473,7 +2504,15 @@ fun PlayerScreen(
                 seasonNumber != null &&
                 episodeNumber != null
             ) {
-                PlaybackEpisodeKey(mediaId, seasonNumber, episodeNumber)
+                PlaybackEpisodeKey(
+                    mediaId = mediaId,
+                    seasonNumber = seasonNumber,
+                    episodeNumber = episodeNumber,
+                    tmdbSeasonNumber = tmdbSeasonNumber ?: seasonNumber,
+                    tmdbEpisodeNumber = tmdbEpisodeNumber ?: episodeNumber,
+                    kitsuId = kitsuId,
+                    kitsuEpisodeNumber = kitsuEpisodeNumber,
+                )
             } else {
                 null
             }
@@ -2484,20 +2523,22 @@ fun PlayerScreen(
                         !showSourceMenu &&
                         !showSubtitleMenu &&
                         uiState.error == null &&
-                        uiState.autoPlayNext,
+                        uiState.autoPlayNext &&
+                        nextEpisodeIdentity != null &&
+                        nextEpisodeAirDateSource == endedEpisodeKey,
+                    airDateResolution = nextEpisodeAirDateResolution,
                 )
             ) {
                 val selected = uiState.selectedStream
-                val next = nextEpisodeIdentity ?: EpisodeIdentity.canonical(
-                    tmdbSeasonNumber ?: endedEpisodeKey.seasonNumber,
-                    (tmdbEpisodeNumber ?: endedEpisodeKey.episodeNumber) + 1
-                )
-                pendingNextIdentity = next
-                pendingNextAddonId = selected?.addonId?.takeIf { it.isNotBlank() }
-                pendingNextSourceName = selected?.source?.takeIf { it.isNotBlank() }
-                pendingNextBingeGroup = selected?.behaviorHints?.bingeGroup?.takeIf { it.isNotBlank() }
-                nextEpisodePromptButton = 0
-                showNextEpisodePrompt = true
+                val next = nextEpisodeIdentity
+                if (next != null) {
+                    pendingNextIdentity = next
+                    pendingNextAddonId = selected?.addonId?.takeIf { it.isNotBlank() }
+                    pendingNextSourceName = selected?.source?.takeIf { it.isNotBlank() }
+                    pendingNextBingeGroup = selected?.behaviorHints?.bingeGroup?.takeIf { it.isNotBlank() }
+                    nextEpisodePromptButton = 0
+                    showNextEpisodePrompt = true
+                }
             }
 
             val tickDelayMs = when {

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerViewModel.kt
@@ -59,6 +59,7 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
+import java.time.Clock
 import javax.inject.Inject
 
 private fun isSupplementalStream(stream: StreamSource): Boolean =
@@ -204,6 +205,13 @@ class PlayerViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(PlayerUiState())
     val uiState: StateFlow<PlayerUiState> = _uiState.asStateFlow()
 
+    private val nextEpisodeAirDateResolver = NextEpisodeAirDateResolver(
+        loadSeason = { tmdbId, seasonNumber ->
+            tmdbApi.getTvSeason(tmdbId, seasonNumber, Constants.TMDB_API_KEY)
+        },
+        clock = Clock.systemDefaultZone(),
+    )
+
     private var currentMediaType: MediaType = MediaType.MOVIE
     private var currentMediaId: Int = 0
     private var currentSeason: Int? = null
@@ -259,6 +267,11 @@ class PlayerViewModel @Inject constructor(
         }
         return fallbackAdjacentEpisodeIdentity(current, forward)
     }
+
+    internal suspend fun resolveNextEpisodeAirDate(
+        tmdbId: Int,
+        target: EpisodeIdentity,
+    ): NextEpisodeAirDateResolution = nextEpisodeAirDateResolver.resolve(tmdbId, target)
 
     // AI subtitle settings (read once per video load)
     private var aiSubtitleEnabled = false

--- a/app/src/test/kotlin/com/arflix/tv/ui/screens/player/NextEpisodeAirDateResolverTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/ui/screens/player/NextEpisodeAirDateResolverTest.kt
@@ -1,0 +1,176 @@
+package com.arflix.tv.ui.screens.player
+
+import com.arflix.tv.data.api.TmdbEpisode
+import com.arflix.tv.data.api.TmdbSeasonDetails
+import com.arflix.tv.data.model.EpisodeIdentity
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+
+class NextEpisodeAirDateResolverTest {
+    private val clock = Clock.fixed(
+        Instant.parse("2026-08-24T12:00:00Z"),
+        ZoneOffset.UTC,
+    )
+
+    @Test
+    fun `past air date allows autoplay`() = runTest {
+        val resolver = resolverWithAirDate("2026-08-23")
+
+        assertThat(resolver.resolve(TMDB_ID, identity(season = 1, episode = 2)))
+            .isEqualTo(NextEpisodeAirDateResolution.Allowed)
+    }
+
+    @Test
+    fun `today air date allows autoplay`() = runTest {
+        val resolver = resolverWithAirDate("2026-08-24")
+
+        assertThat(resolver.resolve(TMDB_ID, identity(season = 1, episode = 2)))
+            .isEqualTo(NextEpisodeAirDateResolution.Allowed)
+    }
+
+    @Test
+    fun `future air date blocks autoplay`() = runTest {
+        val resolver = resolverWithAirDate("2026-08-25")
+
+        assertThat(resolver.resolve(TMDB_ID, identity(season = 1, episode = 2)))
+            .isEqualTo(
+                NextEpisodeAirDateResolution.Blocked(
+                    NextEpisodeAirDateBlockReason.FutureAirDate,
+                )
+            )
+    }
+
+    @Test
+    fun `missing episode metadata blocks autoplay`() = runTest {
+        val resolver = NextEpisodeAirDateResolver(
+            loadSeason = { _, season -> TmdbSeasonDetails(seasonNumber = season) },
+            clock = clock,
+        )
+
+        assertThat(resolver.resolve(TMDB_ID, identity(season = 1, episode = 2)))
+            .isEqualTo(
+                NextEpisodeAirDateResolution.Blocked(
+                    NextEpisodeAirDateBlockReason.MissingEpisode,
+                )
+            )
+    }
+
+    @Test
+    fun `missing air date blocks autoplay`() = runTest {
+        val resolver = resolverWithAirDate(null)
+
+        assertThat(resolver.resolve(TMDB_ID, identity(season = 1, episode = 2)))
+            .isEqualTo(
+                NextEpisodeAirDateResolution.Blocked(
+                    NextEpisodeAirDateBlockReason.MissingAirDate,
+                )
+            )
+    }
+
+    @Test
+    fun `blank air date blocks autoplay`() = runTest {
+        val resolver = resolverWithAirDate("   ")
+
+        assertThat(resolver.resolve(TMDB_ID, identity(season = 1, episode = 2)))
+            .isEqualTo(
+                NextEpisodeAirDateResolution.Blocked(
+                    NextEpisodeAirDateBlockReason.MissingAirDate,
+                )
+            )
+    }
+
+    @Test
+    fun `malformed air date blocks autoplay`() = runTest {
+        val resolver = resolverWithAirDate("24-08-2026")
+
+        assertThat(resolver.resolve(TMDB_ID, identity(season = 1, episode = 2)))
+            .isEqualTo(
+                NextEpisodeAirDateResolution.Blocked(
+                    NextEpisodeAirDateBlockReason.MalformedAirDate,
+                )
+            )
+    }
+
+    @Test
+    fun `API failure blocks autoplay`() = runTest {
+        val resolver = NextEpisodeAirDateResolver(
+            loadSeason = { _, _ -> error("TMDB unavailable") },
+            clock = clock,
+        )
+
+        assertThat(resolver.resolve(TMDB_ID, identity(season = 1, episode = 2)))
+            .isEqualTo(
+                NextEpisodeAirDateResolution.Blocked(
+                    NextEpisodeAirDateBlockReason.MetadataUnavailable,
+                )
+            )
+    }
+
+    @Test(expected = CancellationException::class)
+    fun `cancellation is preserved`() = runTest {
+        val resolver = NextEpisodeAirDateResolver(
+            loadSeason = { _, _ -> throw CancellationException("superseded episode") },
+            clock = clock,
+        )
+
+        resolver.resolve(TMDB_ID, identity(season = 1, episode = 2))
+    }
+
+    @Test
+    fun `season boundary resolves the target season and episode`() = runTest {
+        val requests = mutableListOf<Pair<Int, Int>>()
+        val resolver = NextEpisodeAirDateResolver(
+            loadSeason = { tmdbId, season ->
+                requests += tmdbId to season
+                TmdbSeasonDetails(
+                    seasonNumber = season,
+                    episodes = listOf(
+                        TmdbEpisode(
+                            seasonNumber = 2,
+                            episodeNumber = 1,
+                            airDate = "2026-08-24",
+                        )
+                    ),
+                )
+            },
+            clock = clock,
+        )
+
+        val result = resolver.resolve(TMDB_ID, identity(season = 2, episode = 1))
+
+        assertThat(result).isEqualTo(NextEpisodeAirDateResolution.Allowed)
+        assertThat(requests).containsExactly(TMDB_ID to 2)
+    }
+
+    private fun resolverWithAirDate(airDate: String?) = NextEpisodeAirDateResolver(
+        loadSeason = { _, season ->
+            TmdbSeasonDetails(
+                seasonNumber = season,
+                episodes = listOf(
+                    TmdbEpisode(
+                        seasonNumber = season,
+                        episodeNumber = 2,
+                        airDate = airDate,
+                    )
+                ),
+            )
+        },
+        clock = clock,
+    )
+
+    private fun identity(season: Int, episode: Int) = EpisodeIdentity(
+        displaySeason = season,
+        displayEpisode = episode,
+        tmdbSeason = season,
+        tmdbEpisode = episode,
+    )
+
+    private companion object {
+        const val TMDB_ID = 42
+    }
+}

--- a/app/src/test/kotlin/com/arflix/tv/ui/screens/player/NextEpisodePromptGateTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/ui/screens/player/NextEpisodePromptGateTest.kt
@@ -10,11 +10,11 @@ class NextEpisodePromptGateTest {
         val gate = NextEpisodePromptGate()
         val episode = PlaybackEpisodeKey(mediaId = 42, seasonNumber = 1, episodeNumber = 3)
 
-        assertThat(gate.tryOpen(episode, eligible = true)).isTrue()
+        assertThat(gate.tryOpen(episode, true, NextEpisodeAirDateResolution.Allowed)).isTrue()
 
         // Closing the overlay does not change ExoPlayer's STATE_ENDED. The next polling tick must
         // therefore reject this same episode instead of starting a fresh countdown.
-        assertThat(gate.tryOpen(episode, eligible = true)).isFalse()
+        assertThat(gate.tryOpen(episode, true, NextEpisodeAirDateResolution.Allowed)).isFalse()
     }
 
     @Test
@@ -25,12 +25,14 @@ class NextEpisodePromptGateTest {
             gate.tryOpen(
                 PlaybackEpisodeKey(mediaId = 42, seasonNumber = 1, episodeNumber = 3),
                 eligible = true,
+                airDateResolution = NextEpisodeAirDateResolution.Allowed,
             )
         ).isTrue()
         assertThat(
             gate.tryOpen(
                 PlaybackEpisodeKey(mediaId = 42, seasonNumber = 1, episodeNumber = 4),
                 eligible = true,
+                airDateResolution = NextEpisodeAirDateResolution.Allowed,
             )
         ).isTrue()
     }
@@ -40,7 +42,60 @@ class NextEpisodePromptGateTest {
         val gate = NextEpisodePromptGate()
         val episode = PlaybackEpisodeKey(mediaId = 42, seasonNumber = 1, episodeNumber = 3)
 
-        assertThat(gate.tryOpen(episode, eligible = false)).isFalse()
-        assertThat(gate.tryOpen(episode, eligible = true)).isTrue()
+        assertThat(gate.tryOpen(episode, false, NextEpisodeAirDateResolution.Allowed)).isFalse()
+        assertThat(gate.tryOpen(episode, true, NextEpisodeAirDateResolution.Allowed)).isTrue()
+    }
+
+    @Test
+    fun pendingAirDateDoesNotOpenOrConsumeTheEpisode() {
+        val gate = NextEpisodePromptGate()
+        val episode = PlaybackEpisodeKey(mediaId = 42, seasonNumber = 1, episodeNumber = 3)
+
+        assertThat(
+            gate.tryOpen(
+                episode = episode,
+                eligible = true,
+                airDateResolution = NextEpisodeAirDateResolution.Pending,
+            )
+        ).isFalse()
+        assertThat(
+            gate.tryOpen(
+                episode = episode,
+                eligible = true,
+                airDateResolution = NextEpisodeAirDateResolution.Allowed,
+            )
+        ).isTrue()
+    }
+
+    @Test
+    fun blockedAirDateDoesNotOpenTheEpisode() {
+        val gate = NextEpisodePromptGate()
+        val episode = PlaybackEpisodeKey(mediaId = 42, seasonNumber = 1, episodeNumber = 3)
+
+        assertThat(
+            gate.tryOpen(
+                episode = episode,
+                eligible = true,
+                airDateResolution = NextEpisodeAirDateResolution.Blocked(
+                    NextEpisodeAirDateBlockReason.FutureAirDate,
+                ),
+            )
+        ).isFalse()
+    }
+
+    @Test
+    fun differentTmdbIdentityCanOpenItsOwnPrompt() {
+        val gate = NextEpisodePromptGate()
+        val first = PlaybackEpisodeKey(
+            mediaId = 42,
+            seasonNumber = 1,
+            episodeNumber = 1,
+            tmdbSeasonNumber = 1,
+            tmdbEpisodeNumber = 12,
+        )
+        val second = first.copy(tmdbSeasonNumber = 2, tmdbEpisodeNumber = 1)
+
+        assertThat(gate.tryOpen(first, true, NextEpisodeAirDateResolution.Allowed)).isTrue()
+        assertThat(gate.tryOpen(second, true, NextEpisodeAirDateResolution.Allowed)).isTrue()
     }
 }


### PR DESCRIPTION
Closes #589.

## Summary
- Resolves the next episode's TMDB air date before the autoplay prompt can open.
- Models the decision explicitly as Pending, Allowed, or Blocked so near-end resume cannot autoplay while metadata is still loading.
- Allows episodes aired before or on the current date and blocks future, missing, malformed, or unavailable metadata from automatic advancement.
- Preserves coroutine cancellation and resolves the target TMDB season/episode across season boundaries.

## Why
Autoplay could advance into episodes that have not aired yet. A simple Boolean defaulting to allowed also creates a race where playback near the end can trigger before TMDB metadata returns.

## Testing
- past/today/future air dates
- pending state does not open or consume the prompt
- missing episode/date, blank/malformed date, and API failure
- cancellation propagation
- season-boundary target lookup
- full Sideload unit suite, Kotlin compilation, and `git diff --check`

## Policy
Unknown or unavailable air-date metadata blocks **automatic** advancement only; users can still choose episodes manually.

## Scope
Android autoplay gating only. No subtitle, navigation, IPTV, backend, catalog, or app version changes.
