### PR TITLE
Cache home screen and fix slowness on cold start

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ArflixApplication.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ArflixApplication.kt
@@ -74,14 +74,24 @@ class ArflixApplication : Application(), Configuration.Provider, ImageLoaderFact
     @Inject
     lateinit var appUsageAnalyticsRepository: AppUsageAnalyticsRepository
 
+    /**
+     * [OkHttpProvider.init] must run before *anything* first touches [OkHttpProvider.client]:
+     * the client is built once, lazily, and keeps whatever cache it had at that moment — with no
+     * app context there is no disk cache, for the whole process lifetime.
+     *
+     * `onCreate()` is too late. Hilt performs this Application's field injection inside
+     * `super.onCreate()`, and those injected repositories construct Retrofit — and therefore the
+     * OkHttpClient — before the first line of our own `onCreate()` body runs. `attachBaseContext`
+     * is the first callback where a context exists, so the cache is configured from here.
+     */
+    override fun attachBaseContext(base: android.content.Context) {
+        super.attachBaseContext(base)
+        OkHttpProvider.init(this)
+    }
+
     override fun onCreate() {
         super.onCreate()
         instance = this
-
-        // OkHttpProvider.init(context) just stashes the app context; it does
-        // not build the OkHttpClient. Safe to keep on the main thread — it's
-        // a single volatile assignment.
-        OkHttpProvider.init(this)
 
         // Initialize global DNS provider and user agent from DataStore before network calls.
         appScope.launch(Dispatchers.IO) {

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/MediaRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/MediaRepository.kt
@@ -3319,12 +3319,16 @@ class MediaRepository @Inject constructor(
         return try {
             val videos = tmdbApi.getVideos(type, mediaId, apiKey, language = contentLanguage)
             var results = videos.results
-            // If language-specific request returned no YouTube videos, fall back to English
+            // If language-specific request returned no YouTube videos, fall back to English.
+            // Explicitly "en-US", not null: TMDB's /videos `language` filters the video records
+            // themselves (most titles only ever have English-tagged trailers), and a null here is
+            // dropped by Retrofit and then refilled with the user's language by the TMDB
+            // interceptor — which made this retry an exact repeat of the call that just failed.
             if (
                 results.none { it.site == "YouTube" } &&
                 !contentLanguage.equals("en-US", ignoreCase = true)
             ) {
-                results = tmdbApi.getVideos(type, mediaId, apiKey, language = null).results
+                results = tmdbApi.getVideos(type, mediaId, apiKey, language = "en-US").results
             }
             val trailer = results.find { it.type == "Trailer" && it.site == "YouTube" && it.official }
                 ?: results.find { it.type == "Trailer" && it.site == "YouTube" }

--- a/app/src/main/kotlin/com/arflix/tv/di/AppModule.kt
+++ b/app/src/main/kotlin/com/arflix/tv/di/AppModule.kt
@@ -45,8 +45,15 @@ object AppModule {
                 val lang = langPrefs.getString("locale_tag", "en-US") ?: "en-US"
 
                 // Only inject if it's not the default English. Map "iw" to "he".
+                //
+                // An explicit `language` from the call site wins. setQueryParameter used to
+                // overwrite it, which silently broke every deliberate request for a specific
+                // language: the English fallback in getTrailerKey re-sent the user's language and
+                // returned the same empty result (TMDB's /videos `language` filters the video
+                // records, so a Hebrew user saw no trailers at all), and fetchTitles' explicit
+                // language="en" came back localized.
                 val urlBuilder = originalHttpUrl.newBuilder()
-                if (lang != "en-US") {
+                if (lang != "en-US" && originalHttpUrl.queryParameter("language") == null) {
                     val tmdbLang = lang.replace("iw", "he").replace('_', '-')
                     urlBuilder.setQueryParameter("language", tmdbLang)
                 }

--- a/app/src/main/kotlin/com/arflix/tv/navigation/AppNavigation.kt
+++ b/app/src/main/kotlin/com/arflix/tv/navigation/AppNavigation.kt
@@ -145,14 +145,22 @@ fun AppNavigation(
     }
 
     val navigateHome: () -> Unit = {
-        // Navigate to Home clearing the entire back stack above it.
-        // Uses navigate() instead of popBackStack() because popBackStack can
-        // silently fail if Home is not found, and restoreState on other
-        // navigateTopLevel calls can bring back stale Details pages.
-        navController.navigate(Screen.Home.route) {
-            popUpTo(Screen.Home.route) { inclusive = true; saveState = false }
-            launchSingleTop = true
-            restoreState = false
+        // Pop back to the EXISTING Home entry rather than replacing it.
+        //
+        // navigateTopLevel uses popUpTo(Home) with inclusive = false, so Home is still on the back
+        // stack while the user is on Watchlist/TV/Search. Re-navigating with inclusive = true
+        // destroyed that entry, and with it the HomeViewModel that hiltViewModel() scopes to it —
+        // so every return to Home rebuilt the whole screen from scratch (~550 requests, ~5s).
+        //
+        // popBackStack also clears everything stacked above Home, which is what the previous
+        // comment here wanted (no stale Details pages); the fallback covers the case it worried
+        // about, Home not being on the stack at all.
+        if (!navController.popBackStack(Screen.Home.route, inclusive = false)) {
+            navController.navigate(Screen.Home.route) {
+                popUpTo(Screen.Home.route) { inclusive = true; saveState = false }
+                launchSingleTop = true
+                restoreState = false
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/arflix/tv/network/OkHttpProvider.kt
+++ b/app/src/main/kotlin/com/arflix/tv/network/OkHttpProvider.kt
@@ -74,7 +74,11 @@ object OkHttpProvider {
      * Provides the application context needed for the disk cache directory.
      */
     fun init(context: Context) {
-        appContext = context.applicationContext
+        // `applicationContext` is null when called from Application.attachBaseContext — the
+        // Application is not registered with the framework yet. That is precisely where this has
+        // to run (Hilt builds Retrofit, and therefore this client, inside Application.onCreate's
+        // super call), so fall back to the context we were handed: it is the Application itself.
+        appContext = context.applicationContext ?: context
     }
 
     @Volatile
@@ -318,7 +322,14 @@ object OkHttpProvider {
 
         appContext?.let { ctx ->
             builder.cache(getOrCreateHttpCache(ctx))
-        }
+            // Never persist a failure. A transient 5xx or a rate-limit 429 carrying a cacheable
+            // header would otherwise be replayed from disk for its whole stated lifetime, long
+            // after the server recovered.
+            builder.addNetworkInterceptor(noCacheErrorsInterceptor)
+        } ?: Log.w(
+            TAG,
+            "API client built without app context — HTTP disk cache disabled for this process"
+        )
 
         return builder.build()
     }
@@ -361,6 +372,16 @@ object OkHttpProvider {
 
     private fun isSafeHeaderValue(value: String): Boolean {
         return value.all { ch -> ch == '\t' || ch.code in 32..126 }
+    }
+
+    /** Marks unsuccessful responses `no-store` so the disk cache never keeps a failure. */
+    private val noCacheErrorsInterceptor = Interceptor { chain ->
+        val response = chain.proceed(chain.request())
+        if (response.isSuccessful) {
+            response
+        } else {
+            response.newBuilder().header("Cache-Control", "no-store").build()
+        }
     }
 
     private fun getOrCreateHttpCache(context: Context): Cache {

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
@@ -668,6 +668,9 @@ fun HomeScreen(
                 // Keep the profile-to-Home transition local-first. A forced remote
                 // refresh here cancelled the cache fast path on every app launch.
                 viewModel.refreshContinueWatchingOnly(force = false)
+                // Catalog rows: no-op unless they have gone stale (6h). Home now survives
+                // navigation, so nothing else would re-fetch them in a long session.
+                viewModel.refreshHomeDataIfStale()
                 // Pull the full cloud state (addons, catalogs, settings) on resume.
                 // This catches any changes pushed by another device while this one
                 // was backgrounded — the WebSocket may have been killed by Android,

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
@@ -2393,6 +2393,12 @@ class HomeViewModel @Inject constructor(
                 category.items.any { !it.isPlaceholder }
         }
 
+    private fun markHomeDataLoadSuccessful(requestId: Long) {
+        if (requestId == loadHomeRequestId) {
+            lastHomeDataLoadAtMs = SystemClock.elapsedRealtime()
+        }
+    }
+
     private fun loadHomeData() {
         loadHomeJob?.cancel()
         homeDataLoadAttempted = true
@@ -2530,10 +2536,12 @@ class HomeViewModel @Inject constructor(
                     runCatching { buildFavoriteTvCategory() }.getOrNull()
                 }
 
+                var loadedFreshCatalogRows = false
                 var categories = withContext(networkDispatcher) {
                     val baseCategories = runCatching {
                         mediaRepository.getHomeCategories()
                     }.getOrElse { emptyList() }
+                    loadedFreshCatalogRows = baseCategories.any { hasRealItems(it) }
 
                     val baseById = LinkedHashMap<String, Category>().apply {
                         currentBaseCategories.forEach { put(it.id, it) }
@@ -2631,6 +2639,7 @@ class HomeViewModel @Inject constructor(
                         }
                     }
                     val mdblistCategories = mdblistInitial.awaitAll().filterNotNull()
+                    loadedFreshCatalogRows = loadedFreshCatalogRows || mdblistCategories.any { hasRealItems(it) }
                     // Create placeholder categories for deferred ones (will load on scroll)
                     val deferredCategories = deferredBatch.map { cfg -> Category(id = cfg.id, title = cfg.title, items = emptyList()) }
                     // Merge both lists maintaining the saved catalog order
@@ -2657,13 +2666,14 @@ class HomeViewModel @Inject constructor(
  null }
                                     }
                                 }.awaitAll().filterNotNull()
-                                if (results.isNotEmpty()) {
+                                if (results.isNotEmpty() && requestId == loadHomeRequestId) {
                                     val current = _uiState.value.categories.toMutableList()
                                     for (cat in results) {
                                         val idx = current.indexOfFirst { it.id == cat.id }
                                         if (idx >= 0) current[idx] = cat else current.add(cat)
                                     }
                                     _uiState.value = _uiState.value.copy(categories = current)
+                                    markHomeDataLoadSuccessful(requestId)
                                 }
                             }
                         }
@@ -2707,6 +2717,7 @@ class HomeViewModel @Inject constructor(
                             }
                         }
                     }.awaitAll().filterNotNull()
+                    loadedFreshCatalogRows = loadedFreshCatalogRows || freshCustomCategories.any { hasRealItems(it) }
 
                     // Fall back to previously cached data for any custom catalog
                     // that failed to load in this round
@@ -3001,9 +3012,11 @@ class HomeViewModel @Inject constructor(
                     categoryHasMoreMap = categoryPaginationStates.mapValues { it.value.hasMore },
                     error = null
                 )
-                // Only a load that actually published rows counts as fresh — see
-                // [refreshHomeDataIfStale].
-                lastHomeDataLoadAtMs = SystemClock.elapsedRealtime()
+                // Cached fallback rows keep Home usable, but only freshly fetched rows
+                // suppress the next resume retry.
+                if (loadedFreshCatalogRows) {
+                    markHomeDataLoadSuccessful(requestId)
+                }
                 heroItem?.let { item ->
                     if (isStartupSettling()) {
                         scheduleStartupHeroHydration(item)
@@ -3300,6 +3313,7 @@ class HomeViewModel @Inject constructor(
                     withContext(Dispatchers.Main.immediate) {
                         if (requestId == loadHomeRequestId) {
                             updateMobileCategoryRow(cfg.id, category.withTop10CapIfNeeded(), hasMore = page.hasMore)
+                            markHomeDataLoadSuccessful(requestId)
                             persistCategoriesCache(_uiState.value.categories)
                         }
                     }
@@ -3324,6 +3338,7 @@ class HomeViewModel @Inject constructor(
                             withContext(Dispatchers.Main.immediate) {
                                 if (requestId == loadHomeRequestId) {
                                     updateMobileCategoryRow(cfg.id, category, hasMore = result.hasMore && !isHardCappedTop10Catalog(cfg.id))
+                                    markHomeDataLoadSuccessful(requestId)
                                     persistCategoriesCache(_uiState.value.categories)
                                 }
                             }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
@@ -1198,6 +1198,23 @@ class HomeViewModel @Inject constructor(
     private val dismissedContinueWatchingAt = Collections.synchronizedMap(mutableMapOf<String, Long>())
     private val CONTINUE_WATCHING_REFRESH_MS = 45_000L
     private val WATCHED_BADGES_REFRESH_MS = 90_000L
+
+    /**
+     * How old the catalog rows may get before returning to Home re-fetches them.
+     *
+     * Home is no longer rebuilt on every return (its back-stack entry — and so this ViewModel —
+     * now survives navigation to Watchlist/TV/Search), which is what made returning instant. The
+     * rebuild used to double as the refresh, so without a check here the rows would keep whatever
+     * they loaded for as long as the process lives. Continue Watching has its own, much shorter
+     * refresh above; this covers the slow-moving catalog rows.
+     *
+     * Most of a refresh is served from the HTTP disk cache, and TMDB's own `max-age` decides what
+     * genuinely goes to the network (trending ~8 min, show metadata several hours).
+     */
+    private val HOME_DATA_STALE_AFTER_MS = 6 * 60 * 60 * 1000L
+
+    /** Elapsed-realtime mark of the last [loadHomeData] start; 0 until the first load. */
+    private var lastHomeDataLoadAtMs = 0L
     private var lastWatchedBadgesRefreshMs: Long = 0L
     private val HOME_PLACEHOLDER_ITEM_COUNT = 8
 
@@ -2334,6 +2351,7 @@ class HomeViewModel @Inject constructor(
 
     private fun loadHomeData() {
         loadHomeJob?.cancel()
+        lastHomeDataLoadAtMs = SystemClock.elapsedRealtime()
         val requestId = ++loadHomeRequestId
         loadHomeJob = viewModelScope.launch loadHome@{
             // Skip delay - preloading now happens on profile focus for instant display
@@ -3740,6 +3758,23 @@ class HomeViewModel @Inject constructor(
             if (lastFocusChangeTime != requestedAt) return@launch
             preloadBackdropImages(urls)
         }
+    }
+
+    /**
+     * Called when Home resumes. Re-loads the catalog rows only once they are older than
+     * [HOME_DATA_STALE_AFTER_MS], so ordinary navigation back from Watchlist/TV/Search stays
+     * instant while a long-lived session still picks up new content.
+     *
+     * A zero mark means the first load has not run yet — startup owns that, so this stays out of
+     * its way rather than racing it.
+     */
+    fun refreshHomeDataIfStale() {
+        val lastLoadAtMs = lastHomeDataLoadAtMs
+        if (lastLoadAtMs == 0L) return
+        val ageMs = SystemClock.elapsedRealtime() - lastLoadAtMs
+        if (ageMs < HOME_DATA_STALE_AFTER_MS) return
+        android.util.Log.i("HomeViewModel", "home data ${ageMs / 60_000}min old — refreshing on resume")
+        loadHomeData()
     }
 
     fun refresh() {

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
@@ -1213,8 +1213,15 @@ class HomeViewModel @Inject constructor(
      */
     private val HOME_DATA_STALE_AFTER_MS = 6 * 60 * 60 * 1000L
 
-    /** Elapsed-realtime mark of the last [loadHomeData] start; 0 until the first load. */
+    /**
+     * Elapsed-realtime mark of the last SUCCESSFUL [loadHomeData]; 0 until one completes.
+     * A load that failed must not mark Home fresh, or one transient network error would
+     * suppress the resume refresh for the whole TTL.
+     */
     private var lastHomeDataLoadAtMs = 0L
+
+    /** True once [loadHomeData] has been started at least once, successfully or not. */
+    private var homeDataLoadAttempted = false
     private var lastWatchedBadgesRefreshMs: Long = 0L
     private val HOME_PLACEHOLDER_ITEM_COUNT = 8
 
@@ -1836,9 +1843,9 @@ class HomeViewModel @Inject constructor(
                 // dropped — leaving the screen empty until the network load finished ~5s later.
                 // That race is what made the slow home load intermittent.
                 if (cachedCategories.isNotEmpty() && !hasRealBaseCategories()) {
-                    val heroItem = chooseInitialHero(cachedCategories)
-                    val heroKey = heroItem?.let { "${it.mediaType}_${it.id}" }
-                    val heroLogo = heroKey?.let { getCachedLogo(it) }
+                    val cachedHero = chooseInitialHero(cachedCategories)
+                    val cachedHeroKey = cachedHero?.let { "${it.mediaType}_${it.id}" }
+                    val cachedHeroLogo = cachedHeroKey?.let { getCachedLogo(it) }
                     withContext(Dispatchers.Main) {
                         if (!hasRealBaseCategories()) {
                             // A Continue Watching row already on screen is fresher than the one in
@@ -1850,13 +1857,23 @@ class HomeViewModel @Inject constructor(
                             } else {
                                 cachedCategories
                             }
+                            // Don't stomp a hero the Continue Watching path already set — and take
+                            // the logo from whichever hero wins, so a live hero can never be shown
+                            // with the cached hero's logo.
+                            val liveHero = _uiState.value.heroItem
+                            val finalHero = liveHero ?: cachedHero
+                            val finalLogo = if (liveHero != null) {
+                                _uiState.value.heroLogoUrl
+                                    ?: getCachedLogo("${liveHero.mediaType}_${liveHero.id}")
+                            } else {
+                                cachedHeroLogo
+                            }
                             _uiState.value = _uiState.value.copy(
                                 isLoading = false,
                                 isInitialLoad = false,
                                 categories = merged,
-                                // Don't stomp a hero the Continue Watching path already set.
-                                heroItem = _uiState.value.heroItem ?: heroItem,
-                                heroLogoUrl = _uiState.value.heroLogoUrl ?: heroLogo,
+                                heroItem = finalHero,
+                                heroLogoUrl = finalLogo,
                                 error = null
                             )
                         }
@@ -2378,7 +2395,7 @@ class HomeViewModel @Inject constructor(
 
     private fun loadHomeData() {
         loadHomeJob?.cancel()
-        lastHomeDataLoadAtMs = SystemClock.elapsedRealtime()
+        homeDataLoadAttempted = true
         val requestId = ++loadHomeRequestId
         loadHomeJob = viewModelScope.launch loadHome@{
             // Skip delay - preloading now happens on profile focus for instant display
@@ -2984,6 +3001,9 @@ class HomeViewModel @Inject constructor(
                     categoryHasMoreMap = categoryPaginationStates.mapValues { it.value.hasMore },
                     error = null
                 )
+                // Only a load that actually published rows counts as fresh — see
+                // [refreshHomeDataIfStale].
+                lastHomeDataLoadAtMs = SystemClock.elapsedRealtime()
                 heroItem?.let { item ->
                     if (isStartupSettling()) {
                         scheduleStartupHeroHydration(item)
@@ -3792,12 +3812,20 @@ class HomeViewModel @Inject constructor(
      * [HOME_DATA_STALE_AFTER_MS], so ordinary navigation back from Watchlist/TV/Search stays
      * instant while a long-lived session still picks up new content.
      *
-     * A zero mark means the first load has not run yet — startup owns that, so this stays out of
-     * its way rather than racing it.
+     * Startup owns the first load, so this stays out of its way until one has been started. It
+     * also retries when no load has ever succeeded: [lastHomeDataLoadAtMs] is set only once rows
+     * are published, so a failed load heals on the next resume instead of pinning Home to the
+     * cached rows for the whole TTL.
      */
     fun refreshHomeDataIfStale() {
+        if (!homeDataLoadAttempted) return
+        if (loadHomeJob?.isActive == true) return
         val lastLoadAtMs = lastHomeDataLoadAtMs
-        if (lastLoadAtMs == 0L) return
+        if (lastLoadAtMs == 0L) {
+            android.util.Log.i("HomeViewModel", "no home load has succeeded yet — retrying on resume")
+            loadHomeData()
+            return
+        }
         val ageMs = SystemClock.elapsedRealtime() - lastLoadAtMs
         if (ageMs < HOME_DATA_STALE_AFTER_MS) return
         android.util.Log.i("HomeViewModel", "home data ${ageMs / 60_000}min old — refreshing on resume")

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
@@ -1829,18 +1829,34 @@ class HomeViewModel @Inject constructor(
             try {
                 applyContentLanguageFromPrefs()
                 val cachedCategories = loadCategoriesCache()
-                if (cachedCategories.isNotEmpty() && _uiState.value.categories.isEmpty()) {
+                // Gate on "no real BASE rows yet", not "no categories at all": Continue Watching
+                // is restored from its own cache by a coroutine launched alongside this one, and
+                // whichever finishes first used to decide the outcome. When CW won, it put a row
+                // into `categories`, the isEmpty() guard failed, and every cached base row was
+                // dropped — leaving the screen empty until the network load finished ~5s later.
+                // That race is what made the slow home load intermittent.
+                if (cachedCategories.isNotEmpty() && !hasRealBaseCategories()) {
                     val heroItem = chooseInitialHero(cachedCategories)
                     val heroKey = heroItem?.let { "${it.mediaType}_${it.id}" }
                     val heroLogo = heroKey?.let { getCachedLogo(it) }
                     withContext(Dispatchers.Main) {
-                        if (_uiState.value.categories.isEmpty()) {
+                        if (!hasRealBaseCategories()) {
+                            // A Continue Watching row already on screen is fresher than the one in
+                            // this cache — keep it, and take only the base rows from disk.
+                            val liveCw = _uiState.value.categories
+                                .firstOrNull { it.id == "continue_watching" }
+                            val merged = if (liveCw != null) {
+                                listOf(liveCw) + cachedCategories.filterNot { it.id == "continue_watching" }
+                            } else {
+                                cachedCategories
+                            }
                             _uiState.value = _uiState.value.copy(
                                 isLoading = false,
                                 isInitialLoad = false,
-                                categories = cachedCategories,
-                                heroItem = heroItem,
-                                heroLogoUrl = heroLogo,
+                                categories = merged,
+                                // Don't stomp a hero the Continue Watching path already set.
+                                heroItem = _uiState.value.heroItem ?: heroItem,
+                                heroLogoUrl = _uiState.value.heroLogoUrl ?: heroLogo,
                                 error = null
                             )
                         }
@@ -2348,6 +2364,17 @@ class HomeViewModel @Inject constructor(
             _uiState.value = _uiState.value.copy(categories = current)
         }
     }
+
+    /**
+     * True when a base (non-Continue-Watching, non-collection) row already holds real content.
+     * Mirrors the test [loadHomeData] uses to decide whether the skeleton is still needed.
+     */
+    private fun hasRealBaseCategories(): Boolean =
+        _uiState.value.categories.any { category ->
+            category.id != "continue_watching" &&
+                !category.id.startsWith("collection_row_") &&
+                category.items.any { !it.isPlaceholder }
+        }
 
     private fun loadHomeData() {
         loadHomeJob?.cancel()


### PR DESCRIPTION
 ## perf(home): fix slow home load on cold start and on return                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                    
  Home took ~5s to populate when returning from Watchlist/TV/Search, and intermittently                                                                                                                                                                                                                             
  5–10s on cold start. Four causes:                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                    
  **1. The HTTP disk cache never ran.** `OkHttpProvider.client` is built lazily and memoised,                                                                                                                                                                                                                       
  and `OkHttpProvider.init()` was called from `Application.onCreate()` *after* `super.onCreate()`                                                                                                                                                                                                                   
  — where Hilt's field injection already constructs Retrofit and therefore the client. So it was                                                                                                                                                                                                                    
  always built with no app context and ran cacheless for the whole process (`cache/http_cache`                                                                                                                                                                                                                      
  never existed on device). Moved to `attachBaseContext`, and `init` now falls back to the passed                                                                                                                                                                                                                   
  context because `getApplicationContext()` returns null that early. Added a warning log when the                                                                                                                                                                                                                   
  client builds without a context — it caught the second half of this.                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                    
  **2. `navigateHome()` destroyed HomeViewModel.** `navigateTopLevel` leaves Home on the back stack                                                                                                                                                                                                                 
  (`inclusive = false`), but the return path re-navigated with `inclusive = true`, killing the                                                                                                                                                                                                                      
  `NavBackStackEntry` that `hiltViewModel()` scopes to — so the screen rebuilt from scratch every                                                                                                                                                                                                                   
  time. Now pops back to the existing entry, with the old navigate as fallback. `popBackStack` also                                                                                                                                                                                                                 
  clears anything above Home, which handles the stale-Details case the old comment cited.                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                    
  **3. A startup race discarded the cached rows (the intermittent cold start).** Two coroutines                                                                                                                                                                                                                     
  start together in `HomeViewModel.init`: one restores the cached category rows from disk, the                                                                                                                                                                                                                      
  other restores Continue Watching. The categories publish was guarded by                                                                                                                                                                                                                                           
  `_uiState.value.categories.isEmpty()` — so whenever Continue Watching won the race and inserted                                                                                                                                                                                                                   
  its row first, the guard failed and **every cached base row was silently dropped**. The screen                                                                                                                                                                                                                    
  then showed Continue Watching alone until the network load finished, which is itself held behind                                                                                                                                                                                                                  
  a 4–5.7s startup settle delay. Whichever coroutine finished first decided the outcome, which is                                                                                                                                                                                                                   
  why it only happened sometimes. The guard now tests for real *base* rows                                                                                                                                                                                                                                          
  (`hasRealBaseCategories()`, mirroring what `loadHomeData` already uses), keeps a live Continue                                                                                                                                                                                                                    
  Watching row over the cached copy, and preserves a hero it had already set.                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                    
  **4. Nothing would refresh afterwards.** The rebuild had been doubling as the refresh mechanism.                                                                                                                                                                                                                  
  Added a 6h staleness check on resume (`refreshHomeDataIfStale`); Continue Watching keeps its own                                                                                                                                                                                                                  
  45s refresh.                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                    
  Also: a network interceptor marking unsuccessful responses `no-store`, so a transient 5xx or a                                                                                                                                                                                                                    
  429 can't be cached and replayed.                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                    
  ### Measured on device                                                                                                                                                                                                                                                                                            
  - **Return to Home** — before: `cache/http_cache` absent, ~550 requests per return, ~5s.                                                                                                                                                                                                                          
    After: 464 of 510 responses served from disk, 3 network calls; return is instant.                                                                                                                                                                                                                               
  - **Cold start** — captured a failing run at **5,881ms** to first real content (cached rows                                                                                                                                                                                                                       
    dropped, content only arriving with the network load). After the fix, 6/6 cold starts landed                                                                                                                                                                                                                    
    at **318–458ms**, publishing all 14 cached rows.                                            