### PR TITLE
i18n(de): add the two missing German IPTV VOD strings

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -594,6 +594,8 @@
     <string name="settings_section_categories">KATEGORIEN</string>
     <string name="settings_iptv_channel_order">Kanalreihenfolge</string>
     <string name="settings_iptv_channel_order_description">Wähle, wie Kanäle innerhalb jeder Gruppe angeordnet werden</string>
+    <string name="settings_iptv_vod_search">IPTV-VOD-Streams</string>
+    <string name="settings_iptv_vod_search_desc">IPTV-Filme und -Serien beim Abrufen von Streams einbeziehen</string>
     <string name="settings_iptv_order_provider">Anbieter-Reihenfolge</string>
     <string name="settings_iptv_order_number">Kanalnummer</string>
     <string name="settings_iptv_order_name">Alphabetisch (A–Z)</string>


### PR DESCRIPTION
### What

Adds the two German values that were missing after the new IPTV VOD search
setting landed in #628.

- `settings_iptv_vod_search` → "IPTV-VOD-Streams"
- `settings_iptv_vod_search_desc` → "IPTV-Filme und -Serien beim Abrufen von Streams einbeziehen"

Both are inserted in their matching position inside the IPTV section of
`values-de/strings.xml`, next to `settings_iptv_channel_order_description`,
so the file keeps mirroring the order of `values/strings.xml`.

### Why

`values-de` was completed in #615–#618, but two keys have been added upstream
since then, so the German settings screen currently falls back to English for
this one row. This closes that gap.

`app_name` is intentionally left untranslated — it is the product name.
With this change `values-de` covers every translatable key in `values`.

### Notes

- Resource file only, no code and no behaviour changes.
- Other locale folders are untouched; they keep falling back to English as before.
- Unit tests green locally (`testSideloadDebugUnitTest`).

created by Claude (Anthropic) on behalf of @ReichiMD