### PR TITLE
feat(details): put the age certification in a rounded chip

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/components/ContentRatingChip.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/ContentRatingChip.kt
@@ -1,0 +1,51 @@
+package com.arflix.tv.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.arflix.tv.ui.theme.ArflixTypography
+
+/**
+ * Age certification in a small rounded chip — same shape and padding as the "In Cinema"
+ * pill on the details screen, on a neutral translucent surface instead of a solid colour.
+ * Deliberately not colour coded by age: the age is only unambiguous for a few numeric
+ * rating systems, so a colour would have to be guessed for the letter based ones.
+ */
+@Composable
+fun ContentRatingChip(
+    text: String,
+    fontWeight: FontWeight,
+    textColor: Color,
+    textShadow: Shadow,
+    fontSize: TextUnit = 13.sp,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .background(Color.White.copy(alpha = 0.14f), RoundedCornerShape(6.dp))
+            .padding(horizontal = 10.dp, vertical = 4.dp)
+    ) {
+        Text(
+            text = text,
+            style = ArflixTypography.caption.copy(
+                fontSize = fontSize,
+                fontWeight = fontWeight,
+                shadow = textShadow
+            ),
+            color = textColor,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
@@ -152,23 +152,24 @@ import com.arflix.tv.data.model.MediaType
 import com.arflix.tv.data.model.Review
 import com.arflix.tv.data.repository.MdbExternalRating
 import com.arflix.tv.network.OkHttpProvider
-import com.arflix.tv.ui.components.EpisodeContextMenu
-import com.arflix.tv.ui.components.KeepScreenOn
-import com.arflix.tv.ui.components.SeasonContextMenu
-import com.arflix.tv.ui.components.LoadingIndicator
 import com.arflix.tv.ui.components.AppTopBar
 import com.arflix.tv.ui.components.AppTopBarContentTopInset
 import com.arflix.tv.ui.components.CardLayoutMode
+import com.arflix.tv.ui.components.ContentRatingChip
+import com.arflix.tv.ui.components.EpisodeContextMenu
+import com.arflix.tv.ui.components.KeepScreenOn
+import com.arflix.tv.ui.components.LoadingIndicator
 import com.arflix.tv.ui.components.MediaCard
 import com.arflix.tv.ui.components.PersonModal
 import com.arflix.tv.ui.components.PosterCard
-import com.arflix.tv.ui.components.resolveDetailsBackdropHeightDp
-import com.arflix.tv.ui.components.rememberCatalogueRowLayoutMode
+import com.arflix.tv.ui.components.SeasonContextMenu
 import com.arflix.tv.ui.components.SidebarItem
 import com.arflix.tv.ui.components.SkeletonDetailsPage
 import com.arflix.tv.ui.components.SkeletonEpisodeCard
 import com.arflix.tv.ui.components.StreamSelector
 import com.arflix.tv.ui.components.TrailerPlayer
+import com.arflix.tv.ui.components.rememberCatalogueRowLayoutMode
+import com.arflix.tv.ui.components.resolveDetailsBackdropHeightDp
 import androidx.activity.compose.BackHandler
 import androidx.compose.material.icons.filled.ChevronLeft
 import androidx.compose.material.icons.filled.ChevronRight
@@ -3728,36 +3729,6 @@ private fun MobileMetadataSeparator() {
         color = Color.White.copy(alpha = 0.42f),
         maxLines = 1
     )
-}
-
-/**
- * Age certification chip — same rounded shape and padding as the "In Cinema" pill,
- * but on a neutral translucent surface instead of a solid colour.
- */
-@Composable
-private fun ContentRatingChip(
-    text: String,
-    fontWeight: FontWeight,
-    textColor: Color,
-    textShadow: Shadow
-) {
-    Box(
-        modifier = Modifier
-            .background(Color.White.copy(alpha = 0.14f), RoundedCornerShape(6.dp))
-            .padding(horizontal = 10.dp, vertical = 4.dp)
-    ) {
-        Text(
-            text = text,
-            style = ArflixTypography.caption.copy(
-                fontSize = 13.sp,
-                fontWeight = fontWeight,
-                shadow = textShadow
-            ),
-            color = textColor,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-        )
-    }
 }
 
 /**

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
@@ -1578,19 +1578,11 @@ private fun DetailsContent(
                                     )
                                 }
                                 item.contentRating?.let { contentRating ->
-                                    if (ratingValue > 0f || displayDate.isNotEmpty() || hasDuration) {
-                                        MobileMetadataSeparator()
-                                    }
-                                    Text(
+                                    ContentRatingChip(
                                         text = contentRating,
-                                        style = ArflixTypography.caption.copy(
-                                            fontSize = 13.sp,
-                                            fontWeight = FontWeight.SemiBold,
-                                            shadow = textShadow
-                                        ),
-                                        color = Color.White.copy(alpha = 0.78f),
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis
+                                        fontWeight = FontWeight.SemiBold,
+                                        textColor = Color.White.copy(alpha = 0.78f),
+                                        textShadow = textShadow
                                     )
                                 }
                             }
@@ -2237,16 +2229,11 @@ private fun DetailsContent(
                         }
 
                         item.contentRating?.let { contentRating ->
-                            Text(text = "|", style = separatorStyle, color = Color.White.copy(alpha = 0.7f))
-                            Text(
+                            ContentRatingChip(
                                 text = contentRating,
-                                style = ArflixTypography.caption.copy(
-                                    fontSize = 13.sp,
-                                    fontWeight = FontWeight.Bold,
-                                    shadow = textShadow
-                                ),
-                                color = Color.White,
-                                maxLines = 1
+                                fontWeight = FontWeight.Bold,
+                                textColor = Color.White,
+                                textShadow = textShadow
                             )
                         }
                     }
@@ -3741,6 +3728,36 @@ private fun MobileMetadataSeparator() {
         color = Color.White.copy(alpha = 0.42f),
         maxLines = 1
     )
+}
+
+/**
+ * Age certification chip — same rounded shape and padding as the "In Cinema" pill,
+ * but on a neutral translucent surface instead of a solid colour.
+ */
+@Composable
+private fun ContentRatingChip(
+    text: String,
+    fontWeight: FontWeight,
+    textColor: Color,
+    textShadow: Shadow
+) {
+    Box(
+        modifier = Modifier
+            .background(Color.White.copy(alpha = 0.14f), RoundedCornerShape(6.dp))
+            .padding(horizontal = 10.dp, vertical = 4.dp)
+    ) {
+        Text(
+            text = text,
+            style = ArflixTypography.caption.copy(
+                fontSize = 13.sp,
+                fontWeight = fontWeight,
+                shadow = textShadow
+            ),
+            color = textColor,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
 }
 
 /**

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
@@ -136,12 +136,13 @@ import com.arflix.tv.data.model.MediaItem
 import com.arflix.tv.data.model.MediaType
 import com.arflix.tv.data.model.isPortrait
 import com.arflix.tv.network.OkHttpProvider
+import com.arflix.tv.ui.components.AppTopBar
+import com.arflix.tv.ui.components.AppTopBarContentTopInset
+import com.arflix.tv.ui.components.CardLayoutMode
+import com.arflix.tv.ui.components.ContentRatingChip
 import com.arflix.tv.ui.components.FeaturedMediaCard
 import com.arflix.tv.ui.components.MediaCard as ArvioMediaCard
 import com.arflix.tv.ui.components.TrailerPlayer
-import com.arflix.tv.ui.components.CardLayoutMode
-import com.arflix.tv.ui.components.AppTopBar
-import com.arflix.tv.ui.components.AppTopBarContentTopInset
 import com.arflix.tv.data.model.SportsAddonCapabilities
 import com.arflix.tv.ui.components.SkeletonMobileHeroBanner
 import com.arflix.tv.ui.components.SkeletonPosterCard
@@ -1653,6 +1654,15 @@ private fun HeroSection(
                                     ),
                                     color = Color.White,
                                     maxLines = 1
+                                )
+                            }
+
+                            currentItem.contentRating?.let { contentRating ->
+                                ContentRatingChip(
+                                    text = contentRating,
+                                    fontWeight = FontWeight.Bold,
+                                    textColor = Color.White,
+                                    textShadow = textShadow
                                 )
                             }
                         }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
@@ -212,6 +212,7 @@ class HomeViewModel @Inject constructor(
         val tmdbRating: String,
         val budget: Long?,
         val overview: String,
+        val contentRating: String? = null,
         val primaryNetworkLogo: String? = null,
         val fullyLoaded: Boolean = false
     )
@@ -677,6 +678,7 @@ class HomeViewModel @Inject constructor(
             tmdbRating = snapshot.tmdbRating.ifEmpty { tmdbRating },
             budget = snapshot.budget ?: budget,
             overview = snapshot.overview.ifBlank { overview },
+            contentRating = snapshot.contentRating ?: contentRating,
             primaryNetworkLogo = snapshot.primaryNetworkLogo ?: primaryNetworkLogo
         )
     }
@@ -690,6 +692,7 @@ class HomeViewModel @Inject constructor(
             tmdbRating = cached.tmdbRating,
             budget = cached.budget,
             overview = cached.overview,
+            contentRating = cached.contentRating,
             primaryNetworkLogo = cached.primaryNetworkLogo,
             fullyLoaded = false
         )
@@ -759,6 +762,7 @@ class HomeViewModel @Inject constructor(
                 tmdbRating = details?.tmdbRating.orEmpty(),
                 budget = details?.budget,
                 overview = resolvedOverview,
+                contentRating = details?.contentRating,
                 primaryNetworkLogo = primaryNetworkLogo,
                 fullyLoaded = true
             )


### PR DESCRIPTION
### What
The age certification on the movie and show details screens is now shown in a
small rounded chip instead of plain text in the metadata row, so it reads as a
certification rather than as one more number next to the runtime. The hero
preview on the TV home screen shows it too — it had the data available but was
not displaying it.

### How
- Reuses the existing "In Cinema" pill pattern from the details screen: Box +
  RoundedCornerShape(6.dp) + padding(horizontal 10.dp, vertical 4.dp), moved to
  `ui/components/ContentRatingChip.kt` so both screens share one definition.
- Neutral translucent background, no colour coding by age — deliberately, see
  below.
- Details screen: applied to both layouts (phone and TV). The separator in front
  of the certification is dropped; the chip separates itself.
- TV home screen hero: the certification is carried through `HeroDetailsSnapshot`,
  which already holds the runtime, IMDb rating and budget from the same details
  call — so this costs no additional request.

### Notes for review
- No new strings, no changes to the certification logic or the TMDB models —
  presentation only, apart from the one field added to the hero snapshot.
- On TV the details metadata row has a fixed width and the genre text ellipsises;
  the chip takes slightly more room than the plain text did. Checked on a TCL C7K.

### Deliberately not included
- No colour by age rating: the age is only unambiguous for a few numeric systems
  (FSK, BBFC, ClassInd, ACB, Kijkwijzer) and would have to be guessed for
  letter-based ones (R, PG-13, TV-MA). A wrong colour is worse than none.
- Not shown in the phone home carousel: its cards come straight from the category
  rows and carry no certification, so it would mean a details request per card.
  On the phone the certification is on the details screen.
- No conversion of the remaining metadata (genre, year, runtime) to chips.
- No skin/theme tokens.

### Testing
Built as a sideload debug APK and installed on a phone and on a TCL C7K
(Android TV). Existing unit tests unchanged and green.

<img width="4080" height="3072" alt="PXL_20260904_205556080 MP" src="https://github.com/user-attachments/assets/e4575af4-ce36-44b2-93b9-9c411d79a39c" />
<img width="4080" height="3072" alt="PXL_20260904_205541332 MP" src="https://github.com/user-attachments/assets/4501096e-7a9f-4c9c-af0e-0a38d17debe2" />
<img width="1080" height="2400" alt="Screenshot_20260904-224951" src="https://github.com/user-attachments/assets/b350e0a9-02fd-4480-9232-5011191ab5f6" />


---
created by Claude (Anthropic) on behalf of @ReichiMD