### PR TITLE
fix(catalog): preserve user catalog order for Favorite TV row

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/repository/MediaRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/MediaRepository.kt
@@ -677,9 +677,9 @@ class MediaRepository @Inject constructor(
          */
         internal fun buildPreinstalledDefaults(): List<CatalogConfig> {
             val topLevelCatalogs = listOf(
-                CatalogConfig("favorite_tv", "Favorite TV", CatalogSourceType.PREINSTALLED, isPreinstalled = true),
                 CatalogConfig("trending_movies", "Trending in Movies", CatalogSourceType.MDBLIST, isPreinstalled = true, sourceUrl = "https://mdblist.com/lists/snoak/trending-movies", sourceRef = "mdblist:https://mdblist.com/lists/snoak/trending-movies"),
                 CatalogConfig("trending_tv", "Trending in Shows", CatalogSourceType.MDBLIST, isPreinstalled = true, sourceUrl = "https://mdblist.com/lists/snoak/trakt-s-trending-shows", sourceRef = "mdblist:https://mdblist.com/lists/snoak/trakt-s-trending-shows"),
+                CatalogConfig("favorite_tv", "Favorite TV", CatalogSourceType.PREINSTALLED, isPreinstalled = true),
                 CatalogConfig("trending_anime", "Trending in Anime", CatalogSourceType.MDBLIST, isPreinstalled = true, sourceUrl = "https://mdblist.com/lists/snoak/trending-anime-shows", sourceRef = "mdblist:https://mdblist.com/lists/snoak/trending-anime-shows"),
                 CatalogConfig(SportsAddonCapabilities.SPORTS_CATEGORY_ROW_ID, "Sports", CatalogSourceType.PREINSTALLED, isPreinstalled = true),
                 CatalogConfig(SportsAddonCapabilities.POPULAR_LIVE_TV_ROW_ID, "Popular Live Sports", CatalogSourceType.PREINSTALLED, isPreinstalled = true),

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
@@ -171,6 +171,21 @@ internal fun orderCategoriesBySavedCatalogs(
     }
 }
 
+/**
+ * Filters the Favorite TV row according to the "Show IPTV favorites on home" preference.
+ *
+ * Preserves the user's custom catalog ordering configured in Settings > Catalogs.
+ */
+internal fun applyIptvFavoritesPlacement(
+    savedCatalogs: List<CatalogConfig>,
+    enabled: Boolean
+): List<CatalogConfig> {
+    val favIdx = savedCatalogs.indexOfFirst { it.id == HomeViewModel.FAVORITE_TV_CATEGORY_ID }
+    if (favIdx < 0) return savedCatalogs
+    if (!enabled) return savedCatalogs.filterNot { it.id == HomeViewModel.FAVORITE_TV_CATEGORY_ID }
+    return savedCatalogs
+}
+
 enum class ToastType {
     SUCCESS, ERROR, INFO
 }
@@ -985,31 +1000,6 @@ class HomeViewModel @Inject constructor(
         val prefs = context.settingsDataStore.data.first()
         prefs[profileManager.profileBooleanKey(IPTV_FAVORITES_ON_HOME)] ?: true
     }.getOrDefault(true)
-
-    /**
-     * Places the Favorite TV row according to that preference.
-     *
-     * Every home ordering site resolves rows by walking `savedCatalogs`, so doing this
-     * once here covers all of them instead of special-casing each. On this profile the
-     * catalog sat at index 67 of 71 — below ~60 collection tiles — which put the row
-     * near the bottom of the screen and made it look like it was never built.
-     */
-    private fun applyIptvFavoritesPlacement(
-        savedCatalogs: List<CatalogConfig>,
-        enabled: Boolean
-    ): List<CatalogConfig> {
-        val favIdx = savedCatalogs.indexOfFirst { it.id == FAVORITE_TV_CATEGORY_ID }
-        if (favIdx < 0) return savedCatalogs
-        // Dropping the config keeps the ordering resolvers from emitting the row at all;
-        // buildFavoriteTvOutcome() independently returns Empty so the additive passes,
-        // which never look at savedCatalogs, stay in agreement.
-        if (!enabled) return savedCatalogs.filterNot { it.id == FAVORITE_TV_CATEGORY_ID }
-        if (favIdx == 0) return savedCatalogs
-        return buildList(savedCatalogs.size) {
-            add(savedCatalogs[favIdx])
-            savedCatalogs.forEachIndexed { idx, cfg -> if (idx != favIdx) add(cfg) }
-        }
-    }
 
     private fun isCustomCatalogConfig(cfg: CatalogConfig): Boolean {
         if (cfg.kind == CatalogKind.COLLECTION || cfg.kind == CatalogKind.COLLECTION_RAIL) {

--- a/app/src/test/kotlin/com/arflix/tv/ui/screens/home/HomeMobileCategoryOrderingTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/ui/screens/home/HomeMobileCategoryOrderingTest.kt
@@ -70,4 +70,65 @@ class HomeMobileCategoryOrderingTest {
             "sports"
         ).inOrder()
     }
+
+    @Test
+    fun `applyIptvFavoritesPlacement preserves user catalog order when enabled`() {
+        val savedCatalogs = listOf(
+            CatalogConfig(id = "trending_movies", title = "Trending in Movies", sourceType = CatalogSourceType.MDBLIST, isPreinstalled = true),
+            CatalogConfig(id = "trending_tv", title = "Trending in Shows", sourceType = CatalogSourceType.MDBLIST, isPreinstalled = true),
+            CatalogConfig(id = "favorite_tv", title = "Favorite TV", sourceType = CatalogSourceType.PREINSTALLED, isPreinstalled = true),
+            CatalogConfig(id = "sports", title = "Sports", sourceType = CatalogSourceType.PREINSTALLED, isPreinstalled = true)
+        )
+
+        val result = applyIptvFavoritesPlacement(savedCatalogs, enabled = true)
+
+        assertThat(result.map { it.id }).containsExactly(
+            "trending_movies",
+            "trending_tv",
+            "favorite_tv",
+            "sports"
+        ).inOrder()
+    }
+
+    @Test
+    fun `applyIptvFavoritesPlacement removes favorite tv when disabled`() {
+        val savedCatalogs = listOf(
+            CatalogConfig(id = "trending_movies", title = "Trending in Movies", sourceType = CatalogSourceType.MDBLIST, isPreinstalled = true),
+            CatalogConfig(id = "favorite_tv", title = "Favorite TV", sourceType = CatalogSourceType.PREINSTALLED, isPreinstalled = true),
+            CatalogConfig(id = "sports", title = "Sports", sourceType = CatalogSourceType.PREINSTALLED, isPreinstalled = true)
+        )
+
+        val result = applyIptvFavoritesPlacement(savedCatalogs, enabled = false)
+
+        assertThat(result.map { it.id }).containsExactly(
+            "trending_movies",
+            "sports"
+        ).inOrder()
+    }
+
+    @Test
+    fun `orderCategoriesBySavedCatalogs respects custom placement of favorite tv`() {
+        val savedCatalogs = listOf(
+            CatalogConfig(id = "trending_movies", title = "Trending in Movies", sourceType = CatalogSourceType.MDBLIST, isPreinstalled = true),
+            CatalogConfig(id = "trending_tv", title = "Trending in Shows", sourceType = CatalogSourceType.MDBLIST, isPreinstalled = true),
+            CatalogConfig(id = "favorite_tv", title = "Favorite TV", sourceType = CatalogSourceType.PREINSTALLED, isPreinstalled = true),
+            CatalogConfig(id = "sports", title = "Sports", sourceType = CatalogSourceType.PREINSTALLED, isPreinstalled = true)
+        )
+
+        val categories = listOf(
+            Category(id = "sports", title = "Sports", items = listOf(MediaItem(1, "Live Match", mediaType = MediaType.MOVIE))),
+            Category(id = "favorite_tv", title = "Favorite TV", items = listOf(MediaItem(2, "Channel 1", mediaType = MediaType.TV))),
+            Category(id = "trending_movies", title = "Trending in Movies", items = listOf(MediaItem(3, "Top Movie", mediaType = MediaType.MOVIE))),
+            Category(id = "trending_tv", title = "Trending in Shows", items = listOf(MediaItem(4, "Top Show", mediaType = MediaType.TV)))
+        )
+
+        val ordered = orderCategoriesBySavedCatalogs(categories, savedCatalogs)
+
+        assertThat(ordered.map { it.id }).containsExactly(
+            "trending_movies",
+            "trending_tv",
+            "favorite_tv",
+            "sports"
+        ).inOrder()
+    }
 }


### PR DESCRIPTION
## Description

This PR resolves a catalog ordering issue where favoriting an IPTV channel forcibly hoisted the "Favorite TV" row to the very top of the Home screen, disregarding the user-configured catalog order in **Settings > Catalogs**:

1. **Root Cause**:
   - `HomeViewModel.applyIptvFavoritesPlacement` had hardcoded logic that extracted `favorite_tv` and inserted it at index 0 of `savedCatalogs` whenever `favIdx > 0`. This overrode the user's custom catalog layout on every home screen load.
   - In `MediaRepository.buildPreinstalledDefaults()`, `favorite_tv` was positioned as the first element in `topLevelCatalogs`, ahead of `trending_movies` and `trending_tv`.

2. **Fix**:
   - Refactored `applyIptvFavoritesPlacement` into an `internal` pure function:
     - When `enabled == true`, returns `savedCatalogs` intact, preserving user-configured ordering.
     - When `enabled == false`, filters out `favorite_tv` cleanly without disrupting the placement of other rows.
   - Repositioned `favorite_tv` in `MediaRepository.buildPreinstalledDefaults()` to sit after `trending_movies` and `trending_tv`.
   - Added unit tests covering order preservation, row removal when disabled, and custom catalog order reconciliation.

## Testing

- Ran `./gradlew :app:testSideloadDebugUnitTest --tests "com.arflix.tv.ui.screens.home.HomeMobileCategoryOrderingTest"` (All passed)
- Executed full unit test suite `./gradlew :app:testSideloadDebugUnitTest` (All passed)
- Verified build on Android TV emulator