### PR TITLE
feat(iptv): group Live TV categories by playlist order

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/CategorySidebar.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/CategorySidebar.kt
@@ -97,6 +97,7 @@ import kotlinx.coroutines.launch
 fun CategorySidebar(
     tree: LiveCategoryTree,
     selectedId: String,
+    playlistSections: List<PlaylistCategorySection> = emptyList(),
     expanded: Boolean,
     listState: LazyListState,
     focusRequester: FocusRequester? = null,
@@ -124,6 +125,7 @@ fun CategorySidebar(
     )
     var expandedCountry by rememberSaveable { mutableStateOf<String?>(null) }
     var expandedAll by rememberSaveable { mutableStateOf(false) }
+    var expandedPlaylistIds by rememberSaveable { mutableStateOf(emptyList<String>()) }
     var activeMenu by remember { mutableStateOf<CategoryMenuState?>(null) }
     val searchFocusRequester = remember { FocusRequester() }
     val selectedCategoryFocusRequester = remember { FocusRequester() }
@@ -229,7 +231,7 @@ fun CategorySidebar(
         }
     }
 
-    LaunchedEffect(selectedId, tree) {
+    LaunchedEffect(selectedId, tree, playlistSections) {
         val countryId = selectedCountryGroupId(selectedId, tree)
         if (countryId != null) {
             expandedCountry = countryId
@@ -237,6 +239,13 @@ fun CategorySidebar(
         val allCategory = tree.top.firstOrNull { it.id == "all" }
         if (allCategory?.children?.any { child -> child.containsId(selectedId) } == true) {
             expandedAll = true
+        }
+        playlistSections.firstOrNull { section ->
+            section.categories.any { it.containsId(selectedId) }
+        }?.id?.let { sectionId ->
+            if (sectionId !in expandedPlaylistIds) {
+                expandedPlaylistIds = expandedPlaylistIds + sectionId
+            }
         }
     }
 
@@ -391,7 +400,49 @@ fun CategorySidebar(
                     }
                 }
             }
-            if (tree.global.categories.isNotEmpty()) {
+            if (playlistSections.isNotEmpty()) {
+                playlistSections.forEach { section ->
+                    item(key = "playlist-section:${section.id}") {
+                        val isOpen = section.id in expandedPlaylistIds
+                        SidebarRow(
+                            label = section.label,
+                            count = section.count,
+                            icon = Icons.Filled.LibraryBooks,
+                            active = section.categories.any { it.containsId(selectedId) },
+                            expanded = expanded,
+                            hasChildren = true,
+                            isOpenGroup = isOpen,
+                            onFocused = { onCategoryFocused() },
+                            onClick = {
+                                expandedPlaylistIds = if (isOpen) {
+                                    expandedPlaylistIds - section.id
+                                } else {
+                                    expandedPlaylistIds + section.id
+                                }
+                            },
+                        )
+                    }
+                    if (expanded && section.id in expandedPlaylistIds) {
+                        itemsIndexed(
+                            section.categories,
+                            key = { index, cat -> "playlist:${section.id}:${cat.id}:$index" },
+                        ) { _, cat ->
+                            SidebarRow(
+                                label = liveCategoryLabel(cat.label),
+                                count = cat.count,
+                                icon = iconFor(cat),
+                                active = selectedId == cat.id,
+                                expanded = true,
+                                indent = 28.dp,
+                                focusRequester = if (selectedId == cat.id) selectedCategoryFocusRequester else null,
+                                onFocused = { onCategoryFocused() },
+                                onLongClick = { openCategoryMenu(cat, hidden = false) },
+                                onClick = { onSelect(cat.id) },
+                            )
+                        }
+                    }
+                }
+            } else if (tree.global.categories.isNotEmpty()) {
                 item { SectionHeader(liveSectionLabel(tree.global.label), expanded) }
                 itemsIndexed(tree.global.categories, key = { index, cat -> "global:${cat.id}:$index" }) { _, cat ->
                     SidebarRow(
@@ -921,7 +972,7 @@ private fun selectedCountryGroupId(
     country.id == selectedId || country.children.any { child -> child.id == selectedId }
 }?.id
 
-private fun LiveCategory.containsId(id: String): Boolean {
+internal fun LiveCategory.containsId(id: String): Boolean {
     if (this.id == id) return true
     return children.any { child -> child.containsId(id) }
 }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvEnhancements.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvEnhancements.kt
@@ -64,6 +64,33 @@ data class TvProviderFilter(
     val count: Int,
 )
 
+data class PlaylistCategorySection(
+    val id: String,
+    val label: String,
+    val count: Int,
+    val categories: List<LiveCategory>,
+)
+
+fun buildPlaylistCategorySections(
+    config: IptvConfig,
+    categories: List<LiveCategory>,
+): List<PlaylistCategorySection> = config.playlists
+    .asSequence()
+    .filter { it.enabled && it.id.isNotBlank() }
+    .distinctBy { it.id }
+    .mapNotNull { playlist ->
+        val providerCategories = categories.filter { it.playlistId == playlist.id }
+        providerCategories.takeIf { it.isNotEmpty() }?.let {
+            PlaylistCategorySection(
+                id = playlist.id,
+                label = playlist.name.ifBlank { playlist.id },
+                count = it.sumOf(LiveCategory::count),
+                categories = it,
+            )
+        }
+    }
+    .toList()
+
 data class PlaybackDiagnostic(
     val title: String,
     val detail: String,
@@ -79,6 +106,7 @@ enum class PlaybackDiagnosticSeverity {
 fun buildTvProviderFilters(
     config: IptvConfig,
     channels: List<EnrichedChannel>,
+    playlistGroupCounts: List<Triple<String, String, Int>> = emptyList(),
 ): List<TvProviderFilter> {
     val enabledPlaylists = config.playlists
         .filter { it.enabled && it.id.isNotBlank() }
@@ -86,14 +114,21 @@ fun buildTvProviderFilters(
     if (enabledPlaylists.size <= 1) return emptyList()
 
     val knownIds = enabledPlaylists.mapTo(HashSet()) { it.id }
-    val counts = channels
-        .mapNotNull { channelPlaylistId(it, knownIds) }
-        .groupingBy { it }
-        .eachCount()
+    val pagedCounts = playlistGroupCounts
+        .asSequence()
+        .filter { (playlistId, _, count) -> playlistId in knownIds && count > 0 }
+        .groupingBy { (playlistId, _, _) -> playlistId }
+        .fold(0) { total, (_, _, count) -> total + count }
+    val counts = pagedCounts.ifEmpty {
+        channels
+            .mapNotNull { channelPlaylistId(it, knownIds) }
+            .groupingBy { it }
+            .eachCount()
+    }
     if (counts.size <= 1) return emptyList()
 
     return buildList {
-        add(TvProviderFilter("all", "All providers", channels.size))
+        add(TvProviderFilter("all", "All providers", counts.values.sum()))
         enabledPlaylists.forEach { playlist ->
             val count = counts[playlist.id] ?: 0
             if (count > 0) {

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvEnhancements.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvEnhancements.kt
@@ -74,11 +74,14 @@ data class PlaylistCategorySection(
 fun buildPlaylistCategorySections(
     config: IptvConfig,
     categories: List<LiveCategory>,
-): List<PlaylistCategorySection> = config.playlists
-    .asSequence()
-    .filter { it.enabled && it.id.isNotBlank() }
-    .distinctBy { it.id }
-    .mapNotNull { playlist ->
+): List<PlaylistCategorySection> {
+    val playlists = config.playlists
+        .asSequence()
+        .filter { it.enabled && it.id.isNotBlank() }
+        .distinctBy { it.id }
+        .toList()
+    val knownPlaylistIds = playlists.mapTo(HashSet()) { it.id }
+    val configuredSections = playlists.mapNotNull { playlist ->
         val providerCategories = categories.filter { it.playlistId == playlist.id }
         providerCategories.takeIf { it.isNotEmpty() }?.let {
             PlaylistCategorySection(
@@ -89,7 +92,26 @@ fun buildPlaylistCategorySections(
             )
         }
     }
-    .toList()
+    val unmatchedSections = categories
+        .filter { category -> category.playlistId.isNullOrBlank() || category.playlistId !in knownPlaylistIds }
+        .groupBy { category -> category.playlistId?.takeIf { it.isNotBlank() } ?: "other" }
+        .entries
+        .sortedWith(compareBy<Map.Entry<String, List<LiveCategory>>> { if (it.key == "stalker") 0 else 1 }.thenBy { it.key })
+        .map { (sourceId, sourceCategories) ->
+            PlaylistCategorySection(
+                id = "source:$sourceId",
+                label = when (sourceId) {
+                    "stalker" -> "Stalker"
+                    "other" -> "Other sources"
+                    else -> sourceId.replaceFirstChar { it.uppercase() }
+                },
+                count = sourceCategories.sumOf(LiveCategory::count),
+                categories = sourceCategories,
+            )
+        }
+    val sections = configuredSections + unmatchedSections
+    return sections.takeIf { it.size > 1 }.orEmpty()
+}
 
 data class PlaybackDiagnostic(
     val title: String,

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvScreen.kt
@@ -752,8 +752,16 @@ fun LiveTvScreen(
         enrichedState.value = current.copy(tree = tree)
     }
 
-    val providerFilters = remember(state.config, enrichedState.value.all) {
-        buildTvProviderFilters(state.config, enrichedState.value.all)
+    val providerFilters = remember(state.config, enrichedState.value.all, lastKnownPlaylistGroupCounts) {
+        buildTvProviderFilters(state.config, enrichedState.value.all, lastKnownPlaylistGroupCounts)
+    }
+    val playlistCategorySections = remember(state.config, enrichedState.value.tree.global.categories) {
+        buildPlaylistCategorySections(state.config, enrichedState.value.tree.global.categories)
+    }
+    LaunchedEffect(playlistCategorySections, selectedProviderId) {
+        if (playlistCategorySections.isNotEmpty() && selectedProviderId != "all") {
+            selectedProviderId = "all"
+        }
     }
     LaunchedEffect(providerFilters, selectedProviderId) {
         if (providerFilters.isEmpty() || providerFilters.none { it.id == selectedProviderId }) {
@@ -1593,7 +1601,9 @@ fun LiveTvScreen(
 
     fun focusProviderSwitcher() {
         noteGuideUserNavigation()
-        if (providerFilters.size <= 1) {
+        // Playlist sections replace the standalone provider selector. Route focus
+        // straight into the category rail when that selector is not composed.
+        if (playlistCategorySections.isNotEmpty() || providerFilters.size <= 1) {
             focusPlaylistSearch()
             return
         }
@@ -2415,19 +2425,21 @@ fun LiveTvScreen(
                         .fillMaxSize()
                         .padding(top = contentTopPadding),
                 ) {
-                    ProviderSelector(
-                        providers = providerFilters,
-                        selectedId = selectedProviderId,
-                        onSelect = { id ->
-                            noteGuideUserNavigation()
-                            selectedProviderId = id
-                            selectedCategoryId = "all"
-                            focusedChannelId = null
-                            epgPrefetchAnchorId = null
-                        },
-                        onMoveDown = { focusPlaylistSearch() },
-                        modifier = Modifier.fillMaxWidth(),
-                    )
+                    if (playlistCategorySections.isEmpty()) {
+                        ProviderSelector(
+                            providers = providerFilters,
+                            selectedId = selectedProviderId,
+                            onSelect = { id ->
+                                noteGuideUserNavigation()
+                                selectedProviderId = id
+                                selectedCategoryId = "all"
+                                focusedChannelId = null
+                                epgPrefetchAnchorId = null
+                            },
+                            onMoveDown = { focusPlaylistSearch() },
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
                     MiniPlayerRow(
                         exoPlayer = exoPlayer,
                         channel = playingChannel,
@@ -2444,6 +2456,7 @@ fun LiveTvScreen(
                     TouchCategoryRail(
                         tree = visibleEnrichedState.value.tree,
                         selectedId = selectedCategoryId,
+                        playlistSections = playlistCategorySections,
                         onSelect = { id ->
                             noteGuideUserNavigation()
                             selectedCategoryId = id
@@ -2496,6 +2509,7 @@ fun LiveTvScreen(
                 CategorySidebar(
                     tree = visibleEnrichedState.value.tree,
                     selectedId = selectedCategoryId,
+                    playlistSections = playlistCategorySections,
                     expanded = sidebarExpanded,
                     listState = sidebarListState,
                     focusRequester = sidebarFocus,
@@ -2555,25 +2569,27 @@ fun LiveTvScreen(
                         .fillMaxSize()
                         .padding(top = contentTopPadding),
                 ) {
-                    ProviderSelector(
-                        providers = providerFilters,
-                        selectedId = selectedProviderId,
-                        onSelect = { id ->
-                            noteGuideUserNavigation()
-                            selectedProviderId = id
-                            selectedCategoryId = "all"
-                            focusedChannelId = null
-                            epgPrefetchAnchorId = null
-                        },
-                        focusRequester = providerFocus,
-                        onMoveUp = {
-                            topBarFocusIndex = topBarSelectedIndex(SidebarItem.TV, hasProfile)
-                                .coerceIn(0, maxTopBarIndex)
-                            focusZone = LiveTvFocusZone.TOPBAR
-                        },
-                        onMoveDown = { focusPlaylistSearch() },
-                        modifier = Modifier.fillMaxWidth(),
-                    )
+                    if (playlistCategorySections.isEmpty()) {
+                        ProviderSelector(
+                            providers = providerFilters,
+                            selectedId = selectedProviderId,
+                            onSelect = { id ->
+                                noteGuideUserNavigation()
+                                selectedProviderId = id
+                                selectedCategoryId = "all"
+                                focusedChannelId = null
+                                epgPrefetchAnchorId = null
+                            },
+                            focusRequester = providerFocus,
+                            onMoveUp = {
+                                topBarFocusIndex = topBarSelectedIndex(SidebarItem.TV, hasProfile)
+                                    .coerceIn(0, maxTopBarIndex)
+                                focusZone = LiveTvFocusZone.TOPBAR
+                            },
+                            onMoveDown = { focusPlaylistSearch() },
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
                     MiniPlayerRow(
                         exoPlayer = exoPlayer,
                         channel = playingChannel,

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/TouchCategoryRail.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/TouchCategoryRail.kt
@@ -15,9 +15,16 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -31,6 +38,7 @@ private data class TouchCategoryRailItem(
     val id: String,
     val label: String,
     val count: Int,
+    val playlistSectionId: String? = null,
 )
 
 @OptIn(ExperimentalTvMaterial3Api::class)
@@ -38,11 +46,22 @@ private data class TouchCategoryRailItem(
 fun TouchCategoryRail(
     tree: LiveCategoryTree,
     selectedId: String,
+    playlistSections: List<PlaylistCategorySection> = emptyList(),
     onSelect: (String) -> Unit,
     onOpenSearch: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val items = rememberTouchRailItems(tree, selectedId)
+    var expandedPlaylistIds by rememberSaveable { mutableStateOf(emptyList<String>()) }
+    LaunchedEffect(selectedId, playlistSections) {
+        playlistSections.firstOrNull { section ->
+            section.categories.any { it.containsId(selectedId) }
+        }?.id?.let { sectionId ->
+            if (sectionId !in expandedPlaylistIds) {
+                expandedPlaylistIds = expandedPlaylistIds + sectionId
+            }
+        }
+    }
+    val items = rememberTouchRailItems(tree, selectedId, playlistSections, expandedPlaylistIds)
 
     LazyRow(
         modifier = modifier.fillMaxWidth(),
@@ -73,13 +92,32 @@ fun TouchCategoryRail(
         }
 
         itemsIndexed(items, key = { index, item -> "${item.id}#$index" }) { _, item ->
-            val active = selectedId == item.id
+            val sectionId = item.playlistSectionId
+            val isSectionHeader = sectionId != null
+            val isSectionOpen = sectionId != null && sectionId in expandedPlaylistIds
+            val active = if (isSectionHeader) {
+                playlistSections.firstOrNull { it.id == sectionId }
+                    ?.categories
+                    ?.any { it.containsId(selectedId) } == true
+            } else {
+                selectedId == item.id
+            }
             Box(
                 modifier = Modifier
                     .height(38.dp)
                     .clip(RoundedCornerShape(12.dp))
                     .background(if (active) LiveColors.Accent else LiveColors.Panel)
-                    .clickable { onSelect(item.id) }
+                    .clickable {
+                        if (sectionId != null) {
+                            expandedPlaylistIds = if (isSectionOpen) {
+                                expandedPlaylistIds - sectionId
+                            } else {
+                                expandedPlaylistIds + sectionId
+                            }
+                        } else {
+                            onSelect(item.id)
+                        }
+                    }
                     .padding(horizontal = 14.dp),
                 contentAlignment = Alignment.Center,
             ) {
@@ -87,6 +125,13 @@ fun TouchCategoryRail(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
+                    if (isSectionHeader) {
+                        Icon(
+                            imageVector = if (isSectionOpen) Icons.Filled.KeyboardArrowDown else Icons.Filled.KeyboardArrowRight,
+                            contentDescription = null,
+                            tint = if (active) LiveColors.Bg else LiveColors.FgDim,
+                        )
+                    }
                     Text(
                         text = item.label,
                         style = LiveType.CatLabel.copy(
@@ -112,12 +157,32 @@ fun TouchCategoryRail(
 private fun rememberTouchRailItems(
     tree: LiveCategoryTree,
     selectedId: String,
+    playlistSections: List<PlaylistCategorySection>,
+    expandedPlaylistIds: List<String>,
 ): List<TouchCategoryRailItem> {
     val base = buildList {
         tree.top.forEach { add(TouchCategoryRailItem(it.id, liveCategoryLabel(it.label), it.count)) }
-        tree.global.categories.forEach { add(TouchCategoryRailItem(it.id, liveCategoryLabel(it.label), it.count)) }
-        tree.countries.categories.forEach { add(TouchCategoryRailItem(it.id, liveCategoryLabel(it.label), it.count)) }
-        tree.adult.categories.forEach { add(TouchCategoryRailItem(it.id, liveCategoryLabel(it.label), it.count)) }
+        if (playlistSections.isEmpty()) {
+            tree.global.categories.forEach { add(TouchCategoryRailItem(it.id, liveCategoryLabel(it.label), it.count)) }
+            tree.countries.categories.forEach { add(TouchCategoryRailItem(it.id, liveCategoryLabel(it.label), it.count)) }
+            tree.adult.categories.forEach { add(TouchCategoryRailItem(it.id, liveCategoryLabel(it.label), it.count)) }
+        } else {
+            playlistSections.forEach { section ->
+                add(
+                    TouchCategoryRailItem(
+                        id = "playlist-section:${section.id}",
+                        label = section.label,
+                        count = section.count,
+                        playlistSectionId = section.id,
+                    )
+                )
+                if (section.id in expandedPlaylistIds) {
+                    section.categories.forEach { category ->
+                        add(TouchCategoryRailItem(category.id, liveCategoryLabel(category.label), category.count))
+                    }
+                }
+            }
+        }
     }.distinctBy { it.id }.toMutableList()
 
     val selected = tree.byId(selectedId)

--- a/app/src/test/kotlin/com/arflix/tv/ui/screens/tv/live/PlaylistCategorySectionsTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/ui/screens/tv/live/PlaylistCategorySectionsTest.kt
@@ -48,6 +48,43 @@ class PlaylistCategorySectionsTest {
     }
 
     @Test
+    fun hybridPlaylistAndStalkerKeepsUnmatchedCategoriesVisible() {
+        val config = IptvConfig(
+            playlists = listOf(
+                IptvPlaylistEntry(id = "m3u", name = "M3U playlist", m3uUrl = "https://m3u.test/list.m3u"),
+            )
+        )
+        val categories = listOf(
+            LiveCategory("m3u:movies", "Movies", 8, CategoryIcon.Movie, playlistId = "m3u"),
+            LiveCategory("stalker:news", "News", 6, CategoryIcon.Grid, playlistId = "stalker"),
+            LiveCategory("stalker:sports", "Sports", 4, CategoryIcon.Sport, playlistId = "stalker"),
+        )
+
+        val sections = buildPlaylistCategorySections(config, categories)
+
+        assertThat(sections.map { it.id }).containsExactly("m3u", "source:stalker").inOrder()
+        assertThat(sections[1].label).isEqualTo("Stalker")
+        assertThat(sections[1].categories.map { it.id })
+            .containsExactly("stalker:news", "stalker:sports")
+            .inOrder()
+    }
+
+    @Test
+    fun singlePlaylistUsesLegacyFlatCategoriesWithoutCollapsedParent() {
+        val config = IptvConfig(
+            playlists = listOf(
+                IptvPlaylistEntry(id = "only", name = "Only playlist", m3uUrl = "https://only.test/list.m3u"),
+            )
+        )
+        val categories = listOf(
+            LiveCategory("only:movies", "Movies", 8, CategoryIcon.Movie, playlistId = "only"),
+            LiveCategory("only:series", "Series", 12, CategoryIcon.Grid, playlistId = "only"),
+        )
+
+        assertThat(buildPlaylistCategorySections(config, categories)).isEmpty()
+    }
+
+    @Test
     fun pagedCountsKeepAllConfiguredPlaylistsWhenLoadedWindowContainsOnlyOne() {
         val config = IptvConfig(
             playlists = listOf(

--- a/app/src/test/kotlin/com/arflix/tv/ui/screens/tv/live/PlaylistCategorySectionsTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/ui/screens/tv/live/PlaylistCategorySectionsTest.kt
@@ -1,0 +1,71 @@
+package com.arflix.tv.ui.screens.tv.live
+
+import com.arflix.tv.data.model.IptvChannel
+import com.arflix.tv.data.repository.IptvConfig
+import com.arflix.tv.data.repository.IptvPlaylistEntry
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class PlaylistCategorySectionsTest {
+
+    @Test
+    fun sectionsFollowPlaylistOrderAndDoNotMixCategories() {
+        val config = IptvConfig(
+            playlists = listOf(
+                IptvPlaylistEntry(id = "second", name = "Second playlist", m3uUrl = "https://second.test/list.m3u"),
+                IptvPlaylistEntry(id = "first", name = "First playlist", m3uUrl = "https://first.test/list.m3u"),
+            )
+        )
+        val categories = listOf(
+            LiveCategory("first:a", "Movies", 8, CategoryIcon.Movie, playlistId = "first"),
+            LiveCategory("second:a", "Sports", 10, CategoryIcon.Sport, playlistId = "second"),
+            LiveCategory("first:b", "Series", 12, CategoryIcon.Grid, playlistId = "first"),
+        )
+
+        val sections = buildPlaylistCategorySections(config, categories)
+
+        assertThat(sections.map { it.id }).containsExactly("second", "first").inOrder()
+        assertThat(sections[0].categories.map { it.id }).containsExactly("second:a")
+        assertThat(sections[1].categories.map { it.id }).containsExactly("first:a", "first:b").inOrder()
+    }
+
+    @Test
+    fun providerFiltersPreserveSavedPlaylistReorder() {
+        val config = IptvConfig(
+            playlists = listOf(
+                IptvPlaylistEntry(id = "second", name = "Second playlist", m3uUrl = "https://second.test/list.m3u"),
+                IptvPlaylistEntry(id = "first", name = "First playlist", m3uUrl = "https://first.test/list.m3u"),
+            )
+        )
+        val channels = listOf(
+            IptvChannel("first:1", "First channel", "https://first.test/1", "Movies").enrich(1),
+            IptvChannel("second:1", "Second channel", "https://second.test/1", "News").enrich(2),
+        )
+
+        val filters = buildTvProviderFilters(config, channels)
+
+        assertThat(filters.map { it.id }).containsExactly("all", "second", "first").inOrder()
+    }
+
+    @Test
+    fun pagedCountsKeepAllConfiguredPlaylistsWhenLoadedWindowContainsOnlyOne() {
+        val config = IptvConfig(
+            playlists = listOf(
+                IptvPlaylistEntry(id = "second", name = "Second playlist", m3uUrl = "https://second.test/list.m3u"),
+                IptvPlaylistEntry(id = "first", name = "First playlist", m3uUrl = "https://first.test/list.m3u"),
+            )
+        )
+        val loadedWindow = listOf(
+            IptvChannel("first:1", "First channel", "https://first.test/1", "Movies").enrich(1),
+        )
+        val pagedCounts = listOf(
+            Triple("first", "Movies", 20),
+            Triple("second", "News", 10),
+        )
+
+        val filters = buildTvProviderFilters(config, loadedWindow, pagedCounts)
+
+        assertThat(filters.map { it.id }).containsExactly("all", "second", "first").inOrder()
+        assertThat(filters.map { it.count }).containsExactly(30, 10, 20).inOrder()
+    }
+}


### PR DESCRIPTION
## Summary
- Groups Live TV categories under their configured IPTV playlist/provider instead of flattening similarly named groups together.
- Preserves the saved playlist order in provider filters, TV category navigation, and touch category navigation.
- Keeps configured playlists visible when a large paged channel window currently contains channels from only one provider.
- Adds focused coverage for playlist ordering, category isolation, and paged-count behavior.
- Preserves unmatched Stalker and other-source categories in dedicated sections for hybrid configurations.
- Keeps the legacy flat category list when only one populated source exists.

## Why
Multi-playlist setups can contain the same category names from different providers. Flattening those categories makes navigation ambiguous and can mix channels from the wrong playlist.

## Testing
- `PlaylistCategorySectionsTest`
  - sections follow configured playlist order
  - categories do not mix between playlists
  - provider filters preserve saved reorder
  - paged counts retain all configured playlists
  - hybrid playlist + Stalker categories remain visible
  - single-source navigation remains flat without a collapsed parent
- `./gradlew :app:compileSideloadDebugKotlin`
- `./gradlew :app:testSideloadDebugUnitTest`
- `git diff --check`

## Scope
Android Live TV provider/category navigation only. No EPG actions, VOD lookup, playback rules, responsive layout, backend, or app version changes.
