### PR TITLE
fix(iptv): repair Stalker live playback and drop redundant portal calls

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/data/api/StalkerApi.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/api/StalkerApi.kt
@@ -50,6 +50,9 @@ open class StalkerApi(
         return try {
             if (!apiBaseResolved) {
                 resolveApiBase()
+                // Probing the base path is itself a handshake and keeps the token it
+                // received, so a second one here would only throw that token away.
+                if (token.isNotBlank()) return true
             }
             val url = "$apiBase/server/load.php?type=stb&action=handshake&token=&JsHttpRequest=1-xml"
             val response = doGet(url)

--- a/app/src/main/kotlin/com/arflix/tv/data/api/StalkerApi.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/api/StalkerApi.kt
@@ -1,6 +1,7 @@
 package com.arflix.tv.data.api
 
 import com.arflix.tv.data.model.IptvChannel
+import com.arflix.tv.data.repository.StalkerPortalSupport
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
 import com.google.gson.stream.JsonReader
@@ -139,13 +140,22 @@ open class StalkerApi(
                     newChannelIdCount++
                     val streamCmd = ch.cmd ?: continue
                     val groupName = ch.tvGenreId?.let { genreMap[it] } ?: "Uncategorized"
+                    // Portals that announce no temporary link publish the finished
+                    // address here; storing it as-is lets playback skip create_link.
+                    // Everything else keeps the raw cmd and is resolved before playback.
+                    val directUrl = StalkerPortalSupport.directLiveStreamUrl(
+                        cmd = streamCmd,
+                        useHttpTmpLink = ch.useHttpTmpLink,
+                        wowzaTmpLink = ch.wowzaTmpLink,
+                        flussonicTmpLink = ch.flussonicTmpLink,
+                    )
                     channels.add(
                         IptvChannel(
                             id = channelId,
                             name = ch.name ?: "Unknown",
                             logo = ch.logo,
                             group = groupName,
-                            streamUrl = streamCmd // Will be resolved via create_link before playback
+                            streamUrl = directUrl ?: streamCmd
                         )
                     )
                 }
@@ -428,7 +438,7 @@ open class StalkerApi(
             val url = "$apiBase/server/load.php?type=itv&action=create_link&cmd=$encodedCmd&forced_storage=undefined&disable_ad=0&JsHttpRequest=1-xml"
             val response = doGet(url)
             val parsed = gson.fromJson(response, StalkerLinkResponse::class.java)
-            parsed?.js?.cmd?.replace("ffmpeg ", "")?.trim()
+            StalkerPortalSupport.sanitizePlaybackCommand(parsed?.js?.cmd).takeIf { it.isNotBlank() }
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
 
@@ -484,7 +494,13 @@ open class StalkerApi(
         val name: String?,
         val logo: String?,
         val cmd: String?,
-        @SerializedName("tv_genre_id") val tvGenreId: String?
+        @SerializedName("tv_genre_id") val tvGenreId: String?,
+        // Read as text on purpose: portals send these as 0/1, as "0"/"1", and
+        // occasionally as an empty string, which a numeric field would reject —
+        // taking the whole channel page down with it.
+        @SerializedName("use_http_tmp_link") val useHttpTmpLink: String? = null,
+        @SerializedName("wowza_tmp_link") val wowzaTmpLink: String? = null,
+        @SerializedName("flussonic_tmp_link") val flussonicTmpLink: String? = null
     )
 
     data class StalkerLinkResponse(val js: StalkerLink?)

--- a/app/src/main/kotlin/com/arflix/tv/data/api/StalkerApi.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/api/StalkerApi.kt
@@ -144,8 +144,8 @@ open class StalkerApi(
                     val streamCmd = ch.cmd ?: continue
                     val groupName = ch.tvGenreId?.let { genreMap[it] } ?: "Uncategorized"
                     // Portals that announce no temporary link publish the finished
-                    // address here; storing it as-is lets playback skip create_link.
-                    // Everything else keeps the raw cmd and is resolved before playback.
+                    // address here. Preserve that decision separately: even bare URLs
+                    // can require create_link when the portal says so or omits the flags.
                     val directUrl = StalkerPortalSupport.directLiveStreamUrl(
                         cmd = streamCmd,
                         useHttpTmpLink = ch.useHttpTmpLink,
@@ -158,7 +158,8 @@ open class StalkerApi(
                             name = ch.name ?: "Unknown",
                             logo = ch.logo,
                             group = groupName,
-                            streamUrl = directUrl ?: streamCmd
+                            streamUrl = directUrl ?: streamCmd,
+                            stalkerDirectStream = directUrl != null,
                         )
                     )
                 }

--- a/app/src/main/kotlin/com/arflix/tv/data/model/IptvModels.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/model/IptvModels.kt
@@ -44,6 +44,8 @@ data class IptvChannel(
     val qualityLabel: String? = null,
     val variantKey: String? = null,
     val drmInfo: DrmInfo? = null,
+    // Only true when the portal explicitly confirmed that live playback needs no create_link.
+    val stalkerDirectStream: Boolean = false,
 )
 
 /**

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/IptvChannelStore.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/IptvChannelStore.kt
@@ -64,6 +64,7 @@ internal class IptvChannelStore(context: Context) : SQLiteOpenHelper(
                 quality_label TEXT,
                 variant_key TEXT,
                 drm_json TEXT,
+                stalker_direct_stream INTEGER NOT NULL DEFAULT 0,
                 PRIMARY KEY(source_key, ord)
             )
             """.trimIndent()
@@ -83,7 +84,7 @@ internal class IptvChannelStore(context: Context) : SQLiteOpenHelper(
     }
 
     override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
-        if (oldVersion in 3..5) {
+        if (oldVersion in 3..6) {
             if (oldVersion < 4 && newVersion >= 4) {
                 db.execSQL("ALTER TABLE channel_sources ADD COLUMN group_summary_json TEXT")
             }
@@ -94,9 +95,12 @@ internal class IptvChannelStore(context: Context) : SQLiteOpenHelper(
                 db.execSQL("DROP INDEX IF EXISTS idx_channels_group")
                 db.execSQL("CREATE INDEX idx_channels_group ON channels(source_key, group_title, ord)")
             }
+            if (oldVersion < 7 && newVersion >= 7) {
+                db.execSQL("ALTER TABLE channels ADD COLUMN stalker_direct_stream INTEGER NOT NULL DEFAULT 0")
+            }
             return
         }
-        if (oldVersion !in 3..5) {
+        if (oldVersion !in 3..6) {
             db.execSQL("DROP TABLE IF EXISTS channels")
             db.execSQL("DROP TABLE IF EXISTS channel_sources")
             onCreate(db)
@@ -126,7 +130,7 @@ internal class IptvChannelStore(context: Context) : SQLiteOpenHelper(
                                 (source_key, ord, id, name, stream_url, group_title, logo, epg_id, raw_title,
                                  xtream_stream_id, catchup_days, catchup_type, catchup_source, tvg_name,
                                  provider_channel_number, request_headers_json, language, country, quality_label,
-                                 variant_key, drm_json)
+                                 variant_key, drm_json, stalker_direct_stream)
                                 VALUES $values
                                 """.trimIndent()
                             )
@@ -532,6 +536,7 @@ internal class IptvChannelStore(context: Context) : SQLiteOpenHelper(
             qualityLabel = if (cursor.isNull(c.quality)) null else cursor.getString(c.quality),
             variantKey = if (cursor.isNull(c.variantKey)) null else cursor.getString(c.variantKey),
             drmInfo = drm,
+            stalkerDirectStream = cursor.getInt(c.stalkerDirectStream) != 0,
         )
     }
 
@@ -555,6 +560,7 @@ internal class IptvChannelStore(context: Context) : SQLiteOpenHelper(
         val quality = cursor.getColumnIndexOrThrow("quality_label")
         val variantKey = cursor.getColumnIndexOrThrow("variant_key")
         val drm = cursor.getColumnIndexOrThrow("drm_json")
+        val stalkerDirectStream = cursor.getColumnIndexOrThrow("stalker_direct_stream")
     }
 
     private data class StoredGroupSummary(
@@ -625,6 +631,7 @@ internal class IptvChannelStore(context: Context) : SQLiteOpenHelper(
         bindNullableString(statement, index++, channel.qualityLabel)
         bindNullableString(statement, index++, channel.variantKey)
         bindNullableString(statement, index++, channel.drmInfo?.let { gson.toJson(it) })
+        statement.bindLong(index++, if (channel.stalkerDirectStream) 1L else 0L)
         return index
     }
 
@@ -638,9 +645,10 @@ internal class IptvChannelStore(context: Context) : SQLiteOpenHelper(
         // v4 stores the provider/category summary next to the snapshot.
         // v5 indexes channel ids so focus/EPG actions never scan a 50k-row table.
         // v6 keeps provider order in the group index for instant deep-category reads.
-        const val DATABASE_VERSION = 6
+        // v7 preserves the portal's direct-live decision; old snapshots still resolve links.
+        const val DATABASE_VERSION = 7
         const val MAX_SQL_ARGS = 900
-        const val CHANNEL_BINDINGS_PER_ROW = 21
+        const val CHANNEL_BINDINGS_PER_ROW = 22
         const val MAX_CHANNEL_INSERT_ROWS = MAX_SQL_ARGS / CHANNEL_BINDINGS_PER_ROW
     }
 }

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/IptvPlaybackUrlResolver.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/IptvPlaybackUrlResolver.kt
@@ -28,6 +28,11 @@ internal fun buildXtreamLiveStreamUrl(
 internal data class IptvPlaybackTarget(
     val url: String,
     val isHls: Boolean = false,
+    /**
+     * Container MIME type the server stated in its `Content-Type`, when it is one the
+     * player cannot reliably infer from the URL. Null means "let the player sniff".
+     */
+    val mimeType: String? = null,
 )
 
 internal class IptvPlaybackUrlResolver(
@@ -129,6 +134,7 @@ internal class IptvPlaybackUrlResolver(
                     isHls = looksLikeHlsPlaybackUrl(finalUrl) ||
                         contentType.isHlsContentType() ||
                         bodyStartsWithM3u,
+                    mimeType = contentType.asTransportStreamMimeType(),
                 )
                 ProbeResult(
                     target = target,
@@ -161,11 +167,11 @@ internal fun shouldResolveIptvPlaybackRedirect(url: String): Boolean {
     val lastSegment = path.substringAfterLast('/')
     if (lastSegment.isBlank() || lastSegment.contains('.')) return false
 
-    val segments = path.trim('/').split('/').filter { it.isNotBlank() }
-    if (segments.size < 4 || !segments.first().equals("live", ignoreCase = true)) return false
-
-    // Standard Xtream numeric IDs are direct MPEG-TS streams. Slug-based providers
-    // commonly redirect to HLS, which Media3 cannot infer from the original URL.
+    // Standard Xtream numeric IDs are direct MPEG-TS streams, so there is nothing a
+    // probe could add. Every other extension-less address is opaque — slug providers
+    // that redirect to HLS as well as portals that hand out a single-segment token
+    // URL. For those the server's own `Content-Type` is the only reliable signal, and
+    // guessing where an answer is available is what broke playback on token portals.
     return lastSegment.toLongOrNull() == null
 }
 
@@ -181,6 +187,20 @@ internal fun looksLikeHlsPlaybackUrl(url: String): Boolean {
 private fun String?.isHlsContentType(): Boolean {
     val value = this.orEmpty().lowercase(Locale.US)
     return "mpegurl" in value || "vnd.apple.mpegurl" in value
+}
+
+/**
+ * MPEG-TS is the one container Media3 regularly fails to infer from an extension-less
+ * URL, and the one portals actually announce (`Content-Type: video/mp2t`). Other
+ * containers are left to the player's own sniffing rather than risking a wrong hint.
+ */
+private fun String?.asTransportStreamMimeType(): String? {
+    val value = this.orEmpty().lowercase(Locale.US).substringBefore(';').trim()
+    return when (value) {
+        "video/mp2t", "video/mpeg", "video/ts", "application/mp2t", "application/x-mpegts" ->
+            "video/mp2t"
+        else -> null
+    }
 }
 
 private fun String?.isDirectMediaContentType(): Boolean {

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/StalkerPortalSupport.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/StalkerPortalSupport.kt
@@ -3,6 +3,8 @@ package com.arflix.tv.data.repository
 import com.arflix.tv.data.model.PlaylistGroupKey
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import java.net.URI
+import java.util.Locale
 
 /** Pseudo playlist id for the Stalker/Ministra portal source. */
 const val STALKER_PLAYLIST_ID = "stalker"
@@ -17,6 +19,9 @@ const val MAX_STALKER_PORTALS = 3
 internal object StalkerPortalSupport {
 
     private val gson = Gson()
+
+    /** Hosts a portal placeholder points at; none of them can serve a stream to a device. */
+    private val UNROUTABLE_STREAM_HOSTS = setOf("localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]")
 
     /**
      * Channel ids use the `stalker:<portalId>:<origId>` shape. Returns the
@@ -34,6 +39,21 @@ internal object StalkerPortalSupport {
     fun playlistIdFromChannelId(channelId: String): String {
         return portalIdFromChannelId(channelId)
             ?: channelId.substringBefore(':').trim()
+    }
+
+    /**
+     * Portals that require `create_link` publish an unroutable placeholder as the
+     * channel's `cmd` (`ffmpeg http://localhost/ch/1234_`, alongside
+     * `use_http_tmp_link: 1`). Such an address can never play, so it must not be used
+     * as a fallback when the link call fails. A `cmd` that names a real host is a
+     * legitimate direct address and stays usable.
+     */
+    fun isRoutableStreamAddress(url: String): Boolean {
+        val trimmed = url.trim()
+        if (trimmed.isBlank()) return false
+        val host = runCatching { URI(trimmed).host }.getOrNull().orEmpty().lowercase(Locale.US)
+        if (host.isBlank()) return false
+        return host !in UNROUTABLE_STREAM_HOSTS
     }
 
     fun streamCacheKey(channelId: String, command: String): String {

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/StalkerPortalSupport.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/StalkerPortalSupport.kt
@@ -1,5 +1,6 @@
 package com.arflix.tv.data.repository
 
+import com.arflix.tv.data.model.IptvChannel
 import com.arflix.tv.data.model.PlaylistGroupKey
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
@@ -117,6 +118,9 @@ internal object StalkerPortalSupport {
 
     /** Portals send the flags as `1`/`0`, quoted or not; anything else states nothing. */
     private fun statesTemporaryLink(flag: String?): Boolean = flag?.trim() == "1"
+
+    fun canPlayDirectLiveStream(channel: IptvChannel, rawUrl: String, isCatchup: Boolean): Boolean =
+        !isCatchup && channel.stalkerDirectStream && isDirectStreamAddress(rawUrl)
 
     fun streamCacheKey(channelId: String, command: String): String {
         return "${playlistIdFromChannelId(channelId)}|${command.trim()}"

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/StalkerPortalSupport.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/StalkerPortalSupport.kt
@@ -56,6 +56,68 @@ internal object StalkerPortalSupport {
         return host !in UNROUTABLE_STREAM_HOSTS
     }
 
+    /**
+     * Strips the player command a portal writes in front of an address. Measured
+     * portals use `ffmpeg http://…` and `auto http://…`, so the leading word is
+     * dropped whatever it says; a bare address (or one whose first word already
+     * carries the scheme) is returned untouched.
+     */
+    fun sanitizePlaybackCommand(command: String?): String {
+        val trimmed = command?.trim().orEmpty()
+        if (trimmed.isEmpty()) return ""
+        val firstWord = trimmed.substringBefore(' ')
+        if (firstWord.length == trimmed.length || "://" in firstWord) return trimmed
+        return trimmed.substringAfter(' ').trim()
+    }
+
+    /**
+     * True when an address can go straight to the player: an absolute http(s) URL on a
+     * reachable host, with no portal command word in front of it and not shaped like the
+     * `create_link` placeholder.
+     */
+    fun isDirectStreamAddress(url: String): Boolean {
+        val trimmed = url.trim()
+        if (trimmed.isEmpty() || trimmed.any { it.isWhitespace() }) return false
+        val scheme = trimmed.substringBefore("://", missingDelimiterValue = "").lowercase(Locale.US)
+        if (scheme != "http" && scheme != "https") return false
+        // The placeholder is "http://<host>/ch/<id>_" — a path ending in an underscore.
+        // A play_token can end that way too, so only the path is judged, never the query.
+        if (trimmed.substringBefore('?').substringBefore('#').endsWith("_")) return false
+        return isRoutableStreamAddress(trimmed)
+    }
+
+    /**
+     * Stalker channels carry either a ready-to-play address or a placeholder that has to
+     * be exchanged for a temporary link via `create_link`; the `*_tmp_link` flags say
+     * which. Portals that answer `use_http_tmp_link: 0` publish the complete address in
+     * `cmd` — asking such a portal for a link is not just a wasted round trip: one
+     * measured portal answers it with HTTP 200, `"error": ""` and an address whose
+     * `stream=` id is empty, which then fails to play. A full client skips the call there.
+     *
+     * Returns the playable address when the portal stated that no temporary link is
+     * needed and what it published really is one. Null keeps the `create_link` round
+     * trip, including when a portal states nothing at all — guessing there would change
+     * behaviour for portals nobody has measured.
+     */
+    fun directLiveStreamUrl(
+        cmd: String?,
+        useHttpTmpLink: String?,
+        wowzaTmpLink: String?,
+        flussonicTmpLink: String?,
+    ): String? {
+        if (statesTemporaryLink(useHttpTmpLink) ||
+            statesTemporaryLink(wowzaTmpLink) ||
+            statesTemporaryLink(flussonicTmpLink)
+        ) {
+            return null
+        }
+        if (useHttpTmpLink?.trim() != "0") return null
+        return sanitizePlaybackCommand(cmd).takeIf { isDirectStreamAddress(it) }
+    }
+
+    /** Portals send the flags as `1`/`0`, quoted or not; anything else states nothing. */
+    private fun statesTemporaryLink(flag: String?): Boolean = flag?.trim() == "1"
+
     fun streamCacheKey(channelId: String, command: String): String {
         return "${playlistIdFromChannelId(channelId)}|${command.trim()}"
     }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/TvViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/TvViewModel.kt
@@ -2061,8 +2061,8 @@ class TvViewModel @Inject constructor(
         }
         val resolvedUrl = resolveStalkerStreamIfNeeded(
             rawUrl = rawUrl,
-            channelId = channel.id,
-            isStalkerChannel = channel.id.startsWith("stalker:"),
+            channel = channel,
+            isCatchup = program != null,
             forceRefresh = forceRefresh,
         )
         return iptvPlaybackUrlResolver.resolve(
@@ -2075,18 +2075,14 @@ class TvViewModel @Inject constructor(
 
     private suspend fun resolveStalkerStreamIfNeeded(
         rawUrl: String,
-        channelId: String,
-        isStalkerChannel: Boolean,
+        channel: IptvChannel,
+        isCatchup: Boolean,
         forceRefresh: Boolean,
     ): String {
         val trimmed = rawUrl.trim()
-        if (!isStalkerChannel) return trimmed
-        // Channels of portals that announce no temporary link were stored with their
-        // finished address, so there is nothing to resolve: a full client plays those
-        // straight from the channel list and never calls create_link. At one measured
-        // portal the call answers HTTP 200 with `"error": ""` and an address whose
-        // channel id is missing, and every attempt at it ends in HTTP 444.
-        if (StalkerPortalSupport.isDirectStreamAddress(trimmed)) return trimmed
+        val channelId = channel.id
+        if (!channelId.startsWith("stalker:")) return trimmed
+        if (StalkerPortalSupport.canPlayDirectLiveStream(channel, trimmed, isCatchup)) return trimmed
         val cacheKey = StalkerPortalSupport.streamCacheKey(channelId, trimmed)
 
         val now = System.currentTimeMillis()

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/TvViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/TvViewModel.kt
@@ -2081,6 +2081,12 @@ class TvViewModel @Inject constructor(
     ): String {
         val trimmed = rawUrl.trim()
         if (!isStalkerChannel) return trimmed
+        // Channels of portals that announce no temporary link were stored with their
+        // finished address, so there is nothing to resolve: a full client plays those
+        // straight from the channel list and never calls create_link. At one measured
+        // portal the call answers HTTP 200 with `"error": ""` and an address whose
+        // channel id is missing, and every attempt at it ends in HTTP 444.
+        if (StalkerPortalSupport.isDirectStreamAddress(trimmed)) return trimmed
         val cacheKey = StalkerPortalSupport.streamCacheKey(channelId, trimmed)
 
         val now = System.currentTimeMillis()
@@ -2100,7 +2106,7 @@ class TvViewModel @Inject constructor(
         // player then spent three attempts on an address that can never work before
         // the error banner showed. Fail loudly instead; the caller turns the message
         // into the diagnostic banner right away.
-        val rawAddress = trimmed.removePrefix("ffmpeg").trim()
+        val rawAddress = StalkerPortalSupport.sanitizePlaybackCommand(trimmed)
         val playable = resolved.ifBlank {
             if (StalkerPortalSupport.isRoutableStreamAddress(rawAddress)) rawAddress else ""
         }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/TvViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/TvViewModel.kt
@@ -50,6 +50,8 @@ private object TvViewModelRegexes {
 }
 
 internal const val FAVORITES_GROUP_NAME = "My Favorites"
+/** How long a create_link address stays reusable before it is fetched again. */
+private const val StalkerStreamCacheTtlMs = 60_000L
 private const val EpgLoadingStateLimit = 800
 private const val EpgAttemptedStateLimit = 2_400
 private const val LargeIptvListChannelCount = 10_000
@@ -165,7 +167,13 @@ class TvViewModel @Inject constructor(
     private var deferredCompleteEpgBackfillJob: Job? = null
     private var preparedContentJob: Job? = null
     private var preparedContentRevision: Long = 0L
-    private val resolvedStalkerStreamCache = LinkedHashMap<String, String>()
+    // create_link hands out a *temporary* address (the portals that need it announce
+    // `use_http_tmp_link` and sign the link with `nginx_secure_link`). Caching one
+    // without an expiry meant returning to a channel replayed an address the portal had
+    // long since retired, which surfaced as a channel that had just worked refusing to
+    // start. Keep the cache — it still spares a round trip when a channel is re-entered
+    // right away — but only for as long as such a link can be expected to live.
+    private val resolvedStalkerStreamCache = LinkedHashMap<String, CachedStalkerStream>()
     private val iptvPlaybackUrlResolver by lazy {
         IptvPlaybackUrlResolver(
             OkHttpProvider.playbackClient.newBuilder()
@@ -179,6 +187,11 @@ class TvViewModel @Inject constructor(
     private val catchupHistoryRefreshAt = LinkedHashMap<String, Long>()
     private val currentChannelEpgRefreshAt = LinkedHashMap<String, Long>()
     private val epgRefreshRequests = EpgRefreshRequests()
+
+    private data class CachedStalkerStream(
+        val url: String,
+        val resolvedAtMs: Long,
+    )
 
     private data class VisibleEpgDrain(
         val ids: List<String>,
@@ -2070,9 +2083,12 @@ class TvViewModel @Inject constructor(
         if (!isStalkerChannel) return trimmed
         val cacheKey = StalkerPortalSupport.streamCacheKey(channelId, trimmed)
 
+        val now = System.currentTimeMillis()
         if (!forceRefresh) {
             synchronized(resolvedStalkerStreamCache) {
-                resolvedStalkerStreamCache[cacheKey]?.let { return it }
+                resolvedStalkerStreamCache[cacheKey]
+                    ?.takeIf { now - it.resolvedAtMs <= StalkerStreamCacheTtlMs }
+                    ?.let { return it.url }
             }
         }
 
@@ -2092,7 +2108,7 @@ class TvViewModel @Inject constructor(
             throw IllegalStateException("Stalker portal returned no playable link")
         }
         synchronized(resolvedStalkerStreamCache) {
-            resolvedStalkerStreamCache[cacheKey] = playable
+            resolvedStalkerStreamCache[cacheKey] = CachedStalkerStream(playable, now)
             while (resolvedStalkerStreamCache.size > 200) {
                 val firstKey = resolvedStalkerStreamCache.keys.firstOrNull() ?: break
                 resolvedStalkerStreamCache.remove(firstKey)

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/TvViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/TvViewModel.kt
@@ -2079,17 +2079,26 @@ class TvViewModel @Inject constructor(
         val resolved = withContext(Dispatchers.IO) {
             iptvRepository.resolveStalkerStreamUrl(channelId, trimmed)
         }?.trim().orEmpty()
-        val playable = resolved.ifBlank { trimmed.removePrefix("ffmpeg").trim() }
-        if (playable.isNotBlank()) {
-            synchronized(resolvedStalkerStreamCache) {
-                resolvedStalkerStreamCache[cacheKey] = playable
-                while (resolvedStalkerStreamCache.size > 200) {
-                    val firstKey = resolvedStalkerStreamCache.keys.firstOrNull() ?: break
-                    resolvedStalkerStreamCache.remove(firstKey)
-                }
+        // Falling back to the raw `cmd` used to hand the player an unroutable
+        // placeholder ("http://localhost/ch/1234_") whenever create_link failed. The
+        // player then spent three attempts on an address that can never work before
+        // the error banner showed. Fail loudly instead; the caller turns the message
+        // into the diagnostic banner right away.
+        val rawAddress = trimmed.removePrefix("ffmpeg").trim()
+        val playable = resolved.ifBlank {
+            if (StalkerPortalSupport.isRoutableStreamAddress(rawAddress)) rawAddress else ""
+        }
+        if (playable.isBlank()) {
+            throw IllegalStateException("Stalker portal returned no playable link")
+        }
+        synchronized(resolvedStalkerStreamCache) {
+            resolvedStalkerStreamCache[cacheKey] = playable
+            while (resolvedStalkerStreamCache.size > 200) {
+                val firstKey = resolvedStalkerStreamCache.keys.firstOrNull() ?: break
+                resolvedStalkerStreamCache.remove(firstKey)
             }
         }
-        return playable.ifBlank { trimmed }
+        return playable
     }
 
     private fun setUiState(nextState: TvUiState) {

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvRetryPolicy.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvRetryPolicy.kt
@@ -1,0 +1,17 @@
+package com.arflix.tv.ui.screens.tv.live
+
+private val terminalPlaybackHttpCodes = setOf(401, 403, 429, 444, 451, 513)
+
+internal fun isMissingPlaybackResource(httpCode: Int?): Boolean = httpCode == 404 || httpCode == 410
+
+internal fun shouldRetryLiveTvPlayback(
+    httpCode: Int?,
+    nextAttempt: Int,
+    maxRetryCount: Int,
+    isCatchup: Boolean,
+): Boolean {
+    if (nextAttempt > maxRetryCount || httpCode in terminalPlaybackHttpCodes) return false
+    // Any live source can redirect to an expired URL. Refresh once before giving up;
+    // catch-up retains its existing bounded budget for different archive candidates.
+    return isCatchup || !isMissingPlaybackResource(httpCode) || nextAttempt == 1
+}

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvScreen.kt
@@ -2455,6 +2455,7 @@ fun LiveTvScreen(
 
     var lastPreparedStreamUrl by remember { mutableStateOf<String?>(null) }
     var lastPreparedIsHls by remember { mutableStateOf(false) }
+    var lastPreparedMimeType by remember { mutableStateOf<String?>(null) }
     var lastPreparedHeaders by remember { mutableStateOf<Map<String, String>>(emptyMap()) }
     var lastPreparedCatchupOffsetMs by remember { mutableLongStateOf(-1L) }
     var playerRetryCount by remember { mutableIntStateOf(0) }
@@ -2468,6 +2469,7 @@ fun LiveTvScreen(
         initialPositionMs: Long = 0L,
         drmInfo: com.arflix.tv.data.model.DrmInfo? = null,
         forcePrepare: Boolean = false,
+        resolvedMimeType: String? = null,
     ) {
         val mergedHeaders = (baseRequestHeaders + headers).safePlaybackHeaders()
         iptvDataSourceFactory.setDefaultRequestProperties(mergedHeaders)
@@ -2491,6 +2493,9 @@ fun LiveTvScreen(
             .apply {
                 if (isHls) {
                     setMimeType(MimeTypes.APPLICATION_M3U8)
+                } else if (resolvedMimeType != null) {
+                    // What the server actually answered beats anything read off the URL.
+                    setMimeType(resolvedMimeType)
                 } else if (looksLikeMpegTsUrl(stream)) {
                     setMimeType(MimeTypes.VIDEO_MP2T)
                 }
@@ -2523,6 +2528,7 @@ fun LiveTvScreen(
         exoPlayer.play()
         lastPreparedStreamUrl = stream
         lastPreparedIsHls = isHls
+        lastPreparedMimeType = resolvedMimeType
         lastPreparedHeaders = headers
         lastPreparedCatchupOffsetMs = if (playingCatchupProgram != null) catchupUrlAnchorOffsetMs else -1L
         if (resetRetry) playerRetryCount = 0
@@ -2690,6 +2696,7 @@ fun LiveTvScreen(
             resetRetry = true,
             initialPositionMs = initialSeekMs,
             drmInfo = playingChannel?.source?.drmInfo,
+            resolvedMimeType = target.mimeType,
         )
         // Persist "recent" as soon as playback starts.
         playingChannelId?.let { id ->
@@ -2774,7 +2781,18 @@ fun LiveTvScreen(
                 } else {
                     3
                 }
-                if (nextAttempt > maxRetryCount || httpResponseCode(error) in setOf(401, 403, 429, 513)) {
+                // Catch-up walks through *different* candidate URLs and Stalker asks the
+                // portal for a fresh temporary link, so a not-found answer can still be
+                // recovered from there. A plain live channel re-requests the very same
+                // address, which makes that family futile too.
+                val retryYieldsDifferentUrl = retryProgram != null ||
+                    retryChannel?.id?.startsWith("stalker:") == true
+                val terminalCodes = if (retryYieldsDifferentUrl) {
+                    TERMINAL_PLAYBACK_HTTP_CODES
+                } else {
+                    TERMINAL_PLAYBACK_HTTP_CODES + UNRECOVERABLE_ON_SAME_URL_HTTP_CODES
+                }
+                if (nextAttempt > maxRetryCount || httpResponseCode(error) in terminalCodes) {
                     playbackDiagnostic = PlaybackDiagnostic(
                         title = context.getString(R.string.live_diag_playback_failed),
                         detail = "${error.errorCodeName}: ${classifyPlaybackError(error)}",
@@ -2834,6 +2852,7 @@ fun LiveTvScreen(
                         initialPositionMs = retryChannel?.catchupInSegmentSeekOffset(catchupPlaybackOffsetMs) ?: 0L,
                         drmInfo = retryChannel?.drmInfo,
                         forcePrepare = true,
+                        resolvedMimeType = retryTarget.mimeType,
                     )
                 }
             }
@@ -3583,6 +3602,7 @@ fun LiveTvScreen(
                                         resetRetry = true,
                                         drmInfo = playingChannel?.source?.drmInfo,
                                         forcePrepare = true,
+                                        resolvedMimeType = lastPreparedMimeType,
                                     )
                                 }
                                 hudPokeSignal++
@@ -4044,6 +4064,17 @@ internal fun buildLiveTvBufferProfile(
         backBufferMs = 5_000,
     )
 }
+
+/**
+ * HTTP verdicts a provider repeats verbatim, so a second identical request only adds
+ * black screen. 444 is nginx's "closed the connection without answering" and is what
+ * portals with an exhausted or rejected session send; without it a dead channel burned
+ * three attempts and roughly twenty seconds before the existing error banner appeared.
+ */
+private val TERMINAL_PLAYBACK_HTTP_CODES = setOf(401, 403, 429, 444, 451, 513)
+
+/** Futile only when the retry would re-request the exact same address. */
+private val UNRECOVERABLE_ON_SAME_URL_HTTP_CODES = setOf(404, 410)
 
 private fun httpResponseCode(error: PlaybackException): Int? {
     var cause: Throwable? = error

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvScreen.kt
@@ -2781,12 +2781,16 @@ fun LiveTvScreen(
                 } else {
                     3
                 }
-                // Catch-up walks through *different* candidate URLs and Stalker asks the
-                // portal for a fresh temporary link, so a not-found answer can still be
-                // recovered from there. A plain live channel re-requests the very same
-                // address, which makes that family futile too.
+                // Catch-up walks through *different* candidate URLs, and a Stalker channel
+                // whose portal hands out temporary links asks for a fresh one, so a
+                // not-found answer can still be recovered from there. A plain live channel
+                // re-requests the very same address — as does a Stalker channel whose
+                // portal published the finished address — which makes that family futile.
                 val retryYieldsDifferentUrl = retryProgram != null ||
-                    retryChannel?.id?.startsWith("stalker:") == true
+                    (
+                        retryChannel?.id?.startsWith("stalker:") == true &&
+                            !StalkerPortalSupport.isDirectStreamAddress(retryChannel.streamUrl)
+                        )
                 val terminalCodes = if (retryYieldsDifferentUrl) {
                     TERMINAL_PLAYBACK_HTTP_CODES
                 } else {

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvScreen.kt
@@ -2781,22 +2781,8 @@ fun LiveTvScreen(
                 } else {
                     3
                 }
-                // Catch-up walks through *different* candidate URLs, and a Stalker channel
-                // whose portal hands out temporary links asks for a fresh one, so a
-                // not-found answer can still be recovered from there. A plain live channel
-                // re-requests the very same address — as does a Stalker channel whose
-                // portal published the finished address — which makes that family futile.
-                val retryYieldsDifferentUrl = retryProgram != null ||
-                    (
-                        retryChannel?.id?.startsWith("stalker:") == true &&
-                            !StalkerPortalSupport.isDirectStreamAddress(retryChannel.streamUrl)
-                        )
-                val terminalCodes = if (retryYieldsDifferentUrl) {
-                    TERMINAL_PLAYBACK_HTTP_CODES
-                } else {
-                    TERMINAL_PLAYBACK_HTTP_CODES + UNRECOVERABLE_ON_SAME_URL_HTTP_CODES
-                }
-                if (nextAttempt > maxRetryCount || httpResponseCode(error) in terminalCodes) {
+                val httpCode = httpResponseCode(error)
+                if (!shouldRetryLiveTvPlayback(httpCode, nextAttempt, maxRetryCount, retryProgram != null)) {
                     playbackDiagnostic = PlaybackDiagnostic(
                         title = context.getString(R.string.live_diag_playback_failed),
                         detail = "${error.errorCodeName}: ${classifyPlaybackError(error)}",
@@ -2821,7 +2807,7 @@ fun LiveTvScreen(
                                 program = retryStreamProgram ?: retryProgram,
                                 forceRefresh = true,
                                 catchupAttempt = if (retryProgram != null) nextAttempt else 0,
-                                probeKnownUrl = unsupportedContainer,
+                                probeKnownUrl = unsupportedContainer || isMissingPlaybackResource(httpCode),
                             )
                         } else {
                             IptvPlaybackTarget(prepared, preparedIsHls)
@@ -4068,17 +4054,6 @@ internal fun buildLiveTvBufferProfile(
         backBufferMs = 5_000,
     )
 }
-
-/**
- * HTTP verdicts a provider repeats verbatim, so a second identical request only adds
- * black screen. 444 is nginx's "closed the connection without answering" and is what
- * portals with an exhausted or rejected session send; without it a dead channel burned
- * three attempts and roughly twenty seconds before the existing error banner appeared.
- */
-private val TERMINAL_PLAYBACK_HTTP_CODES = setOf(401, 403, 429, 444, 451, 513)
-
-/** Futile only when the retry would re-request the exact same address. */
-private val UNRECOVERABLE_ON_SAME_URL_HTTP_CODES = setOf(404, 410)
 
 private fun httpResponseCode(error: PlaybackException): Int? {
     var cause: Throwable? = error

--- a/app/src/test/kotlin/com/arflix/tv/data/api/StalkerApiTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/api/StalkerApiTest.kt
@@ -550,6 +550,7 @@ class StalkerApiTest {
             "http://portal.example.com/play/live.php?stream=1&extension=ts",
             channels.single().streamUrl
         )
+        assertTrue(channels.single().stalkerDirectStream)
     }
 
     @Test
@@ -579,6 +580,7 @@ class StalkerApiTest {
         val channels = api.getChannels()
 
         assertEquals("ffmpeg http://localhost/ch/7_", channels.single().streamUrl)
+        assertFalse(channels.single().stalkerDirectStream)
     }
 
     @Test
@@ -604,6 +606,40 @@ class StalkerApiTest {
         val channels = api.getChannels()
 
         assertEquals("ffmpeg http://host/live/3", channels.single().streamUrl)
+        assertFalse(channels.single().stalkerDirectStream)
+    }
+
+    @Test
+    fun `bare URL does not erase temporary link requirements`() = runTest {
+        val cases = listOf(
+            "" to false,
+            "\"use_http_tmp_link\": 1," to false,
+            "\"use_http_tmp_link\": \"1\"," to false,
+            "\"use_http_tmp_link\": \"\"," to false,
+            "\"use_http_tmp_link\": 0, \"wowza_tmp_link\": 1," to false,
+            "\"use_http_tmp_link\": 0, \"flussonic_tmp_link\": \"1\"," to false,
+            "\"use_http_tmp_link\": 0," to true,
+            "\"use_http_tmp_link\": \"0\"," to true,
+        )
+        for ((flags, direct) in cases) {
+            val api = stubApi(requests = mutableListOf()) { url ->
+                when {
+                    url.contains("action=get_genres") -> """{"js": []}"""
+                    url.contains("action=get_all_channels") -> """{"js": {
+                        "data": [{$flags "id": 1, "name": "News", "cmd": "https://portal.test/live/one"}],
+                        "total_items": 1, "max_page_items": 1
+                    }}"""
+                    else -> null
+                }
+            }
+            val channel = api.getChannels().single().copy(id = "stalker:stalker1:1")
+            assertEquals(flags, "https://portal.test/live/one", channel.streamUrl)
+            assertEquals(flags, direct, channel.stalkerDirectStream)
+            assertEquals(flags, direct, com.arflix.tv.data.repository.StalkerPortalSupport
+                .canPlayDirectLiveStream(channel, channel.streamUrl, isCatchup = false))
+            assertFalse(com.arflix.tv.data.repository.StalkerPortalSupport
+                .canPlayDirectLiveStream(channel, channel.streamUrl, isCatchup = true))
+        }
     }
 
     @Test

--- a/app/src/test/kotlin/com/arflix/tv/data/api/StalkerApiTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/api/StalkerApiTest.kt
@@ -3,6 +3,7 @@ package com.arflix.tv.data.api
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.Reader
@@ -519,5 +520,149 @@ class StalkerApiTest {
         val programs = api.getShortEpg("1")
 
         assertTrue(programs.isEmpty())
+    }
+
+    @Test
+    fun `channels of a portal that needs no temporary link keep their finished address`() = runTest {
+        // Measured portal: all 21295 channels report use_http_tmp_link 0 and publish a
+        // complete address, so playback must not ask create_link for one.
+        val requests = mutableListOf<String>()
+        val api = stubApi(requests = requests) { url ->
+            when {
+                url.contains("action=get_genres") -> """{ "js": [{ "id": "1", "title": "News" }] }"""
+                url.contains("action=get_all_channels") -> """{
+                    "js": {
+                        "data": [
+                            {
+                                "id": 1,
+                                "name": "Direct",
+                                "cmd": "ffmpeg http://portal.example.com/play/live.php?stream=1&extension=ts",
+                                "tv_genre_id": "1",
+                                "use_http_tmp_link": "0",
+                                "wowza_tmp_link": "0",
+                                "flussonic_tmp_link": "0"
+                            }
+                        ],
+                        "total_items": 1,
+                        "max_page_items": 1
+                    }
+                }"""
+                else -> null
+            }
+        }
+
+        val channels = api.getChannels()
+
+        assertEquals(
+            "http://portal.example.com/play/live.php?stream=1&extension=ts",
+            channels.single().streamUrl
+        )
+    }
+
+    @Test
+    fun `channels of a portal that asks for a temporary link keep the raw command`() = runTest {
+        val requests = mutableListOf<String>()
+        val api = stubApi(requests = requests) { url ->
+            when {
+                url.contains("action=get_genres") -> """{ "js": [] }"""
+                url.contains("action=get_all_channels") -> """{
+                    "js": {
+                        "data": [
+                            {
+                                "id": 7,
+                                "name": "Placeholder",
+                                "cmd": "ffmpeg http://localhost/ch/7_",
+                                "use_http_tmp_link": 1
+                            }
+                        ],
+                        "total_items": 1,
+                        "max_page_items": 1
+                    }
+                }"""
+                else -> null
+            }
+        }
+
+        val channels = api.getChannels()
+
+        assertEquals("ffmpeg http://localhost/ch/7_", channels.single().streamUrl)
+    }
+
+    @Test
+    fun `channels of a portal that states nothing keep the raw command`() = runTest {
+        // No flag at all is not a statement, so the create_link round trip stays.
+        val requests = mutableListOf<String>()
+        val api = stubApi(requests = requests) { url ->
+            when {
+                url.contains("action=get_genres") -> """{ "js": [] }"""
+                url.contains("action=get_all_channels") -> """{
+                    "js": {
+                        "data": [
+                            { "id": 3, "name": "Unknown", "cmd": "ffmpeg http://host/live/3" }
+                        ],
+                        "total_items": 1,
+                        "max_page_items": 1
+                    }
+                }"""
+                else -> null
+            }
+        }
+
+        val channels = api.getChannels()
+
+        assertEquals("ffmpeg http://host/live/3", channels.single().streamUrl)
+    }
+
+    @Test
+    fun `an empty tmp link flag does not take the whole channel page down`() = runTest {
+        // Portals have been seen sending "" where a number belongs; a numeric field
+        // would abort parsing and lose every channel of the page.
+        val requests = mutableListOf<String>()
+        val api = stubApi(requests = requests) { url ->
+            when {
+                url.contains("action=get_genres") -> """{ "js": [] }"""
+                url.contains("action=get_all_channels") -> """{
+                    "js": {
+                        "data": [
+                            { "id": 5, "name": "Odd", "cmd": "ffmpeg http://host/live/5", "use_http_tmp_link": "" }
+                        ],
+                        "total_items": 1,
+                        "max_page_items": 1
+                    }
+                }"""
+                else -> null
+            }
+        }
+
+        val channels = api.getChannels()
+
+        assertEquals(listOf("5"), channels.map { it.id })
+        assertEquals("ffmpeg http://host/live/5", channels.single().streamUrl)
+    }
+
+    @Test
+    fun `resolveStreamUrl strips whichever command word the portal used`() = runTest {
+        // A third portal writes "auto http://..."; only "ffmpeg " used to be removed,
+        // which left an address no player can open.
+        val requests = mutableListOf<String>()
+        val api = stubApi(requests = requests) { url ->
+            if (url.contains("action=create_link")) {
+                """{ "js": { "cmd": "auto http://host/live.ts?channelId=9" } }"""
+            } else null
+        }
+
+        val resolved = api.resolveStreamUrl("ffmpeg http://host/ch/9_")
+
+        assertEquals("http://host/live.ts?channelId=9", resolved)
+    }
+
+    @Test
+    fun `resolveStreamUrl returns null when the portal answers without a command`() = runTest {
+        val requests = mutableListOf<String>()
+        val api = stubApi(requests = requests) { url ->
+            if (url.contains("action=create_link")) """{ "js": { "id": null } }""" else null
+        }
+
+        assertNull(api.resolveStreamUrl("ffmpeg http://host/ch/9_"))
     }
 }

--- a/app/src/test/kotlin/com/arflix/tv/data/api/StalkerApiTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/api/StalkerApiTest.kt
@@ -43,10 +43,11 @@ class StalkerApiTest {
         val ok = api.handshake()
 
         assertTrue(ok)
+        // The base-path probe is itself a handshake; repeating it would only throw
+        // away the token it just returned.
         assertEquals(
             listOf(
-                "$PORTAL/server/load.php?type=stb&action=handshake",
-                "$PORTAL/server/load.php?type=stb&action=handshake&token=&JsHttpRequest=1-xml"
+                "$PORTAL/server/load.php?type=stb&action=handshake"
             ),
             requests
         )
@@ -70,8 +71,7 @@ class StalkerApiTest {
         assertEquals(
             listOf(
                 "$PORTAL/server/load.php?type=stb&action=handshake",
-                "$PORTAL/stalker_portal/server/load.php?type=stb&action=handshake",
-                "$PORTAL/stalker_portal/server/load.php?type=stb&action=handshake&token=&JsHttpRequest=1-xml"
+                "$PORTAL/stalker_portal/server/load.php?type=stb&action=handshake"
             ),
             requests
         )
@@ -101,7 +101,6 @@ class StalkerApiTest {
                     "<!DOCTYPE html><html><body>404 Not Found</body></html>"
                 url == "$PORTAL/server/load.php?type=stb&action=handshake" ->
                     """{ "js": { "token": "ROOT" } }"""
-                url.contains("action=handshake&token=") -> """{ "js": { "token": "ROOT" } }"""
                 else -> null
             }
         }
@@ -112,8 +111,7 @@ class StalkerApiTest {
         assertEquals(
             listOf(
                 "$PORTAL/c/server/load.php?type=stb&action=handshake",
-                "$PORTAL/server/load.php?type=stb&action=handshake",
-                "$PORTAL/server/load.php?type=stb&action=handshake&token=&JsHttpRequest=1-xml"
+                "$PORTAL/server/load.php?type=stb&action=handshake"
             ),
             requests
         )
@@ -128,7 +126,6 @@ class StalkerApiTest {
                 url == "$PORTAL/server/load.php?type=stb&action=handshake" -> "<html>404</html>"
                 url == "$PORTAL/stalker_portal/server/load.php?type=stb&action=handshake" ->
                     """{ "js": { "token": "SP" } }"""
-                url.contains("action=handshake&token=") -> """{ "js": { "token": "SP" } }"""
                 else -> null
             }
         }
@@ -140,8 +137,7 @@ class StalkerApiTest {
             listOf(
                 "$PORTAL/c/server/load.php?type=stb&action=handshake",
                 "$PORTAL/server/load.php?type=stb&action=handshake",
-                "$PORTAL/stalker_portal/server/load.php?type=stb&action=handshake",
-                "$PORTAL/stalker_portal/server/load.php?type=stb&action=handshake&token=&JsHttpRequest=1-xml"
+                "$PORTAL/stalker_portal/server/load.php?type=stb&action=handshake"
             ),
             requests
         )
@@ -157,7 +153,6 @@ class StalkerApiTest {
                     "<!DOCTYPE html><html><body>404 Not Found</body></html>"
                 url == "$PORTAL/stalker_portal/server/load.php?type=stb&action=handshake" ->
                     """{ "js": { "token": "SPC" } }"""
-                url.contains("action=handshake&token=") -> """{ "js": { "token": "SPC" } }"""
                 else -> null
             }
         }
@@ -168,8 +163,7 @@ class StalkerApiTest {
         assertEquals(
             listOf(
                 "$PORTAL/stalker_portal/c/server/load.php?type=stb&action=handshake",
-                "$PORTAL/stalker_portal/server/load.php?type=stb&action=handshake",
-                "$PORTAL/stalker_portal/server/load.php?type=stb&action=handshake&token=&JsHttpRequest=1-xml"
+                "$PORTAL/stalker_portal/server/load.php?type=stb&action=handshake"
             ),
             requests
         )
@@ -184,7 +178,6 @@ class StalkerApiTest {
                     "<!DOCTYPE html><html><body>404 Not Found</body></html>"
                 url == "$PORTAL/stalker_portal/server/load.php?type=stb&action=handshake" ->
                     """{ "js": { "token": "LATE" } }"""
-                url.contains("action=handshake&token=") -> """{ "js": { "token": "LATE" } }"""
                 else -> null
             }
         }

--- a/app/src/test/kotlin/com/arflix/tv/data/repository/IptvPlaybackUrlResolverTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/repository/IptvPlaybackUrlResolverTest.kt
@@ -141,6 +141,59 @@ class IptvPlaybackUrlResolverTest {
     }
 
     @Test
+    fun `single segment token URL is probed and keeps the stated transport stream type`() = runBlocking {
+        val calls = AtomicInteger()
+        val client = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                calls.incrementAndGet()
+                Response.Builder()
+                    .request(chain.request())
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(200)
+                    .message("OK")
+                    .header("Content-Type", "video/mp2t")
+                    .body("".toResponseBody("video/mp2t".toMediaType()))
+                    .build()
+            }
+            .build()
+        val resolver = IptvPlaybackUrlResolver(client)
+
+        val target = resolver.resolve(
+            rawUrl = "http://provider.test/N2Q4ZjhiMGEyYzFlNGY2ZA",
+            headers = emptyMap(),
+        )
+
+        assertThat(target.isHls).isFalse()
+        assertThat(target.mimeType).isEqualTo("video/mp2t")
+        assertThat(calls.get()).isEqualTo(1)
+    }
+
+    @Test
+    fun `probed HLS target carries no transport stream mime type`() = runBlocking {
+        val client = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                Response.Builder()
+                    .request(chain.request())
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(200)
+                    .message("OK")
+                    .header("Content-Type", "application/vnd.apple.mpegurl")
+                    .body("".toResponseBody("application/vnd.apple.mpegurl".toMediaType()))
+                    .build()
+            }
+            .build()
+        val resolver = IptvPlaybackUrlResolver(client)
+
+        val target = resolver.resolve(
+            rawUrl = "http://provider.test/live/user/pass/channel-slug",
+            headers = emptyMap(),
+        )
+
+        assertThat(target.isHls).isTrue()
+        assertThat(target.mimeType).isNull()
+    }
+
+    @Test
     fun `known direct and adaptive URLs skip redirect probe`() = runBlocking {
         val client = OkHttpClient.Builder()
             .addInterceptor { error("Redirect probe should not run") }

--- a/app/src/test/kotlin/com/arflix/tv/data/repository/IptvPlaybackUrlResolverTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/repository/IptvPlaybackUrlResolverTest.kt
@@ -11,6 +11,28 @@ import org.junit.Test
 import java.util.concurrent.atomic.AtomicInteger
 
 class IptvPlaybackUrlResolverTest {
+    @Test fun `expired redirect can refresh once for both not found responses`() = runBlocking {
+        for (status in listOf(404, 410)) {
+            val calls = AtomicInteger()
+            val resolver = IptvPlaybackUrlResolver(OkHttpClient.Builder().addInterceptor { chain ->
+                val suffix = if (calls.incrementAndGet() == 1) "expired" else "fresh"
+                Response.Builder()
+                    .request(chain.request().newBuilder().url("https://cdn.test/$suffix.m3u8").build())
+                    .protocol(Protocol.HTTP_1_1).code(200).message("OK")
+                    .header("Content-Type", "application/vnd.apple.mpegurl")
+                    .body("".toResponseBody()).build()
+            }.build())
+            val url = "https://provider.test/live/channel-slug"
+            assertThat(resolver.resolve(url, emptyMap()).url).isEqualTo("https://cdn.test/expired.m3u8")
+            assertThat(resolver.resolve(url, emptyMap()).url).isEqualTo("https://cdn.test/expired.m3u8")
+            assertThat(com.arflix.tv.ui.screens.tv.live.shouldRetryLiveTvPlayback(status, 1, 3, false)).isTrue()
+            val refreshed = resolver.resolve(url, emptyMap(), forceRefresh = true,
+                probeKnownUrl = com.arflix.tv.ui.screens.tv.live.isMissingPlaybackResource(status))
+            assertThat(refreshed.url).isEqualTo("https://cdn.test/fresh.m3u8")
+            assertThat(calls.get()).isEqualTo(2)
+        }
+    }
+
     @Test fun `failed numeric stream can explicitly recover an HLS content type`() = runBlocking {
         val calls = AtomicInteger()
         val resolver = IptvPlaybackUrlResolver(OkHttpClient.Builder().addInterceptor { chain ->

--- a/app/src/test/kotlin/com/arflix/tv/data/repository/StalkerPlaybackPersistenceTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/repository/StalkerPlaybackPersistenceTest.kt
@@ -1,0 +1,80 @@
+package com.arflix.tv.data.repository
+
+import android.app.Application
+import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteOpenHelper
+import com.arflix.tv.data.model.IptvChannel
+import com.google.gson.Gson
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.ConscryptMode
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class, manifest = Config.NONE, sdk = [28])
+@ConscryptMode(ConscryptMode.Mode.OFF)
+class StalkerPlaybackPersistenceTest {
+    @Test fun directDecisionSurvivesBatchedStorageAndReopen() {
+        val context = RuntimeEnvironment.getApplication()
+        val channels = List(85) { index ->
+            IptvChannel("stalker:stalker1:$index", "Channel $index", "https://portal.test/live/$index",
+                "News", stalkerDirectStream = index % 2 == 0)
+        }
+        IptvChannelStore(context).use { it.replaceAll("portal", channels, 123L) }
+        IptvChannelStore(context).use { store ->
+            assertEquals(channels, store.loadAll("portal"))
+            assertEquals(channels.takeLast(3), store.window("portal", 82, 3))
+            assertEquals(123L, store.updatedAtMs("portal"))
+        }
+    }
+
+    @Test fun olderJsonDefaultsToCreateLinkAndNewJsonPreservesDecision() {
+        val gson = Gson()
+        val channel = gson.fromJson("""{"id":"stalker:stalker1:1","name":"News",
+            "streamUrl":"https://portal.test/live/one","group":"News"}""", IptvChannel::class.java)
+        assertFalse(channel.stalkerDirectStream)
+        val direct = channel.copy(stalkerDirectStream = true)
+        assertEquals(direct, gson.fromJson(gson.toJson(direct), IptvChannel::class.java))
+    }
+
+    @Test fun versionSixUpgradeKeepsChannelsAndDefaultsToCreateLink() {
+        val context = RuntimeEnvironment.getApplication()
+        val legacy = object : SQLiteOpenHelper(context, "arvio_iptv_channels.db", null, 6) {
+            override fun onCreate(db: SQLiteDatabase) {
+                db.execSQL("""CREATE TABLE channels (
+                    source_key TEXT NOT NULL, ord INTEGER NOT NULL, id TEXT NOT NULL,
+                    name TEXT NOT NULL, stream_url TEXT NOT NULL, group_title TEXT NOT NULL,
+                    logo TEXT, epg_id TEXT, raw_title TEXT, xtream_stream_id INTEGER,
+                    catchup_days INTEGER NOT NULL DEFAULT 0, catchup_type TEXT, catchup_source TEXT,
+                    tvg_name TEXT, provider_channel_number TEXT, request_headers_json TEXT,
+                    language TEXT, country TEXT, quality_label TEXT, variant_key TEXT, drm_json TEXT,
+                    PRIMARY KEY(source_key, ord))""")
+                db.execSQL("""CREATE TABLE channel_sources (source_key TEXT PRIMARY KEY NOT NULL,
+                    updated_ms INTEGER NOT NULL, channel_count INTEGER NOT NULL, group_summary_json TEXT)""")
+                db.execSQL("CREATE INDEX idx_channels_group ON channels(source_key, group_title, ord)")
+                db.execSQL("CREATE INDEX idx_channels_id ON channels(source_key, id)")
+            }
+            override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) = Unit
+        }
+        legacy.use { helper ->
+            helper.writableDatabase.execSQL("""INSERT INTO channels
+                (source_key, ord, id, name, stream_url, group_title)
+                VALUES ('portal', 0, 'stalker:stalker1:1', 'News', 'https://portal.test/live/one', 'News')""")
+            helper.writableDatabase.execSQL("INSERT INTO channel_sources VALUES ('portal', 123, 1, NULL)")
+        }
+        IptvChannelStore(context).use { store ->
+            val channel = store.loadAll("portal").single()
+            assertEquals("stalker:stalker1:1", channel.id)
+            assertFalse(channel.stalkerDirectStream)
+            assertEquals(1, store.count("portal"))
+            assertEquals(123L, store.updatedAtMs("portal"))
+            val direct = channel.copy(stalkerDirectStream = true)
+            store.replaceAll("portal", listOf(direct), 456L)
+            assertEquals(direct, store.loadAll("portal").single())
+        }
+    }
+}

--- a/app/src/test/kotlin/com/arflix/tv/data/repository/StalkerPlaybackPersistenceTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/repository/StalkerPlaybackPersistenceTest.kt
@@ -24,18 +24,27 @@ class StalkerPlaybackPersistenceTest {
             IptvChannel("stalker:stalker1:$index", "Channel $index", "https://portal.test/live/$index",
                 "News", stalkerDirectStream = index % 2 == 0)
         }
-        IptvChannelStore(context).use { it.replaceAll("portal", channels, 123L) }
-        IptvChannelStore(context).use { store ->
+        val initial = IptvChannelStore(context)
+        try {
+            initial.replaceAll("portal", channels, 123L)
+        } finally {
+            initial.close()
+        }
+        val store = IptvChannelStore(context)
+        try {
             assertEquals(channels, store.loadAll("portal"))
             assertEquals(channels.takeLast(3), store.window("portal", 82, 3))
             assertEquals(123L, store.updatedAtMs("portal"))
+        } finally {
+            store.close()
         }
     }
 
     @Test fun olderJsonDefaultsToCreateLinkAndNewJsonPreservesDecision() {
         val gson = Gson()
-        val channel = gson.fromJson("""{"id":"stalker:stalker1:1","name":"News",
-            "streamUrl":"https://portal.test/live/one","group":"News"}""", IptvChannel::class.java)
+        val legacy = gson.toJsonTree(IptvChannel("stalker:stalker1:1", "News",
+            "https://portal.test/live/one", "News")).asJsonObject.apply { remove("stalkerDirectStream") }
+        val channel = gson.fromJson(legacy, IptvChannel::class.java)
         assertFalse(channel.stalkerDirectStream)
         val direct = channel.copy(stalkerDirectStream = true)
         assertEquals(direct, gson.fromJson(gson.toJson(direct), IptvChannel::class.java))
@@ -60,13 +69,16 @@ class StalkerPlaybackPersistenceTest {
             }
             override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) = Unit
         }
-        legacy.use { helper ->
-            helper.writableDatabase.execSQL("""INSERT INTO channels
+        try {
+            legacy.writableDatabase.execSQL("""INSERT INTO channels
                 (source_key, ord, id, name, stream_url, group_title)
                 VALUES ('portal', 0, 'stalker:stalker1:1', 'News', 'https://portal.test/live/one', 'News')""")
-            helper.writableDatabase.execSQL("INSERT INTO channel_sources VALUES ('portal', 123, 1, NULL)")
+            legacy.writableDatabase.execSQL("INSERT INTO channel_sources VALUES ('portal', 123, 1, NULL)")
+        } finally {
+            legacy.close()
         }
-        IptvChannelStore(context).use { store ->
+        val store = IptvChannelStore(context)
+        try {
             val channel = store.loadAll("portal").single()
             assertEquals("stalker:stalker1:1", channel.id)
             assertFalse(channel.stalkerDirectStream)
@@ -75,6 +87,8 @@ class StalkerPlaybackPersistenceTest {
             val direct = channel.copy(stalkerDirectStream = true)
             store.replaceAll("portal", listOf(direct), 456L)
             assertEquals(direct, store.loadAll("portal").single())
+        } finally {
+            store.close()
         }
     }
 }

--- a/app/src/test/kotlin/com/arflix/tv/data/repository/StalkerPortalSupportTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/repository/StalkerPortalSupportTest.kt
@@ -230,4 +230,20 @@ class StalkerPortalSupportTest {
         assertThat(normalized).isNotNull()
         assertThat(normalized!!.enabled).isFalse()
     }
+
+    @Test
+    fun isRoutableStreamAddressRejectsPortalPlaceholders() {
+        assertThat(StalkerPortalSupport.isRoutableStreamAddress("http://localhost/ch/1234_")).isFalse()
+        assertThat(StalkerPortalSupport.isRoutableStreamAddress("http://127.0.0.1:8080/ch/1")).isFalse()
+        assertThat(StalkerPortalSupport.isRoutableStreamAddress("http://0.0.0.0/ch/1")).isFalse()
+        assertThat(StalkerPortalSupport.isRoutableStreamAddress("")).isFalse()
+        assertThat(StalkerPortalSupport.isRoutableStreamAddress("   ")).isFalse()
+        assertThat(StalkerPortalSupport.isRoutableStreamAddress("not a url")).isFalse()
+    }
+
+    @Test
+    fun isRoutableStreamAddressAcceptsRealHosts() {
+        assertThat(StalkerPortalSupport.isRoutableStreamAddress("http://provider.test/live/1")).isTrue()
+        assertThat(StalkerPortalSupport.isRoutableStreamAddress("https://provider.test:8080/token")).isTrue()
+    }
 }

--- a/app/src/test/kotlin/com/arflix/tv/data/repository/StalkerPortalSupportTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/data/repository/StalkerPortalSupportTest.kt
@@ -246,4 +246,71 @@ class StalkerPortalSupportTest {
         assertThat(StalkerPortalSupport.isRoutableStreamAddress("http://provider.test/live/1")).isTrue()
         assertThat(StalkerPortalSupport.isRoutableStreamAddress("https://provider.test:8080/token")).isTrue()
     }
+
+    @Test
+    fun sanitizePlaybackCommandStripsAnyLeadingCommandWord() {
+        // Measured portals: "ffmpeg " at two of them, "auto " at a third.
+        assertThat(StalkerPortalSupport.sanitizePlaybackCommand("ffmpeg http://host/live/1"))
+            .isEqualTo("http://host/live/1")
+        assertThat(StalkerPortalSupport.sanitizePlaybackCommand("auto http://host/live.ts?channelId=1"))
+            .isEqualTo("http://host/live.ts?channelId=1")
+        assertThat(StalkerPortalSupport.sanitizePlaybackCommand("  extension  http://host/live/1  "))
+            .isEqualTo("http://host/live/1")
+    }
+
+    @Test
+    fun sanitizePlaybackCommandLeavesBareAddressesAlone() {
+        assertThat(StalkerPortalSupport.sanitizePlaybackCommand("http://host/live/1"))
+            .isEqualTo("http://host/live/1")
+        // A first word that carries the scheme is the address itself, not a command.
+        assertThat(StalkerPortalSupport.sanitizePlaybackCommand("http://host/live/1 extra"))
+            .isEqualTo("http://host/live/1 extra")
+        assertThat(StalkerPortalSupport.sanitizePlaybackCommand(null)).isEqualTo("")
+        assertThat(StalkerPortalSupport.sanitizePlaybackCommand("   ")).isEqualTo("")
+    }
+
+    @Test
+    fun isDirectStreamAddressAcceptsOnlyReadyToPlayAddresses() {
+        assertThat(StalkerPortalSupport.isDirectStreamAddress("http://host/play/live.php?stream=1")).isTrue()
+        assertThat(StalkerPortalSupport.isDirectStreamAddress("https://host:8080/token")).isTrue()
+        // Still carries the portal's command word.
+        assertThat(StalkerPortalSupport.isDirectStreamAddress("ffmpeg http://host/live/1")).isFalse()
+        // The create_link placeholder, in both of its measured shapes.
+        assertThat(StalkerPortalSupport.isDirectStreamAddress("http://localhost/ch/1234_")).isFalse()
+        assertThat(StalkerPortalSupport.isDirectStreamAddress("http://host/ch/1234_")).isFalse()
+        // A play_token may end in an underscore; only the path decides.
+        assertThat(StalkerPortalSupport.isDirectStreamAddress("http://host/play/live.php?play_token=ab_"))
+            .isTrue()
+        assertThat(StalkerPortalSupport.isDirectStreamAddress("rtmp://host/live/1")).isFalse()
+        assertThat(StalkerPortalSupport.isDirectStreamAddress("")).isFalse()
+    }
+
+    @Test
+    fun directLiveStreamUrlPublishesTheAddressWhenThePortalNeedsNoTemporaryLink() {
+        val cmd = "ffmpeg http://host/play/live.php?stream=1284583&extension=ts&play_token=T"
+        assertThat(
+            StalkerPortalSupport.directLiveStreamUrl(cmd, "0", "0", "0")
+        ).isEqualTo("http://host/play/live.php?stream=1284583&extension=ts&play_token=T")
+        // The other measured shape, from a portal that prefixes with "auto".
+        assertThat(
+            StalkerPortalSupport.directLiveStreamUrl("auto http://host/live.ts?channelId=9", "0", null, null)
+        ).isEqualTo("http://host/live.ts?channelId=9")
+    }
+
+    @Test
+    fun directLiveStreamUrlKeepsTheRoundTripWheneverTheAnswerIsNotClear() {
+        val cmd = "ffmpeg http://host/play/live.php?stream=1&extension=ts"
+        // The portal asks for a temporary link.
+        assertThat(StalkerPortalSupport.directLiveStreamUrl(cmd, "1", "0", "0")).isNull()
+        assertThat(StalkerPortalSupport.directLiveStreamUrl(cmd, "0", "1", "0")).isNull()
+        assertThat(StalkerPortalSupport.directLiveStreamUrl(cmd, "0", "0", "1")).isNull()
+        // The portal says nothing at all.
+        assertThat(StalkerPortalSupport.directLiveStreamUrl(cmd, null, null, null)).isNull()
+        assertThat(StalkerPortalSupport.directLiveStreamUrl(cmd, "", null, null)).isNull()
+        // It says no temporary link but publishes a placeholder anyway.
+        assertThat(
+            StalkerPortalSupport.directLiveStreamUrl("ffmpeg http://localhost/ch/1_", "0", "0", "0")
+        ).isNull()
+        assertThat(StalkerPortalSupport.directLiveStreamUrl(null, "0", "0", "0")).isNull()
+    }
 }

--- a/app/src/test/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvRetryPolicyTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvRetryPolicyTest.kt
@@ -1,0 +1,40 @@
+package com.arflix.tv.ui.screens.tv.live
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LiveTvRetryPolicyTest {
+    @Test fun missingLiveResourceGetsOneFreshResolution() {
+        for (status in listOf(404, 410)) {
+            assertTrue(shouldRetryLiveTvPlayback(status, 1, 3, isCatchup = false))
+            assertFalse(shouldRetryLiveTvPlayback(status, 2, 3, isCatchup = false))
+            assertFalse(shouldRetryLiveTvPlayback(status, 3, 3, isCatchup = false))
+            assertTrue(isMissingPlaybackResource(status))
+        }
+    }
+
+    @Test fun catchupKeepsItsBoundedCandidateBudget() {
+        for (status in listOf(404, 410)) {
+            assertTrue(shouldRetryLiveTvPlayback(status, 1, 2, isCatchup = true))
+            assertTrue(shouldRetryLiveTvPlayback(status, 2, 2, isCatchup = true))
+            assertFalse(shouldRetryLiveTvPlayback(status, 3, 2, isCatchup = true))
+            assertFalse(shouldRetryLiveTvPlayback(status, 1, 0, isCatchup = true))
+        }
+    }
+
+    @Test fun terminalResponsesStillStopImmediately() {
+        for (status in listOf(401, 403, 429, 444, 451, 513)) {
+            assertFalse(shouldRetryLiveTvPlayback(status, 1, 3, isCatchup = false))
+            assertFalse(shouldRetryLiveTvPlayback(status, 1, 2, isCatchup = true))
+        }
+    }
+
+    @Test fun otherFailuresKeepExistingRetryBudget() {
+        for (status in listOf(null, 500, 502, 503)) {
+            assertTrue(shouldRetryLiveTvPlayback(status, 3, 3, isCatchup = false))
+            assertFalse(shouldRetryLiveTvPlayback(status, 4, 3, isCatchup = false))
+            assertFalse(isMissingPlaybackResource(status))
+        }
+    }
+}


### PR DESCRIPTION
Stalker live TV did not play at all on one of my two portals: every channel showed a
black screen for about twenty seconds and then gave up without a message. Captured the
app's own traffic against that portal, next to a capture of a full-featured client on
the same portal and the same account, and the cause turned out to be a call ARVIO makes
that the other client never makes.

## The cause

Stalker channels carry either a ready-to-play address in their `cmd` or a placeholder
that has to be exchanged for a temporary link via `create_link`. The `use_http_tmp_link`,
`wowza_tmp_link` and `flussonic_tmp_link` flags say which it is. ARVIO reads none of them
and calls `create_link` for every live channel of every portal.

On this portal all 21295 channels report `use_http_tmp_link: "0"` and publish a complete
address. Asking it for a temporary link anyway is not just a wasted round trip per channel
start and per zap — the portal answers it like this:

    HTTP/1.1 200 OK
    {"js":{"id":null,"cmd":"ffmpeg http://<host>/play/live.php?mac=<MAC>&stream=&
     extension=ts&play_token=<TOKEN>&sn2="},"streamer_id":0,"link_id":0,"load":0,"error":""}

The `stream=` id is empty. Status 200, `"error": ""`, nothing says anything went wrong.
That address was then played and the provider closed the connection without a response:
16 × HTTP 444 across three channels, four attempts each.

The full-featured client never calls `create_link` for live TV. It plays the address from
the channel list directly, which is what the protocol asks for when the flags are zero.

## What this changes

1. `create_link` is only called when the portal asks for it. A channel whose portal
   states that no temporary link is needed keeps its finished address, and playback
   hands it straight to the player. Portals that do ask for a temporary link, and
   portals that state nothing at all, keep the round trip exactly as before.
2. HTTP 444 and 451 end playback instead of being retried; 404 and 410 do too when the
   retry would only re-request the very same address. Catch-up walks through different
   candidate URLs and a portal that hands out temporary links yields a fresh one, so
   both keep their retries.
3. A failed `create_link` no longer falls back to the unroutable placeholder
   (`http://localhost/ch/1234_`), which burned the retry budget on an address that can
   never work. It fails with the message that already exists.
4. Format detection reads the server's `Content-Type` instead of guessing from the URL.
   It only ran for paths with at least four segments starting with `live`, so a provider
   handing out a single-segment token URL never got probed and its
   `Content-Type: video/mp2t` was never read.
5. The resolved-stream cache had no expiry, so returning to a channel replayed an address
   the portal had long since retired. Ending futile retries earlier removed the retry that
   used to hide this, so the cause is fixed rather than the cover restored.
6. Only the leading `ffmpeg ` was stripped from a playback command. A third portal writes
   its addresses as `auto http://…`, where the command word survived into the player and
   no channel could open. Whatever word a portal puts in front is dropped now, unless it
   carries the scheme itself.
7. Signing in sent two handshakes. Resolving the portal's API base probes the candidate
   paths with a real handshake and keeps the token it got; `handshake()` then sent another
   and threw that token away. One request per sign-in instead of two.

No string resources are touched.

## Result, measured on the same portal

|                          | before | after |
|--------------------------|--------|-------|
| `create_link` calls      | 4      | **0** |
| HTTP 444                 | 16     | **0** |
| channels that played     | 0      | **5 of 5** |
| portal API calls per zap | 1      | **0** |

The capture after the change contains two status codes in total: 19 × 200 and 5 × 302.
Each channel start is now one `GET /play/live.php?…&stream=<id>&…` → 302 → stream,
the same sequence the full-featured client uses.

## Testing

- `./gradlew testSideloadDebugUnitTest` — 886 tests, all green. New unit tests cover the
  flag decision (the three measured `cmd` shapes, an explicit `1`, an absent flag and an
  empty one), the command-word stripping, and the placeholder shapes.
- Installed as a signed sideload staging build on a phone and a TCL C7K and run against a
  real portal: channels play, zapping between three channels is immediate, sign-in
  unchanged.
- Not covered on-device, only by unit tests: a portal that does require `create_link`,
  an Xtream channel, a dead channel, and a portal using the `auto ` prefix.

## Note

An empty `use_http_tmp_link` field would abort parsing of a whole channel page if the flag
were read as a number, so the three flags are read as text. Both measured portals send
them quoted (`"use_http_tmp_link":"0"`).

---
created by Claude (Anthropic) on behalf of @ReichiMD