### PR TITLE
fix(iptv): normalize non-ASCII letters in title matching instead of dropping them

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/IptvRepository.kt
@@ -58,6 +58,7 @@ import java.io.InputStream
 import java.io.InputStreamReader
 import java.io.File
 import java.nio.charset.StandardCharsets
+import java.text.Normalizer
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
@@ -156,6 +157,103 @@ internal fun normalizeIptvSortOrder(value: String?): String = when (value?.trim(
     "number" -> "number"
     "name" -> "name"
     else -> "provider"
+}
+
+/**
+ * Title normalization for Xtream VOD/series lookups.
+ *
+ * Lives at top level so it can be unit-tested without an Android `Context`,
+ * mirroring `HomeServerMatcher.normalizeTitle` in `HomeServerRepository.kt`.
+ */
+internal object IptvTitleNormalizer {
+    val BRACKET_CONTENT_REGEX = Regex("""\[[^\]]*]""")
+    val PAREN_CONTENT_REGEX = Regex("""\([^\)]*\)""")
+    val MULTI_SPACE_REGEX = Regex("\\s+")
+    private val YEAR_PAREN_REGEX = Regex("""\((19|20)\d{2}\)""")
+    private val SEASON_TOKEN_REGEX = Regex("""\b(s|season)\s*\d{1,2}\b""", RegexOption.IGNORE_CASE)
+    private val EPISODE_TOKEN_REGEX = Regex("""\b(e|ep|episode)\s*\d{1,3}\b""", RegexOption.IGNORE_CASE)
+    private val RELEASE_TAG_REGEX = Regex(
+        """\b(2160p|1080p|720p|480p|4k|uhd|fhd|hdr|dv|dovi|hevc|x265|x264|h264|remux|bluray|bdrip|webrip|web[- ]?dl|proper|repack|multi|dubbed|dual[- ]?audio)\b""",
+        RegexOption.IGNORE_CASE
+    )
+    private val NON_ALPHA_NUM_REGEX = Regex("[^a-z0-9]+")
+    private val DIACRITICS_REGEX = Regex("\\p{Mn}+")
+
+    fun normalize(value: String): String {
+        if (value.isBlank()) return ""
+        val stripped = value
+            .replace(BRACKET_CONTENT_REGEX, " ")
+            .replace(PAREN_CONTENT_REGEX, " ")
+            .replace(YEAR_PAREN_REGEX, " ")
+            .replace(SEASON_TOKEN_REGEX, " ")
+            .replace(EPISODE_TOKEN_REGEX, " ")
+            .replace(RELEASE_TAG_REGEX, " ")
+        return foldLetters(stripped)
+            .lowercase(Locale.US)
+            .replace(NON_ALPHA_NUM_REGEX, " ")
+            .trim()
+            .replace(MULTI_SPACE_REGEX, " ")
+    }
+
+    /**
+     * Maps non-ASCII letters onto their ASCII base. Without this the `[^a-z0-9]+`
+     * filter below turns them into a space and splits the word in two — "Doğu"
+     * became "do u" instead of "dogu", so the title never matched again.
+     *
+     * Two steps are needed: [nonDecomposableReplacement] first, because Unicode has
+     * no canonical decomposition for letters such as "ß" or the Turkish dotless "ı"
+     * (NFD leaves them untouched), then NFD plus removal of the combining marks it
+     * splits off for the rest.
+     */
+    fun foldLetters(value: String): String {
+        if (value.all { it.code < 0x80 }) return value
+        val mapped = StringBuilder(value.length + 8)
+        value.forEach { character ->
+            val replacement = nonDecomposableReplacement(character)
+            if (replacement != null) mapped.append(replacement) else mapped.append(character)
+        }
+        return Normalizer.normalize(mapped, Normalizer.Form.NFD).replace(DIACRITICS_REGEX, "")
+    }
+
+    /**
+     * Catalog-side alias for German umlaut transcriptions: providers write "Für"
+     * either transliterated ("Fur", which [normalize] already produces) or
+     * transcribed ("Fuer"). Collapsing "ue"/"oe"/"ae" onto the transliterated form
+     * gives such entries a second index key, so both provider spellings are found.
+     *
+     * Only ever used to *add* keys on the catalog side — applying it to a query
+     * would also rewrite plain-ASCII words ("blue" -> "blu") and change their
+     * scoring.
+     */
+    fun foldUmlautTranscription(value: String): String {
+        if (!value.contains("ue") && !value.contains("oe") && !value.contains("ae")) return value
+        return value
+            .replace("ue", "u")
+            .replace("oe", "o")
+            .replace("ae", "a")
+    }
+
+    private fun nonDecomposableReplacement(character: Char): String? = when (character) {
+        'ß' -> "ss"
+        'ẞ' -> "SS"
+        'ı' -> "i"
+        'İ' -> "I"
+        'ø' -> "o"
+        'Ø' -> "O"
+        'æ' -> "ae"
+        'Æ' -> "AE"
+        'œ' -> "oe"
+        'Œ' -> "OE"
+        'đ' -> "d"
+        'Đ' -> "D"
+        'ð' -> "d"
+        'Ð' -> "D"
+        'ł' -> "l"
+        'Ł' -> "L"
+        'þ' -> "th"
+        'Þ' -> "TH"
+        else -> null
+    }
 }
 
 data class IptvConfig(
@@ -3836,6 +3934,7 @@ class IptvRepository @Inject constructor(
     )
 
     private data class ResolverPersistedCatalog(
+        val formatVersion: Int = 0,
         val createdAtMs: Long = 0L,
         val entries: List<ResolverSeriesEntry> = emptyList()
     )
@@ -3884,12 +3983,41 @@ class IptvRepository @Inject constructor(
         private val seriesInfoLock = Any()
 
         private fun catalogPrefKey(providerKey: String): String = "catalog_${providerKey.hashCode()}"
+
         private val resolvedPrefKey = "resolved_episode_map"
         // v2: stores List<Int> per binding key instead of single Int.
         // Bumping the key avoids parsing failures against the legacy single-id format.
         private val seriesBindingPrefKey = "series_binding_map_v2"
         private fun seriesInfoPrefKey(providerKey: String, seriesId: Int): String =
             "series_info_${(providerKey + "|" + seriesId).hashCode()}"
+
+        /**
+         * Entries are stored with their *pre-computed* normalized name, canonical
+         * key and tokens. Whenever the normalization changes, those fields become
+         * incompatible with freshly normalized queries and every title lookup
+         * silently misses until the 24h TTL expires — longer still, because an
+         * empty network response deliberately keeps the stale catalog alive.
+         * Bumping this version discards such entries instead. Legacy JSON has no
+         * field and therefore deserializes to 0.
+         */
+        private val catalogFormatVersion = 1
+
+        private fun readPersistedCatalog(providerKey: String): ResolverPersistedCatalog? {
+            val raw = runCatching { prefs.getString(catalogPrefKey(providerKey), null) }.getOrNull()
+            if (raw.isNullOrBlank()) return null
+            val persisted = runCatching {
+                gson.fromJson(raw, ResolverPersistedCatalog::class.java)
+            }.getOrNull() ?: return null
+            if (persisted.formatVersion != catalogFormatVersion) {
+                System.err.println(
+                    "[VOD-Resolver] loadCatalog: discarding catalog written in format " +
+                        "${persisted.formatVersion} (current $catalogFormatVersion)"
+                )
+                runCatching { prefs.edit().remove(catalogPrefKey(providerKey)).apply() }
+                return null
+            }
+            return persisted.takeIf { it.entries.isNotEmpty() }
+        }
 
         suspend fun refreshCatalog(
             providerKey: String,
@@ -4221,14 +4349,11 @@ class IptvRepository @Inject constructor(
             if (!allowNetwork) {
                 if (inMem != null) return inMem
                 // Try SharedPreferences for stale data
-                val persistedRaw = runCatching { prefs.getString(catalogPrefKey(providerKey), null) }.getOrNull()
-                if (!persistedRaw.isNullOrBlank()) {
-                    val persisted = runCatching { gson.fromJson(persistedRaw, ResolverPersistedCatalog::class.java) }.getOrNull()
-                    if (persisted != null && persisted.entries.isNotEmpty()) {
-                        val built = buildCatalogIndex(persisted.createdAtMs, persisted.entries)
-                        catalogMemory[providerKey] = built
-                        return built
-                    }
+                val persisted = readPersistedCatalog(providerKey)
+                if (persisted != null) {
+                    val built = buildCatalogIndex(persisted.createdAtMs, persisted.entries)
+                    catalogMemory[providerKey] = built
+                    return built
                 }
                 return ResolverCatalogIndex(now, emptyList(), emptyMap(), emptyMap(), emptyMap(), emptyMap())
             }
@@ -4249,17 +4374,14 @@ class IptvRepository @Inject constructor(
                 // Try SharedPreferences persisted catalog
                 var stalePersisted: ResolverPersistedCatalog? = null
                 if (!forceRefresh) {
-                    val persistedRaw = runCatching { prefs.getString(catalogPrefKey(providerKey), null) }.getOrNull()
-                    if (!persistedRaw.isNullOrBlank()) {
-                        val persisted = runCatching { gson.fromJson(persistedRaw, ResolverPersistedCatalog::class.java) }.getOrNull()
-                        if (persisted != null && persisted.entries.isNotEmpty()) {
-                            stalePersisted = persisted
-                            if (lockNow - persisted.createdAtMs < catalogTtlMs) {
-                                System.err.println("[VOD-Resolver] loadCatalog: building from persisted prefs (${persisted.entries.size} entries)")
-                                val built = buildCatalogIndex(persisted.createdAtMs, persisted.entries)
-                                catalogMemory[providerKey] = built
-                                return@withLock built
-                            }
+                    val persisted = readPersistedCatalog(providerKey)
+                    if (persisted != null) {
+                        stalePersisted = persisted
+                        if (lockNow - persisted.createdAtMs < catalogTtlMs) {
+                            System.err.println("[VOD-Resolver] loadCatalog: building from persisted prefs (${persisted.entries.size} entries)")
+                            val built = buildCatalogIndex(persisted.createdAtMs, persisted.entries)
+                            catalogMemory[providerKey] = built
+                            return@withLock built
                         }
                     }
                 }
@@ -4306,11 +4428,28 @@ class IptvRepository @Inject constructor(
                 // Persist to SharedPreferences in background — don't block resolution
                 if (entries.isNotEmpty() && entries.size <= 50_000) {
                     runCatching {
-                        prefs.edit().putString(catalogPrefKey(providerKey), gson.toJson(ResolverPersistedCatalog(lockNow, entries))).apply()
+                        val payload = ResolverPersistedCatalog(
+                            formatVersion = catalogFormatVersion,
+                            createdAtMs = lockNow,
+                            entries = entries
+                        )
+                        prefs.edit().putString(catalogPrefKey(providerKey), gson.toJson(payload)).apply()
                     }
                 }
                 built
             } }
+        }
+
+        /**
+         * The canonical key plus — when the entry carries a transcribed umlaut —
+         * the transliterated alias, so "Fuer alle Faelle" is also reachable under
+         * the key a query for "Für alle Fälle" produces.
+         */
+        private fun canonicalTitleKeysFor(entry: ResolverSeriesEntry): List<String> {
+            val primary = entry.canonicalTitleKey
+            if (primary.isBlank()) return emptyList()
+            val alias = toCanonicalTitleKeyFromTokens(umlautAliasTokens(entry.titleTokens))
+            return if (alias.isBlank() || alias == primary) listOf(primary) else listOf(primary, alias)
         }
 
         private fun buildCatalogIndex(createdAtMs: Long, entries: List<ResolverSeriesEntry>): ResolverCatalogIndex {
@@ -4321,7 +4460,9 @@ class IptvRepository @Inject constructor(
                 entry.copy(
                     normalizedName = normalizedName,
                     canonicalTitleKey = canonicalTitleKey,
-                    titleTokens = titleTokens
+                    // Alias tokens are index-only: they widen what a query can find
+                    // without changing the persisted entry or any query key.
+                    titleTokens = withUmlautAliasTokens(titleTokens)
                 )
             }
             // IMPORTANT: Normalize keys so lookup matches correctly
@@ -4333,7 +4474,8 @@ class IptvRepository @Inject constructor(
                 .groupBy { normalizeImdbId(it.imdb)!! }
             val canonicalTitleMap = normalizedEntries
                 .filter { it.canonicalTitleKey.isNotBlank() }
-                .groupBy { it.canonicalTitleKey }
+                .flatMap { entry -> canonicalTitleKeysFor(entry).map { key -> key to entry } }
+                .groupBy({ it.first }, { it.second })
             val tokenMap = buildMap<String, List<ResolverSeriesEntry>> {
                 val temp = LinkedHashMap<String, MutableList<ResolverSeriesEntry>>()
                 normalizedEntries.forEach { entry ->
@@ -5640,19 +5782,18 @@ class IptvRepository @Inject constructor(
         }.getOrNull()
     }
 
-    private fun normalizeLookupText(value: String): String {
-        if (value.isBlank()) return ""
-        return value
-            .replace(BRACKET_CONTENT_REGEX, " ")
-            .replace(PAREN_CONTENT_REGEX, " ")
-            .replace(YEAR_PAREN_REGEX, " ")
-            .replace(SEASON_TOKEN_REGEX, " ")
-            .replace(EPISODE_TOKEN_REGEX, " ")
-            .replace(RELEASE_TAG_REGEX, " ")
-            .lowercase(Locale.US)
-            .replace(NON_ALPHA_NUM_REGEX, " ")
-            .trim()
-            .replace(MULTI_SPACE_REGEX, " ")
+    private fun normalizeLookupText(value: String): String = IptvTitleNormalizer.normalize(value)
+
+    /**
+     * Alias tokens for catalog entries — see [IptvTitleNormalizer.foldUmlautTranscription].
+     * Returns the input unchanged when no token carries a transcribed umlaut.
+     */
+    private fun umlautAliasTokens(tokens: Set<String>): Set<String> =
+        tokens.mapTo(LinkedHashSet<String>()) { IptvTitleNormalizer.foldUmlautTranscription(it) }
+
+    private fun withUmlautAliasTokens(tokens: Set<String>): Set<String> {
+        val alias = umlautAliasTokens(tokens)
+        return if (alias == tokens) tokens else tokens + alias
     }
 
     private val titleTokenNoise = setOf(
@@ -5754,6 +5895,13 @@ class IptvRepository @Inject constructor(
 
     private fun scoreNameMatch(providerName: String, normalizedInput: String): Int {
         val normalizedProvider = normalizeLookupText(providerName)
+        val direct = scoreNormalizedNameMatch(normalizedProvider, normalizedInput)
+        val alias = IptvTitleNormalizer.foldUmlautTranscription(normalizedProvider)
+        if (alias == normalizedProvider) return direct
+        return maxOf(direct, scoreNormalizedNameMatch(alias, normalizedInput))
+    }
+
+    private fun scoreNormalizedNameMatch(normalizedProvider: String, normalizedInput: String): Int {
         if (normalizedProvider.isBlank() || normalizedInput.isBlank()) return 0
         if (normalizedProvider == normalizedInput) return 120
         if (normalizedProvider.contains(normalizedInput)) return 90
@@ -5782,6 +5930,13 @@ class IptvRepository @Inject constructor(
 
     private fun looseSeriesTitleScore(providerName: String, normalizedInput: String): Int {
         val normalizedProvider = normalizeLookupText(providerName)
+        val direct = looseSeriesTitleScoreNormalized(normalizedProvider, normalizedInput)
+        val alias = IptvTitleNormalizer.foldUmlautTranscription(normalizedProvider)
+        if (alias == normalizedProvider) return direct
+        return maxOf(direct, looseSeriesTitleScoreNormalized(alias, normalizedInput))
+    }
+
+    private fun looseSeriesTitleScoreNormalized(normalizedProvider: String, normalizedInput: String): Int {
         if (normalizedProvider.isBlank() || normalizedInput.isBlank()) return 0
         val providerWords = normalizedProvider.split(' ').filter { it.length >= 3 }.toSet()
         val inputWords = normalizedInput.split(' ').filter { it.length >= 3 }.toSet()
@@ -9152,7 +9307,13 @@ class IptvRepository @Inject constructor(
                     if (canonical.isNotBlank()) {
                         canonicalTitleMap.getOrPut(canonical) { mutableListOf() }.add(idx)
                     }
-                    tokens.forEach { token ->
+                    // Index-only alias for transcribed umlauts ("Fuer" -> "fur"), so a
+                    // query for the properly spelled title reaches this entry too.
+                    val aliasCanonical = toCanonicalTitleKeyFromTokens(umlautAliasTokens(tokens))
+                    if (aliasCanonical.isNotBlank() && aliasCanonical != canonical) {
+                        canonicalTitleMap.getOrPut(aliasCanonical) { mutableListOf() }.add(idx)
+                    }
+                    withUmlautAliasTokens(tokens).forEach { token ->
                         tokenMap.getOrPut(token) { mutableListOf() }.add(idx)
                     }
                 }
@@ -9404,17 +9565,11 @@ class IptvRepository @Inject constructor(
         const val IPTV_USER_AGENT = "VLC/3.0.20 LibVLC/3.0.20"
         const val BROWSER_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
 
-        val BRACKET_CONTENT_REGEX = Regex("""\[[^\]]*]""")
-        val PAREN_CONTENT_REGEX = Regex("""\([^\)]*\)""")
-        val YEAR_PAREN_REGEX = Regex("""\((19|20)\d{2}\)""")
-        val SEASON_TOKEN_REGEX = Regex("""\b(s|season)\s*\d{1,2}\b""", RegexOption.IGNORE_CASE)
-        val EPISODE_TOKEN_REGEX = Regex("""\b(e|ep|episode)\s*\d{1,3}\b""", RegexOption.IGNORE_CASE)
-        val RELEASE_TAG_REGEX = Regex(
-            """\b(2160p|1080p|720p|480p|4k|uhd|fhd|hdr|dv|dovi|hevc|x265|x264|h264|remux|bluray|bdrip|webrip|web[- ]?dl|proper|repack|multi|dubbed|dual[- ]?audio)\b""",
-            RegexOption.IGNORE_CASE
-        )
-        val NON_ALPHA_NUM_REGEX = Regex("[^a-z0-9]+")
-        val MULTI_SPACE_REGEX = Regex("\\s+")
+        // Title-cleanup regexes live in IptvTitleNormalizer so the whole
+        // normalization stays testable without an Android Context.
+        val BRACKET_CONTENT_REGEX = IptvTitleNormalizer.BRACKET_CONTENT_REGEX
+        val PAREN_CONTENT_REGEX = IptvTitleNormalizer.PAREN_CONTENT_REGEX
+        val MULTI_SPACE_REGEX = IptvTitleNormalizer.MULTI_SPACE_REGEX
         val HTTP_URL_REGEX = Regex("""https?://[^\s,;|"]+""", RegexOption.IGNORE_CASE)
         val SEASON_KEY_REGEX = Regex("""\d{1,2}""")
         val FLEXIBLE_INT_REGEX = Regex("""\d{1,4}""")

--- a/app/src/test/kotlin/com/arflix/tv/data/repository/IptvTitleNormalizerTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/repository/IptvTitleNormalizerTest.kt
@@ -1,0 +1,119 @@
+package com.arflix.tv.data.repository
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Covers the title normalization used for Xtream VOD/series matching.
+ *
+ * The reported bug (#398) was that every letter outside a-z was replaced by a
+ * space, which split the word apart instead of transliterating it: "Doğu" became
+ * "do u" and never matched the provider catalog again.
+ */
+class IptvTitleNormalizerTest {
+
+    @Test
+    fun `letters unicode can decompose are transliterated instead of dropped`() {
+        assertEquals("dogu", IptvTitleNormalizer.normalize("Doğu"))
+        assertEquals("cukur", IptvTitleNormalizer.normalize("Çukur"))
+        assertEquals("amelie", IptvTitleNormalizer.normalize("Amélie"))
+        assertEquals("morderische spiele", IptvTitleNormalizer.normalize("Mörderische Spiele"))
+        assertEquals("fur alle falle", IptvTitleNormalizer.normalize("Für alle Fälle"))
+        assertEquals("lodz", IptvTitleNormalizer.normalize("Łódź"))
+    }
+
+    @Test
+    fun `letters without a unicode decomposition are transliterated too`() {
+        // NFD alone leaves these intact, so the a-z filter would still drop them.
+        assertEquals("strasse der traume", IptvTitleNormalizer.normalize("Straße der Träume"))
+        assertEquals("weissensee", IptvTitleNormalizer.normalize("Weißensee"))
+        assertEquals("die grosste show", IptvTitleNormalizer.normalize("Die Größte Show"))
+        // The dotless "ı" from the issue report's own example.
+        assertEquals("kirmizi oda", IptvTitleNormalizer.normalize("Kırmızı Oda"))
+        assertEquals("odegaard", IptvTitleNormalizer.normalize("Ødegaard"))
+        assertEquals("aeon flux", IptvTitleNormalizer.normalize("Æon Flux"))
+    }
+
+    @Test
+    fun `every non decomposable letter has an ascii replacement in both cases`() {
+        assertEquals("ss ss", IptvTitleNormalizer.normalize("ß ẞ"))
+        assertEquals("i i", IptvTitleNormalizer.normalize("ı İ"))
+        assertEquals("o o", IptvTitleNormalizer.normalize("ø Ø"))
+        assertEquals("ae ae", IptvTitleNormalizer.normalize("æ Æ"))
+        assertEquals("oe oe", IptvTitleNormalizer.normalize("œ Œ"))
+        assertEquals("d d", IptvTitleNormalizer.normalize("đ Đ"))
+        assertEquals("d d", IptvTitleNormalizer.normalize("ð Ð"))
+        assertEquals("l l", IptvTitleNormalizer.normalize("ł Ł"))
+        assertEquals("th th", IptvTitleNormalizer.normalize("þ Þ"))
+    }
+
+    @Test
+    fun `plain ascii titles keep the previous normalization`() {
+        assertEquals("breaking bad", IptvTitleNormalizer.normalize("Breaking Bad"))
+        assertEquals("the walking dead s01e05", IptvTitleNormalizer.normalize("The Walking Dead S01E05"))
+        assertEquals("game of thrones", IptvTitleNormalizer.normalize("Game of Thrones (2011)"))
+        assertEquals("law order svu", IptvTitleNormalizer.normalize("Law & Order: SVU"))
+        assertEquals("marvel s agents of s h i e l d", IptvTitleNormalizer.normalize("Marvel's Agents of S.H.I.E.L.D."))
+        assertEquals("stranger things", IptvTitleNormalizer.normalize("Stranger Things [Multi]"))
+        assertEquals("the office", IptvTitleNormalizer.normalize("The Office 1080p WEB-DL"))
+        assertEquals("dark", IptvTitleNormalizer.normalize("  Dark  "))
+    }
+
+    @Test
+    fun `letter folding leaves ascii input untouched`() {
+        listOf(
+            "Breaking Bad",
+            "The Walking Dead S01E05",
+            "Game of Thrones (2011)",
+            "Law & Order: SVU",
+            "Marvel's Agents of S.H.I.E.L.D.",
+            "Stranger Things [Multi]"
+        ).forEach { title ->
+            assertEquals(title, IptvTitleNormalizer.foldLetters(title))
+        }
+    }
+
+    @Test
+    fun `season episode and release markers are still stripped`() {
+        assertEquals("mord mit aussicht", IptvTitleNormalizer.normalize("Mord mit Aussicht S02 1080p"))
+        assertEquals("tatort", IptvTitleNormalizer.normalize("Tatort [DE] Season 3 Episode 12 WEB-DL"))
+    }
+
+    @Test
+    fun `blank input stays blank`() {
+        assertEquals("", IptvTitleNormalizer.normalize(""))
+        assertEquals("", IptvTitleNormalizer.normalize("   "))
+    }
+
+    @Test
+    fun `transcribed umlauts collapse onto the transliterated spelling`() {
+        // Providers write "Für" either as "Fur" or as "Fuer". The transliterated
+        // form is what normalize() produces, so the transcribed one gets folded
+        // onto it to give catalog entries a second index key.
+        val query = IptvTitleNormalizer.normalize("Für alle Fälle")
+        val transliterated = IptvTitleNormalizer.normalize("Fur alle Falle")
+        val transcribed = IptvTitleNormalizer.normalize("Fuer alle Faelle")
+
+        assertEquals(query, transliterated)
+        assertEquals(query, IptvTitleNormalizer.foldUmlautTranscription(transcribed))
+        assertEquals(query, IptvTitleNormalizer.foldUmlautTranscription(transliterated))
+    }
+
+    @Test
+    fun `umlaut folding only rewrites strings that carry a transcription`() {
+        listOf("breaking bad", "dark", "tatort", "das boot").forEach { title ->
+            assertEquals(title, IptvTitleNormalizer.foldUmlautTranscription(title))
+        }
+        // Documents why this fold is applied to catalog keys only, never to a
+        // query: it would rewrite plain ASCII words as well.
+        assertEquals("blu velvet", IptvTitleNormalizer.foldUmlautTranscription("blue velvet"))
+        assertTrue(IptvTitleNormalizer.foldUmlautTranscription("goethe") == "gothe")
+    }
+
+    @Test
+    fun `folding is idempotent so aliasing an alias changes nothing`() {
+        val once = IptvTitleNormalizer.foldUmlautTranscription("fuer alle faelle")
+        assertEquals(once, IptvTitleNormalizer.foldUmlautTranscription(once))
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #398. IPTV title matching replaced every non-ASCII letter with a space, which
split words apart instead of transliterating them: "Doğu" became "do u", "Für alle
Fälle" became "f r alle f lle". Series and VOD items whose titles contain non-ASCII
letters silently failed to match, even though the provider catalog had them.

## Cause
`normalizeLookupText` in `IptvRepository.kt` lowercases the title and then applies
`Regex("[^a-z0-9]+")`, so any letter outside a-z is treated as punctuation.

## Approach
Normalization now mirrors `HomeServerMatcher.normalizeTitle` in
`HomeServerRepository.kt`, which already handles this correctly, and moved to a
top-level `IptvTitleNormalizer` so it is unit-testable without a `Context`:

1. map letters that have no Unicode decomposition (ß, ı, ø, æ, œ, đ, ð, ł, þ),
2. NFD-decompose and strip combining marks,
3. then apply the existing lowercase / non-alphanumeric / whitespace steps.

Step 1 matters: NFD alone does not fix "ß" or the Turkish dotless "ı" — including
"Kırmızı", the very example pattern from the issue report.

German providers spell umlauts either transliterated ("Fur alle Falle") or
transcribed ("Fuer alle Faelle"). Catalog entries therefore get an additional index
key that collapses `ue`/`oe`/`ae` onto the transliterated form step 2 produces, and
the two name scorers consider it as well. This only ever *adds* keys on the catalog
side — query keys are untouched, so a plain-ASCII title normalizes and scores exactly
as before (applying the same fold to a query would rewrite ASCII words such as "blue"
and shift their scoring). Because the alias can only grow a candidate's token
overlap, never shrink it, a match that works today cannot break.

The persisted resolver catalog stores pre-normalized names, canonical keys and
tokens, so it also gets a format version; stale entries from the old normalization
are discarded instead of being matched against freshly normalized queries for up to
24h — longer still, since an empty network response deliberately keeps the stale
catalog alive.

## Scope
Deliberately limited to `normalizeLookupText`. `normalizeLooseKey` (channel variant
keys) uses the same character class, but its output is persisted as `variant_key` in
`IptvChannelStore`; changing it would need a data migration and belongs in its own
change. The same pattern also exists in CatalogDiscovery/Trakt/Simkl/CollectionTemplate
and is left untouched here.

Known limit: purely non-Latin titles (Cyrillic, Greek, Arabic, CJK) still normalize
to an empty key. Real transliteration would be a much larger change, and there was no
match before this change either — nothing regresses, it simply is not solved here.

## Testing
- Unit tests: 10 new cases (49 assertions) covering German, Turkish, Polish, Nordic
  and accented Latin titles, the letters without a Unicode decomposition, and 8
  plain-ASCII titles as regression guards. Old and new normalization were also
  diffed across the ASCII set — zero differences.
- Device (Android TV, sideload debug build): regression only. I don't have an
  Xtream-Codes provider, so I could not reproduce the original mismatch against a
  real catalog. Verified that the app starts, IPTV lists and live TV load, EPG shows
  and nothing hangs.

created by Claude (Anthropic) on behalf of @ReichiMD