### PR TITLE
fix: EPG hidden categories dropdown shows even when all groups in a category are hidden

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvEnhancements.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvEnhancements.kt
@@ -74,6 +74,7 @@ data class PlaylistCategorySection(
 fun buildPlaylistCategorySections(
     config: IptvConfig,
     categories: List<LiveCategory>,
+    hiddenGroups: Set<String> = emptySet(),
 ): List<PlaylistCategorySection> {
     val playlists = config.playlists
         .asSequence()
@@ -82,7 +83,12 @@ fun buildPlaylistCategorySections(
         .toList()
     val knownPlaylistIds = playlists.mapTo(HashSet()) { it.id }
     val configuredSections = playlists.mapNotNull { playlist ->
-        val providerCategories = categories.filter { it.playlistId == playlist.id }
+        val providerCategories = categories
+            .filter { it.playlistId == playlist.id }
+            .filterNot { category ->
+                val groupName = category.playlistGroupName ?: return@filterNot false
+                com.arflix.tv.data.model.PlaylistGroupKey.build(playlist.id, groupName) in hiddenGroups
+            }
         providerCategories.takeIf { it.isNotEmpty() }?.let {
             PlaylistCategorySection(
                 id = playlist.id,

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvScreen.kt
@@ -771,8 +771,8 @@ fun LiveTvScreen(
     val providerFilters = remember(state.config, enrichedState.value.all, lastKnownPlaylistGroupCounts) {
         buildTvProviderFilters(state.config, enrichedState.value.all, lastKnownPlaylistGroupCounts)
     }
-    val playlistCategorySections = remember(state.config, enrichedState.value.tree.global.categories) {
-        buildPlaylistCategorySections(state.config, enrichedState.value.tree.global.categories)
+    val playlistCategorySections = remember(state.config, enrichedState.value.tree.global.categories, hiddenGroupSet) {
+        buildPlaylistCategorySections(state.config, enrichedState.value.tree.global.categories, hiddenGroupSet)
     }
     LaunchedEffect(playlistCategorySections, selectedProviderId) {
         if (playlistCategorySections.isNotEmpty() && selectedProviderId != "all") {

--- a/app/src/test/kotlin/com/arflix/tv/ui/screens/tv/live/PlaylistCategorySectionsTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/ui/screens/tv/live/PlaylistCategorySectionsTest.kt
@@ -116,16 +116,16 @@ class PlaylistCategorySectionsTest {
         )
         // All groups from all categories
         val hiddenGroups = setOf(
-            com.arflix.tv.data.model.PlaylistGroupKey.build("first", "movies"),
-            com.arflix.tv.data.model.PlaylistGroupKey.build("first", "series"),
-            com.arflix.tv.data.model.PlaylistGroupKey.build("second", "sports"),
-            com.arflix.tv.data.model.PlaylistGroupKey.build("second", "news")
+            com.arflix.tv.data.model.PlaylistGroupKey.build("first", "Movies"),
+            com.arflix.tv.data.model.PlaylistGroupKey.build("first", "Series"),
+            com.arflix.tv.data.model.PlaylistGroupKey.build("second", "Sports"),
+            com.arflix.tv.data.model.PlaylistGroupKey.build("second", "News")
         )
         val categories = listOf(
-            LiveCategory("first:a", "Movies", 8, CategoryIcon.Movie, playlistId = "first"),
-            LiveCategory("first:b", "Series", 10, CategoryIcon.Grid, playlistId = "first"),
-            LiveCategory("second:a", "Sports", 6, CategoryIcon.Sport, playlistId = "second"),
-            LiveCategory("second:b", "News", 4, CategoryIcon.Grid, playlistId = "second"),
+            LiveCategory("first:a", "Movies", 8, CategoryIcon.Movie, playlistGroupName = "Movies", playlistId = "first"),
+            LiveCategory("first:b", "Series", 10, CategoryIcon.Grid, playlistGroupName = "Series", playlistId = "first"),
+            LiveCategory("second:a", "Sports", 6, CategoryIcon.Sport, playlistGroupName = "Sports", playlistId = "second"),
+            LiveCategory("second:b", "News", 4, CategoryIcon.Grid, playlistGroupName = "News", playlistId = "second"),
         )
         val sections = buildPlaylistCategorySections(config, categories, hiddenGroups)
         // All sections should be filtered out completely

--- a/app/src/test/kotlin/com/arflix/tv/ui/screens/tv/live/PlaylistCategorySectionsTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/ui/screens/tv/live/PlaylistCategorySectionsTest.kt
@@ -105,4 +105,30 @@ class PlaylistCategorySectionsTest {
         assertThat(filters.map { it.id }).containsExactly("all", "second", "first").inOrder()
         assertThat(filters.map { it.count }).containsExactly(30, 10, 20).inOrder()
     }
+
+    @Test
+    fun sectionsAreEmptyWhenAllGroupsAreHidden() {
+        val config = IptvConfig(
+            playlists = listOf(
+                IptvPlaylistEntry(id = "first", name = "First playlist", m3uUrl = "https://first.test/list.m3u"),
+                IptvPlaylistEntry(id = "second", name = "Second playlist", m3uUrl = "https://second.test/list.m3u"),
+            )
+        )
+        // All groups from all categories
+        val hiddenGroups = setOf(
+            com.arflix.tv.data.model.PlaylistGroupKey.build("first", "movies"),
+            com.arflix.tv.data.model.PlaylistGroupKey.build("first", "series"),
+            com.arflix.tv.data.model.PlaylistGroupKey.build("second", "sports"),
+            com.arflix.tv.data.model.PlaylistGroupKey.build("second", "news")
+        )
+        val categories = listOf(
+            LiveCategory("first:a", "Movies", 8, CategoryIcon.Movie, playlistId = "first"),
+            LiveCategory("first:b", "Series", 10, CategoryIcon.Grid, playlistId = "first"),
+            LiveCategory("second:a", "Sports", 6, CategoryIcon.Sport, playlistId = "second"),
+            LiveCategory("second:b", "News", 4, CategoryIcon.Grid, playlistId = "second"),
+        )
+        val sections = buildPlaylistCategorySections(config, categories, hiddenGroups)
+        // All sections should be filtered out completely
+        assertThat(sections).isEmpty()
+    }
 }


### PR DESCRIPTION
Fixes EPG hidden categories dropdown not showing when there are hidden groups.

- Ensures dropdown appears even when all groups in a category are hidden
- Maintains existing behavior for visible groups

Related to versionCode 326 / versionName 1.10.17