### PR TITLE
fix(player): prevent flow exception transparency violation during source discovery

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerSourceDiscovery.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerSourceDiscovery.kt
@@ -7,8 +7,8 @@ import com.arflix.tv.ui.screens.details.isAutoPlayableStream
 import com.arflix.tv.ui.screens.details.qualityScoreForAutoPlay
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.withTimeoutOrNull
 
@@ -35,14 +35,14 @@ internal fun mergePlayerSourceDiscovery(
     pluginBatches: Flow<List<StreamSource>>,
     onPluginFailure: (Throwable) -> Unit = {}
 ): Flow<ProgressiveStreamResult> {
-    val plugins = flow {
+    val plugins = channelFlow {
         var sources = emptyList<StreamSource>()
-        emit(PluginSources(sources, false))
+        send(PluginSources(sources, false))
         try {
             withTimeoutOrNull(30_000L) {
                 pluginBatches.collect { batch ->
                     sources = (sources + batch).distinctBy(::providerScopedStreamIdentity)
-                    emit(PluginSources(sources, false))
+                    send(PluginSources(sources, false))
                 }
             }
         } catch (e: CancellationException) {
@@ -50,7 +50,7 @@ internal fun mergePlayerSourceDiscovery(
         } catch (e: Exception) {
             onPluginFailure(e)
         }
-        emit(PluginSources(sources, true))
+        send(PluginSources(sources, true))
     }
     return combine(
         addons.onStart { emit(ProgressiveStreamResult(emptyList(), completedAddons = 0, totalAddons = 0, isFinal = false)) },

--- a/app/src/test/kotlin/com/arflix/tv/ui/screens/player/PlayerSourceDiscoveryTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/ui/screens/player/PlayerSourceDiscoveryTest.kt
@@ -67,6 +67,24 @@ class PlayerSourceDiscoveryTest {
         assertTrue(emissions.last().isFinal)
     }
 
+    @Test fun slowDownstreamDoesNotCauseFlowExceptionTransparencyViolation() = runTest {
+        val plugin = stream("plugin")
+        val job = launch {
+            mergePlayerSourceDiscovery(
+                flowOf(result(listOf(stream("addon")), final = true)),
+                flow {
+                    emit(listOf(plugin))
+                    emit(listOf(plugin))
+                    awaitCancellation()
+                }
+            ).collect {
+                delay(35_000L)
+            }
+        }
+        advanceTimeBy(35_000L)
+        job.cancel()
+    }
+
     @Test fun leavingPlayerCancelsDiscoveryWithoutReportingFailure() = runTest {
         var cancelled = false
         var failed = false


### PR DESCRIPTION
## Description

Fixes a crash/playback error modal where a `Flow exception transparency is violated` error was thrown and displayed over an active stream:
```
Playback Error
Flow exception transparency is violated:
Previous 'emit' call has thrown exception
kotlinx.coroutines.TimeoutCancellationException: Timed out waiting for 30000 ms,
but then emission attempt of value 'PluginSources(streams=[], finished=true)' has been detected.
Emissions from 'catch' blocks are prohibited in order to avoid unspecified behaviour, 'Flow.catch' operator can be used instead.
```

## Root Cause

In `mergePlayerSourceDiscovery`, `plugins` was implemented using the cold `flow { ... }` builder with a `withTimeoutOrNull(30_000L)` wrapping `pluginBatches.collect { ... emit(...) }`.

When a stream starts playing before plugin discovery finishes (for example, Telegram streams or fast debrid streams starting ~20-25 seconds after media loading began), the video begins playing while source discovery continues in the background.

When the 30-second timeout in `withTimeoutOrNull` fired while an `emit` call was in-flight / suspended (due to backpressure from `combine` or downstream UI rendering), `emit` was cancelled with `TimeoutCancellationException`. Kotlin Flow's `SafeCollector` recorded that an emission failed. `withTimeoutOrNull` caught its own timeout cancellation and completed normally, and then line 53 called `emit(PluginSources(sources, true))` to signal completion.

Because `SafeCollector` forbids any subsequent emissions after a previous `emit` threw an exception, it threw `IllegalStateException: Flow exception transparency is violated...`. This uncaught exception was caught in `PlayerViewModel.loadMedia`'s exception handler and displayed as a red playback error modal on top of active playback.

## Changes

- **`PlayerSourceDiscovery.kt`**: Converted `plugins` in `mergePlayerSourceDiscovery` from `flow { ... }` to a channel-backed `channelFlow { ... }` using `send(...)`. This decouples the scraper timeout from downstream backpressure and avoids violating `SafeCollector`'s single-coroutine exception transparency invariant.
- **`PlayerSourceDiscoveryTest.kt`**: Added unit test `slowDownstreamDoesNotCauseFlowExceptionTransparencyViolation` verifying that downstream delay/backpressure combined with timeout expiration completes cleanly without throwing.

## Verification

- Ran `testPlayDebugUnitTest --tests "com.arflix.tv.ui.screens.player.PlayerSourceDiscoveryTest"` (PASSED).
- Ran `testSideloadDebugUnitTest --tests "com.arflix.tv.ui.screens.player.PlayerSourceDiscoveryTest"` (PASSED).