### PR TITLE
i18n(home): localize the remaining preinstalled catalog rows

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
@@ -305,6 +305,13 @@ private fun localizedCategoryTitle(category: Category): String = when (category.
     "collection_row_featured"  -> stringResource(R.string.featured)
     "top10_movies_today"       -> stringResource(R.string.home_top10_movies_today)
     "top10_shows_today"        -> stringResource(R.string.home_top10_shows_today)
+    "favorite_tv"              -> stringResource(R.string.home_favorite_tv)
+    "sports"                   -> stringResource(R.string.home_sports)
+    "popular_live_tv"          -> stringResource(R.string.home_popular_live_sports)
+    "just_added"               -> stringResource(R.string.home_just_added)
+    "top_movies_week"          -> stringResource(R.string.home_top_movies_week)
+    "new_kdramas"              -> stringResource(R.string.home_new_kdramas)
+    "coming_soon"              -> stringResource(R.string.settings_coming_soon)
     else                       -> category.title
 }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -773,6 +773,12 @@
     <string name="live_menu_move_down">Nach unten</string>
     <string name="live_menu_hide_category">Kategorie ausblenden</string>
     <string name="live_menu_unhide_category">Kategorie einblenden</string>
+    <string name="live_menu_lock_category">Mit Profil-PIN sperren</string>
+    <string name="live_menu_unlock_category">PIN-Sperre entfernen</string>
+    <string name="live_group_enter_pin">PIN eingeben, um diese Gruppe zu öffnen</string>
+    <string name="live_group_pin_incorrect">Falsche PIN</string>
+    <string name="live_group_pin_required_title">Profil-PIN erforderlich</string>
+    <string name="live_group_pin_required_message">Lege für dieses Profil eine PIN fest, bevor du TV-Gruppen sperrst.</string>
     <!-- Updates, errors, profile, auth, plugins, streams and misc (de) -->
     <string name="now_playing">JETZT LÄUFT</string>
     <string name="topbar_tv">TV</string>
@@ -1045,6 +1051,12 @@
     <string name="details_cd_season_options">Staffel-Optionen anzeigen</string>
     <string name="home_top10_movies_today">Top 10 Filme heute</string>
     <string name="home_top10_shows_today">Top 10 Serien heute</string>
+    <string name="home_favorite_tv">Lieblingssender</string>
+    <string name="home_sports">Sport</string>
+    <string name="home_popular_live_sports">Beliebter Live-Sport</string>
+    <string name="home_just_added">Neu hinzugefügt</string>
+    <string name="home_top_movies_week">Top-Filme diese Woche</string>
+    <string name="home_new_kdramas">Neu bei K-Dramas</string>
     <string name="home_please_check_connection">Bitte überprüfe deine Verbindung</string>
     <string name="home_sports_addon_required">Füge zuerst ein Sport-Live-TV-Addon hinzu</string>
     <string name="home_sports_opening">Live-Event wird geöffnet…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -880,6 +880,12 @@
     <string name="details_cd_season_options">Show season options</string>
     <string name="home_top10_movies_today">Top 10 Movies Today</string>
     <string name="home_top10_shows_today">Top 10 Shows Today</string>
+    <string name="home_favorite_tv">Favorite TV</string>
+    <string name="home_sports">Sports</string>
+    <string name="home_popular_live_sports">Popular Live Sports</string>
+    <string name="home_just_added">Just Added</string>
+    <string name="home_top_movies_week">Top Movies This Week</string>
+    <string name="home_new_kdramas">New in K-Dramas</string>
     <string name="home_please_check_connection">Please check your connection</string>
     <string name="home_sports_addon_required">Add a sports live TV addon first</string>
     <string name="home_sports_opening">Opening live event...</string>


### PR DESCRIPTION
### What

Same approach as #632, applied to the preinstalled catalog rows on the home screen.

The home screen already localizes preinstalled catalog rows in
`localizedCategoryTitle()`, keyed by `CatalogConfig.id`. Seven of the twelve
preinstalled catalogs were never added to that map, so their row headers stayed
English in every language.

- 7 rows now resolve through `stringResource(...)`: Favorite TV, Sports,
  Popular Live Sports, Just Added, Top Movies This Week, New in K-Dramas and
  Coming Soon
- 1 of them reuses an existing resource (`settings_coming_soon`) instead of
  adding a duplicate key
- 6 new keys added to `values/strings.xml`, in the existing Home section
- German values added to `values-de/strings.xml`

It also adds the German values for the six live TV group PIN strings that came
in recently and had no `values-de` entries yet (`live_menu_lock_category`,
`live_menu_unlock_category`, `live_group_enter_pin`, `live_group_pin_incorrect`,
`live_group_pin_required_title`, `live_group_pin_required_message`). With those,
`values-de` covers every key in `values` except `app_name`.

### Why

Approved in Discord (28 Aug): "Yes try to also bring hardcoded things into this.
That has been kinda a long time bug. They dont have to be in English yea."

This benefits all 50 language folders, not just German — untranslated locales
fall back to English exactly as before.

### Notes

- Stored values and internal keys are unchanged. The lookup is by
  `CatalogConfig.id`, never by the displayed text, so cloud sync, ordering and
  the renamed-catalog detection in `CatalogRepository` keep comparing the same
  English defaults they always did. Follows the existing pattern from
  `LiveCategory.kt`.
- Nothing is resolved outside a composable, so no `ViewModel` picks up the
  system locale instead of the in-app one.
- Brand and franchise names (Netflix, Marvel, James Bond, ...) are left untouched.
- Log messages, telemetry strings and animation labels are out of scope.
- Verified with `testSideloadDebugUnitTest` on the branch; the build is green.

created by Claude (Anthropic) on behalf of @ReichiMD