### PR TITLE
fix(tv): handle back navigation and restore focus in stream selector and source menu

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/components/StreamSelector.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/StreamSelector.kt
@@ -2,6 +2,7 @@ package com.arflix.tv.ui.components
 
 import com.arflix.tv.ui.motion.*
 
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.PredictiveBackHandler
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.runtime.mutableFloatStateOf
@@ -228,8 +229,14 @@ fun StreamSelector(
     onSelect: (StreamSource) -> Unit = {},
     onClose: () -> Unit = {}
 ) {
+    val isMobile = LocalDeviceType.current.isTouchDevice()
     val isRtlLayoutDirection = androidx.compose.ui.platform.LocalLayoutDirection.current == androidx.compose.ui.unit.LayoutDirection.Rtl
-    val backMotion = rememberArvioPredictiveBack(enabled = isVisible, onCommit = onClose)
+    val backMotion = rememberArvioPredictiveBack(enabled = isVisible && isMobile, onCommit = onClose)
+    if (!isMobile) {
+        BackHandler(enabled = isVisible) {
+            onClose()
+        }
+    }
 
     var focusedIndex by remember { mutableIntStateOf(0) }
     var focusedTabIndex by remember { mutableIntStateOf(0) }
@@ -240,7 +247,6 @@ fun StreamSelector(
     val listState = rememberTvLazyListState()
     val addonListState = rememberTvLazyListState()
     val focusRequester = remember { FocusRequester() }
-    val isMobile = LocalDeviceType.current.isTouchDevice()
     val pluginPrefix = stringResource(R.string.plugin_prefix)
 
     var elapsedSeconds by remember { mutableIntStateOf(0) }
@@ -257,13 +263,18 @@ fun StreamSelector(
     // Request focus when visible
     LaunchedEffect(isVisible) {
         if (isVisible) {
-            runCatching { focusRequester.requestFocus() }
             focusedIndex = 0
             focusedTabIndex = 0
             selectedTabIndex = 0
             focusedFilterIndex = 0
             selectedFilterIndex = 0
             focusZone = "streams"
+            if (!isMobile) {
+                kotlinx.coroutines.delay(50)
+                runCatching { focusRequester.requestFocus() }
+            } else {
+                runCatching { focusRequester.requestFocus() }
+            }
         }
     }
 
@@ -424,7 +435,7 @@ fun StreamSelector(
                         } else actualKey
 
                         when (logicalKey) {
-                            Key.Escape -> {
+                            Key.Back, Key.Escape -> {
                                 onClose()
                                 true
                             }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
@@ -1054,7 +1054,10 @@ fun DetailsScreen(
                     null
                 )
             },
-            onClose = { showStreamSelector = false }
+            onClose = {
+                showStreamSelector = false
+                runCatching { focusRequester.requestFocus() }
+            }
         )
 
         // Episode Context Menu

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/PlayerScreen.kt
@@ -3359,6 +3359,19 @@ fun PlayerScreen(
                         }
                     }
 
+                    // Handle source menu
+                    if (showSourceMenu) {
+                        if (event.key == Key.Back || event.key == Key.Escape) {
+                            showSourceMenu = false
+                            showControls = true
+                            coroutineScope.launch {
+                                delay(150)
+                                runCatching { sourceButtonFocusRequester.requestFocus() }
+                            }
+                            return@onKeyEvent true
+                        }
+                    }
+
                     when (event.key) {
                         Key.Back, Key.Escape -> {
                             onExitPlayer()

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/player/tv/ArvioTvPlayer.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/player/tv/ArvioTvPlayer.kt
@@ -322,6 +322,22 @@ fun ArvioTvPlayer(
                         }
                     }
 
+                    // TV Sources Menu D-pad / Back handling
+                    showSourceMenu -> {
+                        when (event.key) {
+                            Key.Back, Key.Escape -> {
+                                showSourceMenu = false
+                                showControls = true
+                                coroutineScope.launch {
+                                    delay(150)
+                                    runCatching { sourceButtonFocusRequester.requestFocus() }
+                                }
+                                true
+                            }
+                            else -> false
+                        }
+                    }
+
                     // Global Controls Key Events
                     else -> when (event.key) {
                         Key.MediaPlayPause -> { onTogglePlayPause(); showControls = true; true }


### PR DESCRIPTION
## Summary
This PR fixes back-key navigation and focus restoration issues when navigating stream selection and player source menus on TV devices:

1. **Source Menu Back Dismissal in Player**:
   - In `PlayerScreen` and `ArvioTvPlayer`, pressing the remote Back / Escape key while the stream source menu is active now dismisses the source menu and restores player controls, rather than falling through to exit playback entirely.

2. **Stream Selector Back Navigation**:
   - In `StreamSelector`, handled `Key.Back` alongside `Key.Escape` in hardware key events and added a TV-only `BackHandler` to ensure remote back cleanly closes the dialog.
   - Preserved predictive back gestures on touch/mobile devices via `enabled = isVisible && isMobile`.

3. **Focus Restoration on Details Screen**:
   - In `DetailsScreen`, re-requests focus on the primary action button when closing `StreamSelector` to prevent D-pad focus loss.

## Verification
- Built and tested with `./gradlew installSideloadDebug -PincludeX86Abis=true` on an Android TV emulator (`Television_1080p AVD - Android 12 x86`).
- Verified that pressing Back while the source menu is open closes the menu and returns focus to the player controls.
- Verified that mobile/touch mode gestures and back handling remain completely unaffected.