### PR TITLE
feat(iptv): add VOD search toggle and fix IPTV catalog resolution & legacy compatibility

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
@@ -13,6 +13,7 @@ import com.arflix.tv.data.model.IptvProgram
 import com.arflix.tv.data.model.IptvSnapshot
 import com.arflix.tv.data.model.StreamSource
 import com.arflix.tv.R
+import com.arflix.tv.util.IPTV_VOD_SEARCH_ENABLED_KEY
 import com.arflix.tv.util.settingsDataStore
 import com.google.gson.Gson
 import com.google.gson.JsonArray
@@ -173,9 +174,9 @@ data class IptvPlaylistEntry(
     val enabled: Boolean = true,
     val epgUrls: List<String> = emptyList(),
     // NEW FIELDS: Selective Import
-    val importLiveTv: Boolean = true,
-    val importVod: Boolean = true,
-    val importSeries: Boolean = true
+    val importLiveTv: Boolean? = true,
+    val importVod: Boolean? = true,
+    val importSeries: Boolean? = true
 )
 
 /**
@@ -584,6 +585,16 @@ class IptvRepository @Inject constructor(
         profileManager.activeProfileId.combine(context.settingsDataStore.data) { _, prefs ->
             decodeGroupOrder(prefs)
         }
+
+    fun observeVodSearchEnabled(): Flow<Boolean> =
+        context.settingsDataStore.data.map { prefs ->
+            prefs[IPTV_VOD_SEARCH_ENABLED_KEY] ?: true
+        }
+
+    suspend fun isVodSearchEnabled(): Boolean =
+        runCatching {
+            context.settingsDataStore.data.first()[IPTV_VOD_SEARCH_ENABLED_KEY] ?: true
+        }.getOrDefault(true)
 
     fun observeTvSessionState(): Flow<IptvTvSessionState> =
         profileManager.activeProfileId.combine(context.settingsDataStore.data) { _, prefs ->
@@ -1016,10 +1027,10 @@ class IptvRepository @Inject constructor(
             epgUrl = epgUrls.firstOrNull().orEmpty(),
             enabled = runCatching { playlist.enabled }.getOrDefault(true),
             epgUrls = epgUrls,
-            // NEW: Save preferences when reading from disk
-            importLiveTv = runCatching { playlist.importLiveTv }.getOrDefault(true),
-            importVod = runCatching { playlist.importVod }.getOrDefault(true),
-            importSeries = runCatching { playlist.importSeries }.getOrDefault(true)
+            // Selective import settings default to true for existing playlists
+            importLiveTv = playlist.importLiveTv ?: true,
+            importVod = playlist.importVod ?: true,
+            importSeries = playlist.importSeries ?: true
         )
     }
 
@@ -3678,7 +3689,7 @@ class IptvRepository @Inject constructor(
     playlist: IptvPlaylistEntry,
     onProgress: (IptvLoadProgress) -> Unit
 ): List<IptvChannel> {
-    if (!playlist.importLiveTv) {
+    if (playlist.importLiveTv == false) {
             return emptyList()
     }
     resolveXtreamCredentials(playlist)?.let { creds ->
@@ -4666,10 +4677,10 @@ class IptvRepository @Inject constructor(
     }
 
     internal fun activeVodPlaylists(config: IptvConfig): List<IptvPlaylistEntry> =
-        activePlaylists(config).filter { it.importVod }
+        activePlaylists(config).filter { it.importVod ?: true }
 
     internal fun activeSeriesPlaylists(config: IptvConfig): List<IptvPlaylistEntry> =
-        activePlaylists(config).filter { it.importSeries }
+        activePlaylists(config).filter { it.importSeries ?: true }
 
     private fun xtreamCredentialsForVodImport(config: IptvConfig): List<XtreamCredentials> =
         activeVodPlaylists(config)
@@ -4703,6 +4714,7 @@ class IptvRepository @Inject constructor(
         allowNetwork: Boolean = true
     ): List<StreamSource> {
         return withContext(Dispatchers.IO) {
+            if (!isVodSearchEnabled()) return@withContext emptyList()
             val config = observeConfig().first()
             xtreamCredentialsForVodImport(config)
                 .flatMap { creds ->
@@ -4837,6 +4849,7 @@ class IptvRepository @Inject constructor(
         allowNetwork: Boolean = true
     ): List<StreamSource> {
         return withContext(Dispatchers.IO) {
+            if (!isVodSearchEnabled()) return@withContext emptyList()
             val config = observeConfig().first()
             xtreamCredentialsForSeriesImport(config)
                 .flatMap { creds ->
@@ -4933,34 +4946,30 @@ class IptvRepository @Inject constructor(
             return sortVodSources(cachedSeriesSources)
         }
 
-        val networkSeriesSources = withTimeoutOrNull(3_500L) {
-            seriesResolver.resolveEpisodeVariants(
-                providerKey = providerKey,
-                creds = creds,
-                showTitle = title,
-                season = season,
-                episode = episode,
-                tmdbId = tmdbId,
-                imdbId = imdbId,
-                year = parseYear(title),
-                allowNetwork = true
-            ).toSeriesVodSources()
-        }.orEmpty()
+        val networkSeriesSources = seriesResolver.resolveEpisodeVariants(
+            providerKey = providerKey,
+            creds = creds,
+            showTitle = title,
+            season = season,
+            episode = episode,
+            tmdbId = tmdbId,
+            imdbId = imdbId,
+            year = parseYear(title),
+            allowNetwork = true
+        ).toSeriesVodSources()
         if (networkSeriesSources.isNotEmpty()) {
             return sortVodSources(networkSeriesSources)
         }
 
-        val vodCatalogSources = withTimeoutOrNull(3_000L) {
-            findEpisodeVodFromVodCatalogFallbackSources(
-                creds = creds,
-                title = title,
-                season = season,
-                episode = episode,
-                normalizedImdb = normalizedImdb,
-                normalizedTmdb = normalizedTmdb,
-                allowNetwork = true
-            )
-        }.orEmpty()
+        val vodCatalogSources = findEpisodeVodFromVodCatalogFallbackSources(
+            creds = creds,
+            title = title,
+            season = season,
+            episode = episode,
+            normalizedImdb = normalizedImdb,
+            normalizedTmdb = normalizedTmdb,
+            allowNetwork = true
+        )
         return sortVodSources(vodCatalogSources + cachedSeriesSources)
     }
 
@@ -5091,6 +5100,7 @@ class IptvRepository @Inject constructor(
 
     suspend fun warmXtreamVodCachesIfPossible() {
         withContext(Dispatchers.IO) {
+            if (!isVodSearchEnabled()) return@withContext
             val config = observeConfig().first()
             xtreamCredentialsForVodImport(config).forEach { creds ->
                 runCatching {
@@ -5116,6 +5126,7 @@ class IptvRepository @Inject constructor(
         tmdbId: Int? = null
     ) {
         withContext(Dispatchers.IO) {
+            if (!isVodSearchEnabled()) return@withContext
             val config = observeConfig().first()
             val activeProfileId = runCatching { profileManager.getProfileIdSync() }.getOrDefault("default")
             xtreamCredentialsForSeriesImport(config).forEach { creds ->
@@ -5143,6 +5154,7 @@ class IptvRepository @Inject constructor(
         tmdbId: Int? = null
     ) {
         withContext(Dispatchers.IO) {
+            if (!isVodSearchEnabled()) return@withContext
             val config = observeConfig().first()
             val activeProfileId = runCatching { profileManager.getProfileIdSync() }.getOrDefault("default")
             xtreamCredentialsForSeriesImport(config).forEach { creds ->
@@ -5279,7 +5291,7 @@ class IptvRepository @Inject constructor(
                 requestJson(
                     url,
                     TypeToken.getParameterized(List::class.java, XtreamVodStream::class.java).type,
-                    client = if (fast) xtreamLookupHttpClient else iptvHttpClient
+                    client = iptvHttpClient
                 ) ?: emptyList()
             val elapsed = System.currentTimeMillis() - downloadStart
             System.err.println("[VOD-Cache] Downloaded ${vod.size} VOD streams in ${elapsed}ms")
@@ -5359,7 +5371,7 @@ class IptvRepository @Inject constructor(
                 requestJson(
                     url,
                     TypeToken.getParameterized(List::class.java, XtreamSeriesItem::class.java).type,
-                    client = if (fast) xtreamLookupHttpClient else iptvHttpClient
+                    client = iptvHttpClient
                 ) ?: emptyList()
             val elapsed = System.currentTimeMillis() - downloadStart
             System.err.println("[VOD-Cache] Downloaded ${series.size} series in ${elapsed}ms")
@@ -8461,9 +8473,9 @@ class IptvRepository @Inject constructor(
                 playlist.epgUrl.trim(),
                 playlist.epgUrls.orEmpty().joinToString(",") { it.trim() },
                 playlist.enabled.toString(),
-                playlist.importLiveTv.toString(),
-                playlist.importVod.toString(),
-                playlist.importSeries.toString()
+                (playlist.importLiveTv ?: true).toString(),
+                (playlist.importVod ?: true).toString(),
+                (playlist.importSeries ?: true).toString()
             ).joinToString("|")
         }
         val raw = listOf(
@@ -8485,9 +8497,9 @@ class IptvRepository @Inject constructor(
                 playlist.name.trim(),
                 playlist.m3uUrl.trim(),
                 playlist.enabled.toString(),
-                playlist.importLiveTv.toString(),
-                playlist.importVod.toString(),
-                playlist.importSeries.toString()
+                (playlist.importLiveTv ?: true).toString(),
+                (playlist.importVod ?: true).toString(),
+                (playlist.importSeries ?: true).toString()
             ).joinToString("|")
         }
         val raw = listOf(

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -519,8 +519,8 @@ fun SettingsScreen(
                 // Reset row + (bulk-toggle row) + category rows.
                 groups.size + (firstIptvGroupIndex(uiState.iptvSelectedPlaylistId.orEmpty(), groups, stalkerIds) - 1)
             } else {
-                // Add-M3U + M3U rows + Add-Stalker + Stalker rows + order + EPG actions + refresh + clear
-                5 + uiState.iptvPlaylists.size + uiState.iptvStalkerPortals.size
+                // Add-M3U + M3U rows + Add-Stalker + Stalker rows + order + VOD search + EPG actions + refresh + clear
+                6 + uiState.iptvPlaylists.size + uiState.iptvStalkerPortals.size
             }
             "home_server" -> uiState.homeServerConnections.size + 3
             "catalogs" -> uiState.catalogs.size + 1 // Add + Import + catalogs
@@ -1169,12 +1169,15 @@ fun SettingsScreen(
                                                         viewModel.setIptvSortOrder(next)
                                                     }
                                                     contentFocusIndex == m3uCount + stalkerCount + 3 -> {
-                                                        viewModel.setEpgVodActionsEnabled(!uiState.epgVodActionsEnabled)
+                                                        viewModel.setVodSearchEnabled(!uiState.vodSearchEnabled)
                                                     }
                                                     contentFocusIndex == m3uCount + stalkerCount + 4 -> {
-                                                        viewModel.refreshIptv(force = true)
+                                                        viewModel.setEpgVodActionsEnabled(!uiState.epgVodActionsEnabled)
                                                     }
                                                     contentFocusIndex == m3uCount + stalkerCount + 5 -> {
+                                                        viewModel.refreshIptv(force = true)
+                                                    }
+                                                    contentFocusIndex == m3uCount + stalkerCount + 6 -> {
                                                         viewModel.clearIptvConfig()
                                                     }
                                                 }
@@ -1738,6 +1741,8 @@ fun SettingsScreen(
                             onManageCategories = openIptvCategories,
                             sortOrder = uiState.iptvSortOrder,
                             onSortOrderChange = { viewModel.setIptvSortOrder(it) },
+                            vodSearchEnabled = uiState.vodSearchEnabled,
+                            onVodSearchToggle = viewModel::setVodSearchEnabled,
                             epgVodActionsEnabled = uiState.epgVodActionsEnabled,
                             onEpgVodActionsToggle = viewModel::setEpgVodActionsEnabled,
                         )
@@ -1795,6 +1800,8 @@ fun SettingsScreen(
                             onManageCategories = openIptvCategories,
                             sortOrder = uiState.iptvSortOrder,
                             onSortOrderChange = { viewModel.setIptvSortOrder(it) },
+                            vodSearchEnabled = uiState.vodSearchEnabled,
+                            onVodSearchToggle = viewModel::setVodSearchEnabled,
                             epgVodActionsEnabled = uiState.epgVodActionsEnabled,
                             onEpgVodActionsToggle = viewModel::setEpgVodActionsEnabled,
                         )
@@ -4779,6 +4786,8 @@ private fun MobileSettingsSubPage(
                     },
                     sortOrder = uiState.iptvSortOrder,
                     onSortOrderChange = { viewModel.setIptvSortOrder(it) },
+                    vodSearchEnabled = uiState.vodSearchEnabled,
+                    onVodSearchToggle = viewModel::setVodSearchEnabled,
                     epgVodActionsEnabled = uiState.epgVodActionsEnabled,
                     onEpgVodActionsToggle = viewModel::setEpgVodActionsEnabled,
                 )
@@ -7025,6 +7034,8 @@ private fun IptvSettings(
     onRemoveStalkerPortal: (String) -> Unit = {},
     onManageStalkerCategories: (String) -> Unit = {},
     onRenameStalkerPortal: (StalkerPortalEntry) -> Unit = {},
+    vodSearchEnabled: Boolean = true,
+    onVodSearchToggle: (Boolean) -> Unit = {},
     epgVodActionsEnabled: Boolean = true,
     onEpgVodActionsToggle: (Boolean) -> Unit = {},
 ) {
@@ -7210,6 +7221,14 @@ private fun IptvSettings(
                     }
                 )
                 MobileSettingsRow(
+                    icon = Icons.Default.Movie,
+                    title = stringResource(R.string.settings_iptv_vod_search),
+                    subtitle = stringResource(R.string.settings_iptv_vod_search_desc),
+                    value = stringResource(if (vodSearchEnabled) R.string.on else R.string.off),
+                    isFocused = false,
+                    onClick = { onVodSearchToggle(!vodSearchEnabled) },
+                )
+                MobileSettingsRow(
                     icon = Icons.Default.LiveTv,
                     title = stringResource(R.string.settings_epg_vod_actions),
                     subtitle = stringResource(R.string.settings_epg_vod_actions_desc),
@@ -7375,19 +7394,28 @@ private fun IptvSettings(
             )
             Spacer(modifier = Modifier.height(16.dp))
             SettingsToggleRow(
-                title = stringResource(R.string.settings_epg_vod_actions),
-                subtitle = stringResource(R.string.settings_epg_vod_actions_desc),
-                isEnabled = epgVodActionsEnabled,
+                title = stringResource(R.string.settings_iptv_vod_search),
+                subtitle = stringResource(R.string.settings_iptv_vod_search_desc),
+                isEnabled = vodSearchEnabled,
                 isFocused = focusedIndex == trailingBase + 1,
-                onToggle = onEpgVodActionsToggle,
+                onToggle = onVodSearchToggle,
                 modifier = Modifier.settingsFocusSlot(trailingBase + 1),
             )
             Spacer(modifier = Modifier.height(16.dp))
+            SettingsToggleRow(
+                title = stringResource(R.string.settings_epg_vod_actions),
+                subtitle = stringResource(R.string.settings_epg_vod_actions_desc),
+                isEnabled = epgVodActionsEnabled,
+                isFocused = focusedIndex == trailingBase + 2,
+                onToggle = onEpgVodActionsToggle,
+                modifier = Modifier.settingsFocusSlot(trailingBase + 2),
+            )
+            Spacer(modifier = Modifier.height(16.dp))
             val refreshSubtitle = when { isLoading -> stringResource(R.string.settings_refreshing_channels_epg); error != null -> error; playlists.none { it.epgUrl.isNotBlank() || it.epgUrls.orEmpty().isNotEmpty() } -> stringResource(R.string.settings_reload_playlists_now); else -> stringResource(R.string.settings_reload_playlist_epg_now) }
-            SettingsRow(icon = Icons.Default.Link, title = stringResource(R.string.refresh_iptv), subtitle = refreshSubtitle, value = if (isLoading) stringResource(R.string.settings_badge_loading) else stringResource(R.string.settings_badge_refresh), isFocused = focusedIndex == trailingBase + 2, onClick = onRefresh, modifier = Modifier.settingsFocusSlot(trailingBase + 2))
+            SettingsRow(icon = Icons.Default.Link, title = stringResource(R.string.refresh_iptv), subtitle = refreshSubtitle, value = if (isLoading) stringResource(R.string.settings_badge_loading) else stringResource(R.string.settings_badge_refresh), isFocused = focusedIndex == trailingBase + 3, onClick = onRefresh, modifier = Modifier.settingsFocusSlot(trailingBase + 3))
             Spacer(modifier = Modifier.height(16.dp))
             val hasNoSources = playlists.isEmpty() && stalkerPortals.isEmpty()
-            SettingsRow(icon = Icons.Default.Delete, title = stringResource(R.string.delete_iptv), subtitle = if (hasNoSources) stringResource(R.string.settings_no_playlists_configured) else stringResource(R.string.settings_remove_playlists_epg), value = if (hasNoSources) stringResource(R.string.settings_badge_empty) else stringResource(R.string.settings_badge_delete), isFocused = focusedIndex == trailingBase + 3, onClick = onDelete, modifier = Modifier.settingsFocusSlot(trailingBase + 3))
+            SettingsRow(icon = Icons.Default.Delete, title = stringResource(R.string.delete_iptv), subtitle = if (hasNoSources) stringResource(R.string.settings_no_playlists_configured) else stringResource(R.string.settings_remove_playlists_epg), value = if (hasNoSources) stringResource(R.string.settings_badge_empty) else stringResource(R.string.settings_badge_delete), isFocused = focusedIndex == trailingBase + 4, onClick = onDelete, modifier = Modifier.settingsFocusSlot(trailingBase + 4))
             if (isLoading && !progressText.isNullOrBlank()) {
                 Spacer(modifier = Modifier.height(12.dp))
                 Text(stringResource(R.string.settings_progress_format, progressText, progressPercent.coerceIn(0, 100)), style = ArflixTypography.caption, color = TextSecondary)

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -66,6 +66,7 @@ import com.arflix.tv.updater.VersionUtils
 import com.arflix.tv.util.AuthEmailValidator
 import com.arflix.tv.util.LAST_APP_LANGUAGE_KEY
 import com.arflix.tv.util.IPTV_EPG_VOD_ACTIONS_ENABLED_KEY
+import com.arflix.tv.util.IPTV_VOD_SEARCH_ENABLED_KEY
 import com.arflix.tv.util.settingsDataStore
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
@@ -204,6 +205,7 @@ data class SettingsUiState(
     val iptvAvailableGroups: List<String> = emptyList(),
     val iptvHiddenGroups: List<String> = emptyList(),
     val iptvGroupOrder: List<String> = emptyList(),
+    val vodSearchEnabled: Boolean = true,
     val epgVodActionsEnabled: Boolean = true,
     // App updates
     val isSelfUpdateSupported: Boolean = true,
@@ -546,6 +548,7 @@ class SettingsViewModel @Inject constructor(
             val volumeBoostDb = prefs[volumeBoostDbKey()]?.toIntOrNull()?.coerceIn(0, 15) ?: 0
             val showLoadingStats = prefs[showLoadingStatsKey()] ?: true
             val smoothScrolling = prefs[smoothScrollingKey()] ?: true
+            val vodSearchEnabled = prefs[IPTV_VOD_SEARCH_ENABLED_KEY] ?: true
             val epgVodActionsEnabled = prefs[IPTV_EPG_VOD_ACTIONS_ENABLED_KEY] ?: true
 
             val subtitleSize = prefs[subtitleSizeKey()] ?: "Medium"
@@ -689,6 +692,7 @@ class SettingsViewModel @Inject constructor(
                 subtitleAiModel = subtitleAiModel,
                 subtitleRemoveHearingImpaired = subtitleRemoveHearingImpaired,
                 smoothScrolling = smoothScrolling,
+                vodSearchEnabled = vodSearchEnabled,
                 epgVodActionsEnabled = epgVodActionsEnabled,
             )
 
@@ -1525,6 +1529,13 @@ class SettingsViewModel @Inject constructor(
             context.settingsDataStore.edit { it[smoothScrollingKey()] = enabled }
             _uiState.value = _uiState.value.copy(smoothScrolling = enabled)
             syncLocalStateToCloud(silent = true)
+        }
+    }
+
+    fun setVodSearchEnabled(enabled: Boolean) {
+        viewModelScope.launch {
+            context.settingsDataStore.edit { it[IPTV_VOD_SEARCH_ENABLED_KEY] = enabled }
+            _uiState.value = _uiState.value.copy(vodSearchEnabled = enabled)
         }
     }
 

--- a/app/src/main/kotlin/com/arflix/tv/util/IptvGuidePreferences.kt
+++ b/app/src/main/kotlin/com/arflix/tv/util/IptvGuidePreferences.kt
@@ -4,3 +4,6 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 
 /** Device-local preference for the optional EPG VOD action lookup. */
 val IPTV_EPG_VOD_ACTIONS_ENABLED_KEY = booleanPreferencesKey("iptv_epg_vod_actions_enabled")
+
+/** Device-local preference to enable or disable searching VOD for movies and TV shows. */
+val IPTV_VOD_SEARCH_ENABLED_KEY = booleanPreferencesKey("iptv_vod_search_enabled")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -593,8 +593,10 @@
     <string name="settings_section_options">OPTIONS</string>
     <string name="settings_iptv_channel_order">Channel order</string>
     <string name="settings_iptv_channel_order_description">Choose how channels are ordered within each group</string>
-    <string name="settings_epg_vod_actions">TV guide streaming options</string>
-    <string name="settings_epg_vod_actions_desc">On a second click, offer Stream Now for matched movies and shows; otherwise open live TV fullscreen</string>
+    <string name="settings_iptv_vod_search">IPTV VOD streams</string>
+    <string name="settings_iptv_vod_search_desc">Include IPTV movies and shows when fetching streams</string>
+    <string name="settings_epg_vod_actions">TV guide Stream Now</string>
+    <string name="settings_epg_vod_actions_desc">Show streaming options on matched TV guide events</string>
     <string name="settings_iptv_order_provider">Provider order</string>
     <string name="settings_iptv_order_number">Channel number</string>
     <string name="settings_iptv_order_name">Alphabetical (A-Z)</string>

--- a/app/src/test/kotlin/com/arflix/tv/data/repository/IptvActivePlaylistsTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/repository/IptvActivePlaylistsTest.kt
@@ -166,4 +166,25 @@ class IptvActivePlaylistsTest {
         assertEquals(1, repository.activeVodPlaylists(config).size)
         assertEquals(1, repository.activeSeriesPlaylists(config).size)
     }
+
+    @Test
+    fun `playlist entry with null import flags defaults to enabled for vod and series`() {
+        val repository = newRepository()
+        val entryWithNullFlags = IptvPlaylistEntry(
+            id = "legacy_list",
+            name = "Legacy Provider",
+            m3uUrl = "http://provider.example/get.php?username=user&password=pass&type=m3u_plus",
+            enabled = true,
+            importLiveTv = null,
+            importVod = null,
+            importSeries = null
+        )
+        val config = IptvConfig(
+            m3uUrl = entryWithNullFlags.m3uUrl,
+            playlists = listOf(entryWithNullFlags)
+        )
+
+        assertEquals(listOf(entryWithNullFlags), repository.activeVodPlaylists(config))
+        assertEquals(listOf(entryWithNullFlags), repository.activeSeriesPlaylists(config))
+    }
 }

--- a/app/src/test/kotlin/com/arflix/tv/data/repository/IptvVodSearchPreferenceTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/repository/IptvVodSearchPreferenceTest.kt
@@ -1,0 +1,20 @@
+package com.arflix.tv.data.repository
+
+import com.arflix.tv.ui.screens.settings.SettingsUiState
+import com.arflix.tv.util.IPTV_VOD_SEARCH_ENABLED_KEY
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class IptvVodSearchPreferenceTest {
+
+    @Test
+    fun vodSearchPreferenceKeyMatchesExpectedName() {
+        assertThat(IPTV_VOD_SEARCH_ENABLED_KEY.name).isEqualTo("iptv_vod_search_enabled")
+    }
+
+    @Test
+    fun settingsUiStateDefaultsVodSearchToEnabled() {
+        val state = SettingsUiState()
+        assertThat(state.vodSearchEnabled).isTrue()
+    }
+}


### PR DESCRIPTION
### Overview
This PR adds a user toggle in Settings to control IPTV VOD stream fetching, simplifies IPTV settings labels for clarity, and fixes catalog download and legacy deserialization bugs that prevented IPTV VOD from returning sources.

### Changes
1. **IPTV VOD Search Toggle**:
   - Added `IPTV_VOD_SEARCH_ENABLED_KEY` DataStore preference.
   - Added toggle row to TV & Mobile settings under the IPTV section.
   - Guarded `findMovieVodSources` and `findEpisodeVodSources` with `isVodSearchEnabled()`.

2. **Cleaned Settings Labels**:
   - Shortened and clarified IPTV settings titles and descriptions in `strings.xml`.

3. **Catalog Download & Coroutine Timeout Fixes**:
   - Replaced short-timeout `xtreamLookupHttpClient` with `iptvHttpClient` for large Xtream VOD (`get_vod_streams`) and series (`get_series`) catalog downloads to prevent `InterruptedIOException: timeout`.
   - Removed premature inner `withTimeoutOrNull` limits inside series episode resolution so caller's outer budget is respected.

4. **Legacy Playlist Compatibility**:
   - Made selective import flags (`importLiveTv`, `importVod`, `importSeries`) in `IptvPlaylistEntry` nullable with default `true` so that legacy saved JSON without these keys does not default to `false` during reflection deserialization.

5. **Unit Tests**:
   - Added unit tests in `IptvVodSearchPreferenceTest` and regression coverage in `IptvActivePlaylistsTest`.