### PR TITLE
fix(search): fix TV filter focus reversion and align mobile catalog layout

### DIFF
--- a/app/src/androidTest/kotlin/com/arflix/tv/ui/screens/search/SearchScreenDeviceTest.kt
+++ b/app/src/androidTest/kotlin/com/arflix/tv/ui/screens/search/SearchScreenDeviceTest.kt
@@ -10,7 +10,10 @@ import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.unit.LayoutDirection
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arflix.tv.R
 import com.arflix.tv.data.model.Category
 import com.arflix.tv.data.model.MediaItem
 import com.arflix.tv.data.model.MediaType
@@ -46,6 +49,7 @@ class SearchScreenDeviceTest {
         keys(listOf(Key.DirectionRight, Key.DirectionCenter))
         filter("shows").assertIsSelected()
         verify(exactly = 1) { viewModel.setDiscoverFilters(DiscoverType.TV_SHOWS, null, null) }
+        finishReload()
         capture("tv-filters")
     }
 
@@ -57,11 +61,13 @@ class SearchScreenDeviceTest {
         filter("movies").assertIsSelected()
         verify(exactly = 2) { viewModel.setDiscoverFilters(DiscoverType.MOVIES, null, null) }
         keys(listOf(Key.DirectionUp, Key.DirectionCenter))
+        assertKeyboardVisible()
         compose.onNodeWithTag("search-input").assertIsFocused().performTextInput("test")
         compose.runOnIdle { assertEquals("test", state.value.query) }
         keys(listOf(Key.Escape, Key.DirectionCenter))
-        compose.onNodeWithTag("search-input").assertIsFocused().performTextInput(" again")
-        compose.runOnIdle { assertEquals("test again", state.value.query) }
+        assertKeyboardVisible()
+        compose.onNodeWithTag("search-input").assertIsFocused().performTextReplacement("updated")
+        compose.runOnIdle { assertEquals("updated", state.value.query) }
     }
 
     @Test fun tvCanEnterResultsAndReturnWithoutSelectingAll() {
@@ -83,6 +89,7 @@ class SearchScreenDeviceTest {
 
     @Test fun tvFilterAccessibilityActionRemainsAvailable() {
         show(DeviceType.TV)
+        filter("movies").assertTextEquals(compose.activity.getString(R.string.movies))
         filter("movies").assertHasClickAction().performSemanticsAction(SemanticsActions.OnClick) { it() }
         filter("movies").assertIsSelected()
         verify(exactly = 1) { viewModel.setDiscoverFilters(DiscoverType.MOVIES, null, null) }
@@ -106,7 +113,7 @@ class SearchScreenDeviceTest {
         val second = compose.onNodeWithTag("search-row-initial-2").fetchSemanticsNode().boundsInRoot
         assertTrue("Rows overlap: $first / $second", second.top >= first.bottom)
         capture("mobile-rows")
-        compose.onNodeWithText("First Movie", useUnmergedTree = true).performClick()
+        compose.onAllNodesWithText("First Movie", useUnmergedTree = true).onFirst().performClick()
         compose.runOnIdle { assertEquals(1, openedId) }
     }
 
@@ -138,6 +145,15 @@ class SearchScreenDeviceTest {
     }
 
     private fun filter(key: String) = compose.onNodeWithTag("search-filter-$key")
+
+    private fun assertKeyboardVisible() {
+        compose.waitUntil(timeoutMillis = 5_000) {
+            compose.runOnUiThread {
+                ViewCompat.getRootWindowInsets(compose.activity.window.decorView)
+                    ?.isVisible(WindowInsetsCompat.Type.ime()) == true
+            }
+        }
+    }
 
     private fun keys(keys: List<Key>) {
         keys.forEach { key ->

--- a/app/src/androidTest/kotlin/com/arflix/tv/ui/screens/search/SearchScreenDeviceTest.kt
+++ b/app/src/androidTest/kotlin/com/arflix/tv/ui/screens/search/SearchScreenDeviceTest.kt
@@ -1,0 +1,162 @@
+package com.arflix.tv.ui.screens.search
+
+import android.graphics.Bitmap
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.arflix.tv.data.model.Category
+import com.arflix.tv.data.model.MediaItem
+import com.arflix.tv.data.model.MediaType
+import com.arflix.tv.util.DeviceType
+import com.arflix.tv.util.LocalDeviceType
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.io.File
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Assert.*
+import org.junit.Assume.assumeTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@OptIn(ExperimentalTestApi::class)
+@RunWith(AndroidJUnit4::class)
+class SearchScreenDeviceTest {
+    @get:Rule val compose = createAndroidComposeRule<ComponentActivity>()
+
+    private val state = MutableStateFlow(SearchUiState(discoverCategories = rows("initial")))
+    private val viewModel = mockk<SearchViewModel>(relaxed = true)
+    private var openedId: Int? = null
+
+    @Test fun tvSelectionSurvivesKeyUpAndCategoryReload() {
+        show(DeviceType.TV)
+        keys(listOf(Key.DirectionDown, Key.DirectionRight, Key.DirectionCenter))
+        filter("movies").assertIsSelected()
+        filter("all").assertIsNotSelected()
+        verify(exactly = 1) { viewModel.setDiscoverFilters(DiscoverType.MOVIES, null, null) }
+        finishReload()
+        keys(listOf(Key.DirectionRight, Key.DirectionCenter))
+        filter("shows").assertIsSelected()
+        verify(exactly = 1) { viewModel.setDiscoverFilters(DiscoverType.TV_SHOWS, null, null) }
+        capture("tv-filters")
+    }
+
+    @Test fun tvSearchReturnKeepsSelectedFilterAndReopensEditor() {
+        show(DeviceType.TV)
+        keys(listOf(Key.DirectionDown, Key.DirectionRight, Key.DirectionCenter))
+        finishReload()
+        keys(listOf(Key.DirectionUp, Key.DirectionDown, Key.DirectionCenter))
+        filter("movies").assertIsSelected()
+        verify(exactly = 2) { viewModel.setDiscoverFilters(DiscoverType.MOVIES, null, null) }
+        keys(listOf(Key.DirectionUp, Key.DirectionCenter))
+        compose.onNodeWithTag("search-input").assertIsFocused().performTextInput("test")
+        compose.runOnIdle { assertEquals("test", state.value.query) }
+        keys(listOf(Key.Escape, Key.DirectionCenter))
+        compose.onNodeWithTag("search-input").assertIsFocused().performTextInput(" again")
+        compose.runOnIdle { assertEquals("test again", state.value.query) }
+    }
+
+    @Test fun tvCanEnterResultsAndReturnWithoutSelectingAll() {
+        show(DeviceType.TV)
+        keys(listOf(Key.DirectionDown, Key.DirectionRight, Key.DirectionCenter))
+        finishReload()
+        keys(listOf(Key.DirectionDown, Key.DirectionCenter))
+        compose.runOnIdle { assertEquals(1, openedId) }
+        keys(listOf(Key.DirectionUp, Key.DirectionCenter))
+        verify(exactly = 2) { viewModel.setDiscoverFilters(DiscoverType.MOVIES, null, null) }
+        filter("movies").assertIsSelected()
+    }
+
+    @Test fun tvRtlFiltersUseMirroredHorizontalNavigation() {
+        show(DeviceType.TV, LayoutDirection.Rtl)
+        keys(listOf(Key.DirectionDown, Key.DirectionLeft, Key.DirectionCenter))
+        filter("movies").assertIsSelected()
+    }
+
+    @Test fun tvFilterAccessibilityActionRemainsAvailable() {
+        show(DeviceType.TV)
+        filter("movies").assertHasClickAction().performSemanticsAction(SemanticsActions.OnClick) { it() }
+        filter("movies").assertIsSelected()
+        verify(exactly = 1) { viewModel.setDiscoverFilters(DiscoverType.MOVIES, null, null) }
+    }
+
+    @Test fun mobileTypeAndGenreFiltersRemainClickable() {
+        show(DeviceType.PHONE)
+        filter("movies").performClick()
+        finishReload()
+        filter("genre_28").performScrollTo().performClick()
+        compose.runOnIdle {
+            assertEquals(DiscoverType.MOVIES, state.value.selectedType)
+            assertEquals(28, state.value.selectedGenre?.id)
+        }
+        filter("genre_28").assertIsSelected()
+    }
+
+    @Test fun mobileRowsDoNotOverlapAndCardsOpenDetails() {
+        show(DeviceType.PHONE)
+        val first = compose.onNodeWithTag("search-row-initial-1").fetchSemanticsNode().boundsInRoot
+        val second = compose.onNodeWithTag("search-row-initial-2").fetchSemanticsNode().boundsInRoot
+        assertTrue("Rows overlap: $first / $second", second.top >= first.bottom)
+        capture("mobile-rows")
+        compose.onNodeWithText("First Movie", useUnmergedTree = true).performClick()
+        compose.runOnIdle { assertEquals(1, openedId) }
+    }
+
+    private fun show(device: DeviceType, direction: LayoutDirection = LayoutDirection.Ltr) {
+        if (device == DeviceType.TV) {
+            val config = compose.activity.resources.configuration
+            assumeTrue("Run TV checks on a landscape TV emulator", config.screenWidthDp >= 600 && config.screenWidthDp > config.screenHeightDp)
+        }
+        every { viewModel.uiState } returns state
+        every { viewModel.setDiscoverFilters(any(), any(), any()) } answers {
+            state.value = state.value.copy(
+                selectedType = firstArg(), selectedGenre = secondArg(), selectedCountry = thirdArg(),
+                discoverCategories = emptyList(), isDiscoverLoading = true
+            )
+        }
+        every { viewModel.updateQuery(any()) } answers { state.value = state.value.copy(query = firstArg()) }
+        compose.setContent {
+            CompositionLocalProvider(LocalDeviceType provides device, LocalLayoutDirection provides direction) {
+                SearchScreen(viewModel = viewModel, onNavigateToDetails = { _, id -> openedId = id })
+            }
+        }
+        compose.waitForIdle()
+    }
+
+    private fun finishReload() {
+        compose.runOnIdle {
+            state.value = state.value.copy(discoverCategories = rows("reloaded"), isDiscoverLoading = false)
+        }
+    }
+
+    private fun filter(key: String) = compose.onNodeWithTag("search-filter-$key")
+
+    private fun keys(keys: List<Key>) {
+        keys.forEach { key ->
+            compose.onNodeWithTag("search-screen").performKeyInput { pressKey(key) }
+            compose.waitForIdle()
+        }
+    }
+
+    private fun capture(name: String) {
+        val bitmap = compose.onNodeWithTag("search-screen").captureToImage().asAndroidBitmap()
+        File(compose.activity.getExternalFilesDir(null), "pr649-$name.png").outputStream().use {
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, it)
+        }
+    }
+
+    companion object {
+        private fun rows(prefix: String) = listOf(
+            Category("$prefix-1", "Trending", listOf(MediaItem(id = 1, title = "First Movie", mediaType = MediaType.MOVIE))),
+            Category("$prefix-2", "Top Rated", listOf(MediaItem(id = 2, title = "Second Movie", mediaType = MediaType.MOVIE)))
+        )
+    }
+}

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/search/SearchScreen.kt
@@ -20,7 +20,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Shadow
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -151,7 +154,7 @@ fun SearchScreen(
     val isCompactHeight = configuration.screenHeightDp <= 780
     val isTouchDevice = LocalDeviceType.current.isTouchDevice()
     val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
-    val searchBarWidth = if (isTouchDevice) configuration.screenWidthDp.dp - 24.dp
+    val searchBarWidth = if (isTouchDevice) configuration.screenWidthDp.dp - 32.dp
         else (configuration.screenWidthDp.dp * 0.48f).coerceIn(460.dp, 680.dp)
 
     val hasSearchResults = uiState.movieResults.isNotEmpty() || uiState.tvResults.isNotEmpty() || uiState.personResults.isNotEmpty()
@@ -195,8 +198,8 @@ fun SearchScreen(
     var searchEditRequestNonce by remember { mutableIntStateOf(0) }
 
     val searchFocusRequester = remember { FocusRequester() }
-    val textInputFocusRequester = remember { FocusRequester() }
     val filtersFocusRequester = remember { FocusRequester() }
+    val textInputFocusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
     val actionGenre = remember { ALL_GENRES.firstOrNull { it.id == 28 } }
     val comedyGenre = remember { ALL_GENRES.firstOrNull { it.id == 35 } }
@@ -336,8 +339,9 @@ fun SearchScreen(
                 FocusZone.RESULTS -> {
                     if (showFilters && quickFilters.isNotEmpty()) {
                         focusZone = FocusZone.FILTERS
-                        focusedFilterIndex = focusedFilterIndex.coerceIn(0, (quickFilters.size - 1).coerceAtLeast(0))
-                        try { filtersFocusRequester.requestFocus() } catch (_: Exception) {}
+                        val selectedIdx = quickFilters.indexOfFirst { it.isSelected }.coerceAtLeast(0)
+                        focusedFilterIndex = if (focusedFilterIndex in quickFilters.indices) focusedFilterIndex else selectedIdx
+                        runCatching { filtersFocusRequester.requestFocus() }
                     } else {
                         focusZone = FocusZone.SEARCH_INPUT
                         runCatching { searchFocusRequester.requestFocus() }
@@ -377,8 +381,9 @@ fun SearchScreen(
                     FocusZone.RESULTS -> {
                         if (showFilters && quickFilters.isNotEmpty()) {
                             focusZone = FocusZone.FILTERS
-                            focusedFilterIndex = focusedFilterIndex.coerceIn(0, (quickFilters.size - 1).coerceAtLeast(0))
-                            try { filtersFocusRequester.requestFocus() } catch (_: Exception) {}
+                            val selectedIdx = quickFilters.indexOfFirst { it.isSelected }.coerceAtLeast(0)
+                            focusedFilterIndex = if (focusedFilterIndex in quickFilters.indices) focusedFilterIndex else selectedIdx
+                            runCatching { filtersFocusRequester.requestFocus() }
                         }
                         else { focusZone = FocusZone.SEARCH_INPUT; searchFocusRequester.requestFocus() }
                         true
@@ -412,8 +417,9 @@ fun SearchScreen(
                         }
                         else if (showFilters && quickFilters.isNotEmpty()) {
                             focusZone = FocusZone.FILTERS
-                            focusedFilterIndex = focusedFilterIndex.coerceIn(0, (quickFilters.size - 1).coerceAtLeast(0))
-                            try { filtersFocusRequester.requestFocus() } catch (_: Exception) {}
+                            val selectedIdx = quickFilters.indexOfFirst { it.isSelected }.coerceAtLeast(0)
+                            focusedFilterIndex = if (focusedFilterIndex in quickFilters.indices) focusedFilterIndex else selectedIdx
+                            runCatching { filtersFocusRequester.requestFocus() }
                             true
                         }
                         else { focusZone = FocusZone.SEARCH_INPUT; searchFocusRequester.requestFocus(); true }
@@ -426,8 +432,9 @@ fun SearchScreen(
                         keyboardController?.hide()
                         if (showFilters && quickFilters.isNotEmpty()) {
                             focusZone = FocusZone.FILTERS
-                            focusedFilterIndex = focusedFilterIndex.coerceIn(0, (quickFilters.size - 1).coerceAtLeast(0))
-                            try { filtersFocusRequester.requestFocus() } catch (_: Exception) {}
+                            val selectedIdx = quickFilters.indexOfFirst { it.isSelected }.coerceAtLeast(0)
+                            focusedFilterIndex = if (selectedIdx in quickFilters.indices) selectedIdx else 0
+                            runCatching { filtersFocusRequester.requestFocus() }
                         }
                         else if (activeCategories.isNotEmpty() || hasAiResults) {
                             resultsLastNavEventTime = SystemClock.elapsedRealtime()
@@ -471,9 +478,6 @@ fun SearchScreen(
                     FocusZone.FILTERS -> {
                         if (focusedFilterIndex > 0) {
                             focusedFilterIndex--
-                        } else {
-                            focusZone = FocusZone.SEARCH_INPUT
-                            runCatching { searchFocusRequester.requestFocus() }
                         }
                         true
                     }
@@ -516,6 +520,7 @@ fun SearchScreen(
                         }
                         FocusZone.FILTERS -> {
                             quickFilters.getOrNull(focusedFilterIndex)?.onSelect?.invoke()
+                            runCatching { filtersFocusRequester.requestFocus() }
                             true
                         }
                         FocusZone.RESULTS -> {
@@ -538,14 +543,22 @@ fun SearchScreen(
     Box(modifier = Modifier.fillMaxSize().background(appBackgroundDark()).then(dpadModifier)) {
         if (!isTouchDevice) AppTopBar(selectedItem = SidebarItem.SEARCH, isFocused = focusZone == FocusZone.SIDEBAR, focusedIndex = sidebarFocusIndex, profile = currentProfile)
 
-        Column(modifier = Modifier.fillMaxSize().padding(top = if (isTouchDevice) 16.dp else AppTopBarContentTopInset).padding(horizontal = if (isTouchDevice) 12.dp else if (isCompactHeight) 20.dp else 28.dp)) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .then(
+                    if (isTouchDevice) Modifier.statusBarsPadding().padding(top = 12.dp)
+                    else Modifier.padding(top = AppTopBarContentTopInset)
+                )
+                .padding(horizontal = if (isTouchDevice) 0.dp else if (isCompactHeight) 20.dp else 28.dp)
+        ) {
             // ── Search Bar ──
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(
-                        start = if (isTouchDevice) 0.dp else 22.dp,
-                        end = if (isTouchDevice) 0.dp else 22.dp,
+                        start = if (isTouchDevice) 16.dp else 22.dp,
+                        end = if (isTouchDevice) 16.dp else 22.dp,
                         bottom = if (isCompactHeight) 6.dp else 8.dp
                     ),
                 horizontalArrangement = Arrangement.Center,
@@ -566,8 +579,9 @@ fun SearchScreen(
                         isSearchEditing = false
                     },
                     onFocused = {
-                        focusZone = FocusZone.SEARCH_INPUT
-                        isSearchInputFocused = true
+                        if (focusZone == FocusZone.SEARCH_INPUT) {
+                            isSearchInputFocused = true
+                        }
                     },
                     onFocusLost = { isSearchInputFocused = false },
                     onStartEditing = {
@@ -585,7 +599,8 @@ fun SearchScreen(
                         keyboardController?.hide()
                         if (showFilters && quickFilters.isNotEmpty()) {
                             focusZone = FocusZone.FILTERS
-                            focusedFilterIndex = 0
+                            val selectedIdx = quickFilters.indexOfFirst { it.isSelected }.coerceAtLeast(0)
+                            focusedFilterIndex = if (selectedIdx in quickFilters.indices) selectedIdx else 0
                             runCatching { filtersFocusRequester.requestFocus() }
                         } else if (activeCategories.isNotEmpty() || hasAiResults) {
                             resultsLastNavEventTime = SystemClock.elapsedRealtime()
@@ -603,9 +618,11 @@ fun SearchScreen(
                     filters = quickFilters,
                     focusZone = focusZone,
                     focusedFilterIndex = focusedFilterIndex,
-                    filtersFocusRequester = filtersFocusRequester,
                     isTouchDevice = isTouchDevice,
-                    modifier = Modifier.align(Alignment.CenterHorizontally),
+                    filtersFocusRequester = filtersFocusRequester,
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .padding(bottom = if (isTouchDevice) 4.dp else 0.dp),
                     isRtl = isRtl,
                     onFocused = { index ->
                         focusZone = FocusZone.FILTERS
@@ -626,9 +643,6 @@ fun SearchScreen(
                     onMoveLeft = {
                         if (focusedFilterIndex > 0) {
                             focusedFilterIndex--
-                        } else {
-                            focusZone = FocusZone.SEARCH_INPUT
-                            runCatching { searchFocusRequester.requestFocus() }
                         }
                     },
                     onMoveRight = {
@@ -740,6 +754,7 @@ private fun SearchInputBar(
             .width(searchBarWidth)
             .height(54.dp)
             .onPreviewKeyEvent { event ->
+                if (!isFocused) return@onPreviewKeyEvent false
                 if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
                 when (event.key) {
                     Key.DirectionUp -> { onMoveUp(); true }
@@ -802,10 +817,10 @@ private fun DiscoverFilterStrip(
     filters: List<DiscoverQuickFilter>,
     focusZone: FocusZone,
     focusedFilterIndex: Int,
-    filtersFocusRequester: FocusRequester,
     isTouchDevice: Boolean,
     modifier: Modifier = Modifier,
     isRtl: Boolean = false,
+    filtersFocusRequester: FocusRequester? = null,
     onFocused: (Int) -> Unit,
     onMoveUp: () -> Unit,
     onMoveDown: () -> Unit,
@@ -827,23 +842,19 @@ private fun DiscoverFilterStrip(
     LazyRow(
         state = rowState,
         modifier = modifier
-            .padding(bottom = if (isTouchDevice) 10.dp else 8.dp)
-            .onPreviewKeyEvent { event ->
-                if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
-                when (event.key) {
-                    Key.DirectionUp -> { onMoveUp(); true }
-                    Key.DirectionDown -> { onMoveDown(); true }
-                    Key.DirectionLeft -> { if (isRtl) onMoveRight() else onMoveLeft(); true }
-                    Key.DirectionRight -> { if (isRtl) onMoveLeft() else onMoveRight(); true }
-                    Key.Enter, Key.DirectionCenter -> false
-                    else -> false
-                }
-            }
+            .padding(bottom = if (isTouchDevice) 8.dp else 8.dp)
+            .then(
+                if (!isTouchDevice && filtersFocusRequester != null) {
+                    Modifier
+                        .focusRequester(filtersFocusRequester)
+                        .focusable()
+                } else Modifier
+            )
             .arvioDpadFocusGroup(),
-        horizontalArrangement = Arrangement.spacedBy(if (isTouchDevice) 7.dp else 9.dp),
+        horizontalArrangement = Arrangement.spacedBy(if (isTouchDevice) 8.dp else 9.dp),
         contentPadding = PaddingValues(
-            start = if (isTouchDevice) 12.dp else 22.dp,
-            end = if (isTouchDevice) 12.dp else 22.dp,
+            start = if (isTouchDevice) 16.dp else 22.dp,
+            end = if (isTouchDevice) 16.dp else 22.dp,
             top = 4.dp,
             bottom = 4.dp
         )
@@ -853,9 +864,7 @@ private fun DiscoverFilterStrip(
                 label = filter.label,
                 isSelected = filter.isSelected,
                 isVisuallyFocused = !isTouchDevice && focusZone == FocusZone.FILTERS && focusedFilterIndex == index,
-                modifier = if (index == 0) Modifier.focusRequester(filtersFocusRequester) else Modifier,
-                onFocused = { onFocused(index) },
-                useSystemFocusForVisuals = isTouchDevice,
+                isTouchDevice = isTouchDevice,
                 onSelect = filter.onSelect
             )
         }
@@ -868,18 +877,16 @@ private fun GlowChip(
     label: String,
     isSelected: Boolean,
     isVisuallyFocused: Boolean = false,
+    isTouchDevice: Boolean = false,
     modifier: Modifier = Modifier,
-    onFocused: () -> Unit = {},
-    useSystemFocusForVisuals: Boolean = true,
     onSelect: () -> Unit
 ) {
-    var systemFocused by remember { mutableStateOf(false) }
-    val focused = isVisuallyFocused || (useSystemFocusForVisuals && systemFocused)
+    val focused = isVisuallyFocused
     val active = focused || isSelected
-    val chipShape = RoundedCornerShape(7.dp)
+    val chipShape = RoundedCornerShape(8.dp)
     val accentColor = resolveAccentColor(fallback = Color.White)
     val backgroundColor = when {
-        focused -> Color.White.copy(alpha = 0.12f)
+        focused -> Color.White.copy(alpha = 0.16f)
         isSelected -> Color.White.copy(alpha = 0.92f)
         else -> Color.White.copy(alpha = 0.075f)
     }
@@ -900,13 +907,10 @@ private fun GlowChip(
                 color = borderColor,
                 shape = chipShape
             )
-            .clickable { onSelect() }
-            .onFocusChanged {
-                systemFocused = it.isFocused
-                if (it.isFocused) onFocused()
-            }
-            .focusable()
-            .padding(horizontal = 17.dp, vertical = 8.dp)
+            .then(
+                if (isTouchDevice) Modifier.clickable { onSelect() } else Modifier
+            )
+            .padding(horizontal = 16.dp, vertical = 7.dp)
     ) {
         Text(
             label,
@@ -941,57 +945,58 @@ private fun RowsLayer(
     val density = LocalDensity.current
     val screenHeight = configuration.screenHeightDp
 
-    val focusBleedPadding = if (isTouchDevice) 14.dp else 22.dp
+    val focusBleedPadding = if (isTouchDevice) 16.dp else 22.dp
 
     val listState = rememberLazyListState()
     var lastAppliedTargetIndex by remember { mutableIntStateOf(-1) }
     val targetIndex = currentRowIndex.coerceIn(0, (categories.size - 1).coerceAtLeast(0))
 
-    // Only move the results viewport in response to actual D-pad navigation.
-    // Search result rows update frequently while typing/loading, and snapping the
-    // LazyColumn on every target change makes the screen feel unstable.
-    LaunchedEffect(targetIndex, lastNavEventTime) {
-        val currentFirst = listState.firstVisibleItemIndex
-        val initialPlacement = lastAppliedTargetIndex < 0
-        if (currentFirst == targetIndex) {
+    // Only move the results viewport in response to actual D-pad navigation on TV.
+    if (!isTouchDevice) {
+        LaunchedEffect(targetIndex, lastNavEventTime) {
+            val currentFirst = listState.firstVisibleItemIndex
+            val initialPlacement = lastAppliedTargetIndex < 0
+            if (currentFirst == targetIndex) {
+                lastAppliedTargetIndex = targetIndex
+                return@LaunchedEffect
+            }
+
+            val recentUserNav = lastNavEventTime > 0L &&
+                (SystemClock.elapsedRealtime() - lastNavEventTime) <= fastScrollThresholdMs
+            if (!initialPlacement && !recentUserNav) return@LaunchedEffect
+
+            val jump = kotlin.math.abs(targetIndex - currentFirst)
+            if (!initialPlacement && jump <= 5) {
+                listState.animateScrollToItem(targetIndex)
+            } else {
+                listState.scrollToItem(targetIndex)
+            }
             lastAppliedTargetIndex = targetIndex
-            return@LaunchedEffect
         }
-
-        val recentUserNav = lastNavEventTime > 0L &&
-            (SystemClock.elapsedRealtime() - lastNavEventTime) <= fastScrollThresholdMs
-        if (!initialPlacement && !recentUserNav) return@LaunchedEffect
-
-        val jump = kotlin.math.abs(targetIndex - currentFirst)
-        if (!initialPlacement && jump <= 5) {
-            listState.animateScrollToItem(targetIndex)
-        } else {
-            listState.scrollToItem(targetIndex)
-        }
-        lastAppliedTargetIndex = targetIndex
     }
 
     BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
         LazyColumn(
             state = listState,
-            contentPadding = PaddingValues(top = focusBleedPadding / 2, bottom = if (isTouchDevice) 16.dp else maxHeight * 0.6f),
+            contentPadding = PaddingValues(
+                top = if (isTouchDevice) 4.dp else focusBleedPadding / 2,
+                bottom = if (isTouchDevice) 24.dp else maxHeight * 0.6f
+            ),
             modifier = Modifier.fillMaxSize().arvioDpadFocusGroup(),
-            verticalArrangement = Arrangement.spacedBy(0.dp)
+            verticalArrangement = Arrangement.spacedBy(if (isTouchDevice) 20.dp else 0.dp)
         ) {
             items(categories.size, key = { categories[it].id }) { index ->
                 val category = categories[index]
-                val isCurrentRow = isFocused && index == currentRowIndex
+                val isCurrentRow = !isTouchDevice && isFocused && index == currentRowIndex
                 val rowKey = remember(category.id) { "search:${category.id}" }
                 val rowUsePosterCards = rememberCatalogueRowLayoutMode(rowKey) == CardLayoutMode.POSTER
                 val isPortrait = category.isPortrait(rowUsePosterCards)
                 val itemWidth = if (isTouchDevice) {
-                    if (isPortrait) 110.dp else 170.dp
+                    if (isPortrait) 120.dp else 200.dp
                 } else {
                     if (isPortrait) 105.dp else 210.dp
                 }
-                val baseRowHeight = if (isTouchDevice) {
-                    if (isPortrait) 275.dp else 225.dp
-                } else if (isPortrait) {
+                val baseRowHeight = if (isPortrait) {
                     // Poster cards (2:3) need extra vertical room for title + date below the image
                     if (screenHeight <= 640) 271.dp else 309.dp
                 } else {
@@ -999,86 +1004,108 @@ private fun RowsLayer(
                     if (screenHeight <= 640) 210.dp else 274.dp
                 }
                 val rowHeight = baseRowHeight + focusBleedPadding
-                // Fade non-current rows
+                // Fade non-current rows on TV only
                 val rowAlpha by animateFloatAsState(
-                    targetValue = if (!isFocused || index <= currentRowIndex) 1f else 0.3f,
+                    targetValue = if (isTouchDevice || !isFocused || index <= currentRowIndex) 1f else 0.3f,
                     animationSpec = tween(250), label = "rowAlpha"
                 )
 
-                Box(modifier = Modifier.fillMaxWidth().height(rowHeight).graphicsLayer { alpha = rowAlpha }) {
-                    Column {
+                val rowContent = @Composable {
+                    Column(modifier = Modifier.fillMaxWidth()) {
                         Row(
-                            modifier = Modifier.padding(start = focusBleedPadding, bottom = 4.dp, top = 4.dp),
+                            modifier = Modifier.padding(
+                                start = if (isTouchDevice) 16.dp else focusBleedPadding,
+                                bottom = if (isTouchDevice) 4.dp else 4.dp,
+                                top = if (isTouchDevice) 0.dp else 4.dp
+                            ),
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(8.dp)
                         ) {
                             Text(
                                 localizedDiscoverRowTitle(category),
-                                style = ArvioSkin.typography.sectionTitle.copy(fontSize = 15.sp),
-                                color = Color.White.copy(alpha = if (isCurrentRow) 0.9f else 0.5f)
+                                style = if (isTouchDevice) {
+                                    ArflixTypography.sectionTitle.copy(
+                                        fontSize = 16.sp,
+                                        fontWeight = FontWeight.Bold,
+                                        shadow = Shadow(
+                                            color = Color.Black.copy(alpha = 0.8f),
+                                            offset = Offset(1f, 1f),
+                                            blurRadius = 4f
+                                        )
+                                    )
+                                } else {
+                                    ArvioSkin.typography.sectionTitle.copy(fontSize = 15.sp)
+                                },
+                                color = if (isTouchDevice) Color.White else Color.White.copy(alpha = if (isCurrentRow) 0.9f else 0.5f)
                             )
                         }
 
                         val rowState = rememberLazyListState()
                         var lastScrollIndex by remember(category.id) { mutableIntStateOf(-1) }
                         var lastScrollOffset by remember(category.id) { mutableIntStateOf(Int.MIN_VALUE) }
-                        // Scroll to focused item in current row
-                        LaunchedEffect(isCurrentRow, currentItemIndex, lastNavEventTime) {
-                            if (!isCurrentRow) return@LaunchedEffect
-                            val safeIndex = currentItemIndex.coerceIn(0, (category.items.size - 1).coerceAtLeast(0))
-                            val first = rowState.firstVisibleItemIndex
-                            val visibleItems = rowState.layoutInfo.visibleItemsInfo
-                            val last = visibleItems.lastOrNull()?.index ?: first
-                            val targetInfo = visibleItems.firstOrNull { it.index == safeIndex }
-                            val targetOutsideViewport = safeIndex < first || safeIndex > last
-                            val viewportEnd = rowState.layoutInfo.viewportEndOffset
-                            val trailingPaddingPx = rowState.layoutInfo.afterContentPadding
-                            val targetNearViewportEnd = targetInfo != null &&
-                                targetInfo.offset + targetInfo.size > viewportEnd - trailingPaddingPx
-                            val scrollTargetIndex = safeIndex
-                            val extraOffset = if (targetNearViewportEnd) {
-                                (with(density) { itemWidth.roundToPx() } * 0.35f).toInt()
-                            } else 0
+                        // Scroll to focused item in current row (TV only)
+                        if (!isTouchDevice) {
+                            LaunchedEffect(isCurrentRow, currentItemIndex, lastNavEventTime) {
+                                if (!isCurrentRow) return@LaunchedEffect
+                                val safeIndex = currentItemIndex.coerceIn(0, (category.items.size - 1).coerceAtLeast(0))
+                                val first = rowState.firstVisibleItemIndex
+                                val visibleItems = rowState.layoutInfo.visibleItemsInfo
+                                val last = visibleItems.lastOrNull()?.index ?: first
+                                val targetInfo = visibleItems.firstOrNull { it.index == safeIndex }
+                                val targetOutsideViewport = safeIndex < first || safeIndex > last
+                                val viewportEnd = rowState.layoutInfo.viewportEndOffset
+                                val trailingPaddingPx = rowState.layoutInfo.afterContentPadding
+                                val targetNearViewportEnd = targetInfo != null &&
+                                    targetInfo.offset + targetInfo.size > viewportEnd - trailingPaddingPx
+                                val scrollTargetIndex = safeIndex
+                                val extraOffset = if (targetNearViewportEnd) {
+                                    (with(density) { itemWidth.roundToPx() } * 0.35f).toInt()
+                                } else 0
 
-                            if (lastScrollIndex == scrollTargetIndex && lastScrollOffset == extraOffset) {
-                                return@LaunchedEffect
-                            }
-                            if (lastScrollIndex == -1) {
-                                rowState.scrollToItem(index = scrollTargetIndex, scrollOffset = extraOffset)
+                                if (lastScrollIndex == scrollTargetIndex && lastScrollOffset == extraOffset) {
+                                    return@LaunchedEffect
+                                }
+                                if (lastScrollIndex == -1) {
+                                    rowState.scrollToItem(index = scrollTargetIndex, scrollOffset = extraOffset)
+                                    lastScrollIndex = scrollTargetIndex
+                                    lastScrollOffset = extraOffset
+                                    return@LaunchedEffect
+                                }
+
+                                val recentUserNav = lastNavEventTime > 0L &&
+                                    (SystemClock.elapsedRealtime() - lastNavEventTime) <= fastScrollThresholdMs
+                                if (!recentUserNav) return@LaunchedEffect
+
+                                val jumpDistance = kotlin.math.abs(scrollTargetIndex - first)
+                                if (jumpDistance > 6) {
+                                    rowState.scrollToItem(index = scrollTargetIndex, scrollOffset = extraOffset)
+                                } else if (scrollTargetIndex != first || targetOutsideViewport) {
+                                    rowState.animateScrollToItem(index = scrollTargetIndex, scrollOffset = extraOffset)
+                                } else {
+                                    rowState.scrollToItem(index = scrollTargetIndex, scrollOffset = extraOffset)
+                                }
                                 lastScrollIndex = scrollTargetIndex
                                 lastScrollOffset = extraOffset
-                                return@LaunchedEffect
                             }
-
-                            val recentUserNav = lastNavEventTime > 0L &&
-                                (SystemClock.elapsedRealtime() - lastNavEventTime) <= fastScrollThresholdMs
-                            if (!recentUserNav) return@LaunchedEffect
-
-                            val jumpDistance = kotlin.math.abs(scrollTargetIndex - first)
-                            if (jumpDistance > 6) {
-                                rowState.scrollToItem(index = scrollTargetIndex, scrollOffset = extraOffset)
-                            } else if (scrollTargetIndex != first || targetOutsideViewport) {
-                                rowState.animateScrollToItem(index = scrollTargetIndex, scrollOffset = extraOffset)
-                            } else {
-                                rowState.scrollToItem(index = scrollTargetIndex, scrollOffset = extraOffset)
-                            }
-                            lastScrollIndex = scrollTargetIndex
-                            lastScrollOffset = extraOffset
                         }
 
                         LazyRow(
                             state = rowState,
                             modifier = Modifier.arvioDpadFocusGroup(),
-                            contentPadding = PaddingValues(
-                                start = focusBleedPadding,
-                                end = itemWidth + 56.dp,
-                                top = 8.dp,
-                                bottom = if (isTouchDevice) 8.dp else (focusBleedPadding + 12.dp)
-                            ),
-                            horizontalArrangement = Arrangement.spacedBy(18.dp)
+                            contentPadding = if (isTouchDevice) {
+                                PaddingValues(start = 16.dp, end = 16.dp, top = 4.dp, bottom = 4.dp)
+                            } else {
+                                PaddingValues(
+                                    start = focusBleedPadding,
+                                    end = itemWidth + 56.dp,
+                                    top = 8.dp,
+                                    bottom = focusBleedPadding + 12.dp
+                                )
+                            },
+                            horizontalArrangement = Arrangement.spacedBy(if (isTouchDevice) 14.dp else 18.dp)
                         ) {
                             itemsIndexed(category.items, key = { _, item -> "${item.mediaType}_${item.id}" }) { itemIdx, item ->
-                                val itemIsFocused = isCurrentRow && itemIdx == currentItemIndex
+                                val itemIsFocused = !isTouchDevice && isCurrentRow && itemIdx == currentItemIndex
                                 MediaCard(
                                     item = item.copy(
                                         title = buildCardTitle(item),
@@ -1102,6 +1129,14 @@ private fun RowsLayer(
                         }
                     }
                 }
+
+                if (isTouchDevice) {
+                    rowContent()
+                } else {
+                    Box(modifier = Modifier.fillMaxWidth().height(rowHeight).graphicsLayer { alpha = rowAlpha }) {
+                        rowContent()
+                    }
+                }
             }
         }
     }
@@ -1113,24 +1148,39 @@ private fun RowsLayer(
 @Composable
 private fun ContentGrid(items: List<MediaItem>, usePosterCards: Boolean, isLoading: Boolean, isTouchDevice: Boolean, onItemClick: (MediaItem) -> Unit, onLoadMore: () -> Unit) {
     val screenHeight = LocalConfiguration.current.screenHeightDp
-    val itemWidth = if (usePosterCards) 105.dp else 210.dp
+    val itemWidth = if (usePosterCards) (if (isTouchDevice) 120.dp else 105.dp) else (if (isTouchDevice) 200.dp else 210.dp)
     val gridState = rememberLazyGridState()
     LaunchedEffect(gridState.firstVisibleItemIndex, items.size) { val lv = gridState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0; if (items.isNotEmpty() && lv >= items.size - 8) onLoadMore() }
 
-    val focusBleedPadding = if (isTouchDevice) 14.dp else 24.dp
-    LazyVerticalGrid(state = gridState, columns = GridCells.Adaptive(minSize = itemWidth + focusBleedPadding), contentPadding = PaddingValues(horizontal = focusBleedPadding, vertical = focusBleedPadding),
-        horizontalArrangement = Arrangement.spacedBy(18.dp), verticalArrangement = Arrangement.spacedBy(26.dp), modifier = Modifier.fillMaxSize().arvioDpadFocusGroup()) {
+    val focusBleedPadding = if (isTouchDevice) 16.dp else 24.dp
+    LazyVerticalGrid(
+        state = gridState,
+        columns = GridCells.Adaptive(minSize = itemWidth + (if (isTouchDevice) 8.dp else focusBleedPadding)),
+        contentPadding = PaddingValues(horizontal = focusBleedPadding, vertical = focusBleedPadding),
+        horizontalArrangement = Arrangement.spacedBy(if (isTouchDevice) 14.dp else 18.dp),
+        verticalArrangement = Arrangement.spacedBy(if (isTouchDevice) 18.dp else 26.dp),
+        modifier = Modifier.fillMaxSize().arvioDpadFocusGroup()
+    ) {
         items(items.size, key = { "${items[it].mediaType}_${items[it].id}" }) { idx ->
             val item = items[idx]
-            MediaCard(item = item.copy(
-                title = buildCardTitle(item),
-                subtitle = buildCardSubtitle(item),
-                releaseDate = null,
-                year = ""
-            ),
-                width = itemWidth, isLandscape = !usePosterCards, showProgress = false, titleMaxLines = 2, subtitleMaxLines = 1,
-                isFocusedOverride = false, enableSystemFocus = true, onFocused = {}, onClick = { onItemClick(item) },
-                modifier = if (isTouchDevice) Modifier.clickable { onItemClick(item) } else Modifier)
+            MediaCard(
+                item = item.copy(
+                    title = buildCardTitle(item),
+                    subtitle = buildCardSubtitle(item),
+                    releaseDate = null,
+                    year = ""
+                ),
+                width = itemWidth,
+                isLandscape = !usePosterCards,
+                showProgress = false,
+                titleMaxLines = 2,
+                subtitleMaxLines = 1,
+                isFocusedOverride = false,
+                enableSystemFocus = !isTouchDevice,
+                onFocused = {},
+                onClick = { onItemClick(item) },
+                modifier = if (isTouchDevice) Modifier.clickable { onItemClick(item) } else Modifier
+            )
         }
         if (isLoading) { item { Box(Modifier.fillMaxWidth().height(80.dp), contentAlignment = Alignment.Center) { LoadingIndicator(color = Pink, size = 32.dp) } } }
     }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/search/SearchScreen.kt
@@ -906,7 +906,7 @@ private fun GlowChip(
     }
     Box(
         modifier = modifier
-            .semantics {
+            .semantics(mergeDescendants = true) {
                 selected = isSelected
                 role = Role.Tab
                 // Accessibility activation must not add a second native D-pad focus target.

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/search/SearchScreen.kt
@@ -71,6 +71,12 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -361,7 +367,7 @@ fun SearchScreen(
         }
     }
 
-    // D-pad handler: manages zone transitions. FILTERS zone lets native focus handle Left/Right.
+    // One D-pad handler owns zone transitions and filter selection.
     val dpadModifier = if (!isTouchDevice) {
         Modifier.onPreviewKeyEvent { event ->
             if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
@@ -540,7 +546,7 @@ fun SearchScreen(
         }
     } else Modifier
 
-    Box(modifier = Modifier.fillMaxSize().background(appBackgroundDark()).then(dpadModifier)) {
+    Box(modifier = Modifier.fillMaxSize().background(appBackgroundDark()).then(dpadModifier).testTag("search-screen")) {
         if (!isTouchDevice) AppTopBar(selectedItem = SidebarItem.SEARCH, isFocused = focusZone == FocusZone.SIDEBAR, focusedIndex = sidebarFocusIndex, profile = currentProfile)
 
         Column(
@@ -740,6 +746,7 @@ private fun SearchInputBar(
             shape = RoundedCornerShape(10.dp),
             modifier = Modifier
                 .fillMaxWidth()
+                .testTag("search-input")
                 .focusRequester(searchFocusRequester)
                 .onFocusChanged {
                     if (it.isFocused) onFocused() else onFocusLost()
@@ -796,6 +803,7 @@ private fun SearchInputBar(
                 keyboardActions = KeyboardActions(onSearch = { onSearch() }),
                 modifier = Modifier
                     .weight(1f)
+                    .testTag("search-input")
                     .focusRequester(textInputFocusRequester),
                 decorationBox = { inner ->
                     if (query.isEmpty()) {
@@ -865,6 +873,7 @@ private fun DiscoverFilterStrip(
                 isSelected = filter.isSelected,
                 isVisuallyFocused = !isTouchDevice && focusZone == FocusZone.FILTERS && focusedFilterIndex == index,
                 isTouchDevice = isTouchDevice,
+                modifier = Modifier.testTag("search-filter-${filter.key}"),
                 onSelect = filter.onSelect
             )
         }
@@ -897,6 +906,12 @@ private fun GlowChip(
     }
     Box(
         modifier = modifier
+            .semantics {
+                selected = isSelected
+                role = Role.Tab
+                // Accessibility activation must not add a second native D-pad focus target.
+                if (!isTouchDevice) onClick { onSelect(); true }
+            }
             .padding(vertical = 2.dp)
             .background(
                 color = backgroundColor,
@@ -1011,7 +1026,7 @@ private fun RowsLayer(
                 )
 
                 val rowContent = @Composable {
-                    Column(modifier = Modifier.fillMaxWidth()) {
+                    Column(modifier = Modifier.fillMaxWidth().testTag("search-row-${category.id}")) {
                         Row(
                             modifier = Modifier.padding(
                                 start = if (isTouchDevice) 16.dp else focusBleedPadding,


### PR DESCRIPTION
## Summary

This PR addresses two search screen issues:
1. **TV Search Filter Focus & Reversion Bugs**:
   - In TV mode, changing the discover filter (e.g. from "All" to "Movies") was previously broken because `GlowChip` had competing Compose `.clickable`, `.focusable()`, and native focus hooks where only chip 0 had a `FocusRequester`. On D-pad selection, native click/KeyUp on chip 0 immediately reverted selection to "All".
   - When changing filters on TV, the category reload unmounted the existing rows, causing Compose's fallback focus search to focus `SearchInputBar`, whose `onFocused` callback reset `focusZone = FocusZone.SEARCH_INPUT`.
   - Anchored native focus with a dedicated `filtersFocusRequester` on `DiscoverFilterStrip`'s `LazyRow`, guarded `SearchInputBar.onFocused` so background Compose focus events cannot hijack the active zone away from `FILTERS`, and preserved the active filter selection when navigating down from the search bar.
   - Removed the behavior where pressing Left on chip 0 ("All") reset focus to the search bar (navigating to the search bar is now purely triggered by D-pad Up).

2. **Mobile Search Screen Layout Alignment with Home**:
   - Removed the rigid `289.dp` row container height on mobile (`isTouchDevice`), allowing catalog rows to wrap content naturally in a `Column` spaced by `20.dp` on the parent `LazyColumn` (matching `MobileHomeRowsLayer`).
   - Aligned card dimensions (`120.dp` portrait / `200.dp` landscape) and horizontal spacing (`14.dp` in `LazyRow`), matching `HomeScreen.kt`.
   - Removed TV-style row dimming (`rowAlpha = 1f`) and focus outlines on touch devices.
   - Added `statusBarsPadding()` and aligned horizontal insets (16dp padding) to respect device notches and display edges.

## Testing
- Verified Kotlin compilation with `./gradlew compileSideloadDebugKotlin`.
- Built universal multi-ABI debug APK (`arm64-v8a`, `armeabi-v7a`, `x86`, `x86_64`) via `./gradlew assembleSideloadDebug -PincludeX86Abis=true`.
- Verified deployment and speed compilation on Android TV.