### PR TITLE
telegram fixes

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/StreamRepository.kt
@@ -2036,7 +2036,12 @@ class StreamRepository @Inject constructor(
                 }
 
                 if (addonStreams.isEmpty() && nativeAnimeAddon) {
-                    val retryAnimeQuery = animeQuery ?: resolveAnimeQuery(NATIVE_ANIME_ID_LOOKUP_TIMEOUT_MS)
+                    // Only resolve an anime id when this item actually looked like anime. The
+                    // retry fires purely because a native-anime addon returned nothing, so without
+                    // this guard a non-anime title (an Israeli drama, say) gets run through the
+                    // Kitsu title search and is offered a completely different show's streams.
+                    val retryAnimeQuery = animeQuery
+                        ?: if (resolveAsAnime) resolveAnimeQuery(NATIVE_ANIME_ID_LOOKUP_TIMEOUT_MS) else null
                     val retryTmdbEpisodeId = if (tmdbId != null && addonSupportsIdFamily(addon, "tmdb")) {
                         "tmdb:$tmdbId:$season:$episode"
                     } else null

--- a/app/src/main/kotlin/com/arflix/tv/data/telegram/TelegramSearchMatcher.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/telegram/TelegramSearchMatcher.kt
@@ -29,6 +29,7 @@ class TelegramSearchMatcher @Inject constructor() {
         title: String,
         localizedTitle: String? = null,
         englishTitle: String? = null,
+        originalTitle: String? = null,
         year: Int?,
         season: Int?,
         episode: Int?
@@ -38,13 +39,18 @@ class TelegramSearchMatcher @Inject constructor() {
         val normalizedTitle = normalize(title)
         val normalizedLocalized = localizedTitle?.let { normalize(it) }
         val normalizedEnglish = englishTitle?.let { normalize(it) }
+        val normalizedOriginal = originalTitle?.let { normalize(it) }
 
-        // Primary match: TMDB English title, TMDB localized title, or app title (in that priority)
+        // Primary match: TMDB English title, TMDB localized title, TMDB original title, or app
+        // title. The original title matters for foreign content whose native name is the one that
+        // actually appears in file names — TMDB often has no translation, in which case the
+        // "localized" title is just the English one again.
         val engMatch = normalizedEnglish != null && normalizedEnglish.isNotBlank() && normalizedCombined.contains(normalizedEnglish)
         val locMatch = normalizedLocalized != null && normalizedLocalized.isNotBlank() && normalizedCombined.contains(normalizedLocalized)
+        val origMatch = normalizedOriginal != null && normalizedOriginal.isNotBlank() && normalizedCombined.contains(normalizedOriginal)
         val appMatch = normalizedCombined.contains(normalizedTitle)
 
-        if (!engMatch && !locMatch && !appMatch) return 0
+        if (!engMatch && !locMatch && !origMatch && !appMatch) return 0
 
         var score = 60
 
@@ -101,17 +107,28 @@ class TelegramSearchMatcher @Inject constructor() {
         return m.groupValues[1].toIntOrNull()
     }
 
-    fun buildMovieQueries(title: String, year: Int?, localizedTitle: String? = null, englishTitle: String? = null): List<String> {
+    fun buildMovieQueries(
+        title: String,
+        year: Int?,
+        localizedTitle: String? = null,
+        englishTitle: String? = null,
+        originalTitle: String? = null
+    ): List<String> {
         // Prefer TMDB English title as primary; fall back to app title
         val primary = englishTitle?.let { cleanTitle(it) } ?: cleanTitle(title)
-        val localized = localizedTitle?.let { cleanTitle(it) }
         val queries = mutableListOf<String>()
         if (year != null) queries.add("$primary $year")
         queries.add(primary)
-        if (localized != null && !localized.equals(primary, ignoreCase = true)) {
-            if (year != null) queries.add("$localized $year")
-            queries.add(localized)
-        }
+        // Localized and original are both searched: for foreign titles TMDB frequently has no
+        // translation (localized == English), and only the original name matches real files.
+        listOfNotNull(localizedTitle, originalTitle)
+            .map { cleanTitle(it) }
+            .filter { it.isNotBlank() && !it.equals(primary, ignoreCase = true) }
+            .distinct()
+            .forEach { alt ->
+                if (year != null) queries.add("$alt $year")
+                queries.add(alt)
+            }
         return queries.distinct()
     }
 
@@ -121,36 +138,49 @@ class TelegramSearchMatcher @Inject constructor() {
         episode: Int,
         localizedTitle: String? = null,
         englishTitle: String? = null,
-        languageCode: String = "en"
+        languageCode: String = "en",
+        originalTitle: String? = null
     ): List<String> {
         val engBase = englishTitle?.let { cleanTitle(it) } ?: cleanTitle(title)
-        val locBase = localizedTitle?.let { cleanTitle(it) }
-        val titlesAreSame = locBase == null || locBase.equals(engBase, ignoreCase = true)
         val s = season.toString()
         val e = episode.toString()
         val s2 = season.toString().padStart(2, '0')
         val e2 = episode.toString().padStart(2, '0')
 
+        // Every distinct name this show is known by. The original title is included because TMDB
+        // frequently has no translation for foreign content — it then returns the English name for
+        // a localized request, so `localizedTitle` alone can silently be English and the native
+        // name (the one actually used in file names and captions) is never searched.
+        val altBases = listOfNotNull(localizedTitle, originalTitle, title)
+            .map { cleanTitle(it) }
+            .filter { it.isNotBlank() && !it.equals(engBase, ignoreCase = true) }
+            .distinct()
+
         val queries = mutableListOf<String>()
 
-        // Hebrew-specific episode markers — only for Hebrew users
+        // Hebrew-specific episode markers — only for Hebrew users, and only paired with a title
+        // that is actually written in Hebrew. Pairing Hebrew markers with a Latin title produces
+        // strings like "on standby עונה 1 פרק 1" that cannot exist in any group.
         if (languageCode == "he") {
-            val hebTitle = if (titlesAreSame) engBase else locBase ?: engBase
-            queries += listOf(
-                "$hebTitle ע$s פ$e",
-                "$hebTitle ע${s}פ${e}",
-                "$hebTitle עונה $s פרק $e",
-            )
-            if (season == 1) queries += listOf("$hebTitle פ$e", "$hebTitle פרק $e")
+            val hebrewBases = altBases.filter { isHebrew(it) }
+                .ifEmpty { listOfNotNull(engBase.takeIf { isHebrew(it) }) }
+            for (hebTitle in hebrewBases) {
+                queries += listOf(
+                    "$hebTitle ע$s פ$e",
+                    "$hebTitle ע${s}פ${e}",
+                    "$hebTitle עונה $s פרק $e",
+                )
+                if (season == 1) queries += listOf("$hebTitle פ$e", "$hebTitle פרק $e")
+            }
         }
 
-        // Localized title with English S/E patterns (any non-English language)
-        if (!titlesAreSame) {
+        // Alternate titles with English S/E patterns (any non-English language)
+        for (alt in altBases) {
             queries += listOf(
-                "$locBase s${s}e${e}",
-                "$locBase s${s2}e${e2}",
-                "$locBase s$s e$e",
-                "$locBase s$s2 e$e2",
+                "$alt s${s}e${e}",
+                "$alt s${s2}e${e2}",
+                "$alt s$s e$e",
+                "$alt s$s2 e$e2",
             )
         }
 

--- a/app/src/main/kotlin/com/arflix/tv/data/telegram/TelegramSourceResolver.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/telegram/TelegramSourceResolver.kt
@@ -98,12 +98,17 @@ class TelegramSourceResolver @Inject constructor(
         val rawLang = context.getSharedPreferences("app_locale", android.content.Context.MODE_PRIVATE)
             .getString("locale_tag", "en-US") ?: "en-US"
         val langCode = rawLang.replace("iw", "he").substringBefore("-")
-        val (englishTitle, localizedTitle) = fetchTitles(imdbId, isMovie, langCode)
+        val titles = fetchTitles(imdbId, isMovie, langCode)
+        val englishTitle = titles.english
+        val localizedTitle = titles.localized
+        val originalTitle = titles.original
 
         val queries = if (season != null && episode != null)
-            matcher.buildSeriesQueries(title, season, episode, localizedTitle, englishTitle, langCode)
+            matcher.buildSeriesQueries(
+                title, season, episode, localizedTitle, englishTitle, langCode, originalTitle
+            )
         else
-            matcher.buildMovieQueries(title, year, localizedTitle, englishTitle)
+            matcher.buildMovieQueries(title, year, localizedTitle, englishTitle, originalTitle)
 
         val seen = mutableSetOf<Pair<String, Long>>()
         val allMessages = mutableListOf<TelegramVideoMessage>()
@@ -138,6 +143,7 @@ class TelegramSourceResolver @Inject constructor(
                     title = title,
                     localizedTitle = localizedTitle,
                     englishTitle = englishTitle,
+                    originalTitle = originalTitle,
                     year = year,
                     season = season,
                     episode = episode
@@ -203,21 +209,33 @@ class TelegramSourceResolver @Inject constructor(
         else -> 0
     }
 
-    private suspend fun fetchTitles(imdbId: String, isMovie: Boolean, langCode: String): Pair<String?, String?> {
-        if (imdbId.isBlank()) return null to null
+    /** The names a title is known by. [original] is the native name from TMDB. */
+    private data class ResolvedTitles(
+        val english: String? = null,
+        val localized: String? = null,
+        val original: String? = null
+    )
+
+    private suspend fun fetchTitles(imdbId: String, isMovie: Boolean, langCode: String): ResolvedTitles {
+        if (imdbId.isBlank()) return ResolvedTitles()
         return try {
             val findResult = tmdbApi.findByExternalId(imdbId, Constants.TMDB_API_KEY)
             val findItem = if (isMovie) findResult.movieResults.firstOrNull()
                            else findResult.tvResults.firstOrNull()
-            val tmdbId = findItem?.id ?: return null to null
+            val tmdbId = findItem?.id ?: return ResolvedTitles()
             // Always fetch English explicitly — the HTTP interceptor may inject the user's
             // content language into all TMDB calls, so findItem.title isn't always English.
-            val englishTitle = if (isMovie)
-                tmdbApi.getMovieDetails(tmdbId, Constants.TMDB_API_KEY, language = "en").title
-                    .takeIf { it.isNotBlank() }
-            else
-                tmdbApi.getTvDetails(tmdbId, Constants.TMDB_API_KEY, language = "en").name
-                    .takeIf { it.isNotBlank() }
+            val englishMovie = if (isMovie)
+                tmdbApi.getMovieDetails(tmdbId, Constants.TMDB_API_KEY, language = "en") else null
+            val englishTv = if (isMovie) null
+                else tmdbApi.getTvDetails(tmdbId, Constants.TMDB_API_KEY, language = "en")
+            val englishTitle = (englishMovie?.title ?: englishTv?.name.orEmpty())
+                .takeIf { it.isNotBlank() }
+            // Native name (e.g. Hebrew for an Israeli show). TMDB returns it regardless of the
+            // requested language, so it is the only reliable source when no translation exists —
+            // a localized request then just returns the English name again.
+            val originalTitle = (englishMovie?.originalTitle ?: englishTv?.originalName)
+                ?.takeIf { it.isNotBlank() }
             // Fetch localized title only when the user's language is not English
             val localizedTitle = if (langCode != "en") {
                 if (isMovie)
@@ -227,12 +245,12 @@ class TelegramSourceResolver @Inject constructor(
                     tmdbApi.getTvDetails(tmdbId, Constants.TMDB_API_KEY, language = langCode).name
                         .takeIf { it.isNotBlank() }
             } else null
-            englishTitle to localizedTitle
+            ResolvedTitles(english = englishTitle, localized = localizedTitle, original = originalTitle)
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
 
             Log.w(TAG, "Failed to fetch titles for $imdbId: ${e.message}")
-            null to null
+            ResolvedTitles()
         }
     }
 

--- a/app/src/main/kotlin/com/arflix/tv/util/AnimeMapper.kt
+++ b/app/src/main/kotlin/com/arflix/tv/util/AnimeMapper.kt
@@ -779,13 +779,30 @@ class AnimeMapper @Inject constructor(
 
         val normalizedQuery = title.lowercase().trim()
 
-        // Try to find an exact or close title match
+        // Try to find an exact or close title match.
+        //
+        // There is deliberately NO "just take the first result" fallback: Kitsu's filter[text]
+        // is a fuzzy search that always returns *something*, so an unrelated show (e.g. the
+        // Israeli drama "On Standby") would silently resolve to whatever anime happened to rank
+        // first and then be offered as that show's sources.
         val bestMatch = results.firstOrNull { anime ->
             val canonical = anime.attributes?.canonicalTitle?.lowercase()?.trim()
             val english = anime.attributes?.titles?.get("en")?.lowercase()?.trim()
             val enJp = anime.attributes?.titles?.get("en_jp")?.lowercase()?.trim()
             canonical == normalizedQuery || english == normalizedQuery || enJp == normalizedQuery
-        } ?: results.firstOrNull() // Fall back to first result
+        } ?: results.firstOrNull { anime ->
+            // Looser second pass: one title fully contains the other (handles subtitles and
+            // season suffixes like "Title 2nd Season"), still anchored on the real name.
+            listOfNotNull(
+                anime.attributes?.canonicalTitle,
+                anime.attributes?.titles?.get("en"),
+                anime.attributes?.titles?.get("en_jp")
+            ).any { raw ->
+                val candidate = raw.lowercase().trim()
+                candidate.isNotBlank() && normalizedQuery.isNotBlank() &&
+                    (candidate.contains(normalizedQuery) || normalizedQuery.contains(candidate))
+            }
+        }
 
         val kitsuId = bestMatch?.id?.toIntOrNull()
         if (kitsuId != null) {


### PR DESCRIPTION
 ## Fix Telegram search and incorrect anime source matching                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                    
  ### Telegram found no sources for titles without a TMDB translation                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                    
  When TMDB has no translation for a title, it falls back to returning the English name for a                                                                                                                                                                                                                       
  localized request. The query builder compared localized vs English, concluded the title had a                                                                                                                                                                                                                     
  single name, and paired that English name with localized episode markers — producing queries that                                                                                                                                                                                                                 
  could never match. The native name was never searched.                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                    
  Query building now also uses TMDB's original (native) title, builds queries from every distinct                                                                                                                                                                                                                   
  name a title is known by, and only pairs localized episode markers with a title actually written                                                                                                                                                                                                                  
  in that script. Scoring accepts the original title as well, so matches aren't found and then                                                                                                                                                                                                                      
  discarded.                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                    
  ### Unrelated anime returned as a title's sources                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                    
  When an anime-capable addon returned no results, a retry path resolved an anime ID **without                                                                                                                                                                                                                      
  checking the title had ever been classified as anime**. That lookup ends in a fuzzy Kitsu title                                                                                                                                                                                                                   
  search which always returns something, and it accepted the first result unconditionally — so an                                                                                                                                                                                                                   
  unrelated series could be offered as the title's sources.                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                    
  The retry now only runs for titles actually classified as anime, and the Kitsu search no longer                                                                                                                                                                                                                   
  falls back to an arbitrary result when nothing matches.                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                    
  This affected any title an addon had no results for, not one specific case.      