### PR TITLE
fix(iptv): stop resurrecting a disabled M3U playlist via the legacy m3uUrl fallback

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
@@ -377,24 +377,31 @@ class IptvRepository @Inject constructor(
         config.m3uUrl.isNotBlank() ||
             config.stalkerPortals.any { it.enabled && it.portalUrl.isNotBlank() } ||
             config.playlists.any { it.enabled && it.m3uUrl.isNotBlank() }
-    private fun activePlaylists(config: IptvConfig): List<IptvPlaylistEntry> =
-        config.playlists.filter { it.enabled }.ifEmpty {
-            if (config.m3uUrl.isNotBlank()) {
-                val epgUrls = normalizeEpgInputs(config.epgUrl)
-                listOf(
-                    IptvPlaylistEntry(
-                        "list_1",
-                        "List 1",
-                        config.m3uUrl,
-                        epgUrls.firstOrNull().orEmpty(),
-                        enabled = true,
-                        epgUrls = epgUrls
-                    )
-                )
-            } else {
-                emptyList()
-            }
+    internal fun activePlaylists(config: IptvConfig): List<IptvPlaylistEntry> {
+        // config.playlists.isEmpty() means the user has never created a playlist entry
+        // (pre-multi-playlist legacy state) - fall back to the single legacy m3uUrl field.
+        // Once config.playlists is non-empty, respect it as-is (including "all disabled"):
+        // config.m3uUrl always mirrors playlists.firstOrNull()?.m3uUrl regardless of that
+        // entry's enabled state (see observeConfig()), so checking m3uUrl.isNotBlank() here
+        // instead would resurrect a playlist the user explicitly disabled.
+        if (config.playlists.isNotEmpty()) {
+            return config.playlists.filter { it.enabled }
         }
+        if (config.m3uUrl.isBlank()) {
+            return emptyList()
+        }
+        val epgUrls = normalizeEpgInputs(config.epgUrl)
+        return listOf(
+            IptvPlaylistEntry(
+                "list_1",
+                "List 1",
+                config.m3uUrl,
+                epgUrls.firstOrNull().orEmpty(),
+                enabled = true,
+                epgUrls = epgUrls
+            )
+        )
+    }
 
     /** Enabled Stalker portals with a non-blank URL — the ones that load channels. */
     private fun activeStalkerPortals(config: IptvConfig): List<StalkerPortalEntry> =

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
@@ -373,10 +373,10 @@ class IptvRepository @Inject constructor(
         val url: String,
         val playlistId: String? = null
     )
-    private fun hasAnyConfiguredSource(config: IptvConfig): Boolean =
-        config.m3uUrl.isNotBlank() ||
-            config.stalkerPortals.any { it.enabled && it.portalUrl.isNotBlank() } ||
-            config.playlists.any { it.enabled && it.m3uUrl.isNotBlank() }
+    internal fun hasAnyConfiguredSource(config: IptvConfig): Boolean =
+        activePlaylists(config).any { it.m3uUrl.isNotBlank() } ||
+            activeStalkerPortals(config).isNotEmpty()
+
     internal fun activePlaylists(config: IptvConfig): List<IptvPlaylistEntry> {
         // config.playlists.isEmpty() means the user has never created a playlist entry
         // (pre-multi-playlist legacy state) - fall back to the single legacy m3uUrl field.

--- a/app/src/test/kotlin/com/arflix/tv/data/repository/IptvActivePlaylistsTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/repository/IptvActivePlaylistsTest.kt
@@ -1,0 +1,110 @@
+package com.arflix.tv.data.repository
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression tests for [IptvRepository.activePlaylists] (marked `internal` so tests can
+ * call it directly, same convention as the Stalker EPG helpers).
+ *
+ * Root cause: `observeConfig()` always mirrors `playlists.firstOrNull()?.m3uUrl` into the
+ * legacy top-level `config.m3uUrl` field, regardless of that entry's `enabled` state - it's
+ * kept in sync for backward compatibility, not cleared on migration. `activePlaylists()`
+ * used to treat "zero enabled playlists" as "never migrated" and resurrect a synthetic,
+ * always-enabled "List 1" entry from that legacy field - so disabling the only configured
+ * M3U playlist did nothing: the disabled entry's own URL came right back via the legacy
+ * fallback, under a name ("List 1") that isn't the one the user configured.
+ */
+class IptvActivePlaylistsTest {
+
+    private fun newRepository(): IptvRepository {
+        val context = io.mockk.mockk<android.content.Context>(relaxed = true)
+        val okHttpClient = io.mockk.mockk<okhttp3.OkHttpClient>(relaxed = true)
+        val profileManager = io.mockk.mockk<ProfileManager>(relaxed = true)
+        val invalidationBus = io.mockk.mockk<CloudSyncInvalidationBus>(relaxed = true)
+        return IptvRepository(context, okHttpClient, profileManager, invalidationBus)
+    }
+
+    @Test
+    fun `enabled playlists are returned as configured`() {
+        val repository = newRepository()
+        val playlist = IptvPlaylistEntry(
+            id = "my_list",
+            name = "My Provider",
+            m3uUrl = "http://example.com/list.m3u",
+            enabled = true
+        )
+        val config = IptvConfig(
+            m3uUrl = playlist.m3uUrl,
+            playlists = listOf(playlist)
+        )
+
+        assertEquals(listOf(playlist), repository.activePlaylists(config))
+    }
+
+    @Test
+    fun `disabling the only configured playlist does not resurrect it via the legacy m3uUrl field`() {
+        val repository = newRepository()
+        // config.m3uUrl mirrors the (disabled) entry's URL, as observeConfig() always does -
+        // this must NOT bring the playlist back to life.
+        val disabled = IptvPlaylistEntry(
+            id = "my_list",
+            name = "My Provider",
+            m3uUrl = "http://example.com/list.m3u",
+            enabled = false
+        )
+        val config = IptvConfig(
+            m3uUrl = disabled.m3uUrl,
+            playlists = listOf(disabled)
+        )
+
+        assertTrue(repository.activePlaylists(config).isEmpty())
+    }
+
+    @Test
+    fun `disabling one of several playlists keeps the rest active`() {
+        val repository = newRepository()
+        val enabled = IptvPlaylistEntry(
+            id = "list_a",
+            name = "Provider A",
+            m3uUrl = "http://example.com/a.m3u",
+            enabled = true
+        )
+        val disabled = IptvPlaylistEntry(
+            id = "list_b",
+            name = "Provider B",
+            m3uUrl = "http://example.com/b.m3u",
+            enabled = false
+        )
+        val config = IptvConfig(
+            m3uUrl = enabled.m3uUrl,
+            playlists = listOf(enabled, disabled)
+        )
+
+        assertEquals(listOf(enabled), repository.activePlaylists(config))
+    }
+
+    @Test
+    fun `legacy pre-migration config with no playlist entries still falls back to m3uUrl`() {
+        val repository = newRepository()
+        val config = IptvConfig(
+            m3uUrl = "http://example.com/legacy.m3u",
+            playlists = emptyList()
+        )
+
+        val result = repository.activePlaylists(config)
+
+        assertEquals(1, result.size)
+        assertEquals("http://example.com/legacy.m3u", result.single().m3uUrl)
+        assertTrue(result.single().enabled)
+    }
+
+    @Test
+    fun `no playlists and no legacy m3uUrl returns nothing`() {
+        val repository = newRepository()
+        val config = IptvConfig(playlists = emptyList(), m3uUrl = "")
+
+        assertTrue(repository.activePlaylists(config).isEmpty())
+    }
+}

--- a/app/src/test/kotlin/com/arflix/tv/data/repository/IptvActivePlaylistsTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/repository/IptvActivePlaylistsTest.kt
@@ -60,6 +60,7 @@ class IptvActivePlaylistsTest {
         )
 
         assertTrue(repository.activePlaylists(config).isEmpty())
+        assertTrue(repository.hasAnyConfiguredSource(config).not())
     }
 
     @Test
@@ -98,6 +99,7 @@ class IptvActivePlaylistsTest {
         assertEquals(1, result.size)
         assertEquals("http://example.com/legacy.m3u", result.single().m3uUrl)
         assertTrue(result.single().enabled)
+        assertTrue(repository.hasAnyConfiguredSource(config))
     }
 
     @Test


### PR DESCRIPTION
Summary
Disabling the only configured M3U playlist in Settings didn't actually stop it from loading/streaming, and (in a mixed setup with other providers) it could show up under the wrong name in the Live TV sidebar. Found while testing the Stalker EPG feature, but unrelated to it — this is a pre-existing bug reproducible on current main.
Root cause
observeConfig() always mirrors playlists.firstOrNull()?.m3uUrl into the legacy top-level config.m3uUrl field, regardless of that entry's enabled state — it's kept in sync for backward compatibility and never cleared once the user has migrated to the multi-playlist system. IptvRepository.activePlaylists() then treated "zero enabled playlists" as "user hasn't migrated yet" and resurrected a synthetic, always-enabled "List 1" entry sourced straight from that mirrored legacy field.
Net effect for anyone with a single M3U playlist: disabling it in Settings did nothing — the disabled entry's own URL came right back through the legacy fallback, under the synthetic "list_1" id/name instead of the name actually configured for it (the real, disabled entry is filtered out of buildPlaylistCategorySections by the same enabled check).
Fix
Only take the legacy-fallback branch when config.playlists itself is empty (true pre-migration state). Once the user has playlist entries, respect their enabled state as configured — including "all disabled". activePlaylists() made internal for direct unit testing (same convention already used for the Stalker EPG helpers).
Testing
New unit tests (IptvActivePlaylistsTest): enabled playlists pass through unchanged; a disabled sole playlist is no longer resurrected via m3uUrl; disabling one of several playlists keeps the rest active; the legacy pre-migration fallback (empty playlists, non-blank m3uUrl) still works; no playlists + no legacy URL returns nothing.
./gradlew testSideloadDebugUnitTest green.
Generated by Claude Code