### PR TITLE
feat(stalker): add EPG guide support

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/api/StalkerApi.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/api/StalkerApi.kt
@@ -160,21 +160,69 @@ open class StalkerApi(
     }
 
     /**
-     * Fetch the portal's lightweight now/next EPG table for all channels in one call.
+     * Fetch the portal's now/next EPG data for all channels.
      * [date] uses `YYYY-MM-DD`; blank means "today" on the server side.
+     *
+     * Tries `type=epg&action=get_simple_data_table` first (lightweight, one flat
+     * list). Some Stalker/Ministra portal builds don't implement the `epg` type
+     * handler at all (confirmed on-device: 0-byte response, while `itv`/`stb`
+     * actions on the same portal work fine) - for those, falls back to
+     * `type=itv&action=get_epg_info`, which some portals return as a flat list
+     * like the first action and others as an object keyed by channel id.
      */
     suspend fun getEpg(date: String = ""): List<StalkerEpgProgram> {
+        val dateParam = if (date.isBlank()) "" else "&date=${java.net.URLEncoder.encode(date, "UTF-8")}"
+        val simpleTable = fetchSimpleDataTableEpg(dateParam)
+        if (simpleTable.isNotEmpty()) return simpleTable
+        return fetchEpgInfoFallback(dateParam)
+    }
+
+    private fun fetchSimpleDataTableEpg(dateParam: String): List<StalkerEpgProgram> {
         return try {
-            val dateParam = if (date.isBlank()) "" else "&date=${java.net.URLEncoder.encode(date, "UTF-8")}"
             val url = "$apiBase/server/load.php?type=epg&action=get_simple_data_table&ch_id=all$dateParam&JsHttpRequest=1-xml"
             val response = doGet(url)
-            System.err.println("[Stalker] getEpg raw response (${response.length} chars): ${response.take(500)}")
+            System.err.println("[Stalker] get_simple_data_table raw response (${response.length} chars): ${response.take(500)}")
             val parsed = gson.fromJson(response, StalkerEpgResponse::class.java)
             parsed?.js.orEmpty().filterNotNull()
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
+            System.err.println("[Stalker] get_simple_data_table failed: ${e.message}")
+            emptyList()
+        }
+    }
 
-            System.err.println("[Stalker] Get EPG failed: ${e.message}")
+    /**
+     * `get_epg_info` response shape varies by portal build: either a flat `js`
+     * list (same as get_simple_data_table) or a `js` object keyed by channel id,
+     * each holding that channel's program list. Both are tried.
+     */
+    private fun fetchEpgInfoFallback(dateParam: String): List<StalkerEpgProgram> {
+        return try {
+            val url = "$apiBase/server/load.php?type=itv&action=get_epg_info$dateParam&JsHttpRequest=1-xml"
+            val response = doGet(url)
+            System.err.println("[Stalker] get_epg_info raw response (${response.length} chars): ${response.take(800)}")
+
+            val asList = runCatching {
+                gson.fromJson(response, StalkerEpgResponse::class.java)?.js.orEmpty().filterNotNull()
+            }.getOrDefault(emptyList())
+            if (asList.isNotEmpty()) return asList
+
+            val mapType = com.google.gson.reflect.TypeToken.getParameterized(
+                Map::class.java,
+                String::class.java,
+                com.google.gson.reflect.TypeToken.getParameterized(List::class.java, StalkerEpgProgram::class.java).type
+            ).type
+            val asMap = runCatching {
+                gson.fromJson<Map<String, List<StalkerEpgProgram?>?>>(response, mapType)
+            }.getOrNull().orEmpty()
+            asMap.flatMap { (channelId, programs) ->
+                programs.orEmpty().filterNotNull().map { program ->
+                    if (program.chId.isNullOrBlank()) program.copy(chId = channelId) else program
+                }
+            }
+        } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            System.err.println("[Stalker] get_epg_info failed: ${e.message}")
             emptyList()
         }
     }

--- a/app/src/main/kotlin/com/arflix/tv/data/api/StalkerApi.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/api/StalkerApi.kt
@@ -202,23 +202,40 @@ open class StalkerApi(
             val response = doGet(url)
             System.err.println("[Stalker] get_epg_info raw response (${response.length} chars): ${response.take(800)}")
 
-            val asList = runCatching {
-                gson.fromJson(response, StalkerEpgResponse::class.java)?.js.orEmpty().filterNotNull()
-            }.getOrDefault(emptyList())
-            if (asList.isNotEmpty()) return asList
+            // Parse the envelope first and inspect the "js" member's own shape -
+            // it's either a flat array or an object keyed by channel id, and
+            // trying to Gson-deserialize the whole envelope directly as one or
+            // the other (like get_simple_data_table's model does) mismatches
+            // whichever shape it isn't.
+            val jsElement = runCatching {
+                com.google.gson.JsonParser.parseString(response).asJsonObject.get("js")
+            }.getOrNull() ?: return emptyList()
 
-            val mapType = com.google.gson.reflect.TypeToken.getParameterized(
-                Map::class.java,
-                String::class.java,
-                com.google.gson.reflect.TypeToken.getParameterized(List::class.java, StalkerEpgProgram::class.java).type
-            ).type
-            val asMap = runCatching {
-                gson.fromJson<Map<String, List<StalkerEpgProgram?>?>>(response, mapType)
-            }.getOrNull().orEmpty()
-            asMap.flatMap { (channelId, programs) ->
-                programs.orEmpty().filterNotNull().map { program ->
-                    if (program.chId.isNullOrBlank()) program.copy(chId = channelId) else program
+            when {
+                jsElement.isJsonArray -> {
+                    val listType = com.google.gson.reflect.TypeToken.getParameterized(
+                        List::class.java, StalkerEpgProgram::class.java
+                    ).type
+                    runCatching {
+                        gson.fromJson<List<StalkerEpgProgram?>>(jsElement, listType)
+                    }.getOrNull().orEmpty().filterNotNull()
                 }
+                jsElement.isJsonObject -> {
+                    val mapType = com.google.gson.reflect.TypeToken.getParameterized(
+                        Map::class.java,
+                        String::class.java,
+                        com.google.gson.reflect.TypeToken.getParameterized(List::class.java, StalkerEpgProgram::class.java).type
+                    ).type
+                    val asMap = runCatching {
+                        gson.fromJson<Map<String, List<StalkerEpgProgram?>?>>(jsElement, mapType)
+                    }.getOrNull().orEmpty()
+                    asMap.flatMap { (channelId, programs) ->
+                        programs.orEmpty().filterNotNull().map { program ->
+                            if (program.chId.isNullOrBlank()) program.copy(chId = channelId) else program
+                        }
+                    }
+                }
+                else -> emptyList()
             }
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e

--- a/app/src/main/kotlin/com/arflix/tv/data/api/StalkerApi.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/api/StalkerApi.kt
@@ -168,6 +168,7 @@ open class StalkerApi(
             val dateParam = if (date.isBlank()) "" else "&date=${java.net.URLEncoder.encode(date, "UTF-8")}"
             val url = "$apiBase/server/load.php?type=epg&action=get_simple_data_table&ch_id=all$dateParam&JsHttpRequest=1-xml"
             val response = doGet(url)
+            System.err.println("[Stalker] getEpg raw response (${response.length} chars): ${response.take(500)}")
             val parsed = gson.fromJson(response, StalkerEpgResponse::class.java)
             parsed?.js.orEmpty().filterNotNull()
         } catch (e: Exception) {

--- a/app/src/main/kotlin/com/arflix/tv/data/api/StalkerApi.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/api/StalkerApi.kt
@@ -159,6 +159,25 @@ open class StalkerApi(
         return channels
     }
 
+    /**
+     * Fetch the portal's lightweight now/next EPG table for all channels in one call.
+     * [date] uses `YYYY-MM-DD`; blank means "today" on the server side.
+     */
+    suspend fun getEpg(date: String = ""): List<StalkerEpgProgram> {
+        return try {
+            val dateParam = if (date.isBlank()) "" else "&date=${java.net.URLEncoder.encode(date, "UTF-8")}"
+            val url = "$apiBase/server/load.php?type=epg&action=get_simple_data_table&ch_id=all$dateParam&JsHttpRequest=1-xml"
+            val response = doGet(url)
+            val parsed = gson.fromJson(response, StalkerEpgResponse::class.java)
+            parsed?.js.orEmpty().filterNotNull()
+        } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+
+            System.err.println("[Stalker] Get EPG failed: ${e.message}")
+            emptyList()
+        }
+    }
+
     /** Resolve a channel's cmd to a playable stream URL */
     suspend fun resolveStreamUrl(cmd: String): String? {
         return try {
@@ -206,4 +225,15 @@ open class StalkerApi(
 
     data class StalkerLinkResponse(val js: StalkerLink?)
     data class StalkerLink(val cmd: String?)
+
+    data class StalkerEpgResponse(val js: List<StalkerEpgProgram?>?)
+
+    /** Field names vary by portal software/version, hence the alternates. */
+    data class StalkerEpgProgram(
+        @SerializedName(value = "ch_id", alternate = ["channel_id"]) val chId: String?,
+        @SerializedName(value = "name", alternate = ["title"]) val name: String?,
+        @SerializedName(value = "descr", alternate = ["description"]) val descr: String?,
+        @SerializedName(value = "start_timestamp", alternate = ["start"]) val startTimestamp: String?,
+        @SerializedName(value = "stop_timestamp", alternate = ["end_timestamp", "end"]) val stopTimestamp: String?
+    )
 }

--- a/app/src/main/kotlin/com/arflix/tv/data/api/StalkerApi.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/api/StalkerApi.kt
@@ -3,8 +3,13 @@ package com.arflix.tv.data.api
 import com.arflix.tv.data.model.IptvChannel
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
+import com.google.gson.stream.JsonReader
+import com.google.gson.stream.JsonToken
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import java.io.FilterReader
+import java.io.Reader
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 
 /**
@@ -25,6 +30,11 @@ open class StalkerApi(
     private val gson = Gson()
     private var token: String = ""
     private var serialNumber: String = ""
+
+    /** Stable identity for EPG caches; intentionally never written to logs or disk. */
+    internal val epgCacheIdentity: String =
+        portalUrl.trim().trimEnd('/').lowercase(Locale.ROOT) + "\u0000" +
+            macAddress.trim().uppercase(Locale.ROOT)
 
     private val baseHeaders: Map<String, String>
         get() = mapOf(
@@ -170,24 +180,40 @@ open class StalkerApi(
      * `type=itv&action=get_epg_info`, which some portals return as a flat list
      * like the first action and others as an object keyed by channel id.
      */
-    suspend fun getEpg(date: String = ""): List<StalkerEpgProgram> {
+    suspend fun getEpg(
+        date: String = "",
+        notBeforeEpochSeconds: Long? = null,
+        maxProgramsPerChannel: Int = Int.MAX_VALUE
+    ): List<StalkerEpgProgram> {
+        require(maxProgramsPerChannel > 0) { "maxProgramsPerChannel must be positive" }
         val dateParam = if (date.isBlank()) "" else "&date=${java.net.URLEncoder.encode(date, "UTF-8")}"
-        val simpleTable = fetchSimpleDataTableEpg(dateParam)
-        if (simpleTable.isNotEmpty()) return simpleTable
-        return fetchEpgInfoFallback(dateParam)
+        val simpleTable = fetchSimpleDataTableEpg(
+            dateParam = dateParam,
+            notBeforeEpochSeconds = notBeforeEpochSeconds,
+            maxProgramsPerChannel = maxProgramsPerChannel
+        )
+        if (simpleTable.sawProgramEntry) return simpleTable.programs
+        return fetchEpgInfoFallback(
+            dateParam = dateParam,
+            notBeforeEpochSeconds = notBeforeEpochSeconds,
+            maxProgramsPerChannel = maxProgramsPerChannel
+        ).programs
     }
 
-    private fun fetchSimpleDataTableEpg(dateParam: String): List<StalkerEpgProgram> {
+    private fun fetchSimpleDataTableEpg(
+        dateParam: String,
+        notBeforeEpochSeconds: Long?,
+        maxProgramsPerChannel: Int
+    ): StalkerEpgParseResult {
         return try {
             val url = "$apiBase/server/load.php?type=epg&action=get_simple_data_table&ch_id=all$dateParam&JsHttpRequest=1-xml"
-            val response = doGet(url)
-            System.err.println("[Stalker] get_simple_data_table raw response (${response.length} chars): ${response.take(500)}")
-            val parsed = gson.fromJson(response, StalkerEpgResponse::class.java)
-            parsed?.js.orEmpty().filterNotNull()
+            doGetReader(url).use { response ->
+                parseEpgResponse(response, notBeforeEpochSeconds, maxProgramsPerChannel)
+            }
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
             System.err.println("[Stalker] get_simple_data_table failed: ${e.message}")
-            emptyList()
+            StalkerEpgParseResult()
         }
     }
 
@@ -199,54 +225,175 @@ open class StalkerApi(
      * builds may skip the "data" wrapper and put the array/object directly under
      * "js" (matching the get_simple_data_table shape) - both are handled.
      */
-    private fun fetchEpgInfoFallback(dateParam: String): List<StalkerEpgProgram> {
+    private fun fetchEpgInfoFallback(
+        dateParam: String,
+        notBeforeEpochSeconds: Long?,
+        maxProgramsPerChannel: Int
+    ): StalkerEpgParseResult {
         return try {
             val url = "$apiBase/server/load.php?type=itv&action=get_epg_info$dateParam&JsHttpRequest=1-xml"
-            val response = doGet(url)
-            System.err.println("[Stalker] get_epg_info raw response (${response.length} chars): ${response.take(800)}")
-
-            val jsElement = runCatching {
-                com.google.gson.JsonParser.parseString(response).asJsonObject.get("js")
-            }.getOrNull() ?: return emptyList()
-
-            // Unwrap the "data" wrapper when present; otherwise treat "js" itself
-            // as the array/object to parse (older/other portal builds).
-            val dataElement = if (jsElement.isJsonObject && jsElement.asJsonObject.has("data")) {
-                jsElement.asJsonObject.get("data")
-            } else {
-                jsElement
-            }
-
-            when {
-                dataElement.isJsonArray -> {
-                    val listType = com.google.gson.reflect.TypeToken.getParameterized(
-                        List::class.java, StalkerEpgProgram::class.java
-                    ).type
-                    runCatching {
-                        gson.fromJson<List<StalkerEpgProgram?>>(dataElement, listType)
-                    }.getOrNull().orEmpty().filterNotNull()
-                }
-                dataElement.isJsonObject -> {
-                    val mapType = com.google.gson.reflect.TypeToken.getParameterized(
-                        Map::class.java,
-                        String::class.java,
-                        com.google.gson.reflect.TypeToken.getParameterized(List::class.java, StalkerEpgProgram::class.java).type
-                    ).type
-                    val asMap = runCatching {
-                        gson.fromJson<Map<String, List<StalkerEpgProgram?>?>>(dataElement, mapType)
-                    }.getOrNull().orEmpty()
-                    asMap.flatMap { (channelId, programs) ->
-                        programs.orEmpty().filterNotNull().map { program ->
-                            if (program.chId.isNullOrBlank()) program.copy(chId = channelId) else program
-                        }
-                    }
-                }
-                else -> emptyList()
+            doGetReader(url).use { response ->
+                parseEpgResponse(response, notBeforeEpochSeconds, maxProgramsPerChannel)
             }
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
             System.err.println("[Stalker] get_epg_info failed: ${e.message}")
-            emptyList()
+            StalkerEpgParseResult()
+        }
+    }
+
+    /**
+     * Streams the portal response instead of materializing a large response String and
+     * a second Gson tree. Production callers can also bound each channel to the nearest
+     * current/future entries so multi-thousand-channel portals stay within TV memory limits.
+     */
+    private fun parseEpgResponse(
+        response: Reader,
+        notBeforeEpochSeconds: Long?,
+        maxProgramsPerChannel: Int
+    ): StalkerEpgParseResult {
+        val collector = StalkerEpgCollector(notBeforeEpochSeconds, maxProgramsPerChannel)
+        JsonReader(response).use { reader ->
+            reader.isLenient = true
+            when (reader.peek()) {
+                JsonToken.BEGIN_OBJECT -> {
+                    reader.beginObject()
+                    while (reader.hasNext()) {
+                        if (reader.nextName() == "js") {
+                            readEpgContainer(reader, collector, inheritedChannelId = null)
+                        } else {
+                            reader.skipValue()
+                        }
+                    }
+                    reader.endObject()
+                }
+                JsonToken.BEGIN_ARRAY -> readProgramArray(reader, collector, inheritedChannelId = null)
+                else -> reader.skipValue()
+            }
+        }
+        return collector.result()
+    }
+
+    private fun readEpgContainer(
+        reader: JsonReader,
+        collector: StalkerEpgCollector,
+        inheritedChannelId: String?
+    ) {
+        when (reader.peek()) {
+            JsonToken.BEGIN_ARRAY -> readProgramArray(reader, collector, inheritedChannelId)
+            JsonToken.BEGIN_OBJECT -> {
+                reader.beginObject()
+                while (reader.hasNext()) {
+                    val name = reader.nextName()
+                    when {
+                        name == "data" -> readEpgContainer(reader, collector, inheritedChannelId = null)
+                        reader.peek() == JsonToken.BEGIN_ARRAY ->
+                            readProgramArray(reader, collector, inheritedChannelId = name)
+                        else -> reader.skipValue()
+                    }
+                }
+                reader.endObject()
+            }
+            JsonToken.NULL -> reader.nextNull()
+            else -> reader.skipValue()
+        }
+    }
+
+    private fun readProgramArray(
+        reader: JsonReader,
+        collector: StalkerEpgCollector,
+        inheritedChannelId: String?
+    ) {
+        reader.beginArray()
+        while (reader.hasNext()) {
+            if (reader.peek() == JsonToken.BEGIN_OBJECT) {
+                collector.add(readProgram(reader, inheritedChannelId))
+            } else {
+                reader.skipValue()
+            }
+        }
+        reader.endArray()
+    }
+
+    private fun readProgram(reader: JsonReader, inheritedChannelId: String?): StalkerEpgProgram {
+        var chId: String? = inheritedChannelId
+        var name: String? = null
+        var descr: String? = null
+        var startTimestamp: String? = null
+        var stopTimestamp: String? = null
+        reader.beginObject()
+        while (reader.hasNext()) {
+            when (reader.nextName()) {
+                "ch_id", "channel_id" -> chId = reader.nextNullableString() ?: chId
+                "name", "title" -> name = reader.nextNullableString()
+                "descr", "description" -> descr = reader.nextNullableString()
+                "start_timestamp", "start" -> startTimestamp = reader.nextNullableString()
+                "stop_timestamp", "end_timestamp", "end" -> stopTimestamp = reader.nextNullableString()
+                else -> reader.skipValue()
+            }
+        }
+        reader.endObject()
+        return StalkerEpgProgram(chId, name, descr, startTimestamp, stopTimestamp)
+    }
+
+    private fun JsonReader.nextNullableString(): String? = when (peek()) {
+        JsonToken.NULL -> {
+            nextNull()
+            null
+        }
+        JsonToken.STRING, JsonToken.NUMBER, JsonToken.BOOLEAN -> nextString()
+        else -> {
+            skipValue()
+            null
+        }
+    }
+
+    private data class StalkerEpgParseResult(
+        val programs: List<StalkerEpgProgram> = emptyList(),
+        val sawProgramEntry: Boolean = false
+    )
+
+    private class StalkerEpgCollector(
+        private val notBeforeEpochSeconds: Long?,
+        private val maxProgramsPerChannel: Int
+    ) {
+        private val bounded = notBeforeEpochSeconds != null || maxProgramsPerChannel != Int.MAX_VALUE
+        private val programsByChannel = LinkedHashMap<String, MutableList<StalkerEpgProgram>>()
+        private val ungroupedPrograms = mutableListOf<StalkerEpgProgram>()
+        private var sawProgramEntry = false
+
+        fun add(program: StalkerEpgProgram) {
+            sawProgramEntry = true
+            val channelId = program.chId?.takeIf { it.isNotBlank() }
+            if (!bounded) {
+                if (channelId == null) ungroupedPrograms += program
+                else programsByChannel.getOrPut(channelId) { mutableListOf() } += program
+                return
+            }
+            if (channelId == null) return
+            val start = program.startTimestamp?.toLongOrNull() ?: return
+            val stop = program.stopTimestamp?.toLongOrNull() ?: return
+            if (stop <= start || (notBeforeEpochSeconds != null && stop <= notBeforeEpochSeconds)) return
+
+            val channelPrograms = programsByChannel.getOrPut(channelId) { mutableListOf() }
+            channelPrograms += program
+            if (channelPrograms.size > maxProgramsPerChannel) {
+                val latestIndex = channelPrograms.indices.maxBy { index ->
+                    channelPrograms[index].startTimestamp?.toLongOrNull() ?: Long.MAX_VALUE
+                }
+                channelPrograms.removeAt(latestIndex)
+            }
+        }
+
+        fun result(): StalkerEpgParseResult {
+            val programs = ArrayList<StalkerEpgProgram>(
+                ungroupedPrograms.size + programsByChannel.values.sumOf { it.size }
+            )
+            programs += ungroupedPrograms
+            programsByChannel.values.forEach { channelPrograms ->
+                programs += channelPrograms.sortedBy { it.startTimestamp?.toLongOrNull() ?: Long.MAX_VALUE }
+            }
+            return StalkerEpgParseResult(programs, sawProgramEntry)
         }
     }
 
@@ -264,7 +411,9 @@ open class StalkerApi(
             val url = "$apiBase/server/load.php?type=itv&action=get_short_epg&ch_id=$encodedChId&size=10&JsHttpRequest=1-xml"
             val response = doGet(url)
             val parsed = gson.fromJson(response, StalkerEpgResponse::class.java)
-            parsed?.js.orEmpty().filterNotNull()
+            parsed?.js.orEmpty().filterNotNull().map { program ->
+                if (program.chId.isNullOrBlank()) program.copy(chId = chId) else program
+            }
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
             System.err.println("[Stalker] get_short_epg failed for ch_id=$chId: ${e.message}")
@@ -288,11 +437,32 @@ open class StalkerApi(
         }
     }
 
-    open fun doGet(url: String): String {
+    private fun buildRequest(url: String): Request {
         val builder = Request.Builder().url(url)
         baseHeaders.forEach { (k, v) -> builder.addHeader(k, v) }
-        val response = client.newCall(builder.build()).execute()
-        return response.body?.string() ?: ""
+        return builder.build()
+    }
+
+    open fun doGet(url: String): String =
+        client.newCall(buildRequest(url)).execute().use { response ->
+            response.body?.string().orEmpty()
+        }
+
+    internal open fun doGetReader(url: String): Reader {
+        val response = client.newCall(buildRequest(url)).execute()
+        val body = response.body ?: run {
+            response.close()
+            return "".reader()
+        }
+        return object : FilterReader(body.charStream()) {
+            override fun close() {
+                try {
+                    super.close()
+                } finally {
+                    response.close()
+                }
+            }
+        }
     }
 
     // ── Response models ──

--- a/app/src/main/kotlin/com/arflix/tv/data/api/StalkerApi.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/api/StalkerApi.kt
@@ -250,6 +250,28 @@ open class StalkerApi(
         }
     }
 
+    /**
+     * Per-channel EPG fallback for portals whose `get_simple_data_table`/`get_epg_info`
+     * both come back empty (confirmed live on-device: 8/8 channels succeed on such a
+     * portal when neither bulk action returns anything). Response shape is the same flat
+     * `{"js":[...]}` array as `get_simple_data_table`. [chId] is the portal's own numeric
+     * channel id (the same value used as `ch_id` elsewhere, i.e. the last segment of our
+     * `stalker:<portalId>:<origId>` channel id).
+     */
+    suspend fun getShortEpg(chId: String): List<StalkerEpgProgram> {
+        return try {
+            val encodedChId = java.net.URLEncoder.encode(chId, "UTF-8")
+            val url = "$apiBase/server/load.php?type=itv&action=get_short_epg&ch_id=$encodedChId&size=10&JsHttpRequest=1-xml"
+            val response = doGet(url)
+            val parsed = gson.fromJson(response, StalkerEpgResponse::class.java)
+            parsed?.js.orEmpty().filterNotNull()
+        } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            System.err.println("[Stalker] get_short_epg failed for ch_id=$chId: ${e.message}")
+            emptyList()
+        }
+    }
+
     /** Resolve a channel's cmd to a playable stream URL */
     suspend fun resolveStreamUrl(cmd: String): String? {
         return try {

--- a/app/src/main/kotlin/com/arflix/tv/data/api/StalkerApi.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/api/StalkerApi.kt
@@ -192,9 +192,12 @@ open class StalkerApi(
     }
 
     /**
-     * `get_epg_info` response shape varies by portal build: either a flat `js`
-     * list (same as get_simple_data_table) or a `js` object keyed by channel id,
-     * each holding that channel's program list. Both are tried.
+     * `get_epg_info` response shape varies by portal build. Confirmed on-device
+     * against two different portals: `{"js":{"data":[]}}` (nothing available) and
+     * `{"js":{"data":{"<ch_id>":[{...program...}], ...}}}` (real data, one entry
+     * per channel id, ~tens of MB for a multi-thousand-channel portal). Some
+     * builds may skip the "data" wrapper and put the array/object directly under
+     * "js" (matching the get_simple_data_table shape) - both are handled.
      */
     private fun fetchEpgInfoFallback(dateParam: String): List<StalkerEpgProgram> {
         return try {
@@ -202,32 +205,35 @@ open class StalkerApi(
             val response = doGet(url)
             System.err.println("[Stalker] get_epg_info raw response (${response.length} chars): ${response.take(800)}")
 
-            // Parse the envelope first and inspect the "js" member's own shape -
-            // it's either a flat array or an object keyed by channel id, and
-            // trying to Gson-deserialize the whole envelope directly as one or
-            // the other (like get_simple_data_table's model does) mismatches
-            // whichever shape it isn't.
             val jsElement = runCatching {
                 com.google.gson.JsonParser.parseString(response).asJsonObject.get("js")
             }.getOrNull() ?: return emptyList()
 
+            // Unwrap the "data" wrapper when present; otherwise treat "js" itself
+            // as the array/object to parse (older/other portal builds).
+            val dataElement = if (jsElement.isJsonObject && jsElement.asJsonObject.has("data")) {
+                jsElement.asJsonObject.get("data")
+            } else {
+                jsElement
+            }
+
             when {
-                jsElement.isJsonArray -> {
+                dataElement.isJsonArray -> {
                     val listType = com.google.gson.reflect.TypeToken.getParameterized(
                         List::class.java, StalkerEpgProgram::class.java
                     ).type
                     runCatching {
-                        gson.fromJson<List<StalkerEpgProgram?>>(jsElement, listType)
+                        gson.fromJson<List<StalkerEpgProgram?>>(dataElement, listType)
                     }.getOrNull().orEmpty().filterNotNull()
                 }
-                jsElement.isJsonObject -> {
+                dataElement.isJsonObject -> {
                     val mapType = com.google.gson.reflect.TypeToken.getParameterized(
                         Map::class.java,
                         String::class.java,
                         com.google.gson.reflect.TypeToken.getParameterized(List::class.java, StalkerEpgProgram::class.java).type
                     ).type
                     val asMap = runCatching {
-                        gson.fromJson<Map<String, List<StalkerEpgProgram?>?>>(jsElement, mapType)
+                        gson.fromJson<Map<String, List<StalkerEpgProgram?>?>>(dataElement, mapType)
                     }.getOrNull().orEmpty()
                     asMap.flatMap { (channelId, programs) ->
                         programs.orEmpty().filterNotNull().map { program ->

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
@@ -1838,10 +1838,21 @@ class IptvRepository @Inject constructor(
                 cachedChannels = stalkerChannels
                 cachedGroupedChannels = grouped
                 cachedStalkerApis = stalkerApis
+                val stalkerNowNext = if (allowNetworkEpgFetch) {
+                    val fresh = runCatching {
+                        fetchStalkerEpgForActivePortals(stalkerApis, stalkerChannels)
+                    }.getOrDefault(emptyMap())
+                    if (fresh.isNotEmpty()) persistEpgIndexChannels(config, fresh, System.currentTimeMillis())
+                    fresh
+                } else {
+                    runCatching {
+                        epgIndex.loadNowNext(currentEpgIndexKey(config), stalkerChannels.asSequence().map { it.id }.toSet())
+                    }.getOrDefault(emptyMap())
+                }
                 val snapshot = IptvSnapshot(
                     channels = stalkerChannels,
                     grouped = grouped,
-                    nowNext = emptyMap(),
+                    nowNext = stalkerNowNext,
                     favoriteGroups = favGroups,
                     favoriteChannels = favChannels,
                     hiddenGroups = hiddenGroups,
@@ -2244,6 +2255,46 @@ class IptvRepository @Inject constructor(
                 }
                 resolvedNowNext
             }
+
+            // Stalker channels never had an epgCandidate/Xtream path above, so merge
+            // their now/next data in here — additive only, never overwrites data the
+            // M3U/Xtream/XMLTV resolution above already found for a channel (C1/C4/C6).
+            val stalkerChannelsInSnapshot = if (stalkerPortals.isNotEmpty()) {
+                channels.filter { StalkerPortalSupport.portalIdFromChannelId(it.id) != null }
+            } else {
+                emptyList()
+            }
+            val stalkerNowNextHybrid = if (stalkerChannelsInSnapshot.isNotEmpty()) {
+                if (allowNetworkEpgFetch) {
+                    val fresh = runCatching {
+                        fetchStalkerEpgForActivePortals(cachedStalkerApis, stalkerChannelsInSnapshot)
+                    }.getOrDefault(emptyMap())
+                    if (fresh.isNotEmpty()) {
+                        persistEpgIndexChannels(config, fresh, System.currentTimeMillis())
+                        epgUpdated = true
+                    }
+                    fresh
+                } else {
+                    runCatching {
+                        epgIndex.loadNowNext(
+                            currentEpgIndexKey(config),
+                            stalkerChannelsInSnapshot.asSequence().map { it.id }.toSet()
+                        )
+                    }.getOrDefault(emptyMap())
+                }
+            } else {
+                emptyMap()
+            }
+            val finalNowNext = if (stalkerNowNextHybrid.isEmpty()) {
+                nowNext
+            } else {
+                HashMap(nowNext).apply {
+                    stalkerNowNextHybrid.forEach { (channelId, value) ->
+                        if (!hasProgramData(this[channelId])) this[channelId] = value
+                    }
+                }
+            }
+
             val epgFailure = epgFailureMessage
             val epgWarning = if (epgCandidates.isNotEmpty() && nowNext.isEmpty()) {
                 if (!epgFailure.isNullOrBlank()) {
@@ -2270,7 +2321,7 @@ class IptvRepository @Inject constructor(
             IptvSnapshot(
                 channels = channels,
                 grouped = grouped,
-                nowNext = nowNext,
+                nowNext = finalNowNext,
                 favoriteGroups = favoriteGroups,
                 favoriteChannels = favoriteChannels,
                 hiddenGroups = hiddenGroups,
@@ -2282,7 +2333,7 @@ class IptvRepository @Inject constructor(
                     writeCache(
                         config = config,
                         channels = channels,
-                        nowNext = nowNext,
+                        nowNext = finalNowNext,
                         loadedAtMs = System.currentTimeMillis()
                     )
                 }
@@ -6222,6 +6273,86 @@ class IptvRepository @Inject constructor(
             }
         }
         return merged.takeIf { hasAnyProgramData(it) }
+    }
+
+    /**
+     * Fetches now/next EPG data from every active Stalker portal and returns it keyed by
+     * the same `stalker:<portalId>:<origId>` channel ids the portal's channel list already
+     * uses (see [StalkerPortalSupport]) — no separate EPG-index source key needed, isolation
+     * comes from the channel id prefix like everywhere else.
+     */
+    private suspend fun fetchStalkerEpgForActivePortals(
+        stalkerApis: Map<String, com.arflix.tv.data.api.StalkerApi>,
+        stalkerChannels: List<IptvChannel>
+    ): Map<String, IptvNowNext> {
+        if (stalkerApis.isEmpty() || stalkerChannels.isEmpty()) return emptyMap()
+        val nowMs = System.currentTimeMillis()
+        val merged = ConcurrentHashMap<String, IptvNowNext>()
+        coroutineScope {
+            stalkerApis.entries.map { (portalId, api) ->
+                async {
+                    val portalChannels = stalkerChannels.filter {
+                        StalkerPortalSupport.portalIdFromChannelId(it.id) == portalId
+                    }
+                    if (portalChannels.isEmpty()) return@async
+                    // Stalker's ch_id is the portal's own numeric id, i.e. the last
+                    // segment of our "stalker:<portalId>:<origId>" channel id.
+                    val origIdToChannelId = portalChannels.associateBy(
+                        keySelector = { it.id.substringAfterLast(':') },
+                        valueTransform = { it.id }
+                    )
+                    val programs = runCatching { api.getEpg() }.getOrElse { error ->
+                        if (error is kotlinx.coroutines.CancellationException) throw error
+                        System.err.println("[Stalker-EPG] Portal $portalId EPG fetch failed: ${error.message}")
+                        emptyList()
+                    }
+                    if (programs.isEmpty()) return@async
+
+                    val byChannel = LinkedHashMap<String, MutableList<IptvProgram>>()
+                    for (p in programs) {
+                        val channelId = p.chId?.let { origIdToChannelId[it] } ?: continue
+                        val startMs = p.startTimestamp?.toLongOrNull()?.let { it * 1000L } ?: continue
+                        val stopMs = p.stopTimestamp?.toLongOrNull()?.let { it * 1000L } ?: continue
+                        if (stopMs <= startMs) continue
+                        byChannel.getOrPut(channelId) { mutableListOf() } += IptvProgram(
+                            title = p.name?.takeIf { it.isNotBlank() } ?: context.getString(R.string.program_no_title),
+                            description = p.descr?.takeIf { it.isNotBlank() },
+                            startUtcMillis = startMs,
+                            endUtcMillis = stopMs
+                        )
+                    }
+                    byChannel.forEach { (channelId, channelPrograms) ->
+                        stalkerNowNextFromPrograms(channelPrograms, nowMs)?.let { merged[channelId] = it }
+                    }
+                }
+            }.awaitAll()
+        }
+        return merged
+    }
+
+    /**
+     * Compacts one channel's programs into a now/next slice. Unlike the Xtream/XMLTV
+     * paths this keeps no "recent" history — Stalker catchup isn't in scope here (K10).
+     */
+    private fun stalkerNowNextFromPrograms(programs: List<IptvProgram>, nowMs: Long): IptvNowNext? {
+        val sorted = programs.sortedBy { it.startUtcMillis }
+        var now: IptvProgram? = null
+        var next: IptvProgram? = null
+        var later: IptvProgram? = null
+        val upcoming = mutableListOf<IptvProgram>()
+        for (p in sorted) {
+            when {
+                p.isLive(nowMs) -> now = p
+                p.startUtcMillis > nowMs && next == null -> next = p
+                p.startUtcMillis > nowMs && later == null -> later = p
+                p.startUtcMillis > nowMs -> {
+                    upcoming.add(p)
+                    if (upcoming.size >= epgUpcomingProgramLimit) break
+                }
+            }
+        }
+        if (now == null && next == null && later == null && upcoming.isEmpty()) return null
+        return IptvNowNext(now = now, next = next, later = later, upcoming = upcoming)
     }
 
     private fun addChannelIdToLookup(

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
@@ -429,6 +429,16 @@ class IptvRepository @Inject constructor(
     private val fullCatchupHistoryChannelLimit = 4
     private val xtreamShortEpgBatchSize = 1024
     private val xtreamShortEpgConcurrency = 64
+
+    // Per-channel `get_short_epg` fallback (portals whose bulk EPG actions return
+    // nothing, e.g. get_simple_data_table/get_epg_info both empty - confirmed
+    // live). Only worth doing for small batches (the on-demand visible-guide
+    // refresh, typically tens of channels); a full-catalog backfill can be
+    // thousands of channels and would hammer the portal with that many
+    // individual requests, so it's skipped above this cap and that batch
+    // simply gets no EPG until it's requested via the on-demand path instead.
+    private val stalkerShortEpgFallbackMaxChannels = 100
+    private val stalkerShortEpgFallbackConcurrency = 8
     private val cacheUpcomingProgramLimit = 48
     private val cacheRecentProgramLimit = 1
     private val cacheCatchupRecentProgramLimit = 96
@@ -6338,12 +6348,41 @@ class IptvRepository @Inject constructor(
                         valueTransform = { it.id }
                     )
                     System.err.println("[Stalker-EPG] Portal $portalId: requesting getEpg() for ${portalChannels.size} channels")
-                    val programs = runCatching { api.getEpg() }.getOrElse { error ->
+                    var programs = runCatching { api.getEpg() }.getOrElse { error ->
                         if (error is kotlinx.coroutines.CancellationException) throw error
                         System.err.println("[Stalker-EPG] Portal $portalId EPG fetch failed: ${error.message}")
                         emptyList()
                     }
                     System.err.println("[Stalker-EPG] Portal $portalId: getEpg() returned ${programs.size} raw entries")
+
+                    // Bulk EPG actions confirmed empty on some portal builds -
+                    // fall back to get_short_epg per channel. Only for small
+                    // batches (see stalkerShortEpgFallbackMaxChannels comment).
+                    if (programs.isEmpty() && origIdToChannelId.size <= stalkerShortEpgFallbackMaxChannels) {
+                        System.err.println(
+                            "[Stalker-EPG] Portal $portalId: bulk EPG empty, falling back to " +
+                                "get_short_epg for ${origIdToChannelId.size} channels"
+                        )
+                        val gate = Semaphore(stalkerShortEpgFallbackConcurrency)
+                        val shortEpgResult = ConcurrentLinkedQueue<com.arflix.tv.data.api.StalkerApi.StalkerEpgProgram>()
+                        coroutineScope {
+                            origIdToChannelId.keys.map { origId ->
+                                async {
+                                    gate.withPermit {
+                                        val channelPrograms = runCatching { api.getShortEpg(origId) }.getOrElse { error ->
+                                            if (error is kotlinx.coroutines.CancellationException) throw error
+                                            emptyList()
+                                        }
+                                        shortEpgResult.addAll(channelPrograms)
+                                    }
+                                }
+                            }.awaitAll()
+                        }
+                        programs = shortEpgResult.toList()
+                        System.err.println(
+                            "[Stalker-EPG] Portal $portalId: get_short_epg fallback returned ${programs.size} raw entries"
+                        )
+                    }
                     if (programs.isEmpty()) return@async
 
                     val byChannel = LinkedHashMap<String, MutableList<IptvProgram>>()

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
@@ -246,21 +246,32 @@ class IptvRepository @Inject constructor(
     @Volatile
     private var cachedStalkerApis: Map<String, com.arflix.tv.data.api.StalkerApi> = emptyMap()
 
-    /**
-     * Short-lived cache of each portal's raw `getEpg()` bulk result (see
-     * [fetchStalkerEpgForActivePortals]). Without this, every small on-demand
-     * visible-guide batch (`refreshEpgForChannels`, often called every few
-     * seconds while scrolling/switching channels) re-fetches the full bulk
-     * response from scratch - confirmed live on a large portal to be ~25 MB,
-     * taking 1.5-5s per fetch. `now/next` data doesn't need second-level
-     * freshness, so a short TTL is enough to remove the redundant re-fetch.
-     */
+    private data class StalkerEpgPortalCacheKey(
+        val portalId: String,
+        val apiIdentity: String
+    )
+
+    /** Compact, timestamp-safe guide slices produced from the streamed bulk response. */
     private data class StalkerEpgCacheEntry(
         val fetchedAtMs: Long,
-        val programs: List<com.arflix.tv.data.api.StalkerApi.StalkerEpgProgram>
+        val programsByChannel: Map<String, List<IptvProgram>>
     )
-    private val stalkerEpgCache = ConcurrentHashMap<String, StalkerEpgCacheEntry>()
+
+    private data class StalkerShortEpgCacheKey(
+        val portal: StalkerEpgPortalCacheKey,
+        val originalChannelId: String
+    )
+
+    private data class StalkerShortEpgCacheEntry(
+        val fetchedAtMs: Long,
+        val programs: List<IptvProgram>
+    )
+
+    private val stalkerEpgCache = ConcurrentHashMap<StalkerEpgPortalCacheKey, StalkerEpgCacheEntry>()
+    private val stalkerShortEpgCache = ConcurrentHashMap<StalkerShortEpgCacheKey, StalkerShortEpgCacheEntry>()
     private val stalkerEpgCacheTtlMs = 5 * 60 * 1000L
+    private val stalkerShortEpgCacheTtlMs = 2 * 60 * 1000L
+    private val stalkerBulkProgramsPerChannelLimit = 16
 
     /**
      * Public accessor kept for compatibility with code that previously read the
@@ -3212,6 +3223,8 @@ class IptvRepository @Inject constructor(
         cachedNowNext = ConcurrentHashMap()
         cachedPlaylistAt = 0L
         cachedEpgAt = 0L
+        stalkerEpgCache.clear()
+        stalkerShortEpgCache.clear()
         discoveredM3uEpgUrls.clear()
         xtreamVodCacheKey = null
         xtreamVodLoadedAtMs = 0L
@@ -6363,90 +6376,125 @@ class IptvRepository @Inject constructor(
                         keySelector = { it.id.substringAfterLast(':') },
                         valueTransform = { it.id }
                     )
-                    val cachedBulk = stalkerEpgCache[portalId]
-                    var programs = if (cachedBulk != null && nowMs - cachedBulk.fetchedAtMs < stalkerEpgCacheTtlMs) {
+                    val portalCacheKey = StalkerEpgPortalCacheKey(portalId, api.epgCacheIdentity)
+                    val cachedBulk = stalkerEpgCache[portalCacheKey]
+                    var programsByOriginalChannel = if (
+                        cachedBulk != null && nowMs - cachedBulk.fetchedAtMs < stalkerEpgCacheTtlMs
+                    ) {
                         System.err.println(
                             "[Stalker-EPG] Portal $portalId: using cached getEpg() result " +
-                                "(${cachedBulk.programs.size} entries, age=${nowMs - cachedBulk.fetchedAtMs}ms)"
+                                "(${cachedBulk.programsByChannel.size} channels, age=${nowMs - cachedBulk.fetchedAtMs}ms)"
                         )
-                        cachedBulk.programs
+                        cachedBulk.programsByChannel
                     } else {
                         System.err.println("[Stalker-EPG] Portal $portalId: requesting getEpg() for ${portalChannels.size} channels")
-                        val fetched = runCatching { api.getEpg() }.getOrElse { error ->
+                        val fetched = runCatching {
+                            api.getEpg(
+                                notBeforeEpochSeconds = nowMs / 1000L,
+                                maxProgramsPerChannel = stalkerBulkProgramsPerChannelLimit
+                            )
+                        }.getOrElse { error ->
                             if (error is kotlinx.coroutines.CancellationException) throw error
                             System.err.println("[Stalker-EPG] Portal $portalId EPG fetch failed: ${error.message}")
                             emptyList()
                         }
-                        stalkerEpgCache[portalId] = StalkerEpgCacheEntry(nowMs, fetched)
-                        fetched
+                        val compact = compactStalkerProgramsByChannel(fetched, nowMs)
+                        stalkerEpgCache[portalCacheKey] = StalkerEpgCacheEntry(nowMs, compact)
+                        compact
                     }
-                    System.err.println("[Stalker-EPG] Portal $portalId: getEpg() returned ${programs.size} raw entries")
+                    System.err.println(
+                        "[Stalker-EPG] Portal $portalId: getEpg() retained " +
+                            "${programsByOriginalChannel.size} channels"
+                    )
 
                     // Bulk EPG actions confirmed empty on some portal builds -
                     // fall back to get_short_epg per channel. Only for small
                     // batches (see stalkerShortEpgFallbackMaxChannels comment).
-                    if (programs.isEmpty() && origIdToChannelId.size <= stalkerShortEpgFallbackMaxChannels) {
+                    if (
+                        programsByOriginalChannel.isEmpty() &&
+                        origIdToChannelId.size <= stalkerShortEpgFallbackMaxChannels
+                    ) {
                         System.err.println(
                             "[Stalker-EPG] Portal $portalId: bulk EPG empty, falling back to " +
                                 "get_short_epg for ${origIdToChannelId.size} channels"
                         )
                         val gate = Semaphore(stalkerShortEpgFallbackConcurrency)
-                        val shortEpgResult = ConcurrentLinkedQueue<com.arflix.tv.data.api.StalkerApi.StalkerEpgProgram>()
+                        val shortEpgResult = ConcurrentHashMap<String, List<IptvProgram>>()
                         coroutineScope {
                             origIdToChannelId.keys.map { origId ->
                                 async {
                                     gate.withPermit {
-                                        val channelPrograms = runCatching { api.getShortEpg(origId) }.getOrElse { error ->
-                                            if (error is kotlinx.coroutines.CancellationException) throw error
-                                            emptyList()
+                                        val shortCacheKey = StalkerShortEpgCacheKey(portalCacheKey, origId)
+                                        val cachedShort = stalkerShortEpgCache[shortCacheKey]
+                                        val channelPrograms = if (
+                                            cachedShort != null &&
+                                            nowMs - cachedShort.fetchedAtMs < stalkerShortEpgCacheTtlMs
+                                        ) {
+                                            cachedShort.programs
+                                        } else {
+                                            val fetched = runCatching { api.getShortEpg(origId) }.getOrElse { error ->
+                                                if (error is kotlinx.coroutines.CancellationException) throw error
+                                                emptyList()
+                                            }
+                                            val compact = compactStalkerProgramsByChannel(fetched, nowMs)[origId].orEmpty()
+                                            stalkerShortEpgCache[shortCacheKey] =
+                                                StalkerShortEpgCacheEntry(nowMs, compact)
+                                            compact
                                         }
-                                        shortEpgResult.addAll(channelPrograms)
+                                        shortEpgResult[origId] = channelPrograms
                                     }
                                 }
                             }.awaitAll()
                         }
-                        programs = shortEpgResult.toList()
+                        programsByOriginalChannel = shortEpgResult
                         System.err.println(
-                            "[Stalker-EPG] Portal $portalId: get_short_epg fallback returned ${programs.size} raw entries"
+                            "[Stalker-EPG] Portal $portalId: get_short_epg fallback retained " +
+                                "${programsByOriginalChannel.count { it.value.isNotEmpty() }} channels"
                         )
                     }
-                    if (programs.isEmpty()) return@async
+                    if (programsByOriginalChannel.isEmpty()) return@async
 
-                    val byChannel = LinkedHashMap<String, MutableList<IptvProgram>>()
                     var skippedUnknownChannel = 0
-                    var skippedBadTimestamp = 0
-                    for (p in programs) {
-                        val channelId = p.chId?.let { origIdToChannelId[it] }
+                    programsByOriginalChannel.forEach { (originalChannelId, channelPrograms) ->
+                        val channelId = origIdToChannelId[originalChannelId]
                         if (channelId == null) {
-                            skippedUnknownChannel++
-                            continue
+                            skippedUnknownChannel += channelPrograms.size
+                            return@forEach
                         }
-                        val startMs = p.startTimestamp?.toLongOrNull()?.let { it * 1000L }
-                        val stopMs = p.stopTimestamp?.toLongOrNull()?.let { it * 1000L }
-                        if (startMs == null || stopMs == null || stopMs <= startMs) {
-                            skippedBadTimestamp++
-                            continue
-                        }
-                        byChannel.getOrPut(channelId) { mutableListOf() } += IptvProgram(
-                            title = p.name?.takeIf { it.isNotBlank() } ?: context.getString(R.string.program_no_title),
-                            description = p.descr?.takeIf { it.isNotBlank() },
-                            startUtcMillis = startMs,
-                            endUtcMillis = stopMs
-                        )
-                    }
-                    System.err.println(
-                        "[Stalker-EPG] Portal $portalId: matched ${byChannel.size} channels, " +
-                            "skippedUnknownChannel=$skippedUnknownChannel skippedBadTimestamp=$skippedBadTimestamp " +
-                            "sampleReturnedChIds=${programs.take(3).map { it.chId }} sampleExpectedIds=${origIdToChannelId.keys.take(3)}"
-                    )
-                    byChannel.forEach { (channelId, channelPrograms) ->
                         stalkerNowNextFromPrograms(channelPrograms, nowMs)?.let { merged[channelId] = it }
                     }
+                    System.err.println(
+                        "[Stalker-EPG] Portal $portalId: matched ${merged.size} channels, " +
+                            "skippedUnknownChannel=$skippedUnknownChannel"
+                    )
                 }
             }.awaitAll()
         }
         System.err.println("[Stalker-EPG] fetchStalkerEpgForActivePortals result: ${merged.size} channels with data")
         return merged
+    }
+
+    private fun compactStalkerProgramsByChannel(
+        programs: List<com.arflix.tv.data.api.StalkerApi.StalkerEpgProgram>,
+        nowMs: Long
+    ): Map<String, List<IptvProgram>> {
+        val byChannel = LinkedHashMap<String, MutableList<IptvProgram>>()
+        programs.forEach { program ->
+            val channelId = program.chId?.takeIf { it.isNotBlank() } ?: return@forEach
+            val startMs = program.startTimestamp?.toLongOrNull()?.let { it * 1000L } ?: return@forEach
+            val stopMs = program.stopTimestamp?.toLongOrNull()?.let { it * 1000L } ?: return@forEach
+            if (stopMs <= startMs || stopMs <= nowMs) return@forEach
+            byChannel.getOrPut(channelId) { mutableListOf() } += IptvProgram(
+                title = program.name?.takeIf { it.isNotBlank() }
+                    ?: context.getString(R.string.program_no_title),
+                description = program.descr?.takeIf { it.isNotBlank() },
+                startUtcMillis = startMs,
+                endUtcMillis = stopMs
+            )
+        }
+        return byChannel.mapValues { (_, channelPrograms) ->
+            channelPrograms.sortedBy { it.startUtcMillis }
+        }
     }
 
     /**

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
@@ -2853,6 +2853,23 @@ class IptvRepository @Inject constructor(
                     mergedNowNext.putAll(freshNowNext)
                 }
             }
+
+            // Stalker channels never have Xtream credentials, so the loop above never
+            // touches them - without this they'd silently fall through to the XMLTV
+            // fallback below (which also can't help them) and this on-demand refresh,
+            // used all over the visible guide/grid, would return nothing for them.
+            val stalkerRequestedChannels = channels.filter {
+                StalkerPortalSupport.portalIdFromChannelId(it.id) != null
+            }
+            if (stalkerRequestedChannels.isNotEmpty()) {
+                val stalkerFresh = runCatching {
+                    fetchStalkerEpgForActivePortals(cachedStalkerApis, stalkerRequestedChannels)
+                }.getOrDefault(emptyMap())
+                if (stalkerFresh.isNotEmpty()) {
+                    mergedNowNext.putAll(stalkerFresh)
+                }
+            }
+
             val missingXmlChannels = channels.filter { channel ->
                 !hasProgramData(mergedNowNext[channel.id])
             }

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
@@ -247,6 +247,22 @@ class IptvRepository @Inject constructor(
     private var cachedStalkerApis: Map<String, com.arflix.tv.data.api.StalkerApi> = emptyMap()
 
     /**
+     * Short-lived cache of each portal's raw `getEpg()` bulk result (see
+     * [fetchStalkerEpgForActivePortals]). Without this, every small on-demand
+     * visible-guide batch (`refreshEpgForChannels`, often called every few
+     * seconds while scrolling/switching channels) re-fetches the full bulk
+     * response from scratch - confirmed live on a large portal to be ~25 MB,
+     * taking 1.5-5s per fetch. `now/next` data doesn't need second-level
+     * freshness, so a short TTL is enough to remove the redundant re-fetch.
+     */
+    private data class StalkerEpgCacheEntry(
+        val fetchedAtMs: Long,
+        val programs: List<com.arflix.tv.data.api.StalkerApi.StalkerEpgProgram>
+    )
+    private val stalkerEpgCache = ConcurrentHashMap<String, StalkerEpgCacheEntry>()
+    private val stalkerEpgCacheTtlMs = 5 * 60 * 1000L
+
+    /**
      * Public accessor kept for compatibility with code that previously read the
      * single cached Stalker API instance. Returns the first cached portal API.
      */
@@ -6347,11 +6363,22 @@ class IptvRepository @Inject constructor(
                         keySelector = { it.id.substringAfterLast(':') },
                         valueTransform = { it.id }
                     )
-                    System.err.println("[Stalker-EPG] Portal $portalId: requesting getEpg() for ${portalChannels.size} channels")
-                    var programs = runCatching { api.getEpg() }.getOrElse { error ->
-                        if (error is kotlinx.coroutines.CancellationException) throw error
-                        System.err.println("[Stalker-EPG] Portal $portalId EPG fetch failed: ${error.message}")
-                        emptyList()
+                    val cachedBulk = stalkerEpgCache[portalId]
+                    var programs = if (cachedBulk != null && nowMs - cachedBulk.fetchedAtMs < stalkerEpgCacheTtlMs) {
+                        System.err.println(
+                            "[Stalker-EPG] Portal $portalId: using cached getEpg() result " +
+                                "(${cachedBulk.programs.size} entries, age=${nowMs - cachedBulk.fetchedAtMs}ms)"
+                        )
+                        cachedBulk.programs
+                    } else {
+                        System.err.println("[Stalker-EPG] Portal $portalId: requesting getEpg() for ${portalChannels.size} channels")
+                        val fetched = runCatching { api.getEpg() }.getOrElse { error ->
+                            if (error is kotlinx.coroutines.CancellationException) throw error
+                            System.err.println("[Stalker-EPG] Portal $portalId EPG fetch failed: ${error.message}")
+                            emptyList()
+                        }
+                        stalkerEpgCache[portalId] = StalkerEpgCacheEntry(nowMs, fetched)
+                        fetched
                     }
                     System.err.println("[Stalker-EPG] Portal $portalId: getEpg() returned ${programs.size} raw entries")
 

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
@@ -1838,6 +1838,10 @@ class IptvRepository @Inject constructor(
                 cachedChannels = stalkerChannels
                 cachedGroupedChannels = grouped
                 cachedStalkerApis = stalkerApis
+                System.err.println(
+                    "[EPG] loadSnapshot Stalker-only: allowNetworkEpgFetch=$allowNetworkEpgFetch " +
+                        "apis=${stalkerApis.keys} channels=${stalkerChannels.size}"
+                )
                 val stalkerNowNext = if (allowNetworkEpgFetch) {
                     val fresh = runCatching {
                         fetchStalkerEpgForActivePortals(stalkerApis, stalkerChannels)
@@ -2722,6 +2726,7 @@ class IptvRepository @Inject constructor(
                 channelIds
             }
             val channels = channelsForEpgRefresh(requested)
+            System.err.println("[EPG-Refresh] refreshEpgForChannels: requested=${requested.size} resolved=${channels.size}")
             if (channels.isEmpty()) return@withContext null
 
             val activePlaylistById = activePlaylists(config).associateBy { it.id }
@@ -2861,10 +2866,17 @@ class IptvRepository @Inject constructor(
             val stalkerRequestedChannels = channels.filter {
                 StalkerPortalSupport.portalIdFromChannelId(it.id) != null
             }
+            System.err.println(
+                "[EPG-Refresh] refreshEpgForChannels: batch=${channels.size} " +
+                    "stalkerChannels=${stalkerRequestedChannels.size} cachedStalkerApis=${cachedStalkerApis.keys}"
+            )
             if (stalkerRequestedChannels.isNotEmpty()) {
                 val stalkerFresh = runCatching {
                     fetchStalkerEpgForActivePortals(cachedStalkerApis, stalkerRequestedChannels)
-                }.getOrDefault(emptyMap())
+                }.getOrElse { error ->
+                    System.err.println("[EPG-Refresh] fetchStalkerEpgForActivePortals threw: ${error.message}")
+                    emptyMap()
+                }
                 if (stalkerFresh.isNotEmpty()) {
                     mergedNowNext.putAll(stalkerFresh)
                 }
@@ -6302,7 +6314,11 @@ class IptvRepository @Inject constructor(
         stalkerApis: Map<String, com.arflix.tv.data.api.StalkerApi>,
         stalkerChannels: List<IptvChannel>
     ): Map<String, IptvNowNext> {
-        if (stalkerApis.isEmpty() || stalkerChannels.isEmpty()) return emptyMap()
+        System.err.println("[Stalker-EPG] fetchStalkerEpgForActivePortals called: apis=${stalkerApis.keys} channels=${stalkerChannels.size}")
+        if (stalkerApis.isEmpty() || stalkerChannels.isEmpty()) {
+            System.err.println("[Stalker-EPG] Nothing to fetch (apis or channels empty), returning early")
+            return emptyMap()
+        }
         val nowMs = System.currentTimeMillis()
         val merged = ConcurrentHashMap<String, IptvNowNext>()
         coroutineScope {
@@ -6311,26 +6327,40 @@ class IptvRepository @Inject constructor(
                     val portalChannels = stalkerChannels.filter {
                         StalkerPortalSupport.portalIdFromChannelId(it.id) == portalId
                     }
-                    if (portalChannels.isEmpty()) return@async
+                    if (portalChannels.isEmpty()) {
+                        System.err.println("[Stalker-EPG] Portal $portalId: no channels in batch, skipping")
+                        return@async
+                    }
                     // Stalker's ch_id is the portal's own numeric id, i.e. the last
                     // segment of our "stalker:<portalId>:<origId>" channel id.
                     val origIdToChannelId = portalChannels.associateBy(
                         keySelector = { it.id.substringAfterLast(':') },
                         valueTransform = { it.id }
                     )
+                    System.err.println("[Stalker-EPG] Portal $portalId: requesting getEpg() for ${portalChannels.size} channels")
                     val programs = runCatching { api.getEpg() }.getOrElse { error ->
                         if (error is kotlinx.coroutines.CancellationException) throw error
                         System.err.println("[Stalker-EPG] Portal $portalId EPG fetch failed: ${error.message}")
                         emptyList()
                     }
+                    System.err.println("[Stalker-EPG] Portal $portalId: getEpg() returned ${programs.size} raw entries")
                     if (programs.isEmpty()) return@async
 
                     val byChannel = LinkedHashMap<String, MutableList<IptvProgram>>()
+                    var skippedUnknownChannel = 0
+                    var skippedBadTimestamp = 0
                     for (p in programs) {
-                        val channelId = p.chId?.let { origIdToChannelId[it] } ?: continue
-                        val startMs = p.startTimestamp?.toLongOrNull()?.let { it * 1000L } ?: continue
-                        val stopMs = p.stopTimestamp?.toLongOrNull()?.let { it * 1000L } ?: continue
-                        if (stopMs <= startMs) continue
+                        val channelId = p.chId?.let { origIdToChannelId[it] }
+                        if (channelId == null) {
+                            skippedUnknownChannel++
+                            continue
+                        }
+                        val startMs = p.startTimestamp?.toLongOrNull()?.let { it * 1000L }
+                        val stopMs = p.stopTimestamp?.toLongOrNull()?.let { it * 1000L }
+                        if (startMs == null || stopMs == null || stopMs <= startMs) {
+                            skippedBadTimestamp++
+                            continue
+                        }
                         byChannel.getOrPut(channelId) { mutableListOf() } += IptvProgram(
                             title = p.name?.takeIf { it.isNotBlank() } ?: context.getString(R.string.program_no_title),
                             description = p.descr?.takeIf { it.isNotBlank() },
@@ -6338,12 +6368,18 @@ class IptvRepository @Inject constructor(
                             endUtcMillis = stopMs
                         )
                     }
+                    System.err.println(
+                        "[Stalker-EPG] Portal $portalId: matched ${byChannel.size} channels, " +
+                            "skippedUnknownChannel=$skippedUnknownChannel skippedBadTimestamp=$skippedBadTimestamp " +
+                            "sampleReturnedChIds=${programs.take(3).map { it.chId }} sampleExpectedIds=${origIdToChannelId.keys.take(3)}"
+                    )
                     byChannel.forEach { (channelId, channelPrograms) ->
                         stalkerNowNextFromPrograms(channelPrograms, nowMs)?.let { merged[channelId] = it }
                     }
                 }
             }.awaitAll()
         }
+        System.err.println("[Stalker-EPG] fetchStalkerEpgForActivePortals result: ${merged.size} channels with data")
         return merged
     }
 

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
@@ -6281,7 +6281,7 @@ class IptvRepository @Inject constructor(
      * uses (see [StalkerPortalSupport]) — no separate EPG-index source key needed, isolation
      * comes from the channel id prefix like everywhere else.
      */
-    private suspend fun fetchStalkerEpgForActivePortals(
+    internal suspend fun fetchStalkerEpgForActivePortals(
         stalkerApis: Map<String, com.arflix.tv.data.api.StalkerApi>,
         stalkerChannels: List<IptvChannel>
     ): Map<String, IptvNowNext> {
@@ -6334,7 +6334,7 @@ class IptvRepository @Inject constructor(
      * Compacts one channel's programs into a now/next slice. Unlike the Xtream/XMLTV
      * paths this keeps no "recent" history — Stalker catchup isn't in scope here (K10).
      */
-    private fun stalkerNowNextFromPrograms(programs: List<IptvProgram>, nowMs: Long): IptvNowNext? {
+    internal fun stalkerNowNextFromPrograms(programs: List<IptvProgram>, nowMs: Long): IptvNowNext? {
         val sorted = programs.sortedBy { it.startUtcMillis }
         var now: IptvProgram? = null
         var next: IptvProgram? = null

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/TvViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/TvViewModel.kt
@@ -1057,8 +1057,12 @@ class TvViewModel @Inject constructor(
             )
             return
         }
+        // Stalker channels never carry epgId/tvgName (M3U/Xtream identity fields) - they're
+        // matched by channel id instead (see StalkerApi.getEpg/IptvRepository), so treat a
+        // Stalker channel id as its own "has identity for guide backfill" signal too.
         if (!force && channels.none { channel ->
-                !channel.epgId.isNullOrBlank() || !channel.tvgName.isNullOrBlank()
+                !channel.epgId.isNullOrBlank() || !channel.tvgName.isNullOrBlank() ||
+                    StalkerPortalSupport.portalIdFromChannelId(channel.id) != null
             }
         ) {
             AppLogger.breadcrumb(

--- a/app/src/test/kotlin/com/arflix/tv/data/api/StalkerApiTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/api/StalkerApiTest.kt
@@ -352,6 +352,45 @@ class StalkerApiTest {
     }
 
     @Test
+    fun `getEpg get_epg_info fallback parses the confirmed data-wrapped per-channel shape`() = runTest {
+        // Confirmed on-device response shape: {"js":{"data":{"<ch_id>":[...]}}}.
+        val requests = mutableListOf<String>()
+        val api = stubApi(requests = requests) { url ->
+            when {
+                url.contains("action=get_simple_data_table") -> """{ "js": [] }"""
+                url.contains("action=get_epg_info") ->
+                    """{ "js": { "data": {
+                        "1359": [{ "ch_id": "1359", "name": "Beestenboel", "start_timestamp": "1788110700", "stop_timestamp": "1788113400" }]
+                    } } }"""
+                else -> null
+            }
+        }
+
+        val programs = api.getEpg()
+
+        assertEquals(1, programs.size)
+        assertEquals("1359", programs[0].chId)
+        assertEquals("Beestenboel", programs[0].name)
+    }
+
+    @Test
+    fun `getEpg get_epg_info fallback returns empty list for the confirmed empty data-wrapped shape`() = runTest {
+        // Confirmed on-device response shape when a portal has no programs: {"js":{"data":[]}}.
+        val requests = mutableListOf<String>()
+        val api = stubApi(requests = requests) { url ->
+            when {
+                url.contains("action=get_simple_data_table") -> """{ "js": [] }"""
+                url.contains("action=get_epg_info") -> """{ "js": { "data": [] } }"""
+                else -> null
+            }
+        }
+
+        val programs = api.getEpg()
+
+        assertTrue(programs.isEmpty())
+    }
+
+    @Test
     fun `getEpg get_epg_info fallback parses a per-channel object shape`() = runTest {
         val requests = mutableListOf<String>()
         val api = stubApi(requests = requests) { url ->

--- a/app/src/test/kotlin/com/arflix/tv/data/api/StalkerApiTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/api/StalkerApiTest.kt
@@ -5,6 +5,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.io.Reader
 
 private const val PORTAL = "http://portal.example.com"
 private const val MAC = "00:1A:79:AA:BB:CC"
@@ -20,6 +21,11 @@ class StalkerApiTest {
             override fun doGet(url: String): String {
                 requests += url
                 return respond(url) ?: error("Unexpected url: $url")
+            }
+
+            override fun doGetReader(url: String): Reader {
+                requests += url
+                return (respond(url) ?: error("Unexpected url: $url")).reader()
             }
         }
 
@@ -297,6 +303,29 @@ class StalkerApiTest {
     }
 
     @Test
+    fun `getEpg bounded mode keeps only the nearest current and future programs per channel`() = runTest {
+        val requests = mutableListOf<String>()
+        val api = stubApi(requests = requests) { url ->
+            if (url.contains("action=get_simple_data_table")) {
+                """{ "js": [
+                    { "ch_id": "1", "name": "Past", "start_timestamp": "800", "stop_timestamp": "900" },
+                    { "ch_id": "1", "name": "Now", "start_timestamp": "900", "stop_timestamp": "1100" },
+                    { "ch_id": "1", "name": "Next", "start_timestamp": "1100", "stop_timestamp": "1200" },
+                    { "ch_id": "1", "name": "Later", "start_timestamp": "1200", "stop_timestamp": "1300" },
+                    { "ch_id": "1", "name": "Too far", "start_timestamp": "1300", "stop_timestamp": "1400" },
+                    { "ch_id": "2", "name": "Other channel", "start_timestamp": "900", "stop_timestamp": "1100" }
+                ] }"""
+            } else null
+        }
+
+        val programs = api.getEpg(notBeforeEpochSeconds = 1_000L, maxProgramsPerChannel = 3)
+
+        assertEquals(listOf("Now", "Next", "Later"), programs.filter { it.chId == "1" }.map { it.name })
+        assertEquals(listOf("Other channel"), programs.filter { it.chId == "2" }.map { it.name })
+        assertEquals(1, requests.size)
+    }
+
+    @Test
     fun `getEpg falls back to get_epg_info when get_simple_data_table is malformed`() = runTest {
         val requests = mutableListOf<String>()
         val api = stubApi(requests = requests) { url ->
@@ -464,6 +493,20 @@ class StalkerApiTest {
         val programs = api.getShortEpg("679826")
 
         assertTrue(programs.isEmpty())
+    }
+
+    @Test
+    fun `getShortEpg fills the requested channel id when the portal omits it`() = runTest {
+        val requests = mutableListOf<String>()
+        val api = stubApi(requests = requests) { url ->
+            if (url.contains("action=get_short_epg")) {
+                """{ "js": [{ "name": "News", "start_timestamp": "1000", "stop_timestamp": "2000" }] }"""
+            } else null
+        }
+
+        val programs = api.getShortEpg("42")
+
+        assertEquals("42", programs.single().chId)
     }
 
     @Test

--- a/app/src/test/kotlin/com/arflix/tv/data/api/StalkerApiTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/api/StalkerApiTest.kt
@@ -216,4 +216,102 @@ class StalkerApiTest {
         assertEquals(2, requests.count { it.contains("action=get_all_channels") })
         assertFalse(requests.any { it.contains("p=3") })
     }
+
+    @Test
+    fun `getEpg builds url without date param when date is blank`() = runTest {
+        val requests = mutableListOf<String>()
+        val api = stubApi(requests = requests) { url ->
+            if (url.contains("action=get_simple_data_table")) """{ "js": [] }""" else null
+        }
+
+        api.getEpg()
+
+        assertEquals(
+            listOf("$PORTAL/server/load.php?type=epg&action=get_simple_data_table&ch_id=all&JsHttpRequest=1-xml"),
+            requests
+        )
+    }
+
+    @Test
+    fun `getEpg appends encoded date param when date is set`() = runTest {
+        val requests = mutableListOf<String>()
+        val api = stubApi(requests = requests) { url ->
+            if (url.contains("action=get_simple_data_table")) """{ "js": [] }""" else null
+        }
+
+        api.getEpg(date = "2026-08-29")
+
+        assertEquals(
+            listOf(
+                "$PORTAL/server/load.php?type=epg&action=get_simple_data_table&ch_id=all&date=2026-08-29&JsHttpRequest=1-xml"
+            ),
+            requests
+        )
+    }
+
+    @Test
+    fun `getEpg parses standard field names`() = runTest {
+        val requests = mutableListOf<String>()
+        val api = stubApi(requests = requests) { url ->
+            if (url.contains("action=get_simple_data_table")) {
+                """{ "js": [
+                    { "ch_id": "1", "name": "News", "descr": "Daily news", "start_timestamp": "1000", "stop_timestamp": "2000" }
+                ] }"""
+            } else null
+        }
+
+        val programs = api.getEpg()
+
+        assertEquals(1, programs.size)
+        assertEquals("1", programs[0].chId)
+        assertEquals("News", programs[0].name)
+        assertEquals("Daily news", programs[0].descr)
+        assertEquals("1000", programs[0].startTimestamp)
+        assertEquals("2000", programs[0].stopTimestamp)
+    }
+
+    @Test
+    fun `getEpg parses alternate field names from other portal software`() = runTest {
+        val requests = mutableListOf<String>()
+        val api = stubApi(requests = requests) { url ->
+            if (url.contains("action=get_simple_data_table")) {
+                """{ "js": [
+                    { "channel_id": "7", "title": "Movie", "description": "A film", "start": "1500", "end": "3000" }
+                ] }"""
+            } else null
+        }
+
+        val programs = api.getEpg()
+
+        assertEquals(1, programs.size)
+        assertEquals("7", programs[0].chId)
+        assertEquals("Movie", programs[0].name)
+        assertEquals("A film", programs[0].descr)
+        assertEquals("1500", programs[0].startTimestamp)
+        assertEquals("3000", programs[0].stopTimestamp)
+    }
+
+    @Test
+    fun `getEpg returns empty list on malformed response instead of throwing`() = runTest {
+        val requests = mutableListOf<String>()
+        val api = stubApi(requests = requests) { url ->
+            if (url.contains("action=get_simple_data_table")) "<html>not json</html>" else null
+        }
+
+        val programs = api.getEpg()
+
+        assertTrue(programs.isEmpty())
+    }
+
+    @Test
+    fun `getEpg returns empty list when js is null or absent`() = runTest {
+        val requests = mutableListOf<String>()
+        val api = stubApi(requests = requests) { url ->
+            if (url.contains("action=get_simple_data_table")) """{ "js": null }""" else null
+        }
+
+        val programs = api.getEpg()
+
+        assertTrue(programs.isEmpty())
+    }
 }

--- a/app/src/test/kotlin/com/arflix/tv/data/api/StalkerApiTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/api/StalkerApiTest.kt
@@ -221,11 +221,14 @@ class StalkerApiTest {
     fun `getEpg builds url without date param when date is blank`() = runTest {
         val requests = mutableListOf<String>()
         val api = stubApi(requests = requests) { url ->
-            if (url.contains("action=get_simple_data_table")) """{ "js": [] }""" else null
+            if (url.contains("action=get_simple_data_table")) {
+                """{ "js": [{ "ch_id": "1", "name": "News", "start_timestamp": "1000", "stop_timestamp": "2000" }] }"""
+            } else null
         }
 
         api.getEpg()
 
+        // get_simple_data_table returned data, so no fallback request is made.
         assertEquals(
             listOf("$PORTAL/server/load.php?type=epg&action=get_simple_data_table&ch_id=all&JsHttpRequest=1-xml"),
             requests
@@ -236,7 +239,9 @@ class StalkerApiTest {
     fun `getEpg appends encoded date param when date is set`() = runTest {
         val requests = mutableListOf<String>()
         val api = stubApi(requests = requests) { url ->
-            if (url.contains("action=get_simple_data_table")) """{ "js": [] }""" else null
+            if (url.contains("action=get_simple_data_table")) {
+                """{ "js": [{ "ch_id": "1", "name": "News", "start_timestamp": "1000", "stop_timestamp": "2000" }] }"""
+            } else null
         }
 
         api.getEpg(date = "2026-08-29")
@@ -292,26 +297,80 @@ class StalkerApiTest {
     }
 
     @Test
-    fun `getEpg returns empty list on malformed response instead of throwing`() = runTest {
+    fun `getEpg falls back to get_epg_info when get_simple_data_table is malformed`() = runTest {
         val requests = mutableListOf<String>()
         val api = stubApi(requests = requests) { url ->
-            if (url.contains("action=get_simple_data_table")) "<html>not json</html>" else null
+            when {
+                url.contains("action=get_simple_data_table") -> "<html>not json</html>"
+                url.contains("action=get_epg_info") -> """{ "js": [] }"""
+                else -> null
+            }
         }
 
         val programs = api.getEpg()
 
         assertTrue(programs.isEmpty())
+        assertEquals(2, requests.size)
+        assertTrue(requests[0].contains("action=get_simple_data_table"))
+        assertTrue(requests[1].contains("action=get_epg_info"))
     }
 
     @Test
-    fun `getEpg returns empty list when js is null or absent`() = runTest {
+    fun `getEpg falls back to get_epg_info when js is null or absent`() = runTest {
         val requests = mutableListOf<String>()
         val api = stubApi(requests = requests) { url ->
-            if (url.contains("action=get_simple_data_table")) """{ "js": null }""" else null
+            when {
+                url.contains("action=get_simple_data_table") -> """{ "js": null }"""
+                url.contains("action=get_epg_info") -> """{ "js": null }"""
+                else -> null
+            }
         }
 
         val programs = api.getEpg()
 
         assertTrue(programs.isEmpty())
+        assertEquals(2, requests.size)
+    }
+
+    @Test
+    fun `getEpg get_epg_info fallback parses a flat js list like get_simple_data_table`() = runTest {
+        val requests = mutableListOf<String>()
+        val api = stubApi(requests = requests) { url ->
+            when {
+                url.contains("action=get_simple_data_table") -> """{ "js": [] }"""
+                url.contains("action=get_epg_info") ->
+                    """{ "js": [{ "ch_id": "1", "name": "News", "start_timestamp": "1000", "stop_timestamp": "2000" }] }"""
+                else -> null
+            }
+        }
+
+        val programs = api.getEpg()
+
+        assertEquals(1, programs.size)
+        assertEquals("1", programs[0].chId)
+        assertEquals("News", programs[0].name)
+    }
+
+    @Test
+    fun `getEpg get_epg_info fallback parses a per-channel object shape`() = runTest {
+        val requests = mutableListOf<String>()
+        val api = stubApi(requests = requests) { url ->
+            when {
+                url.contains("action=get_simple_data_table") -> """{ "js": [] }"""
+                url.contains("action=get_epg_info") ->
+                    """{ "js": {
+                        "1": [{ "name": "News", "start_timestamp": "1000", "stop_timestamp": "2000" }],
+                        "2": [{ "name": "Movie", "start_timestamp": "1500", "stop_timestamp": "3000" }]
+                    } }"""
+                else -> null
+            }
+        }
+
+        val programs = api.getEpg()
+
+        assertEquals(2, programs.size)
+        // The per-channel object's key becomes ch_id since the program entry itself has none.
+        assertEquals(setOf("1", "2"), programs.map { it.chId }.toSet())
+        assertEquals(setOf("News", "Movie"), programs.map { it.name }.toSet())
     }
 }

--- a/app/src/test/kotlin/com/arflix/tv/data/api/StalkerApiTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/api/StalkerApiTest.kt
@@ -412,4 +412,69 @@ class StalkerApiTest {
         assertEquals(setOf("1", "2"), programs.map { it.chId }.toSet())
         assertEquals(setOf("News", "Movie"), programs.map { it.name }.toSet())
     }
+
+    @Test
+    fun `getShortEpg builds url with ch_id and size`() = runTest {
+        val requests = mutableListOf<String>()
+        val api = stubApi(requests = requests) { url ->
+            if (url.contains("action=get_short_epg")) """{ "js": [] }""" else null
+        }
+
+        api.getShortEpg("1441855")
+
+        assertEquals(
+            listOf("$PORTAL/server/load.php?type=itv&action=get_short_epg&ch_id=1441855&size=10&JsHttpRequest=1-xml"),
+            requests
+        )
+    }
+
+    @Test
+    fun `getShortEpg parses the confirmed real-world response shape (integer id field)`() = runTest {
+        // Confirmed live on-device: js is a flat array directly (same container shape as
+        // get_simple_data_table), but the "id" field is a number, not a string, on this
+        // portal build - our model doesn't map "id" at all, so this must still parse fine.
+        val requests = mutableListOf<String>()
+        val api = stubApi(requests = requests) { url ->
+            if (url.contains("action=get_short_epg")) {
+                """{ "js": [{
+                    "id": 1788113700, "ch_id": "1441855",
+                    "start_timestamp": 1788113700, "stop_timestamp": 1788118800,
+                    "name": "Tatort: Roomservice", "descr": "Ein Krimi."
+                }] }"""
+            } else null
+        }
+
+        val programs = api.getShortEpg("1441855")
+
+        assertEquals(1, programs.size)
+        assertEquals("1441855", programs[0].chId)
+        assertEquals("Tatort: Roomservice", programs[0].name)
+        assertEquals("1788113700", programs[0].startTimestamp)
+        assertEquals("1788118800", programs[0].stopTimestamp)
+    }
+
+    @Test
+    fun `getShortEpg returns empty list for a channel with no programs`() = runTest {
+        // Confirmed live: a group-placeholder channel with blank xmltv_id returns {"js":[]}.
+        val requests = mutableListOf<String>()
+        val api = stubApi(requests = requests) { url ->
+            if (url.contains("action=get_short_epg")) """{ "js": [] }""" else null
+        }
+
+        val programs = api.getShortEpg("679826")
+
+        assertTrue(programs.isEmpty())
+    }
+
+    @Test
+    fun `getShortEpg returns empty list on malformed response instead of throwing`() = runTest {
+        val requests = mutableListOf<String>()
+        val api = stubApi(requests = requests) { url ->
+            if (url.contains("action=get_short_epg")) "<html>error</html>" else null
+        }
+
+        val programs = api.getShortEpg("1")
+
+        assertTrue(programs.isEmpty())
+    }
 }

--- a/app/src/test/kotlin/com/arflix/tv/data/repository/IptvRepositoryStalkerEpgTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/repository/IptvRepositoryStalkerEpgTest.kt
@@ -1,0 +1,160 @@
+package com.arflix.tv.data.repository
+
+import com.arflix.tv.data.api.StalkerApi
+import com.arflix.tv.data.model.IptvChannel
+import com.arflix.tv.data.model.IptvNowNext
+import com.arflix.tv.data.model.IptvProgram
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.suspendCancellableCoroutine
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests for the Stalker EPG merge helpers added to [IptvRepository] (isolation
+ * comes from the channel id prefix, see [StalkerPortalSupport] - not a separate
+ * per-portal EPG-index source key).
+ */
+class IptvRepositoryStalkerEpgTest {
+
+    private fun newRepository(): IptvRepository {
+        val context = io.mockk.mockk<android.content.Context>(relaxed = true)
+        val okHttpClient = io.mockk.mockk<okhttp3.OkHttpClient>(relaxed = true)
+        val profileManager = io.mockk.mockk<ProfileManager>(relaxed = true)
+        val invalidationBus = io.mockk.mockk<CloudSyncInvalidationBus>(relaxed = true)
+        return IptvRepository(context, okHttpClient, profileManager, invalidationBus)
+    }
+
+    private fun stubStalkerApi(respond: (String) -> String?): StalkerApi =
+        object : StalkerApi("http://portal.example.com", "00:1A:79:AA:BB:CC") {
+            override fun doGet(url: String): String = respond(url) ?: error("Unexpected url: $url")
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun invokeStalkerNowNextFromPrograms(
+        repository: IptvRepository,
+        programs: List<IptvProgram>,
+        nowMs: Long
+    ): IptvNowNext? {
+        val method = IptvRepository::class.java.getDeclaredMethod(
+            "stalkerNowNextFromPrograms",
+            List::class.java,
+            Long::class.javaPrimitiveType
+        )
+        method.isAccessible = true
+        return method.invoke(repository, programs, nowMs) as IptvNowNext?
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun invokeFetchStalkerEpgForActivePortals(
+        repository: IptvRepository,
+        stalkerApis: Map<String, StalkerApi>,
+        stalkerChannels: List<IptvChannel>
+    ): Map<String, IptvNowNext> = runBlocking {
+        val method = IptvRepository::class.java.getDeclaredMethod(
+            "fetchStalkerEpgForActivePortals",
+            Map::class.java,
+            List::class.java,
+            kotlin.coroutines.Continuation::class.java
+        )
+        method.isAccessible = true
+        suspendCancellableCoroutine<Any?> { cont ->
+            method.invoke(repository, stalkerApis, stalkerChannels, cont)
+        } as Map<String, IptvNowNext>
+    }
+
+    private fun program(startMs: Long, endMs: Long, title: String) =
+        IptvProgram(title = title, startUtcMillis = startMs, endUtcMillis = endMs)
+
+    @Test
+    fun `stalkerNowNextFromPrograms returns null for empty list`() {
+        val repository = newRepository()
+        val result = invokeStalkerNowNextFromPrograms(repository, emptyList(), nowMs = 10_000L)
+        assertNull(result)
+    }
+
+    @Test
+    fun `stalkerNowNextFromPrograms compacts sorted programs into now next later upcoming`() {
+        val repository = newRepository()
+        val nowMs = 10_000L
+        val programs = listOf(
+            program(0L, 5_000L, "Past"), // already over, not "now"
+            program(5_000L, 15_000L, "Now"), // live at nowMs
+            program(15_000L, 20_000L, "Next"),
+            program(20_000L, 25_000L, "Later"),
+            program(25_000L, 30_000L, "Upcoming1"),
+            program(30_000L, 35_000L, "Upcoming2")
+        )
+
+        val result = invokeStalkerNowNextFromPrograms(repository, programs.shuffled(), nowMs)
+
+        requireNotNull(result)
+        assertEquals("Now", result.now?.title)
+        assertEquals("Next", result.next?.title)
+        assertEquals("Later", result.later?.title)
+        assertEquals(listOf("Upcoming1", "Upcoming2"), result.upcoming.map { it.title })
+        assertTrue("Stalker EPG keeps no recent/catchup history (K10 out of scope)", result.recent.isEmpty())
+    }
+
+    @Test
+    fun `fetchStalkerEpgForActivePortals keys results by full channel id and isolates portals`() {
+        val repository = newRepository()
+        val portal1Api = stubStalkerApi { url ->
+            if (url.contains("action=get_simple_data_table")) {
+                """{ "js": [
+                    { "ch_id": "100", "name": "Portal1 News", "start_timestamp": "0", "stop_timestamp": "10" }
+                ] }"""
+            } else null
+        }
+        val portal2Api = stubStalkerApi { url ->
+            if (url.contains("action=get_simple_data_table")) {
+                // Same ch_id as portal 1 on purpose: without isolation this would collide (C1/C6).
+                """{ "js": [
+                    { "ch_id": "100", "name": "Portal2 Movie", "start_timestamp": "0", "stop_timestamp": "10" }
+                ] }"""
+            } else null
+        }
+        val channels = listOf(
+            IptvChannel(id = "stalker:stalker1:100", name = "Ch A", logo = null, group = "g", streamUrl = "cmd"),
+            IptvChannel(id = "stalker:stalker2:100", name = "Ch B", logo = null, group = "g", streamUrl = "cmd")
+        )
+
+        val result = invokeFetchStalkerEpgForActivePortals(
+            repository,
+            mapOf("stalker1" to portal1Api, "stalker2" to portal2Api),
+            channels
+        )
+
+        assertEquals(setOf("stalker:stalker1:100", "stalker:stalker2:100"), result.keys)
+        assertEquals("Portal1 News", result.getValue("stalker:stalker1:100").now?.title)
+        assertEquals("Portal2 Movie", result.getValue("stalker:stalker2:100").now?.title)
+    }
+
+    @Test
+    fun `fetchStalkerEpgForActivePortals skips programs with unknown channel id or malformed timestamps`() {
+        val repository = newRepository()
+        val api = stubStalkerApi { url ->
+            if (url.contains("action=get_simple_data_table")) {
+                """{ "js": [
+                    { "ch_id": "999", "name": "Unknown channel", "start_timestamp": "0", "stop_timestamp": "10" },
+                    { "ch_id": "100", "name": "Bad timestamps", "start_timestamp": "not-a-number", "stop_timestamp": "10" },
+                    { "ch_id": "100", "name": "End before start", "start_timestamp": "10", "stop_timestamp": "5" }
+                ] }"""
+            } else null
+        }
+        val channels = listOf(
+            IptvChannel(id = "stalker:stalker1:100", name = "Ch A", logo = null, group = "g", streamUrl = "cmd")
+        )
+
+        val result = invokeFetchStalkerEpgForActivePortals(repository, mapOf("stalker1" to api), channels)
+
+        assertTrue("No valid programs in the response, result must stay empty", result.isEmpty())
+    }
+
+    @Test
+    fun `fetchStalkerEpgForActivePortals returns empty map without network calls when no portals or channels`() {
+        val repository = newRepository()
+        assertTrue(invokeFetchStalkerEpgForActivePortals(repository, emptyMap(), emptyList()).isEmpty())
+    }
+}

--- a/app/src/test/kotlin/com/arflix/tv/data/repository/IptvRepositoryStalkerEpgTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/repository/IptvRepositoryStalkerEpgTest.kt
@@ -25,9 +25,15 @@ class IptvRepositoryStalkerEpgTest {
         return IptvRepository(context, okHttpClient, profileManager, invalidationBus)
     }
 
-    private fun stubStalkerApi(respond: (String) -> String?): StalkerApi =
-        object : StalkerApi("http://portal.example.com", "00:1A:79:AA:BB:CC") {
+    private fun stubStalkerApi(
+        portal: String = "http://portal.example.com",
+        mac: String = "00:1A:79:AA:BB:CC",
+        respond: (String) -> String?
+    ): StalkerApi =
+        object : StalkerApi(portal, mac) {
             override fun doGet(url: String): String = respond(url) ?: error("Unexpected url: $url")
+            override fun doGetReader(url: String): java.io.Reader =
+                (respond(url) ?: error("Unexpected url: $url")).reader()
         }
 
     private fun program(startMs: Long, endMs: Long, title: String) =
@@ -191,6 +197,90 @@ class IptvRepositoryStalkerEpgTest {
         assertEquals(1, bulkRequestCount)
         assertEquals("Cached Show", first.getValue("stalker:stalker1:100").now?.title)
         assertEquals("Cached Show", second.getValue("stalker:stalker1:100").now?.title)
+    }
+
+    @Test
+    fun `bulk cache is isolated when the same portal id points to different credentials`() = runTest {
+        val repository = newRepository()
+        val nowSec = System.currentTimeMillis() / 1000
+        val channels = listOf(
+            IptvChannel(id = "stalker:stalker1:100", name = "Ch A", logo = null, group = "g", streamUrl = "cmd")
+        )
+        fun response(title: String) = """{ "js": [
+            { "ch_id": "100", "name": "$title", "start_timestamp": "${nowSec - 60}", "stop_timestamp": "${nowSec + 60}" }
+        ] }"""
+        val firstApi = stubStalkerApi(portal = "http://first.example.com") { url ->
+            if (url.contains("action=get_simple_data_table")) response("First portal") else null
+        }
+        val secondApi = stubStalkerApi(portal = "http://second.example.com") { url ->
+            if (url.contains("action=get_simple_data_table")) response("Second portal") else null
+        }
+
+        val first = repository.fetchStalkerEpgForActivePortals(mapOf("stalker1" to firstApi), channels)
+        val second = repository.fetchStalkerEpgForActivePortals(mapOf("stalker1" to secondApi), channels)
+
+        assertEquals("First portal", first.getValue("stalker:stalker1:100").now?.title)
+        assertEquals("Second portal", second.getValue("stalker:stalker1:100").now?.title)
+    }
+
+    @Test
+    fun `invalidateCache clears the Stalker bulk cache`() = runTest {
+        val repository = newRepository()
+        val nowSec = System.currentTimeMillis() / 1000
+        var bulkRequestCount = 0
+        val api = stubStalkerApi { url ->
+            if (url.contains("action=get_simple_data_table")) {
+                bulkRequestCount++
+                """{ "js": [
+                    { "ch_id": "100", "name": "News", "start_timestamp": "${nowSec - 60}", "stop_timestamp": "${nowSec + 60}" }
+                ] }"""
+            } else null
+        }
+        val channels = listOf(
+            IptvChannel(id = "stalker:stalker1:100", name = "Ch A", logo = null, group = "g", streamUrl = "cmd")
+        )
+
+        repository.fetchStalkerEpgForActivePortals(mapOf("stalker1" to api), channels)
+        repository.invalidateCache()
+        repository.fetchStalkerEpgForActivePortals(mapOf("stalker1" to api), channels)
+
+        assertEquals(2, bulkRequestCount)
+    }
+
+    @Test
+    fun `empty short EPG results are cached within the TTL`() = runTest {
+        val repository = newRepository()
+        var simpleRequestCount = 0
+        var fallbackRequestCount = 0
+        var shortRequestCount = 0
+        val api = stubStalkerApi { url ->
+            when {
+                url.contains("action=get_simple_data_table") -> {
+                    simpleRequestCount++
+                    """{ "js": [] }"""
+                }
+                url.contains("action=get_epg_info") -> {
+                    fallbackRequestCount++
+                    """{ "js": { "data": [] } }"""
+                }
+                url.contains("action=get_short_epg") -> {
+                    shortRequestCount++
+                    """{ "js": [] }"""
+                }
+                else -> null
+            }
+        }
+        val channels = listOf(
+            IptvChannel(id = "stalker:stalker1:100", name = "Ch A", logo = null, group = "g", streamUrl = "cmd"),
+            IptvChannel(id = "stalker:stalker1:200", name = "Ch B", logo = null, group = "g", streamUrl = "cmd")
+        )
+
+        repository.fetchStalkerEpgForActivePortals(mapOf("stalker1" to api), channels)
+        repository.fetchStalkerEpgForActivePortals(mapOf("stalker1" to api), channels)
+
+        assertEquals(1, simpleRequestCount)
+        assertEquals(1, fallbackRequestCount)
+        assertEquals(2, shortRequestCount)
     }
 
     @Test

--- a/app/src/test/kotlin/com/arflix/tv/data/repository/IptvRepositoryStalkerEpgTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/repository/IptvRepositoryStalkerEpgTest.kt
@@ -65,10 +65,16 @@ class IptvRepositoryStalkerEpgTest {
     @Test
     fun `fetchStalkerEpgForActivePortals keys results by full channel id and isolates portals`() = runTest {
         val repository = newRepository()
+        // fetchStalkerEpgForActivePortals compacts against the real wall-clock "now"
+        // (System.currentTimeMillis()), so the stubbed program must actually be live now -
+        // a fixed epoch like 0/10 would always be in the past and get dropped, not merged.
+        val nowSec = System.currentTimeMillis() / 1000
+        val startSec = nowSec - 60
+        val stopSec = nowSec + 60
         val portal1Api = stubStalkerApi { url ->
             if (url.contains("action=get_simple_data_table")) {
                 """{ "js": [
-                    { "ch_id": "100", "name": "Portal1 News", "start_timestamp": "0", "stop_timestamp": "10" }
+                    { "ch_id": "100", "name": "Portal1 News", "start_timestamp": "$startSec", "stop_timestamp": "$stopSec" }
                 ] }"""
             } else null
         }
@@ -76,7 +82,7 @@ class IptvRepositoryStalkerEpgTest {
             if (url.contains("action=get_simple_data_table")) {
                 // Same ch_id as portal 1 on purpose: without isolation this would collide (C1/C6).
                 """{ "js": [
-                    { "ch_id": "100", "name": "Portal2 Movie", "start_timestamp": "0", "stop_timestamp": "10" }
+                    { "ch_id": "100", "name": "Portal2 Movie", "start_timestamp": "$startSec", "stop_timestamp": "$stopSec" }
                 ] }"""
             } else null
         }

--- a/app/src/test/kotlin/com/arflix/tv/data/repository/IptvRepositoryStalkerEpgTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/repository/IptvRepositoryStalkerEpgTest.kt
@@ -2,19 +2,18 @@ package com.arflix.tv.data.repository
 
 import com.arflix.tv.data.api.StalkerApi
 import com.arflix.tv.data.model.IptvChannel
-import com.arflix.tv.data.model.IptvNowNext
 import com.arflix.tv.data.model.IptvProgram
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Tests for the Stalker EPG merge helpers added to [IptvRepository] (isolation
- * comes from the channel id prefix, see [StalkerPortalSupport] - not a separate
- * per-portal EPG-index source key).
+ * Tests for the Stalker EPG merge helpers on [IptvRepository] (marked `internal`
+ * so tests can call them directly, same convention as [IptvEpgIndex]/[StalkerPortalSupport]).
+ * Isolation comes from the channel id prefix (see [StalkerPortalSupport]), not a
+ * separate per-portal EPG-index source key.
  */
 class IptvRepositoryStalkerEpgTest {
 
@@ -31,47 +30,13 @@ class IptvRepositoryStalkerEpgTest {
             override fun doGet(url: String): String = respond(url) ?: error("Unexpected url: $url")
         }
 
-    @Suppress("UNCHECKED_CAST")
-    private fun invokeStalkerNowNextFromPrograms(
-        repository: IptvRepository,
-        programs: List<IptvProgram>,
-        nowMs: Long
-    ): IptvNowNext? {
-        val method = IptvRepository::class.java.getDeclaredMethod(
-            "stalkerNowNextFromPrograms",
-            List::class.java,
-            Long::class.javaPrimitiveType
-        )
-        method.isAccessible = true
-        return method.invoke(repository, programs, nowMs) as IptvNowNext?
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun invokeFetchStalkerEpgForActivePortals(
-        repository: IptvRepository,
-        stalkerApis: Map<String, StalkerApi>,
-        stalkerChannels: List<IptvChannel>
-    ): Map<String, IptvNowNext> = runBlocking {
-        val method = IptvRepository::class.java.getDeclaredMethod(
-            "fetchStalkerEpgForActivePortals",
-            Map::class.java,
-            List::class.java,
-            kotlin.coroutines.Continuation::class.java
-        )
-        method.isAccessible = true
-        suspendCancellableCoroutine<Any?> { cont ->
-            method.invoke(repository, stalkerApis, stalkerChannels, cont)
-        } as Map<String, IptvNowNext>
-    }
-
     private fun program(startMs: Long, endMs: Long, title: String) =
         IptvProgram(title = title, startUtcMillis = startMs, endUtcMillis = endMs)
 
     @Test
     fun `stalkerNowNextFromPrograms returns null for empty list`() {
         val repository = newRepository()
-        val result = invokeStalkerNowNextFromPrograms(repository, emptyList(), nowMs = 10_000L)
-        assertNull(result)
+        assertNull(repository.stalkerNowNextFromPrograms(emptyList(), nowMs = 10_000L))
     }
 
     @Test
@@ -87,7 +52,7 @@ class IptvRepositoryStalkerEpgTest {
             program(30_000L, 35_000L, "Upcoming2")
         )
 
-        val result = invokeStalkerNowNextFromPrograms(repository, programs.shuffled(), nowMs)
+        val result = repository.stalkerNowNextFromPrograms(programs.shuffled(), nowMs)
 
         requireNotNull(result)
         assertEquals("Now", result.now?.title)
@@ -98,7 +63,7 @@ class IptvRepositoryStalkerEpgTest {
     }
 
     @Test
-    fun `fetchStalkerEpgForActivePortals keys results by full channel id and isolates portals`() {
+    fun `fetchStalkerEpgForActivePortals keys results by full channel id and isolates portals`() = runTest {
         val repository = newRepository()
         val portal1Api = stubStalkerApi { url ->
             if (url.contains("action=get_simple_data_table")) {
@@ -120,8 +85,7 @@ class IptvRepositoryStalkerEpgTest {
             IptvChannel(id = "stalker:stalker2:100", name = "Ch B", logo = null, group = "g", streamUrl = "cmd")
         )
 
-        val result = invokeFetchStalkerEpgForActivePortals(
-            repository,
+        val result = repository.fetchStalkerEpgForActivePortals(
             mapOf("stalker1" to portal1Api, "stalker2" to portal2Api),
             channels
         )
@@ -132,7 +96,7 @@ class IptvRepositoryStalkerEpgTest {
     }
 
     @Test
-    fun `fetchStalkerEpgForActivePortals skips programs with unknown channel id or malformed timestamps`() {
+    fun `fetchStalkerEpgForActivePortals skips programs with unknown channel id or malformed timestamps`() = runTest {
         val repository = newRepository()
         val api = stubStalkerApi { url ->
             if (url.contains("action=get_simple_data_table")) {
@@ -147,14 +111,14 @@ class IptvRepositoryStalkerEpgTest {
             IptvChannel(id = "stalker:stalker1:100", name = "Ch A", logo = null, group = "g", streamUrl = "cmd")
         )
 
-        val result = invokeFetchStalkerEpgForActivePortals(repository, mapOf("stalker1" to api), channels)
+        val result = repository.fetchStalkerEpgForActivePortals(mapOf("stalker1" to api), channels)
 
         assertTrue("No valid programs in the response, result must stay empty", result.isEmpty())
     }
 
     @Test
-    fun `fetchStalkerEpgForActivePortals returns empty map without network calls when no portals or channels`() {
+    fun `fetchStalkerEpgForActivePortals returns empty map without network calls when no portals or channels`() = runTest {
         val repository = newRepository()
-        assertTrue(invokeFetchStalkerEpgForActivePortals(repository, emptyMap(), emptyList()).isEmpty())
+        assertTrue(repository.fetchStalkerEpgForActivePortals(emptyMap(), emptyList()).isEmpty())
     }
 }

--- a/app/src/test/kotlin/com/arflix/tv/data/repository/IptvRepositoryStalkerEpgTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/repository/IptvRepositoryStalkerEpgTest.kt
@@ -161,6 +161,39 @@ class IptvRepositoryStalkerEpgTest {
     }
 
     @Test
+    fun `fetchStalkerEpgForActivePortals reuses the cached bulk result within the TTL instead of re-fetching`() = runTest {
+        // Confirmed live: a large portal's get_epg_info response can be ~25 MB, taking
+        // seconds per fetch - refetching it on every small on-demand batch call caused
+        // real, user-visible lag. A short per-portal cache must avoid that repeat fetch.
+        val repository = newRepository()
+        val nowSec = System.currentTimeMillis() / 1000
+        val startSec = nowSec - 60
+        val stopSec = nowSec + 60
+        var bulkRequestCount = 0
+        val api = stubStalkerApi { url ->
+            when {
+                url.contains("action=get_simple_data_table") -> {
+                    bulkRequestCount++
+                    """{ "js": [
+                        { "ch_id": "100", "name": "Cached Show", "start_timestamp": "$startSec", "stop_timestamp": "$stopSec" }
+                    ] }"""
+                }
+                else -> null
+            }
+        }
+        val channels = listOf(
+            IptvChannel(id = "stalker:stalker1:100", name = "Ch A", logo = null, group = "g", streamUrl = "cmd")
+        )
+
+        val first = repository.fetchStalkerEpgForActivePortals(mapOf("stalker1" to api), channels)
+        val second = repository.fetchStalkerEpgForActivePortals(mapOf("stalker1" to api), channels)
+
+        assertEquals(1, bulkRequestCount)
+        assertEquals("Cached Show", first.getValue("stalker:stalker1:100").now?.title)
+        assertEquals("Cached Show", second.getValue("stalker:stalker1:100").now?.title)
+    }
+
+    @Test
     fun `fetchStalkerEpgForActivePortals skips the get_short_epg fallback for large batches`() = runTest {
         // A full-catalog backfill can be thousands of channels - falling back to one
         // get_short_epg request per channel at that scale would hammer the portal, so

--- a/app/src/test/kotlin/com/arflix/tv/data/repository/IptvRepositoryStalkerEpgTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/repository/IptvRepositoryStalkerEpgTest.kt
@@ -127,4 +127,64 @@ class IptvRepositoryStalkerEpgTest {
         val repository = newRepository()
         assertTrue(repository.fetchStalkerEpgForActivePortals(emptyMap(), emptyList()).isEmpty())
     }
+
+    @Test
+    fun `fetchStalkerEpgForActivePortals falls back to get_short_epg per channel when both bulk actions are empty`() = runTest {
+        // Confirmed live on-device (EPG-Test.md, Portal 1): get_simple_data_table and
+        // get_epg_info both return nothing on some portal builds, only get_short_epg works.
+        val repository = newRepository()
+        val nowSec = System.currentTimeMillis() / 1000
+        val startSec = nowSec - 60
+        val stopSec = nowSec + 60
+        val api = stubStalkerApi { url ->
+            when {
+                url.contains("action=get_simple_data_table") -> """{ "js": [] }"""
+                url.contains("action=get_epg_info") -> """{ "js": { "data": [] } }"""
+                url.contains("action=get_short_epg") && url.contains("ch_id=100") ->
+                    """{ "js": [
+                        { "ch_id": "100", "name": "Fallback Show", "start_timestamp": "$startSec", "stop_timestamp": "$stopSec" }
+                    ] }"""
+                url.contains("action=get_short_epg") && url.contains("ch_id=200") ->
+                    """{ "js": [] }"""
+                else -> null
+            }
+        }
+        val channels = listOf(
+            IptvChannel(id = "stalker:stalker1:100", name = "Ch A", logo = null, group = "g", streamUrl = "cmd"),
+            IptvChannel(id = "stalker:stalker1:200", name = "Ch B (no programs)", logo = null, group = "g", streamUrl = "cmd")
+        )
+
+        val result = repository.fetchStalkerEpgForActivePortals(mapOf("stalker1" to api), channels)
+
+        assertEquals(setOf("stalker:stalker1:100"), result.keys)
+        assertEquals("Fallback Show", result.getValue("stalker:stalker1:100").now?.title)
+    }
+
+    @Test
+    fun `fetchStalkerEpgForActivePortals skips the get_short_epg fallback for large batches`() = runTest {
+        // A full-catalog backfill can be thousands of channels - falling back to one
+        // get_short_epg request per channel at that scale would hammer the portal, so
+        // the fallback is capped and simply yields no EPG for an oversized batch instead.
+        val repository = newRepository()
+        val shortEpgRequested = mutableListOf<String>()
+        val api = stubStalkerApi { url ->
+            when {
+                url.contains("action=get_simple_data_table") -> """{ "js": [] }"""
+                url.contains("action=get_epg_info") -> """{ "js": { "data": [] } }"""
+                url.contains("action=get_short_epg") -> {
+                    shortEpgRequested += url
+                    """{ "js": [] }"""
+                }
+                else -> null
+            }
+        }
+        val channels = (1..150).map {
+            IptvChannel(id = "stalker:stalker1:$it", name = "Ch $it", logo = null, group = "g", streamUrl = "cmd")
+        }
+
+        val result = repository.fetchStalkerEpgForActivePortals(mapOf("stalker1" to api), channels)
+
+        assertTrue("Oversized batch must not trigger per-channel fallback requests", shortEpgRequested.isEmpty())
+        assertTrue(result.isEmpty())
+    }
 }


### PR DESCRIPTION
Summary
Stalker/Ministra portal channels currently show no EPG guide data in Live TV (the guide grid stays empty), even though the portal API supports lightweight now/next endpoints. This adds a Stalker EPG fetch path and merges it for Stalker channels only, leaving M3U/Xtream EPG untouched.
Approach
Live-tested against two real portals (raw findings documented privately, not part of this PR): portal EPG behavior varies — some answer get_simple_data_table (ch_id=all), some only get_epg_info, and some only respond per-channel via get_short_epg. The implementation therefore tries three things, in order, per active portal:
StalkerApi.getEpg() — get_simple_data_table (bulk, one request per portal), falling back automatically to get_epg_info when the first comes back empty. Both known response shapes are handled (flat array, and the {"data": {"<ch_id>": [...]}} wrapper confirmed on a real ~25 MB portal response).
StalkerApi.getShortEpg(chId) — per-channel fallback for portals where both bulk endpoints come back empty, used for batches up to 100 channels (limited concurrency, matching the existing Xtream short-epg pattern). Oversized batches (a full catalog backfill can be thousands of channels) skip this and rely on the on-demand visible-guide refresh path instead, which already requests small batches.
The raw per-portal bulk result is cached for 5 minutes — the on-demand visible-guide refresh calls the fetch for every small visible batch (often every few seconds while scrolling/switching channels), and a large portal's response can take 1.5–5s to fetch; without caching this caused noticeable lag, confirmed live.
Scope
StalkerApi: getEpg() + getShortEpg() (+ response models), robust to multiple field-name variants and both known container shapes.
IptvRepository: fetch Stalker EPG per active portal and merge into the EPG now/next map for Stalker channels only — no change to M3U/Xtream EPG handling. Wired into both places that populate the guide: the automatic background backfill (startCompleteEpgBackfill, previously gated on M3U/Xtream-only fields and never fired for a Stalker-only setup) and the on-demand visible-guide refresh (refreshEpgForChannels, previously Xtream-only and silently dropped every Stalker channel).
Unit tests for URL building, response parsing (all confirmed real-world shapes), and the now/next merge/isolation behavior.
Testing
Unit tests: ./gradlew testSideloadDebugUnitTest (existing suite + new cases) green.
On-device (phone, TV mode): Stalker portal → Live TV guide now shows program info for Stalker channels, smoothly (no lag) after the caching fix; M3U/Xtream guide unaffected. Verified across two independent portals with different response behavior; a portal with genuinely no EPG data shows no guide entries for it (expected, no crash, other sources unaffected).
Generated by Claude Code