### PR TITLE
i18n(home/search): localize TMDB genre names and discover row titles

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/components/TmdbGenreNames.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/TmdbGenreNames.kt
@@ -1,0 +1,61 @@
+package com.arflix.tv.ui.components
+
+import androidx.annotation.StringRes
+import com.arflix.tv.R
+
+/**
+ * Display-only localization of the TMDB genre names shown on the home screen
+ * and in the search filter chips.
+ *
+ * The numeric TMDB genre id is the stable key — it is what the API is queried
+ * with and what a selected filter is compared by — so only the rendered label
+ * is translated. Same approach as `liveCategoryLabel` in `LiveCategory.kt`.
+ *
+ * Movie and TV ids are kept apart on purpose: TMDB uses separate genre lists
+ * per media type, and an id that is absent from a list must stay absent so the
+ * rendered metadata does not change.
+ */
+@StringRes
+fun movieGenreNameRes(genreId: Int): Int? = when (genreId) {
+    28 -> R.string.collections_genre_action
+    12 -> R.string.collections_genre_adventure
+    16 -> R.string.collections_genre_animation
+    35 -> R.string.collections_genre_comedy
+    80 -> R.string.tmdb_genre_crime
+    99 -> R.string.collections_genre_documentary
+    18 -> R.string.collections_genre_drama
+    10751 -> R.string.collections_genre_family
+    14 -> R.string.collections_genre_fantasy
+    36 -> R.string.tmdb_genre_history
+    27 -> R.string.collections_genre_horror
+    10402 -> R.string.tmdb_genre_music
+    9648 -> R.string.tmdb_genre_mystery
+    10749 -> R.string.collections_genre_romance
+    878 -> R.string.collections_genre_sci_fi
+    10770 -> R.string.tmdb_genre_tv_movie
+    53 -> R.string.collections_genre_thriller
+    10752 -> R.string.tmdb_genre_war
+    37 -> R.string.tmdb_genre_western
+    else -> null
+}
+
+@StringRes
+fun tvGenreNameRes(genreId: Int): Int? = when (genreId) {
+    10759 -> R.string.tmdb_genre_action_adventure
+    16 -> R.string.collections_genre_animation
+    35 -> R.string.collections_genre_comedy
+    80 -> R.string.tmdb_genre_crime
+    99 -> R.string.collections_genre_documentary
+    18 -> R.string.collections_genre_drama
+    10751 -> R.string.collections_genre_family
+    10762 -> R.string.tmdb_genre_kids
+    9648 -> R.string.tmdb_genre_mystery
+    10763 -> R.string.tmdb_genre_news
+    10764 -> R.string.tmdb_genre_reality
+    10765 -> R.string.tmdb_genre_sci_fi_fantasy
+    10766 -> R.string.tmdb_genre_soap
+    10767 -> R.string.tmdb_genre_talk
+    10768 -> R.string.tmdb_genre_war_politics
+    37 -> R.string.tmdb_genre_western
+    else -> null
+}

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
@@ -137,6 +137,8 @@ import com.arflix.tv.data.model.MediaType
 import com.arflix.tv.data.model.isPortrait
 import com.arflix.tv.network.OkHttpProvider
 import com.arflix.tv.ui.components.FeaturedMediaCard
+import com.arflix.tv.ui.components.movieGenreNameRes
+import com.arflix.tv.ui.components.tvGenreNameRes
 import com.arflix.tv.ui.components.MediaCard as ArvioMediaCard
 import com.arflix.tv.ui.components.TrailerPlayer
 import com.arflix.tv.ui.components.CardLayoutMode
@@ -216,32 +218,23 @@ private object HomeRegexes {
     val WHITESPACE = Regex("\\s+")
 }
 
-private fun cleanOverviewText(value: String): String {
+private fun Context.cleanOverviewText(value: String): String {
     return value
         .replace(HomeRegexes.HTML_TAG, " ")
         .replace(HomeRegexes.NON_BREAKING_SPACE, " ")
         .replace(HomeRegexes.UNICODE_SPACE, " ")
         .replace(HomeRegexes.WHITESPACE, " ")
         .trim()
-        .ifBlank { "No description available." }
+        .ifBlank { getString(R.string.home_no_description) }
 }
 
-// Genre ID to name mapping (TMDB standard)
-private val movieGenres = mapOf(
-    28 to "Action", 12 to "Adventure", 16 to "Animation", 35 to "Comedy",
-    80 to "Crime", 99 to "Documentary", 18 to "Drama", 10751 to "Family",
-    14 to "Fantasy", 36 to "History", 27 to "Horror", 10402 to "Music",
-    9648 to "Mystery", 10749 to "Romance", 878 to "Sci-Fi", 10770 to "TV Movie",
-    53 to "Thriller", 10752 to "War", 37 to "Western"
-)
-
-private val tvGenres = mapOf(
-    10759 to "Action & Adventure", 16 to "Animation", 35 to "Comedy",
-    80 to "Crime", 99 to "Documentary", 18 to "Drama", 10751 to "Family",
-    10762 to "Kids", 9648 to "Mystery", 10763 to "News", 10764 to "Reality",
-    10765 to "Sci-Fi & Fantasy", 10766 to "Soap", 10767 to "Talk",
-    10768 to "War & Politics", 37 to "Western"
-)
+// Genre ID to display name (TMDB standard). The numeric id stays the key;
+// only the rendered label is localized — see `TmdbGenreNames.kt`.
+private fun Context.genreNames(mediaType: MediaType, genreIds: List<Int>): List<String> =
+    genreIds.mapNotNull { id ->
+        val res = if (mediaType == MediaType.TV) tvGenreNameRes(id) else movieGenreNameRes(id)
+        res?.let { getString(it) }
+    }
 
 @Stable
 private class HomeFocusState(
@@ -1561,9 +1554,8 @@ private fun HeroSection(
                     }
                 } else {
                     // Get actual genre names from genre IDs (memoized to avoid list allocations per recomposition)
-                    val genreText = remember(currentItem.id, currentItem.genreIds) {
-                        val genreMap = if (currentItem.mediaType == MediaType.TV) tvGenres else movieGenres
-                        currentItem.genreIds.mapNotNull { genreMap[it] }.take(2).joinToString(" / ")
+                    val genreText = remember(currentItem.id, currentItem.genreIds, context) {
+                        context.genreNames(currentItem.mediaType, currentItem.genreIds).take(2).joinToString(" / ")
                     }
                     val displayDate = currentItem.releaseDate?.takeIf { it.isNotEmpty() } ?: currentItem.year
                     val hasDuration = currentItem.duration.isNotEmpty() && currentItem.duration != "0m"
@@ -1737,8 +1729,8 @@ private fun HeroSection(
                 Spacer(modifier = Modifier.height(6.dp))
 
                 // Overview text (EPG data for IPTV, synopsis for movies/shows)
-                val displayOverview = remember(overviewOverride, currentItem.overview) {
-                    cleanOverviewText(overviewOverride ?: currentItem.overview)
+                val displayOverview = remember(overviewOverride, currentItem.overview, context) {
+                    context.cleanOverviewText(overviewOverride ?: currentItem.overview)
                 }
 
                 val overviewMaxHeight = 72.dp
@@ -1906,17 +1898,16 @@ private fun MobileHeroOverlay(
         blurRadius = 8f
     )
 
-    val genreText = remember(item.id, item.genreIds) {
-        val genreMap = if (item.mediaType == MediaType.TV) tvGenres else movieGenres
-        item.genreIds.mapNotNull { genreMap[it] }.take(2).joinToString(" | ")
+    val genreText = remember(item.id, item.genreIds, context) {
+        context.genreNames(item.mediaType, item.genreIds).take(2).joinToString(" | ")
     }
     val year = item.releaseDate?.take(4)?.takeIf { it.isNotEmpty() } ?: item.year
     val rating = imdbRatingFor(item)
     val ratingValue = parseRatingValue(rating)
     val hasMetadata = genreText.isNotEmpty() || year.isNotEmpty() || ratingValue > 0f
 
-    val displayOverview = remember(overviewOverride, item.overview) {
-        cleanOverviewText(overviewOverride ?: item.overview)
+    val displayOverview = remember(overviewOverride, item.overview, context) {
+        context.cleanOverviewText(overviewOverride ?: item.overview)
     }
 
     Box(
@@ -2101,6 +2092,7 @@ private fun MobileHeroCarousel(
     onNavigateToDetails: (MediaType, Int, Int?, Int?) -> Unit,
     onPreloadHeroImdbRatings: (List<MediaItem>) -> Unit = {}
 ) {
+    val context = LocalContext.current
     val heroItems = remember(categories) {
         val eligibleRows = categories.filter {
             it.id != "continue_watching" &&
@@ -2244,9 +2236,8 @@ private fun MobileHeroCarousel(
             modifier = Modifier.fillMaxWidth()
         ) { page ->
             val item = heroItems[page % heroItems.size]
-            val genres = remember(item.id, item.genreIds) {
-                val genreMap = if (item.mediaType == MediaType.TV) tvGenres else movieGenres
-                item.genreIds.mapNotNull { genreMap[it] }.take(3)
+            val genres = remember(item.id, item.genreIds, context) {
+                context.genreNames(item.mediaType, item.genreIds).take(3)
             }
             // releaseDate is stored as "d MMM yyyy" by MediaRepository.formatDate()
             val year = remember(item.id, item.releaseDate, item.year) {
@@ -3147,12 +3138,12 @@ private fun MobileHomeRowsLayer(
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     Text(
-                        text = "Still loading your catalogue…",
+                        text = stringResource(R.string.home_still_loading_catalogue),
                         color = Color.White.copy(alpha = 0.7f),
                         fontSize = 14.sp
                     )
                     TextButton(onClick = onRetry) {
-                        Text("Retry", color = Color(0xFF00F0D0), fontWeight = FontWeight.Bold)
+                        Text(stringResource(R.string.retry), color = Color(0xFF00F0D0), fontWeight = FontWeight.Bold)
                     }
                 }
             }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/search/SearchScreen.kt
@@ -82,6 +82,7 @@ import com.arflix.tv.data.model.MediaType
 import com.arflix.tv.data.model.Category
 import com.arflix.tv.data.model.isPortrait
 import com.arflix.tv.ui.components.LoadingIndicator
+import com.arflix.tv.ui.components.movieGenreNameRes
 import com.arflix.tv.ui.components.CardLayoutMode
 import com.arflix.tv.ui.components.AppTopBar
 import com.arflix.tv.ui.components.AppTopBarContentTopInset
@@ -103,6 +104,33 @@ import com.arflix.tv.ui.theme.Pink
 import com.arflix.tv.ui.theme.TextPrimary
 import com.arflix.tv.ui.theme.TextSecondary
 import com.arflix.tv.util.LocalDeviceType
+
+/**
+ * Display-only localization of a TMDB genre chip label. [Genre.id] stays the key
+ * the filter is compared and queried by; the English [Genre.name] is the fallback
+ * for ids without a resource.
+ */
+@Composable
+private fun Genre.localizedName(): String {
+    val res = movieGenreNameRes(id)
+    return if (res != null) stringResource(res) else name
+}
+
+/**
+ * Display-only localization of the five discover row titles built in
+ * `SearchViewModel.buildRow`. The English title stays in [Category.title] because
+ * it is part of the category id used as the row's focus key — only the rendered
+ * label is translated. Same approach as `liveCategoryLabel` in `LiveCategory.kt`.
+ */
+@Composable
+private fun localizedDiscoverRowTitle(category: Category): String = when (category.title) {
+    "Trending" -> stringResource(R.string.search_row_trending)
+    "Popular This Year" -> stringResource(R.string.search_row_popular_this_year)
+    "Top Rated" -> stringResource(R.string.search_row_top_rated)
+    "New Releases" -> stringResource(R.string.search_row_new_releases)
+    "Hidden Gems" -> stringResource(R.string.search_row_hidden_gems)
+    else -> category.title
+}
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
@@ -205,7 +233,7 @@ fun SearchScreen(
         actionGenre?.let { genre ->
             DiscoverQuickFilter(
                 key = "genre_${genre.id}",
-                label = genre.name,
+                label = genre.localizedName(),
                 isSelected = uiState.selectedGenre?.id == genre.id,
                 onSelect = { viewModel.setDiscoverFilters(uiState.selectedType, genre, uiState.selectedCountry) }
             )
@@ -213,7 +241,7 @@ fun SearchScreen(
         comedyGenre?.let { genre ->
             DiscoverQuickFilter(
                 key = "genre_${genre.id}",
-                label = genre.name,
+                label = genre.localizedName(),
                 isSelected = uiState.selectedGenre?.id == genre.id,
                 onSelect = { viewModel.setDiscoverFilters(uiState.selectedType, genre, uiState.selectedCountry) }
             )
@@ -221,7 +249,7 @@ fun SearchScreen(
         horrorGenre?.let { genre ->
             DiscoverQuickFilter(
                 key = "genre_${genre.id}",
-                label = genre.name,
+                label = genre.localizedName(),
                 isSelected = uiState.selectedGenre?.id == genre.id,
                 onSelect = { viewModel.setDiscoverFilters(uiState.selectedType, genre, uiState.selectedCountry) }
             )
@@ -229,7 +257,7 @@ fun SearchScreen(
         sciFiGenre?.let { genre ->
             DiscoverQuickFilter(
                 key = "genre_${genre.id}",
-                label = genre.name,
+                label = genre.localizedName(),
                 isSelected = uiState.selectedGenre?.id == genre.id,
                 onSelect = { viewModel.setDiscoverFilters(uiState.selectedType, genre, uiState.selectedCountry) }
             )
@@ -985,7 +1013,7 @@ private fun RowsLayer(
                             horizontalArrangement = Arrangement.spacedBy(8.dp)
                         ) {
                             Text(
-                                category.title,
+                                localizedDiscoverRowTitle(category),
                                 style = ArvioSkin.typography.sectionTitle.copy(fontSize = 15.sp),
                                 color = Color.White.copy(alpha = if (isCurrentRow) 0.9f else 0.5f)
                             )

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/search/SearchViewModel.kt
@@ -132,6 +132,9 @@ class SearchViewModel @Inject constructor(
 
                 val categories = withContext(Dispatchers.IO) {
                     coroutineScope {
+                        // Row titles stay English: they are part of the Category id used
+                        // as the row's focus key. SearchScreen localizes them for display
+                        // only (localizedDiscoverRowTitle).
                         // Row 1: Trending - popular with minimum votes to filter garbage
                         val row1 = async { buildRow("Trending", type, genre, "popularity.desc", 50, lang, isAnime, 1, releaseDateLte = today) }
                         // Row 2: Popular This Year - recent + popular, no obscure stuff

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -672,6 +672,8 @@
     <string name="settings_iptv_channel_order_description">Wähle, wie Kanäle innerhalb jeder Gruppe angeordnet werden</string>
     <string name="settings_iptv_vod_search">IPTV-VOD-Streams</string>
     <string name="settings_iptv_vod_search_desc">IPTV-Filme und -Serien beim Abrufen von Streams einbeziehen</string>
+    <string name="settings_iptv_favorites_home">Lieblingssender auf der Startseite</string>
+    <string name="settings_iptv_favorites_home_desc">Deine markierten IPTV-Kanäle oben auf der Startseite anheften</string>
     <string name="settings_iptv_order_provider">Anbieter-Reihenfolge</string>
     <string name="settings_iptv_order_number">Kanalnummer</string>
     <string name="settings_iptv_order_name">Alphabetisch (A–Z)</string>
@@ -790,6 +792,23 @@
     <string name="collections_decade_80s">Filme der 80er</string>
     <string name="collections_decade_70s">Filme der 70er</string>
     <string name="collections_decade_60s">Filme der 60er</string>
+
+    <!-- TMDB genre names (display-only; the numeric TMDB genre id stays the key) -->
+    <string name="tmdb_genre_crime">Krimi</string>
+    <string name="tmdb_genre_history">Historie</string>
+    <string name="tmdb_genre_music">Musik</string>
+    <string name="tmdb_genre_mystery">Mystery</string>
+    <string name="tmdb_genre_tv_movie">Fernsehfilm</string>
+    <string name="tmdb_genre_war">Krieg</string>
+    <string name="tmdb_genre_western">Western</string>
+    <string name="tmdb_genre_action_adventure">Action &amp; Abenteuer</string>
+    <string name="tmdb_genre_kids">Kinder</string>
+    <string name="tmdb_genre_news">Nachrichten</string>
+    <string name="tmdb_genre_reality">Reality</string>
+    <string name="tmdb_genre_sci_fi_fantasy">Sci-Fi &amp; Fantasy</string>
+    <string name="tmdb_genre_soap">Seifenoper</string>
+    <string name="tmdb_genre_talk">Talk</string>
+    <string name="tmdb_genre_war_politics">Krieg &amp; Politik</string>
     <string name="iptv_connecting_stalker">Mit Stalker-Portal verbinden…</string>
     <string name="iptv_loaded_api">%1$d Live-Kanäle über Anbieter-API geladen</string>
     <string name="iptv_loaded_channels">%1$d Kanäle geladen</string>
@@ -806,6 +825,11 @@
     <string name="live_menu_unhide_category">Kategorie einblenden</string>
     <string name="live_menu_lock_category">Mit Profil-PIN sperren</string>
     <string name="live_menu_unlock_category">PIN-Sperre entfernen</string>
+    <string name="live_menu_favorite_move_up">Nach oben</string>
+    <string name="live_menu_favorite_move_down">Nach unten</string>
+    <string name="live_menu_favorite_remove">Aus Favoriten entfernen</string>
+    <string name="live_menu_favorite_add">Zu Favoriten hinzufügen</string>
+    <string name="live_menu_channel_variants">Qualitätsvarianten</string>
     <string name="live_group_enter_pin">PIN eingeben, um diese Gruppe zu öffnen</string>
     <string name="live_group_pin_incorrect">Falsche PIN</string>
     <string name="live_group_pin_required_title">Profil-PIN erforderlich</string>
@@ -1097,6 +1121,13 @@
     <string name="home_cd_rank">Platz #%1$d</string>
     <string name="search_filter_all">Alle</string>
     <string name="search_filter_anime">Anime</string>
+    <string name="home_no_description">Keine Beschreibung verfügbar.</string>
+    <string name="home_still_loading_catalogue">Dein Katalog wird noch geladen …</string>
+    <string name="search_row_trending">Angesagt</string>
+    <string name="search_row_popular_this_year">Beliebt dieses Jahr</string>
+    <string name="search_row_top_rated">Bestbewertet</string>
+    <string name="search_row_new_releases">Neuerscheinungen</string>
+    <string name="search_row_hidden_gems">Geheimtipps</string>
     <string name="epg_watch_live">Live ansehen</string>
     <string name="epg_search_sources">Jetzt streamen</string>
     <string name="person_section_biography">Biografie</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -902,6 +902,13 @@
     <string name="home_cd_rank">Rank #%1$d</string>
     <string name="search_filter_all">All</string>
     <string name="search_filter_anime">Anime</string>
+    <string name="home_no_description">No description available.</string>
+    <string name="home_still_loading_catalogue">Still loading your catalogue…</string>
+    <string name="search_row_trending">Trending</string>
+    <string name="search_row_popular_this_year">Popular This Year</string>
+    <string name="search_row_top_rated">Top Rated</string>
+    <string name="search_row_new_releases">New Releases</string>
+    <string name="search_row_hidden_gems">Hidden Gems</string>
     <string name="player_cd_rewind">Rewind 10s</string>
     <string name="player_cd_forward">Forward 10s</string>
     <string name="player_cd_pip">Picture in Picture</string>
@@ -1333,6 +1340,24 @@
     <string name="collections_decade_80s">80\'s Movies</string>
     <string name="collections_decade_70s">70\'s Movies</string>
     <string name="collections_decade_60s">60\'s Movies</string>
+
+
+    <!-- TMDB genre names (display-only; the numeric TMDB genre id stays the key) -->
+    <string name="tmdb_genre_crime">Crime</string>
+    <string name="tmdb_genre_history">History</string>
+    <string name="tmdb_genre_music">Music</string>
+    <string name="tmdb_genre_mystery">Mystery</string>
+    <string name="tmdb_genre_tv_movie">TV Movie</string>
+    <string name="tmdb_genre_war">War</string>
+    <string name="tmdb_genre_western">Western</string>
+    <string name="tmdb_genre_action_adventure">Action &amp; Adventure</string>
+    <string name="tmdb_genre_kids">Kids</string>
+    <string name="tmdb_genre_news">News</string>
+    <string name="tmdb_genre_reality">Reality</string>
+    <string name="tmdb_genre_sci_fi_fantasy">Sci-Fi &amp; Fantasy</string>
+    <string name="tmdb_genre_soap">Soap</string>
+    <string name="tmdb_genre_talk">Talk</string>
+    <string name="tmdb_genre_war_politics">War &amp; Politics</string>
 
 
     <!-- Settings option values (display-only localization) -->


### PR DESCRIPTION
### What

Same approach as #632, applied to the home screen and search.

Moves the remaining hardcoded English UI strings on the home screen and in
search into the string resource system and adds the German values. No
behaviour changes, no logic changes.

- the 27 TMDB genre names were kept as two separate English maps, one in
  `HomeScreen.kt` and one in `SearchViewModel.kt`. They now resolve from the
  numeric TMDB genre id through a shared helper (`TmdbGenreNames.kt`), so the
  home metadata rows and the search filter chips read from one place
- 12 of those 27 reused the existing `collections_genre_*` resources; 15 are
  new keys
- the five discover row titles (Trending, Popular This Year, Top Rated, New
  Releases, Hidden Gems) are localized for display only
- home: "Still loading your catalogue…" and "No description available." are
  new keys, "Retry" reuses the existing `R.string.retry`
- also fills seven `values-de` entries that were missing after the recent
  IPTV favourites and channel-variant work, so the German locale is complete
  again

### Why

Approved in Discord (28 Aug): "Yes try to also bring hardcoded things into
this. That has been kinda a long time bug. They dont have to be in English
yea."

This benefits all 50 language folders, not just German — untranslated locales
fall back to English exactly as before.

### Notes

- Stored values and internal keys are unchanged; only rendered text is
  localized. Follows the existing pattern from `LiveCategory.kt`.
- The English discover row title stays in `Category.title` on purpose: it is
  part of the category id used as the row's focus key.
- Movie and TV genre ids stay in separate lookups, matching the two maps that
  were there before, so no item gains or loses a genre label.
- Language names (`COUNTRIES`), brand names and animation labels are left
  untouched.
- Compile and unit tests verified green on CI.

created by Claude (Anthropic) on behalf of @ReichiMD