### PR TITLE
i18n(plugins/crash/watchlist): move hardcoded UI strings into string resources

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/crash/CrashReportActivity.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/crash/CrashReportActivity.kt
@@ -4,6 +4,7 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
+import android.content.res.Configuration
 import android.net.Uri
 import android.os.Bundle
 import android.widget.Toast
@@ -24,12 +25,14 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.arflix.tv.MainActivity
+import com.arflix.tv.R
 import com.arflix.tv.ui.components.QrCodeImage
 import com.arflix.tv.ui.theme.ArflixTvTheme
 import com.arflix.tv.util.DeviceType
@@ -39,6 +42,20 @@ import java.text.SimpleDateFormat
 import java.util.*
 
 class CrashReportActivity : ComponentActivity() {
+
+    override fun attachBaseContext(newBase: Context) {
+        val tag = newBase.getSharedPreferences("app_locale", Context.MODE_PRIVATE)
+            .getString("locale_tag", null)
+        if (!tag.isNullOrEmpty()) {
+            val locale = Locale.forLanguageTag(tag)
+            Locale.setDefault(locale)
+            val config = Configuration(newBase.resources.configuration)
+            config.setLocale(locale)
+            super.attachBaseContext(newBase.createConfigurationContext(config))
+        } else {
+            super.attachBaseContext(newBase)
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -141,7 +158,7 @@ fun CrashReportScreen(
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             Text(
-                text = "⚠️ ARVIO Encountered an Error",
+                text = stringResource(R.string.crash_title),
                 color = Color.White,
                 fontSize = if (isTv) 26.sp else 22.sp,
                 fontWeight = FontWeight.Bold,
@@ -150,9 +167,9 @@ fun CrashReportScreen(
 
             Text(
                 text = if (isTv) {
-                    "Scan the QR code below with your phone camera to automatically copy the crash report & open our Discord bug channel."
+                    stringResource(R.string.crash_desc_tv)
                 } else {
-                    "We apologize for the interruption. You can report this crash directly to our Discord channel to help us fix it."
+                    stringResource(R.string.crash_desc_mobile)
                 },
                 color = Color(0xFFA0A6B2),
                 fontSize = 14.sp,
@@ -176,7 +193,7 @@ fun CrashReportScreen(
                 }
 
                 Text(
-                    text = "Scan to open arvio.tv — 1 tap to copy report & jump into Discord.",
+                    text = stringResource(R.string.crash_qr_hint),
                     color = Color(0xFF00F0D0),
                     fontSize = 14.sp,
                     fontWeight = FontWeight.SemiBold,
@@ -195,7 +212,7 @@ fun CrashReportScreen(
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     Text(
-                        text = "Crash Reference Details",
+                        text = stringResource(R.string.crash_details_title),
                         color = Color.White,
                         fontSize = 13.sp,
                         fontWeight = FontWeight.Bold
@@ -222,7 +239,7 @@ fun CrashReportScreen(
                             val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
                             val clip = ClipData.newPlainText("ARVIO Crash Report", formattedReport)
                             clipboard.setPrimaryClip(clip)
-                            Toast.makeText(context, "Crash details copied! Opening Discord...", Toast.LENGTH_LONG).show()
+                            Toast.makeText(context, R.string.crash_copied_toast, Toast.LENGTH_LONG).show()
 
                             val intent = Intent(Intent.ACTION_VIEW, Uri.parse(CrashReportActivity.DISCORD_BUG_CHANNEL_URL)).apply {
                                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
@@ -233,7 +250,7 @@ fun CrashReportScreen(
                         shape = RoundedCornerShape(8.dp),
                         modifier = Modifier.weight(1f)
                     ) {
-                        Text("Report on Discord", color = Color.White, fontWeight = FontWeight.SemiBold)
+                        Text(stringResource(R.string.crash_report_discord), color = Color.White, fontWeight = FontWeight.SemiBold)
                     }
                 }
 
@@ -255,7 +272,7 @@ fun CrashReportScreen(
                             }
                         )
                 ) {
-                    Text("Restart ARVIO", color = Color.Black, fontWeight = FontWeight.Bold)
+                    Text(stringResource(R.string.crash_restart_app), color = Color.Black, fontWeight = FontWeight.Bold)
                 }
             }
         }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/plugin/PluginScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/plugin/PluginScreen.kt
@@ -189,7 +189,7 @@ fun PluginScreen(
                             icon = Icons.Default.Extension,
                             title = scraper.name,
                             subtitle = scraper.id,
-                            value = if (scraper.enabled) "On" else "Off",
+                            value = if (scraper.enabled) stringResource(R.string.on) else stringResource(R.string.off),
                             isFocused = false,
                             showDivider = idx < scrapers.lastIndex,
                             onClick = { viewModel.onEvent(PluginUiEvent.ToggleScraper(scraper.id, !scraper.enabled)) }
@@ -201,8 +201,8 @@ fun PluginScreen(
             MobileSettingsCategory(title = "") {
                 MobileSettingsRow(
                     icon = Icons.Default.Delete,
-                    title = "Reset Plugins & Extensions",
-                    subtitle = "Deletes all repositories, scrapers, and local data",
+                    title = stringResource(R.string.plugin_screen_reset_title),
+                    subtitle = stringResource(R.string.plugin_screen_reset_desc),
                     value = "",
                     isFocused = false,
                     showDivider = false,
@@ -359,7 +359,7 @@ fun PluginScreen(
                 )
                 Spacer(modifier = Modifier.width(12.dp))
                 Text(
-                    text = "Reset Plugins & Extensions",
+                    text = stringResource(R.string.plugin_screen_reset_title),
                     style = ArflixTypography.button,
                     color = Color.Red
                 )
@@ -381,8 +381,8 @@ fun PluginScreen(
 
     if (showResetDialog) {
         WarningDialog(
-            title = "Warning",
-            message = "Are you sure you want to delete all plugins, scrapers, and local code data? This action cannot be undone.",
+            title = stringResource(R.string.plugin_screen_reset_warning_title),
+            message = stringResource(R.string.plugin_screen_reset_warning_message),
             cancelText = stringResource(R.string.cancel),
             confirmText = stringResource(R.string.delete),
             onConfirm = {
@@ -397,7 +397,7 @@ fun PluginScreen(
     repoToDelete?.let { repo ->
         WarningDialog(
             title = stringResource(R.string.delete),
-            message = "Are you sure you want to remove '${repo.name}'?",
+            message = stringResource(R.string.plugin_screen_remove_repo_message, repo.name),
             cancelText = stringResource(R.string.cancel),
             confirmText = stringResource(R.string.delete),
             onConfirm = {

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/plugin/PluginViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/plugin/PluginViewModel.kt
@@ -107,7 +107,7 @@ class PluginViewModel @Inject constructor(
 
     private fun addRepository(url: String) {
         if (url.isBlank()) {
-            _uiState.update { it.copy(errorMessage = "Error") }
+            _uiState.update { it.copy(errorMessage = context.getString(R.string.plugin_error_invalid_url)) }
             return
         }
 
@@ -147,7 +147,7 @@ class PluginViewModel @Inject constructor(
             _uiState.update {
                 it.copy(
                     isLoading = false,
-                    successMessage = "Error"
+                    successMessage = context.getString(R.string.plugin_repo_removed)
                 )
             }
         }
@@ -164,7 +164,7 @@ class PluginViewModel @Inject constructor(
                     _uiState.update {
                         it.copy(
                             isLoading = false,
-                            successMessage = "Error"
+                            successMessage = context.getString(R.string.plugin_repo_refreshed)
                         )
                     }
                 },
@@ -232,7 +232,7 @@ class PluginViewModel @Inject constructor(
                             testResults = results,
                             testDiagnostics = diagnostics,
                             successMessage = if (results.isEmpty()) {
-                                "Error"
+                                context.getString(R.string.plugin_test_no_results)
                             } else {
                                 context.getString(R.string.plugin_test_found_streams, results.size)
                             }
@@ -263,7 +263,7 @@ class PluginViewModel @Inject constructor(
             _uiState.update {
                 it.copy(
                     isLoading = false,
-                    successMessage = "All plugins and extensions cleared successfully"
+                    successMessage = context.getString(R.string.plugin_all_cleared)
                 )
             }
         }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/watchlist/WatchlistScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/watchlist/WatchlistScreen.kt
@@ -216,15 +216,17 @@ fun WatchlistScreen(
             .mapNotNull { source -> source.trackerProviderLabel()?.let { label -> label to source } }
             .groupBy(keySelector = { it.first }, valueTransform = { it.second })
     }
-    val providers = remember(libraryState.providers, trackerGroups) {
+    val myWatchlistLabel = stringResource(R.string.watchlist_my_watchlist)
+    val unknownServerLabel = stringResource(R.string.watchlist_provider_home_server)
+    val providers = remember(libraryState.providers, trackerGroups, myWatchlistLabel, unknownServerLabel) {
         buildList {
-            add(LibraryProviderOption(id = WATCHLIST_PROVIDER_ID, label = "My Watchlist"))
+            add(LibraryProviderOption(id = WATCHLIST_PROVIDER_ID, label = myWatchlistLabel))
             libraryState.providers.forEach { kind ->
                 val label = when (kind) {
                     HomeServerKind.PLEX -> "Plex"
                     HomeServerKind.JELLYFIN -> "Jellyfin"
                     HomeServerKind.EMBY -> "Emby"
-                    HomeServerKind.UNKNOWN -> "Server"
+                    HomeServerKind.UNKNOWN -> unknownServerLabel
                 }
                 add(LibraryProviderOption(id = "provider:home:${kind.name}", label = label, homeServerKind = kind))
             }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/watchlist/WatchlistViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/watchlist/WatchlistViewModel.kt
@@ -317,7 +317,7 @@ class WatchlistViewModel @Inject constructor(
                         WatchlistSourceItem.TrackerList(
                             provider = TrackerLibraryProvider.TRAKT,
                             listKey = TRAKT_WATCHLIST_KEY,
-                            title = "Watchlist"
+                            title = context.getString(R.string.watchlist_tracker_default_list)
                         )
                     )
                 } else {
@@ -333,12 +333,12 @@ class WatchlistViewModel @Inject constructor(
                 }
             }
             if (simklConnected) {
-                SIMKL_LIBRARY_LISTS.forEach { (status, title) ->
+                SIMKL_LIBRARY_LISTS.forEach { (status, titleRes) ->
                     add(
                         WatchlistSourceItem.TrackerList(
                             provider = TrackerLibraryProvider.SIMKL,
                             listKey = status,
-                            title = title
+                            title = context.getString(titleRes)
                         )
                     )
                 }
@@ -1271,12 +1271,14 @@ class WatchlistViewModel @Inject constructor(
         private const val LIBRARY_CACHE_ENTRY_LIMIT = 12
         private const val TRACKER_LIST_ITEM_LIMIT = 240
         private const val TRAKT_WATCHLIST_KEY = "__watchlist__"
+        // The status keys stay English so the Simkl API calls keep working;
+        // only the rendered list title is localized.
         private val SIMKL_LIBRARY_LISTS = listOf(
-            "watching" to "Watching",
-            "plantowatch" to "Plan to watch",
-            "completed" to "Completed",
-            "hold" to "On hold",
-            "dropped" to "Dropped"
+            "watching" to R.string.watchlist_simkl_watching,
+            "plantowatch" to R.string.watchlist_simkl_plan_to_watch,
+            "completed" to R.string.watchlist_simkl_completed,
+            "hold" to R.string.watchlist_simkl_on_hold,
+            "dropped" to R.string.watchlist_simkl_dropped
         )
         private val BROWSABLE_LIBRARY_TYPES = setOf(
             "",

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -941,6 +941,23 @@
     <string name="plugin_screen_no_scrapers">Keine Scraper installiert.</string>
     <string name="plugin_screen_add_repo_dialog_title">Plugin-Repository hinzufügen</string>
     <string name="plugin_screen_repo_url">Repository-URL</string>
+    <string name="plugin_screen_reset_title">Plugins &amp; Erweiterungen zurücksetzen</string>
+    <string name="plugin_screen_reset_desc">Löscht alle Repositorys, Scraper und lokalen Daten</string>
+    <string name="plugin_screen_reset_warning_title">Warnung</string>
+    <string name="plugin_screen_reset_warning_message">Möchtest du wirklich alle Plugins, Scraper und lokalen Code-Daten löschen? Das lässt sich nicht rückgängig machen.</string>
+    <string name="plugin_screen_remove_repo_message">Möchtest du \'%1$s\' wirklich entfernen?</string>
+    <string name="plugin_all_cleared">Alle Plugins und Erweiterungen wurden entfernt</string>
+
+    <!-- Crash report screen (de) -->
+    <string name="crash_title">⚠️ In ARVIO ist ein Fehler aufgetreten</string>
+    <string name="crash_desc_tv">Scanne den QR-Code unten mit der Handy-Kamera, um den Absturzbericht automatisch zu kopieren und unseren Discord-Fehlerkanal zu öffnen.</string>
+    <string name="crash_desc_mobile">Entschuldige die Unterbrechung. Du kannst diesen Absturz direkt in unserem Discord-Kanal melden und uns so bei der Fehlersuche helfen.</string>
+    <string name="crash_qr_hint">Scannen, um arvio.tv zu öffnen — ein Tipp kopiert den Bericht und öffnet Discord.</string>
+    <string name="crash_details_title">Angaben zum Absturz</string>
+    <string name="crash_copied_toast">Absturzdetails kopiert. Discord wird geöffnet …</string>
+    <string name="crash_report_discord">Auf Discord melden</string>
+    <string name="crash_restart_app">ARVIO neu starten</string>
+
     <string name="profile_edit_title">Profil bearbeiten</string>
     <string name="profile_name_hint">Profilname</string>
     <string name="profile_lock">Profilsperre</string>
@@ -1043,6 +1060,14 @@
     <string name="watchlist_error_load_trakt">Trakt-Merkliste konnte nicht geladen werden</string>
     <string name="watchlist_error_refresh">Aktualisieren fehlgeschlagen</string>
     <string name="watchlist_toast_removed">Aus Merkliste entfernt</string>
+    <string name="watchlist_my_watchlist">Meine Merkliste</string>
+    <string name="watchlist_provider_home_server">Server</string>
+    <string name="watchlist_tracker_default_list">Merkliste</string>
+    <string name="watchlist_simkl_watching">Wird gesehen</string>
+    <string name="watchlist_simkl_plan_to_watch">Geplant</string>
+    <string name="watchlist_simkl_completed">Abgeschlossen</string>
+    <string name="watchlist_simkl_on_hold">Pausiert</string>
+    <string name="watchlist_simkl_dropped">Abgebrochen</string>
     <string name="continue_season_episode">Weiterschauen S%1$dE%2$d</string>
     <string name="continue_season_episode_at">Weiterschauen S%1$dE%2$d bei %3$s</string>
     <string name="continue_at">Weiterschauen bei %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -819,6 +819,22 @@
     <string name="plugin_screen_no_scrapers">No scrapers installed.</string>
     <string name="plugin_screen_add_repo_dialog_title">Add Plugin Repository</string>
     <string name="plugin_screen_repo_url">Repository URL</string>
+    <string name="plugin_screen_reset_title">Reset Plugins &amp; Extensions</string>
+    <string name="plugin_screen_reset_desc">Deletes all repositories, scrapers, and local data</string>
+    <string name="plugin_screen_reset_warning_title">Warning</string>
+    <string name="plugin_screen_reset_warning_message">Are you sure you want to delete all plugins, scrapers, and local code data? This action cannot be undone.</string>
+    <string name="plugin_screen_remove_repo_message">Are you sure you want to remove \'%1$s\'?</string>
+    <string name="plugin_all_cleared">All plugins and extensions cleared successfully</string>
+
+    <!-- Extracted from code: Crash report screen -->
+    <string name="crash_title">⚠️ ARVIO Encountered an Error</string>
+    <string name="crash_desc_tv">Scan the QR code below with your phone camera to automatically copy the crash report &amp; open our Discord bug channel.</string>
+    <string name="crash_desc_mobile">We apologize for the interruption. You can report this crash directly to our Discord channel to help us fix it.</string>
+    <string name="crash_qr_hint">Scan to open arvio.tv — 1 tap to copy report &amp; jump into Discord.</string>
+    <string name="crash_details_title">Crash Reference Details</string>
+    <string name="crash_copied_toast">Crash details copied! Opening Discord...</string>
+    <string name="crash_report_discord">Report on Discord</string>
+    <string name="crash_restart_app">Restart ARVIO</string>
 
     <!-- Extracted from code: Profile, Login and Collections -->
     <string name="profile_edit_title">Edit Profile</string>
@@ -1034,6 +1050,14 @@
     <string name="watchlist_error_load_trakt">Failed to load Trakt watchlist</string>
     <string name="watchlist_error_refresh">Failed to refresh</string>
     <string name="watchlist_toast_removed">Removed from watchlist</string>
+    <string name="watchlist_my_watchlist">My Watchlist</string>
+    <string name="watchlist_provider_home_server">Server</string>
+    <string name="watchlist_tracker_default_list">Watchlist</string>
+    <string name="watchlist_simkl_watching">Watching</string>
+    <string name="watchlist_simkl_plan_to_watch">Plan to watch</string>
+    <string name="watchlist_simkl_completed">Completed</string>
+    <string name="watchlist_simkl_on_hold">On hold</string>
+    <string name="watchlist_simkl_dropped">Dropped</string>
 
 
     <!-- Extracted from code (data layer): shared labels and errors -->


### PR DESCRIPTION
### What

Moves the hardcoded English UI strings in the plugin screen, the crash report
screen and the watchlist library picker into the string resource system and
adds the German values.

- 22 strings moved from Kotlin literals to `stringResource(...)` / `getString(...)`
- 6 of them reuse resources that were already present but unused
- new keys added to `values/strings.xml` in their matching sections
- German values added to `values-de/strings.xml`

Two small fixes came out of this pass and are included on purpose:

1. `PluginViewModel` showed the literal `"Error"` as the *success* message after
   removing or refreshing a repository, and as the error for a blank repository
   URL and for an empty test result. The correct strings
   (`plugin_repo_removed`, `plugin_repo_refreshed`, `plugin_error_invalid_url`,
   `plugin_test_no_results`) already existed in `strings.xml` but were never
   wired up, so those four call sites now use them.
2. `CrashReportActivity` did not pick up the in-app language, unlike
   `MainActivity`. It now uses the same `attachBaseContext` block, otherwise the
   localized crash screen would still render in the system language.

### Why

Approved in Discord (28 Aug): "Yes try to also bring hardcoded things into this.
That has been kinda a long time bug. They dont have to be in English yea."

This benefits all 50 language folders, not just German — untranslated locales fall
back to English exactly as before.

This is the first of a series of small, area-by-area PRs; the following ones will
apply the same approach to the player, catalogs, home/search, settings and live TV.

### Notes

- Stored values and internal keys are unchanged; only rendered text is localized.
  Follows the existing pattern from `LiveCategory.kt`. Concretely: the Simkl list
  status keys (`watching`, `plantowatch`, …) stay English and only the rendered
  list title is localized, and `WatchlistSourceItem.MyWatchlist.title` is left
  untouched because it is not rendered anywhere.
- Brand names (Netflix, Plex, Jellyfin, Emby, Trakt, Simkl, MDBList) are left
  untouched — `WatchlistScreen` compares provider labels against `"Trakt"` and
  `"Simkl"` to pick their accent colours, so those must not be translated.
- Log messages, telemetry strings (`"error_area" to "Watchlist"`) and internal
  exception fallbacks are out of scope.
- The English text of "My watchlist" in the library picker is normalized to
  "My Watchlist" so both call sites can share one resource.
- Independent of #631 — test-merged both ways against current `main`, no
  conflicts. They touch different sections of `values-de/strings.xml`, so they
  can be merged in either order.
- Unit tests pass (`testSideloadDebugUnitTest`), including the existing
  `WatchlistSourceItemTest`. Device-tested on a TCL C7K.

created by Claude (Anthropic) on behalf of @ReichiMD