### PR TITLE
fix(stalker): show the configured portal name instead of the raw id in the playlist sidebar (multi-portal setups)

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvEnhancements.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvEnhancements.kt
@@ -102,13 +102,22 @@ fun buildPlaylistCategorySections(
         .filter { category -> category.playlistId.isNullOrBlank() || category.playlistId !in knownPlaylistIds }
         .groupBy { category -> category.playlistId?.takeIf { it.isNotBlank() } ?: "other" }
         .entries
-        .sortedWith(compareBy<Map.Entry<String, List<LiveCategory>>> { if (it.key == "stalker") 0 else 1 }.thenBy { it.key })
+        .sortedWith(compareBy<Map.Entry<String, List<LiveCategory>>> { if (it.key.startsWith("stalker")) 0 else 1 }.thenBy { it.key })
         .map { (sourceId, sourceCategories) ->
+            // Multi-portal Stalker ids look like "stalker1"/"stalker2" (see
+            // StalkerPortalSupport), not the legacy single-portal "stalker" - look
+            // up the name the user configured for that portal before falling back
+            // to a generic capitalized id.
+            val stalkerPortalName = config.stalkerPortals
+                .firstOrNull { it.id == sourceId }
+                ?.name
+                ?.takeIf { it.isNotBlank() }
             PlaylistCategorySection(
                 id = "source:$sourceId",
-                label = when (sourceId) {
-                    "stalker" -> "Stalker"
-                    "other" -> "Other sources"
+                label = when {
+                    stalkerPortalName != null -> stalkerPortalName
+                    sourceId == "stalker" -> "Stalker"
+                    sourceId == "other" -> "Other sources"
                     else -> sourceId.replaceFirstChar { it.uppercase() }
                 },
                 count = sourceCategories.sumOf(LiveCategory::count),

--- a/app/src/test/kotlin/com/arflix/tv/ui/screens/tv/live/PlaylistCategorySectionsTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/ui/screens/tv/live/PlaylistCategorySectionsTest.kt
@@ -70,6 +70,35 @@ class PlaylistCategorySectionsTest {
     }
 
     @Test
+    fun multiPortalStalkerSectionsUseTheConfiguredPortalNameNotTheRawId() {
+        val config = IptvConfig(
+            stalkerPortals = listOf(
+                com.arflix.tv.data.repository.StalkerPortalEntry(
+                    id = "stalker1",
+                    name = "Home Portal",
+                    portalUrl = "http://portal1.test",
+                    macAddress = "00:1A:79:AA:BB:01",
+                ),
+                com.arflix.tv.data.repository.StalkerPortalEntry(
+                    id = "stalker2",
+                    name = "Backup Portal",
+                    portalUrl = "http://portal2.test",
+                    macAddress = "00:1A:79:AA:BB:02",
+                ),
+            )
+        )
+        val categories = listOf(
+            LiveCategory("stalker:stalker1:news", "News", 6, CategoryIcon.Grid, playlistId = "stalker1"),
+            LiveCategory("stalker:stalker2:sports", "Sports", 4, CategoryIcon.Sport, playlistId = "stalker2"),
+        )
+
+        val sections = buildPlaylistCategorySections(config, categories)
+
+        assertThat(sections.map { it.id }).containsExactly("source:stalker1", "source:stalker2").inOrder()
+        assertThat(sections.map { it.label }).containsExactly("Home Portal", "Backup Portal").inOrder()
+    }
+
+    @Test
     fun singlePlaylistUsesLegacyFlatCategoriesWithoutCollapsedParent() {
         val config = IptvConfig(
             playlists = listOf(


### PR DESCRIPTION
Summary
In a multi-portal Stalker setup, the Live TV sidebar showed the raw source id ("Stalker1", "Stalker2", ...) instead of the friendly name configured for each portal. Found while testing the Stalker EPG feature, but unrelated to it and reproducible on current main — filed as its own focused fix per our usual "one PR, one topic" approach.
Root cause
buildPlaylistCategorySections() only recognized the legacy single-portal source id "stalker" for a friendly label ("Stalker"). Multi-portal ids are "stalker1"/"stalker2"/etc (see StalkerPortalSupport), which always fell through to the generic "capitalize the raw id" branch.
Fix
Look up the matching StalkerPortalEntry by id in config.stalkerPortals and use its configured name when present, before falling back to the legacy/generic cases.
Testing
New regression test for the multi-portal case; existing single-portal legacy test unaffected (no stalkerPortals configured there, so it still hits the "stalker" → "Stalker" branch).
./gradlew testSideloadDebugUnitTest green.
Generated by Claude Code