### PR TITLE
feat(details): show age certification on movie and show details

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/api/TmdbApi.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/api/TmdbApi.kt
@@ -64,6 +64,7 @@ interface TmdbApi {
     suspend fun getMovieDetails(
         @Path("movie_id") movieId: Int,
         @Query("api_key") apiKey: String,
+        @Query("append_to_response") appendToResponse: String = "release_dates",
         @Query("language") language: String? = null
     ): TmdbMovieDetails
 
@@ -71,6 +72,7 @@ interface TmdbApi {
     suspend fun getTvDetails(
         @Path("tv_id") tvId: Int,
         @Query("api_key") apiKey: String,
+        @Query("append_to_response") appendToResponse: String = "content_ratings",
         @Query("language") language: String? = null
     ): TmdbTvDetails
 
@@ -263,7 +265,10 @@ data class TmdbMovieDetails(
     val genres: List<TmdbGenre> = emptyList(),
     val status: String? = null,
     val adult: Boolean = false,
-    @SerializedName("belongs_to_collection") val belongsToCollection: TmdbCollectionRef? = null
+    @SerializedName("belongs_to_collection") val belongsToCollection: TmdbCollectionRef? = null,
+    // Appended via append_to_response. Nullable so the response stays valid
+    // when TMDB omits the block.
+    @SerializedName("release_dates") val releaseDates: TmdbReleaseDatesResponse? = null
 )
 
 /** Reference to a TMDB collection (franchise) returned inside movie/TV details. */
@@ -289,7 +294,10 @@ data class TmdbTvDetails(
     @SerializedName("episode_run_time") val episodeRunTime: List<Int> = emptyList(),
     val status: String? = null,
     val genres: List<TmdbGenre> = emptyList(),
-    val seasons: List<TmdbTvSeason> = emptyList()
+    val seasons: List<TmdbTvSeason> = emptyList(),
+    // Appended via append_to_response. Nullable so the response stays valid
+    // when TMDB omits the block.
+    @SerializedName("content_ratings") val contentRatings: TmdbContentRatingsResponse? = null
 )
 
 data class TmdbSeasonDetails(
@@ -311,6 +319,32 @@ data class TmdbEpisode(
     @SerializedName("vote_average") val voteAverage: Float = 0f,
     val runtime: Int? = null,
     @SerializedName("air_date") val airDate: String? = null
+)
+
+/**
+ * Age certifications for a movie, appended to /movie/{id} as `release_dates`.
+ * A country can list several certifications (theatrical, TV, streaming), so the
+ * per-country entry carries a list.
+ */
+data class TmdbReleaseDatesResponse(val results: List<TmdbReleaseDatesResult> = emptyList())
+data class TmdbReleaseDatesResult(
+    @SerializedName("iso_3166_1") val iso31661: String = "",
+    @SerializedName("release_dates") val releaseDates: List<TmdbReleaseDate> = emptyList()
+)
+/** `type` 3 is the theatrical release. Unknown types sort last, see ContentRating. */
+data class TmdbReleaseDate(
+    val certification: String? = null,
+    val type: Int = Int.MAX_VALUE
+)
+
+/**
+ * Age certifications for a TV show, appended to /tv/{id} as `content_ratings`.
+ * Unlike movies there is exactly one value per country.
+ */
+data class TmdbContentRatingsResponse(val results: List<TmdbContentRatingResult> = emptyList())
+data class TmdbContentRatingResult(
+    @SerializedName("iso_3166_1") val iso31661: String = "",
+    val rating: String? = null
 )
 
 data class TmdbGenre(val id: Int = 0, val name: String = "")

--- a/app/src/main/kotlin/com/arflix/tv/data/model/Models.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/model/Models.kt
@@ -16,6 +16,9 @@ data class MediaItem(
     val year: String = "",
     val releaseDate: String? = null,
     val rating: String = "",
+    // Age certification, already labelled for display ("FSK 16", "R", "US · R").
+    // Null when TMDB has none for the content country or the US fallback.
+    val contentRating: String? = null,
     val duration: String = "",
     val imdbRating: String = "",
     val tmdbRating: String = "",

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/MediaRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/MediaRepository.kt
@@ -35,6 +35,7 @@ import com.arflix.tv.data.model.Review
 import com.arflix.tv.data.model.SportsAddonCapabilities
 import com.arflix.tv.util.CatalogUrlParser
 import com.arflix.tv.util.Constants
+import com.arflix.tv.util.ContentRating
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -2927,7 +2928,10 @@ class MediaRepository @Inject constructor(
             val details = detailsDeferred.await()
             val imdbId = externalIdsDeferred.await()?.imdbId?.also { cacheImdbId(MediaType.MOVIE, movieId, it) }
             val imdbRating = imdbId?.let { getImdbRating(MediaType.MOVIE, movieId, it) }
-            details.toMediaItem().copy(imdbRating = imdbRating.orEmpty())
+            details.toMediaItem().copy(
+                imdbRating = imdbRating.orEmpty(),
+                contentRating = ContentRating.forMovie(details.releaseDates, contentLanguage)
+            )
         }
         cacheFullDetailsItem(item)
         return item
@@ -2957,7 +2961,10 @@ class MediaRepository @Inject constructor(
             val details = detailsDeferred.await()
             val imdbId = externalIdsDeferred.await()?.imdbId?.also { cacheImdbId(MediaType.TV, tvId, it) }
             val imdbRating = imdbId?.let { getImdbRating(MediaType.TV, tvId, it) }
-            details.toMediaItem().copy(imdbRating = imdbRating.orEmpty())
+            details.toMediaItem().copy(
+                imdbRating = imdbRating.orEmpty(),
+                contentRating = ContentRating.forTv(details.contentRatings, contentLanguage)
+            )
         }
         cacheFullDetailsItem(item)
         return item

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
@@ -1577,6 +1577,22 @@ private fun DetailsContent(
                                         overflow = TextOverflow.Ellipsis
                                     )
                                 }
+                                item.contentRating?.let { contentRating ->
+                                    if (ratingValue > 0f || displayDate.isNotEmpty() || hasDuration) {
+                                        MobileMetadataSeparator()
+                                    }
+                                    Text(
+                                        text = contentRating,
+                                        style = ArflixTypography.caption.copy(
+                                            fontSize = 13.sp,
+                                            fontWeight = FontWeight.SemiBold,
+                                            shadow = textShadow
+                                        ),
+                                        color = Color.White.copy(alpha = 0.78f),
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis
+                                    )
+                                }
                             }
 
                             if (externalRatings.isNotEmpty()) {
@@ -2210,6 +2226,20 @@ private fun DetailsContent(
                             Text(text = "|", style = separatorStyle, color = Color.White.copy(alpha = 0.7f))
                             Text(
                                 text = item.duration,
+                                style = ArflixTypography.caption.copy(
+                                    fontSize = 13.sp,
+                                    fontWeight = FontWeight.Bold,
+                                    shadow = textShadow
+                                ),
+                                color = Color.White,
+                                maxLines = 1
+                            )
+                        }
+
+                        item.contentRating?.let { contentRating ->
+                            Text(text = "|", style = separatorStyle, color = Color.White.copy(alpha = 0.7f))
+                            Text(
+                                text = contentRating,
                                 style = ArflixTypography.caption.copy(
                                     fontSize = 13.sp,
                                     fontWeight = FontWeight.Bold,

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsViewModel.kt
@@ -342,6 +342,7 @@ class DetailsViewModel @Inject constructor(
             year = primary.year.ifBlank { fallback.year },
             releaseDate = primary.releaseDate ?: fallback.releaseDate,
             rating = primary.rating.ifBlank { fallback.rating },
+            contentRating = primary.contentRating ?: fallback.contentRating,
             duration = primary.duration.ifBlank { fallback.duration },
             imdbRating = if (isBlankRating(primary.imdbRating)) fallback.imdbRating else primary.imdbRating,
             tmdbRating = if (isBlankRating(primary.tmdbRating)) fallback.tmdbRating else primary.tmdbRating,

--- a/app/src/main/kotlin/com/arflix/tv/util/ContentRating.kt
+++ b/app/src/main/kotlin/com/arflix/tv/util/ContentRating.kt
@@ -1,0 +1,134 @@
+package com.arflix.tv.util
+
+import com.arflix.tv.data.api.TmdbContentRatingResult
+import com.arflix.tv.data.api.TmdbContentRatingsResponse
+import com.arflix.tv.data.api.TmdbReleaseDatesResponse
+import com.arflix.tv.data.api.TmdbReleaseDatesResult
+
+/**
+ * Turns TMDB age certifications into the short label shown on a details screen.
+ *
+ * The certification is data, not translatable text: a German title keeps its
+ * "FSK 16" even when the interface runs in English, and a US title stays
+ * "Rated R" for a viewer with a German interface. The system names below
+ * therefore live in code and deliberately not in `strings.xml` — they follow
+ * where the certification comes from, not the interface language.
+ *
+ * The country comes from the profile's TMDB content language ("de-DE" -> "DE"),
+ * so no extra setting is needed. When that country has no certification the US
+ * value is shown, marked with its country code so nobody mistakes it for a
+ * national rating. With nothing at all the caller gets `null` and hides the
+ * badge.
+ */
+object ContentRating {
+
+    /** Used when the content language carries no usable country, and as fallback source. */
+    const val FALLBACK_REGION = "US"
+
+    /** TMDB release type for the theatrical release, preferred over TV/streaming. */
+    private const val TYPE_THEATRICAL = 3
+
+    /**
+     * Countries whose certifications are bare numbers and would otherwise read
+     * as a second score next to the IMDb rating. Small on purpose: every other
+     * country falls back to its country code, which stays readable.
+     */
+    private val RATING_SYSTEMS = mapOf(
+        "DE" to "FSK",
+        "GB" to "BBFC",
+        "BR" to "ClassInd",
+        "AU" to "ACB",
+        "NL" to "Kijkwijzer"
+    )
+
+    /** A certification that was actually found, and where it came from. */
+    data class Selection(
+        val certification: String,
+        val region: String,
+        val isFallback: Boolean
+    )
+
+    /**
+     * Country code from a TMDB content language such as "de-DE" or "pt-BR".
+     * Anything without a usable two-letter country (e.g. "en", "zh-Hans")
+     * falls back to [FALLBACK_REGION].
+     */
+    fun regionOf(contentLanguage: String?): String {
+        val region = contentLanguage
+            ?.substringAfter('-', "")
+            ?.trim()
+            ?.uppercase()
+            .orEmpty()
+        return region.takeIf { it.length == 2 && it.all { char -> char in 'A'..'Z' } }
+            ?: FALLBACK_REGION
+    }
+
+    /** Finished label for a movie, or null when neither the own nor the US country has one. */
+    fun forMovie(response: TmdbReleaseDatesResponse?, contentLanguage: String?): String? =
+        label(selectMovie(response, regionOf(contentLanguage)))
+
+    /** Finished label for a TV show, or null when neither the own nor the US country has one. */
+    fun forTv(response: TmdbContentRatingsResponse?, contentLanguage: String?): String? =
+        label(selectTv(response, regionOf(contentLanguage)))
+
+    /**
+     * Picks the movie certification for [region], falling back to the US value.
+     * A country can hold several certifications that disagree (cinema 16, TV 12);
+     * the theatrical one wins, otherwise the lowest known release type.
+     */
+    fun selectMovie(response: TmdbReleaseDatesResponse?, region: String): Selection? {
+        val results = response?.results ?: return null
+        movieCertification(results, region)?.let { return Selection(it, region, isFallback = false) }
+        if (region == FALLBACK_REGION) return null
+        return movieCertification(results, FALLBACK_REGION)
+            ?.let { Selection(it, FALLBACK_REGION, isFallback = true) }
+    }
+
+    /** Picks the TV certification for [region], falling back to the US value. */
+    fun selectTv(response: TmdbContentRatingsResponse?, region: String): Selection? {
+        val results = response?.results ?: return null
+        tvCertification(results, region)?.let { return Selection(it, region, isFallback = false) }
+        if (region == FALLBACK_REGION) return null
+        return tvCertification(results, FALLBACK_REGION)
+            ?.let { Selection(it, FALLBACK_REGION, isFallback = true) }
+    }
+
+    /**
+     * Applies the labelling rule:
+     * a value that speaks for itself stays untouched ("R", "PG-13", "TV-MA"),
+     * a bare number gets its rating system ("16" in DE -> "FSK 16") or else its
+     * country code ("12" in FR -> "FR 12"), and anything taken from the fallback
+     * country is always marked ("US · R").
+     */
+    fun label(selection: Selection?): String? {
+        if (selection == null) return null
+        val value = selection.certification
+        if (selection.isFallback) return "${selection.region} · $value"
+        if (!value.all { it.isDigit() }) return value
+        RATING_SYSTEMS[selection.region]?.let { return "$it $value" }
+        return "${selection.region} $value"
+    }
+
+    private fun movieCertification(
+        results: List<TmdbReleaseDatesResult>,
+        region: String
+    ): String? {
+        val entry = results.firstOrNull { it.iso31661.equals(region, ignoreCase = true) }
+            ?: return null
+        val candidates = entry.releaseDates.mapNotNull { release ->
+            release.certification?.trim()?.takeIf { it.isNotEmpty() }?.let { it to release.type }
+        }
+        if (candidates.isEmpty()) return null
+        return candidates.firstOrNull { it.second == TYPE_THEATRICAL }?.first
+            ?: candidates.minByOrNull { it.second }?.first
+    }
+
+    private fun tvCertification(
+        results: List<TmdbContentRatingResult>,
+        region: String
+    ): String? = results
+        .firstOrNull { it.iso31661.equals(region, ignoreCase = true) }
+        ?.rating
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+}

--- a/app/src/test/kotlin/com/arflix/tv/util/ContentRatingTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/util/ContentRatingTest.kt
@@ -1,0 +1,179 @@
+package com.arflix.tv.util
+
+import com.arflix.tv.data.api.TmdbContentRatingResult
+import com.arflix.tv.data.api.TmdbContentRatingsResponse
+import com.arflix.tv.data.api.TmdbReleaseDate
+import com.arflix.tv.data.api.TmdbReleaseDatesResponse
+import com.arflix.tv.data.api.TmdbReleaseDatesResult
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ContentRatingTest {
+
+    private fun movie(vararg countries: Pair<String, List<Pair<String?, Int>>>) =
+        TmdbReleaseDatesResponse(
+            results = countries.map { (country, releases) ->
+                TmdbReleaseDatesResult(
+                    iso31661 = country,
+                    releaseDates = releases.map { (certification, type) ->
+                        TmdbReleaseDate(certification = certification, type = type)
+                    }
+                )
+            }
+        )
+
+    private fun tv(vararg countries: Pair<String, String?>) =
+        TmdbContentRatingsResponse(
+            results = countries.map { (country, rating) ->
+                TmdbContentRatingResult(iso31661 = country, rating = rating)
+            }
+        )
+
+    // === country from the content language ===
+
+    @Test
+    fun `content language yields its country`() {
+        assertEquals("DE", ContentRating.regionOf("de-DE"))
+        assertEquals("BR", ContentRating.regionOf("pt-BR"))
+        assertEquals("US", ContentRating.regionOf("en-US"))
+    }
+
+    @Test
+    fun `content language without a usable country falls back to US`() {
+        assertEquals("US", ContentRating.regionOf("en"))
+        assertEquals("US", ContentRating.regionOf("zh-Hans"))
+        assertEquals("US", ContentRating.regionOf(""))
+        assertEquals("US", ContentRating.regionOf(null))
+    }
+
+    @Test
+    fun `lower case country in the content language still matches`() {
+        assertEquals("DE", ContentRating.regionOf("de-de"))
+    }
+
+    // === labelling rule ===
+
+    @Test
+    fun `a bare number gets the rating system of its country`() {
+        assertEquals("FSK 16", ContentRating.forMovie(movie("DE" to listOf("16" to 3)), "de-DE"))
+        assertEquals("BBFC 15", ContentRating.forMovie(movie("GB" to listOf("15" to 3)), "en-GB"))
+    }
+
+    @Test
+    fun `a bare number in a country without a known system gets the country code`() {
+        assertEquals("FR 12", ContentRating.forMovie(movie("FR" to listOf("12" to 3)), "fr-FR"))
+    }
+
+    @Test
+    fun `a value that speaks for itself stays untouched`() {
+        assertEquals("R", ContentRating.forMovie(movie("US" to listOf("R" to 3)), "en-US"))
+        assertEquals("PG-13", ContentRating.forMovie(movie("US" to listOf("PG-13" to 3)), "en-US"))
+        assertEquals("TV-MA", ContentRating.forTv(tv("US" to "TV-MA"), "en-US"))
+        assertEquals("12A", ContentRating.forMovie(movie("GB" to listOf("12A" to 3)), "en-GB"))
+        assertEquals(
+            "Tous publics",
+            ContentRating.forMovie(movie("FR" to listOf("Tous publics" to 3)), "fr-FR")
+        )
+        assertEquals("-12", ContentRating.forMovie(movie("FR" to listOf("-12" to 3)), "fr-FR"))
+    }
+
+    // === US fallback (E2) ===
+
+    @Test
+    fun `without a national certification the US value is shown and marked`() {
+        assertEquals(
+            "US · R",
+            ContentRating.forMovie(movie("US" to listOf("R" to 3)), "de-DE")
+        )
+        assertEquals(
+            "US · TV-MA",
+            ContentRating.forTv(tv("US" to "TV-MA"), "de-DE")
+        )
+    }
+
+    @Test
+    fun `a US viewer sees the US value without a marking`() {
+        assertEquals("R", ContentRating.forMovie(movie("US" to listOf("R" to 3)), "en-US"))
+    }
+
+    @Test
+    fun `a national certification wins over the US one`() {
+        val response = movie(
+            "US" to listOf("R" to 3),
+            "DE" to listOf("16" to 3)
+        )
+        assertEquals("FSK 16", ContentRating.forMovie(response, "de-DE"))
+    }
+
+    // === empty certification counts as absent ===
+
+    @Test
+    fun `an empty certification is treated as absent and falls back to US`() {
+        val response = movie(
+            "DE" to listOf("" to 3),
+            "US" to listOf("PG-13" to 3)
+        )
+        assertEquals("US · PG-13", ContentRating.forMovie(response, "de-DE"))
+    }
+
+    @Test
+    fun `a blank certification is treated as absent`() {
+        val response = movie("DE" to listOf("   " to 3))
+        assertNull(ContentRating.forMovie(response, "de-DE"))
+    }
+
+    @Test
+    fun `an empty TV rating is treated as absent`() {
+        assertNull(ContentRating.forTv(tv("DE" to ""), "de-DE"))
+    }
+
+    @Test
+    fun `an empty certification is skipped in favour of a filled one for the same country`() {
+        val response = movie("DE" to listOf("" to 3, "12" to 5))
+        assertEquals("FSK 12", ContentRating.forMovie(response, "de-DE"))
+    }
+
+    // === nothing at all hides the badge ===
+
+    @Test
+    fun `no certification anywhere yields null`() {
+        assertNull(ContentRating.forMovie(movie("FR" to listOf("12" to 3)), "de-DE"))
+        assertNull(ContentRating.forMovie(movie(), "de-DE"))
+        assertNull(ContentRating.forMovie(null, "de-DE"))
+        assertNull(ContentRating.forTv(null, "de-DE"))
+        assertNull(ContentRating.forTv(tv(), "de-DE"))
+    }
+
+    @Test
+    fun `a null certification yields null`() {
+        assertNull(ContentRating.forMovie(movie("DE" to listOf(null to 3)), "de-DE"))
+        assertNull(ContentRating.forTv(tv("DE" to null), "de-DE"))
+    }
+
+    // === several certifications for one country (movies only) ===
+
+    @Test
+    fun `the theatrical certification wins over TV and streaming`() {
+        val response = movie("DE" to listOf("12" to 5, "16" to 3, "6" to 4))
+        assertEquals("FSK 16", ContentRating.forMovie(response, "de-DE"))
+    }
+
+    @Test
+    fun `without a theatrical release the lowest release type wins`() {
+        val response = movie("DE" to listOf("18" to 6, "12" to 4))
+        assertEquals("FSK 12", ContentRating.forMovie(response, "de-DE"))
+    }
+
+    @Test
+    fun `an entry without a release type does not beat a known one`() {
+        val response = movie("DE" to listOf("18" to Int.MAX_VALUE, "12" to 4))
+        assertEquals("FSK 12", ContentRating.forMovie(response, "de-DE"))
+    }
+
+    @Test
+    fun `surrounding whitespace is trimmed from the certification`() {
+        assertEquals("FSK 16", ContentRating.forMovie(movie("DE" to listOf(" 16 " to 3)), "de-DE"))
+        assertEquals("TV-MA", ContentRating.forTv(tv("US" to " TV-MA "), "en-US"))
+    }
+}


### PR DESCRIPTION
### What

Movie and TV show details pages now show the age certification (FSK 16, PG-13, TV-MA, ...) next to the existing metadata line (rating - year - runtime), on both the phone and the TV layout.

### How

- The certification comes from TMDB through `append_to_response` on the detail calls that already run: `release_dates` for `/movie/{id}`, `content_ratings` for `/tv/{id}`. No new endpoint, no extra network request.
- The country is derived from `MediaRepository.contentLanguage` ("de-DE" -> "DE"), so no new setting is needed.
- Selection and labelling live in `util/ContentRating.kt`:
  - A movie can carry several certifications per country (theatrical, TV, streaming) that disagree. The theatrical one (`type` 3) wins, otherwise the lowest release type with a non-empty value.
  - An empty `certification` counts as absent - TMDB returns a lot of those.
  - Nothing for the content country -> the US value is used and marked as such (`US - R`). Nothing at all -> the badge is hidden entirely, no "unrated" placeholder.
  - Labelling: values that speak for themselves stay untouched (`R`, `PG-13`, `TV-MA`); bare numbers get their rating system (`16` in DE -> `FSK 16`) or else their country code (`12` in FR -> `FR 12`).

### Notes for review

- The rating-system names are deliberately kept in code and not in `strings.xml`: "FSK" is not a translation of "Rated", it is the name of the system a certification comes from. It follows the content country, not the interface language.
- Both new response fields are nullable with a default, so the shared movie/TV detail models stay valid when TMDB omits the block.
- `MediaItem.rating` is already used as a numeric score, so the new field is called `contentRating`.
- `append_to_response` is set as a default on the API interface, so it applies to every detail call. No behaviour change; the response is a few KB larger.
- Known, pre-existing limitation left alone on purpose: `detailsCache` is keyed without the content language, so after a language switch the certification can be up to 5 minutes stale - exactly as titles and overviews behave today.

### Deliberately not included

Kids-profile filtering / parental lock, MDBList as a second source, a settings toggle, and certifications on catalog cards. Each of those is its own topic.

### Testing

- 19 unit tests covering the selection and labelling rule (`ContentRatingTest`).
- Sideload debug build installed and checked on a phone (TV layout) and on a TCL C7K Android TV with the remote. The badge appears in both layouts and disappears cleanly when TMDB has no certification.

---
created by Claude (Anthropic) on behalf of @ReichiMD