### PR TITLE
fix(web): restore TV favorites/recent sync and refine guide UI

### DIFF
--- a/web/app/dev/stabilization/fixture.tsx
+++ b/web/app/dev/stabilization/fixture.tsx
@@ -65,7 +65,7 @@ export function StabilizationFixture() {
     profiles: [], addons: sportsAddons, watchlist: media, continueWatching: media.slice(0, 4), traktConnected: true, simklConnected: true, mdblistConnected: false,
     openDetails: (item: MediaItem) => setToast(`Selected: ${item.title}`), openContextMenu: noop, isWatched: () => false,
     loadTrackerLibrary, loadTraktLists, loadTraktListItems: async () => media,
-    playChannel: (channel: IptvChannel) => setToast(`Selected: ${channel.name}`), playCatchup: noop, setToast,
+    playChannel: (channel: IptvChannel) => setToast(`Selected: ${channel.name}`), recordChannelPlayback: noop, playCatchup: noop, setToast,
     trackingPreferences: { watchlistReadMode: "trakt", continueWatchingReadMode: "both", watchedReadMode: "both", writeToTrakt: true, writeToSimkl: true },
     settingsSyncState: "local", saveTrackingPreferences: noop, setSection: setPage, signOut: noop, refreshData: empty,
     homeServerRows: [], categories: [], catalogConfigs: [], selected: null, streams: [], activeStream, activeChannel, selectedEpisode: null,

--- a/web/app/dev/tv-sync/fixture.tsx
+++ b/web/app/dev/tv-sync/fixture.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { TopNav } from "@/components/shell/TopNav";
+import { AppContext, defaultSettings, type AppStore } from "@/lib/store";
+import { LiveTvScreen } from "@/components/livetv/LiveTvScreen";
+import { iptvPlaylistSignature } from "@/lib/iptv";
+import { recordTvPlayback } from "@/lib/iptvSession";
+import type { AppSettings, IptvChannel, IptvNowNext } from "@/lib/types";
+
+const names = ["ESPN", "NPO 1", "NPO 2", "NPO 3", "Ziggo Sport", "RTL 4", "BBC One", "BBC Two", "Discovery", "National Geographic", "Sky Sports", "Eurosport"];
+const channels: IptvChannel[] = Array.from({ length: 55_000 }, (_, i) => ({
+  id: `fixture:xtream:${i}`, cloudId: `fixture:m3u:exact-${i}`, name: i < 12 ? names[i] : `${names[i % 12]} ${i + 1}`,
+  group: i < 12 ? "Netherlands" : `International sports and entertainment ${Math.floor(i / 200)}`,
+  number: String(i + 1), streamUrl: "https://example.invalid/fixture.m3u8", tvgId: `fixture-${i}`
+}));
+const noop = () => {};
+export function TvSyncFixture() {
+  const [settings, setSettings] = useState<AppSettings>({ ...defaultSettings,
+    iptvPlaylists: [{ id: "fixture", name: "Reference playlist", enabled: true, m3uUrl: "https://example.invalid/list.m3u" }],
+    favoriteChannelIds: channels.slice(1, 4).map(c => c.cloudId!),
+    iptvTvSession: { lastChannelId: channels[0].cloudId!, lastGroupName: "recent", lastFocusedZone: "GUIDE", lastOpenedAt: 1,
+      recentChannelIds: channels.slice(0, 12).reverse().map(c => c.cloudId!) }
+  });
+  const [nowNext, setNowNext] = useState<Record<string, IptvNowNext>>({});
+  const loadIptvGuide = useCallback(async (rows: IptvChannel[]) => {
+    const start = Math.floor(Date.now() / 3_600_000) * 3_600_000;
+    const titles = ["Eredivisie Highlights", "NOS Journaal", "BinnensteBuiten", "Checkpoint", "Grand Prix Review", "RTL Nieuws"];
+    setNowNext(old => ({ ...old, ...Object.fromEntries(rows.map((channel, index) => {
+      const programs = Array.from({ length: 5 }, (_, i) => ({ title: titles[(index + i) % titles.length],
+        description: "The latest news, highlights and analysis from today's programme.", startUtcMillis: start + i * 3_600_000, endUtcMillis: start + (i + 1) * 3_600_000 }));
+      return [channel.id, { now: programs[0], next: programs[1], upcoming: programs.slice(1), recent: [] }];
+    })) }));
+  }, []);
+  const record = useCallback((channel: IptvChannel) => setSettings(old => ({ ...old, iptvTvSession: recordTvPlayback(old.iptvTvSession, channel) })), []);
+  const snapshot = useMemo(() => ({ allChannels: channels, channels, grouped: {}, nowNext, identitiesLoaded: true,
+    favoriteChannels: settings.favoriteChannelIds, favoriteGroups: [], hiddenGroups: [], groupOrder: [],
+    loadedAt: Date.now(), signature: iptvPlaylistSignature(settings.iptvPlaylists) }), [nowNext, settings]);
+  const app = { settings, setSettings, iptvSnapshot: snapshot, playChannel: record, recordChannelPlayback: record,
+    view: "app", section: "tv", setSection: noop, switchProfile: noop, avatarImages: [], closeDetails: noop, selected: null,
+    playCatchup: noop, setToast: noop, refreshIptv: async () => {}, loadIptvGuide, busy: "", auth: null,
+    activeProfile: { id: "tv-sync-fixture", name: "Test profile" }, addons: [] } as unknown as AppStore;
+  return <AppContext.Provider value={app}>
+    <main className="app-shell"><TopNav /><section className="content"><LiveTvScreen /></section></main>
+  </AppContext.Provider>;
+}

--- a/web/app/dev/tv-sync/page.tsx
+++ b/web/app/dev/tv-sync/page.tsx
@@ -1,0 +1,8 @@
+import { notFound } from "next/navigation";
+import { TvSyncFixture } from "./fixture";
+
+export const dynamic = "force-dynamic";
+export default function Page() {
+  if (process.env.NODE_ENV !== "development" || process.env.ARVIO_UI_FIXTURES !== "true") notFound();
+  return <TvSyncFixture />;
+}

--- a/web/app/tv-guide.css
+++ b/web/app/tv-guide.css
@@ -13,13 +13,14 @@
 .player-dock-controls button, .player-dock-return { pointer-events: auto; width: 36px; height: 36px; display: grid; place-items: center; border: 0; border-radius: 4px; background: #000b; color: white; }
 .player-dock-return { position: absolute; inset-inline-end: 24px; top: 90px; z-index: 20; }
 .player-dock-controls button:focus-visible, .player-dock-return:focus-visible { outline: 2px solid white; }
-.screen.livetv-shell { padding-inline: 16px; }
-.tv-guide-workspace { gap: 0; border-radius: 0; grid-template-columns: 320px minmax(0, 1fr); grid-template-rows: auto minmax(0, 1fr); }
+.screen.livetv-shell { padding-inline: 16px; animation: none; transform: none; }
+.tv-drawer-scrim { display: none; }
+.tv-guide-workspace { --guide-channel-width: 260px; gap: 0; border-radius: 0; grid-template-columns: 300px minmax(0, 1fr); grid-template-rows: clamp(210px, 28dvh, 286px) minmax(0, 1fr); height: calc(100dvh - clamp(84px, 9vh, 108px) - 24px); min-height: 480px; flex: none; transition: grid-template-columns 240ms cubic-bezier(.2,.7,.2,1); }
 .tv-guide-workspace.groups-collapsed { grid-template-columns: 0 minmax(0, 1fr); }
-.tv-guide-workspace .livetv-cats { grid-column: 1; grid-row: 1 / 3; background: #08090a; border: 0; border-radius: 0; padding: 14px; }
+.tv-guide-workspace .livetv-cats { grid-column: 1; grid-row: 1 / 3; background: #080808; border: 0; border-inline-end: 1px solid #202020; border-radius: 0; padding: 8px 14px; position: static; max-height: none; height: 100%; }
 .tv-guide-workspace .livetv-cats { min-width: 0; overflow: hidden; }
 .tv-guide-workspace .livetv-cats > select { width: 100%; min-height: 48px; margin-bottom: 10px; background: #111315; color: #eee; border: 1px solid #25282d; border-radius: 6px; padding: 8px 12px; }
-.tv-guide-workspace .livetv-cats .livetv-search { flex: none; width: 100%; min-width: 0; margin-bottom: 16px; }
+.tv-guide-workspace .livetv-cats .livetv-search { flex: none; width: 100%; min-width: 0; margin-bottom: 12px; border-radius: 6px; min-height: 46px; }
 .tv-guide-workspace .livetv-cats button { width: 100%; border-radius: 5px; font-size: 16px; }
 .tv-guide-workspace .livetv-cats button svg { color: #ddd; }
 .tv-guide-workspace .livetv-cats button em { font-size: 13px; }
@@ -44,13 +45,20 @@
 .tv-guide-workspace .livetv-cats button.is-active { color: #fff; background: #292929; }
 .tv-guide-workspace .livetv-cats button.is-active em { color: #ccc; }
 .tv-guide-workspace button:focus-visible, .tv-event-picker button:focus-visible { outline: 2px solid #fff; outline-offset: -2px; box-shadow: none; }
-.tv-guide-workspace .livetv-list { grid-column: 2; grid-row: 2; background: #080808; border: 0; border-radius: 0; min-width: 0; }
-.tv-guide-workspace .livetv-detail { grid-column: 2; grid-row: 1; position: static; display: grid; grid-template-columns: minmax(0, 1fr) minmax(240px, min(40%, 453px)); gap: 6px 24px; background: #080808; border: 0; border-radius: 0; padding: 8px 24px; max-height: 290px; overflow: auto; }
-.tv-guide-workspace .livetv-detail-art { grid-column: 2; grid-row: 1 / 7; width: 100%; height: auto; aspect-ratio: 16 / 9; max-height: none; border-radius: 4px; background: #141414; }
+.tv-guide-workspace .livetv-list { grid-column: 2; grid-row: 2; background: #080808; border: 0; border-radius: 0; min-width: 0; min-height: 0; overflow: hidden; }
+.tv-guide-workspace .livetv-detail { grid-column: 2; grid-row: 1; position: static; display: grid; grid-template-columns: minmax(0, 1fr) minmax(210px, 38%); align-content: start; gap: 8px 20px; background: #080808; border: 0; border-bottom: 1px solid #202020; border-radius: 0; padding: 8px 20px 16px; max-height: none; overflow: auto; }
+.tv-guide-workspace .livetv-detail-art { grid-column: 2; grid-row: 1 / 5; width: 100%; height: auto; aspect-ratio: 16 / 9; max-height: none; border-radius: 4px; background: #141414; }
 .tv-guide-workspace .livetv-detail-art img { width: 100%; height: 100%; object-fit: contain; padding: 22px; }
+.tv-guide-workspace .livetv-detail { height: 100%; min-height: 0; }
+.tv-guide-workspace .livetv-detail { row-gap: 4px; }
+.tv-guide-workspace .livetv-detail-art { max-height: calc(clamp(210px, 28dvh, 286px) - 24px); }
 .tv-guide-workspace .livetv-detail > :not(.livetv-detail-art) { grid-column: 1; margin: 0; }
 .tv-guide-workspace .livetv-detail h2 { font-size: 30px; }
-.tv-guide-workspace .livetv-channel-identity { color: #bfc3ca; font-size: 16px; }
+.tv-guide-workspace .livetv-channel-identity { color: #bfc3ca; font-size: 14px; display: flex; gap: 12px; align-items: center; min-height: 32px; }
+.tv-guide-workspace .tv-identity-logo { width: 72px; height: 32px; flex: none; overflow: hidden; }
+.tv-guide-workspace .tv-identity-logo > span { grid-template: minmax(0, 1fr) / minmax(0, 1fr); }
+.tv-guide-workspace .livetv-channel-identity > span { min-width: 0; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
+.tv-guide-workspace .livetv-detail-actions button[aria-label="Show catch-up archive"] { width: auto; padding: 0 10px; }
 .tv-guide-workspace .livetv-detail-actions button { background: transparent; color: #f5f5f5; border-color: transparent; box-shadow: none; }
 .tv-guide-workspace .livetv-detail .is-next, .tv-guide-workspace .livetv-detail-group { display: none; }
 .tv-guide-workspace .livetv-program p { -webkit-line-clamp: 2; display: -webkit-box; -webkit-box-orient: vertical; overflow: hidden; }
@@ -64,7 +72,24 @@
 .tv-guide-workspace .livetv-catchup { max-height: 120px; }
 .tv-guide-workspace .livetv-guide-block { background: #171717; color: #ddd; }
 .tv-guide-workspace .livetv-progress > span { background: #56d8c5; }
-.tv-guide-workspace.sports-active .livetv-list { grid-row: 1 / 3; }
+.tv-guide-workspace.sports-active .livetv-list { grid-row: 1 / 3; overflow: auto; }
+.tv-guide-workspace .livetv-guide { display: flex; flex-direction: column; flex: 1; min-height: 0; border: 0; border-radius: 0; background: transparent; }
+.tv-guide-workspace .tv-guide-grid { flex: 1; height: auto; min-height: 0; scroll-padding-top: 36px; }
+.tv-guide-workspace .livetv-rows { flex: 1; min-height: 0; }
+.tv-guide-workspace .livetv-rows > .virtual-list { height: 100%; min-height: 0; }
+.tv-guide-workspace .livetv-guide-channel, .tv-guide-workspace .livetv-guide-corner { flex-basis: var(--guide-channel-width); }
+.tv-guide-workspace .livetv-guide-channel { background: #141719; border-radius: 5px; margin-inline-end: 4px; flex-basis: calc(var(--guide-channel-width) - 4px); }
+.tv-guide-workspace .livetv-guide-row { height: 58px; min-height: 58px; content-visibility: visible; border: 0; }
+.tv-guide-workspace .livetv-guide-block { top: 0; bottom: 0; border: 1px solid transparent; border-radius: 4px; align-items: flex-start; }
+.tv-guide-workspace .livetv-guide-block.is-live { background: #232628; border-color: transparent; }
+.tv-guide-workspace .livetv-guide-block:focus-visible { background: #343739; }
+.tv-guide-workspace .livetv-guide-channel .livetv-row-logo { background: transparent; }
+.tv-guide-workspace .guide-window-controls { flex: none; justify-content: flex-end; padding: 0 0 8px; }
+.tv-guide-workspace .guide-window-controls span { order: -1; margin-inline-end: auto; font-size: 14px; }
+.tv-guide-workspace .guide-window-controls button { border: 0; background: transparent; }
+.tv-guide-workspace .livetv-guide-timebar { height: 36px; z-index: 4; }
+.tv-guide-workspace .livetv-guide-ticks span { color: #bfc3ca; font-size: 13px; }
+.tv-guide-workspace .livetv-guide-nowline b { position: absolute; top: 1px; left: -26px; font-family: inherit; font-size: 12px; font-weight: 500; line-height: 24px; font-style: normal; background: #56d8c5; color: #080808; border-radius: 5px; padding: 0 7px; white-space: nowrap; }
 .tv-sports { color: #eee; padding: 8px 0 24px; min-width: 0; container: sports / inline-size; }
 .tv-sports h2 { font-size: 32px; padding: 0 24px; margin: 0 0 10px; display: flex; gap: 18px; align-items: center; }
 .tv-sports-drawer { background: transparent; border: 0; color: inherit; width: 32px; height: 40px; display: grid; place-items: center; }
@@ -143,13 +168,23 @@
 @media (max-width: 700px) {
   .screen.livetv-shell { padding-inline: 0; }
   .tv-guide-workspace, .tv-guide-workspace.groups-collapsed { display: grid; grid-template-columns: minmax(0, 1fr); position: relative; }
-  .tv-guide-workspace .livetv-cats { position: fixed; z-index: 55; inset: 85px auto 80px 0; width: min(300px, 86vw); max-height: none; box-shadow: 10px 0 35px #0009; transition: transform 200ms ease, opacity 150ms ease; }
+  .tv-guide-workspace { --guide-channel-width: 170px; height: auto; min-height: 0; grid-template-rows: auto minmax(360px, 58dvh); }
+  .tv-guide-workspace.sports-active { grid-template-rows: auto; }
+  .tv-guide-workspace.sports-active .livetv-list { overflow: visible; }
+  .tv-guide-workspace .livetv-cats { position: fixed; z-index: 55; inset: calc(56px + env(safe-area-inset-top)) auto calc(62px + env(safe-area-inset-bottom)) 0; width: min(300px, 86vw); max-height: none; box-shadow: 10px 0 35px #0009; transition: transform 200ms ease, opacity 150ms ease; }
+  .tv-drawer-scrim { display: block; position: fixed; z-index: 54; inset: 56px 0 62px; width: 100%; border: 0; border-radius: 0; background: #0008; }
+  .tv-guide-workspace .livetv-cats { height: auto; background: #101112; }
   .tv-guide-workspace .livetv-cats { flex-direction: column; }
   .tv-guide-workspace .livetv-cats .virtual-list { height: 100%; min-height: 0; }
   .tv-guide-workspace.groups-collapsed .livetv-cats { transform: translateX(-100%); padding: 8px; }
   .tv-guide-workspace .livetv-list, .tv-guide-workspace .livetv-detail { grid-column: 1; }
   .tv-guide-workspace .livetv-detail { grid-template-columns: minmax(0, 1fr); max-height: none; }
+  .tv-guide-workspace .livetv-detail h2 { font-size: 22px; }
+  .tv-guide-workspace .livetv-detail { padding: 8px 4px 12px; }
+  .tv-guide-workspace .livetv-detail { height: auto; }
+  .tv-guide-workspace .livetv-guide-channel strong { font-size: 13px; }
   .tv-guide-workspace .livetv-detail-art { display: block; grid-column: 1; grid-row: auto; width: 100%; max-height: 210px; }
+  .tv-guide-workspace .livetv-detail-art:not(.has-live-playback) { display: none; }
   .tv-sports h2 { font-size: 24px; padding-inline: 12px; }
   .tv-sports-row-heading { margin-inline: 12px; }
   .tv-sports-row-heading h3 { font-size: 18px; }

--- a/web/components/livetv/LiveTvScreen.tsx
+++ b/web/components/livetv/LiveTvScreen.tsx
@@ -7,6 +7,7 @@ import { accessibleChannels, groupKey, loadXtreamCatchup, type CatchupProgram } 
 import { VirtualList } from "@/components/ui/VirtualList";
 import { SportsGuidePane } from "@/components/livetv/SportsGuidePane";
 import { ChannelLogo } from "@/components/livetv/ChannelLogo";
+import { channelIdentityIndex, normalizeTvSession, resolveChannelReferences } from "@/lib/iptvSession";
 import { IPTV_SNAPSHOT_TTL_MS, iptvPlaylistSignature } from "@/lib/iptv";
 import { loadStored, saveStored } from "@/lib/storage";
 import { authClient, useApp } from "@/lib/store";
@@ -32,7 +33,7 @@ function groupLabel(group: string) {
 }
 
 export function LiveTvScreen() {
-  const { iptvSnapshot, settings, setSettings, playChannel, playCatchup, setToast, refreshIptv, loadIptvGuide, busy, auth, activeProfile, addons } = useApp();
+  const { iptvSnapshot, settings, setSettings, playChannel, recordChannelPlayback, playCatchup, setToast, refreshIptv, loadIptvGuide, busy, auth, activeProfile, activeChannel, addons } = useApp();
   const lastChannelKey = `${LAST_CHANNEL_KEY}:${auth?.userId ?? "local"}:${activeProfile?.id ?? "local"}`;
   const listRef = useRef<HTMLElement>(null);
 
@@ -53,8 +54,9 @@ export function LiveTvScreen() {
       channel.name,
       settings.defaultSubtitle
     );
+    recordChannelPlayback(channel);
     void trackPremiumEvent(authClient, "external_playback_requested", { player, entry: "live_tv" }, true);
-  }, [setToast, settings.defaultSubtitle]);
+  }, [setToast, settings.defaultSubtitle, recordChannelPlayback]);
 
   const playlists = settings.iptvPlaylists;
   const favorites = settings.favoriteChannelIds;
@@ -76,6 +78,8 @@ export function LiveTvScreen() {
   const [groupsOpen, setGroupsOpen] = useState(true);
   const [provider, setProvider] = useState("all");
   const [catchup, setCatchup] = useState<{ channelId: string; programs: CatchupProgram[]; loading: boolean } | null>(null);
+  const [archiveOpen, setArchiveOpen] = useState(false);
+  const tvSession = useMemo(() => normalizeTvSession(settings.iptvTvSession), [settings.iptvTvSession]);
 
   const allChannels = iptvSnapshot.allChannels ?? iptvSnapshot.channels;
   const providerChannels = useMemo(() => provider === "all" ? allChannels : allChannels.filter((ch) => ch.id.startsWith(`${provider}:`)), [allChannels, provider]);
@@ -85,12 +89,15 @@ export function LiveTvScreen() {
     for (const channel of channels) (result[groupKey(channel)] ??= []).push(channel);
     return result;
   }, [channels]);
-  const channelById = useMemo(() => new Map(channels.map((ch) => [ch.id, ch])), [channels]);
-  const favoriteIds = useMemo(() => new Set(favorites), [favorites]);
+  const channelById = useMemo(() => channelIdentityIndex(channels), [channels]);
   const enabledPlaylists = playlists.filter((playlist) => playlist.enabled && playlist.m3uUrl.trim());
-  const favoriteChannels = useMemo(() => favorites.map((id) => channelById.get(id)).filter((ch): ch is IptvChannel => Boolean(ch)), [favorites, channelById]);
+  const favoriteChannels = useMemo(() => resolveChannelReferences(favorites, channelById), [favorites, channelById]);
+  const favoriteIds = useMemo(() => new Set(favoriteChannels.map(channel => channel.id)), [favoriteChannels]);
+  const recentChannels = useMemo(() => resolveChannelReferences([...tvSession.recentChannelIds].reverse(), channelById), [tvSession, channelById]);
   const isLoadingTv = Boolean(busy && (busy.toLowerCase().includes("syncing") || busy.toLowerCase().includes("loading tv")));
   const hasWarnings = Boolean(iptvSnapshot.playlistWarnings?.length);
+  const resolvingSavedChannels = !iptvSnapshot.identitiesLoaded && Boolean(allChannels.length)
+    && (favorites.length > favoriteChannels.length || tvSession.recentChannelIds.length > recentChannels.length);
   // Same helper the store stamps onto the snapshot, so both sides agree on when
   // a cached channel list still matches the configured playlists.
   const playlistSignature = iptvPlaylistSignature(playlists);
@@ -135,16 +142,18 @@ export function LiveTvScreen() {
         return 0;
       });
     return [
+      { id: "favorites", label: "Favorites", count: favoriteChannels.length, favorite: true, hidden: false },
+      { id: "recent", label: "Recently Watched", count: recentChannels.length, favorite: false, hidden: false },
       { id: "all", label: "All Channels", count: channels.length, favorite: false, hidden: false },
       { id: "sports", label: "Sports", count: 0, favorite: false, hidden: false },
-      { id: "favorites", label: "Favorites", count: favoriteChannels.length, favorite: true, hidden: false },
       ...groupRows
     ];
-  }, [channels.length, favoriteChannels.length, favoriteGroups, groups, hiddenGroups, settings.groupOrder, settings.iptvSortOrder]);
+  }, [channels.length, favoriteChannels.length, recentChannels.length, favoriteGroups, groups, hiddenGroups, settings.groupOrder, settings.iptvSortOrder]);
 
   const visibleChannels = useMemo(() => {
     const base = activeCategory === "favorites"
       ? favoriteChannels
+      : activeCategory === "recent" ? recentChannels
       : activeCategory.startsWith("group:")
         ? groups[activeCategory.slice(6)] ?? []
         : channels;
@@ -157,7 +166,7 @@ export function LiveTvScreen() {
         )
       : base;
     const sortMode = settings.iptvSortOrder ?? "provider";
-    if (activeCategory === "favorites") return filtered;
+    if (activeCategory === "favorites" || activeCategory === "recent") return filtered;
     if (sortMode === "number") {
       return [...filtered].sort((a, b) => {
         const numA = a.number ? parseInt(a.number, 10) : Number.MAX_SAFE_INTEGER;
@@ -170,7 +179,7 @@ export function LiveTvScreen() {
       return [...filtered].sort((a, b) => a.name.localeCompare(b.name));
     }
     return filtered;
-  }, [activeCategory, channels, favoriteChannels, groups, query, settings.iptvSortOrder]);
+  }, [activeCategory, channels, favoriteChannels, recentChannels, groups, query, settings.iptvSortOrder]);
 
   useEffect(() => {
     if (!categories.some((category) => category.id === activeCategory)) setActiveCategory("all");
@@ -181,8 +190,8 @@ export function LiveTvScreen() {
 
   // Restore the last played channel, not every row crossed while browsing.
   useEffect(() => {
-    setSelectedChannelId(loadStored<string | null>(lastChannelKey, null));
-  }, [lastChannelKey]);
+    setSelectedChannelId(tvSession.lastChannelId || loadStored<string | null>(lastChannelKey, null));
+  }, [lastChannelKey, tvSession.lastChannelId]);
   const watchChannel = useCallback((channel: IptvChannel) => {
     saveStored(lastChannelKey, channel.id);
     playChannel(channel);
@@ -190,7 +199,7 @@ export function LiveTvScreen() {
 
   // Catch-up listings for the selected channel (channels the panel archives).
   useEffect(() => {
-    if (!selectedChannel?.catchupDays || selectedChannel.catchupType !== "xtream") {
+    if (!archiveOpen || !selectedChannel?.catchupDays || selectedChannel.catchupType !== "xtream") {
       setCatchup(null);
       return undefined;
     }
@@ -203,7 +212,8 @@ export function LiveTvScreen() {
     }, 400);
     return () => { active = false; window.clearTimeout(timer); };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedChannel?.id]);
+  }, [selectedChannel?.id, archiveOpen]);
+  useEffect(() => setArchiveOpen(false), [selectedChannel?.id]);
 
   // Guide loads lazily for rows as they scroll into view, batched so a fast
   // scroll doesn't fire hundreds of EPG requests.
@@ -235,13 +245,13 @@ export function LiveTvScreen() {
   const toggleFavorite = (channelId: string) =>
     setSettings({
       ...settings,
-      favoriteChannelIds: favorites.includes(channelId)
-        ? favorites.filter((id) => id !== channelId)
-        : [channelId, ...favorites]
+      favoriteChannelIds: favoriteIds.has(channelId)
+        ? favorites.filter((id) => channelById.get(id)?.id !== channelId)
+        : [channelById.get(channelId)?.cloudId ?? channelId, ...favorites]
     });
 
   const moveFavorite = (id: string, direction: number) => {
-    const index = favorites.indexOf(id);
+    const index = favorites.findIndex(reference => channelById.get(reference)?.id === id);
     const next = index + direction;
     if (index < 0 || next < 0 || next >= favorites.length) return;
     const ordered = [...favorites];
@@ -292,11 +302,11 @@ export function LiveTvScreen() {
   const renderCategory = (category: typeof categories[number]) => <button type="button"
     className={activeCategory === category.id ? "is-active" : ""} title={category.label}
     onClick={() => {
-      setActiveCategory(category.id); setSelectedChannelId(null); setGroupsOpen(false);
-      requestAnimationFrame(() => listRef.current?.querySelector<HTMLElement>('[data-virtual-index] button')?.focus({ preventScroll: true }));
+      setActiveCategory(category.id); setSelectedChannelId(null);
+      if (window.matchMedia("(max-width: 760px)").matches) setGroupsOpen(false);
     }}>
-    {category.id === "favorites" ? <Star size={20} /> : category.id === "sports" ? <Trophy size={20} /> : <LayoutGrid size={20} />}
-    <span>{category.label}</span>{category.id !== "sports" && <em>{category.count.toLocaleString()}</em>}
+    {category.id === "favorites" ? <Star size={20} /> : category.id === "recent" ? <History size={20} /> : category.id === "sports" ? <Trophy size={20} /> : <LayoutGrid size={20} />}
+    <span>{category.label}</span>{category.id !== "sports" && <em>{resolvingSavedChannels && ["favorites", "recent"].includes(category.id) && !category.count ? <RefreshCw size={14} className="is-spinning" aria-label="Loading saved channels" /> : category.count.toLocaleString()}</em>}
   </button>;
 
   return (
@@ -383,7 +393,13 @@ export function LiveTvScreen() {
 
       {channels.length > 0 && (
         <div className={`livetv-columns tv-guide-workspace ${activeCategory === "sports" ? "sports-active" : ""} ${groupsOpen ? "" : "groups-collapsed"}`}>
-          <nav className="livetv-cats" aria-label="Channel categories" inert={!groupsOpen}>
+          {groupsOpen && <button className="tv-drawer-scrim" type="button" aria-label="Close categories" onClick={() => setGroupsOpen(false)} />}
+          <nav className="livetv-cats" aria-label="Channel categories" inert={!groupsOpen} onKeyDown={event => {
+            if (event.key === "ArrowRight" && !(event.target as HTMLElement).matches("input, select")) {
+              const first = listRef.current?.querySelector<HTMLElement>('[data-virtual-index] button, .tv-event-card');
+              if (first) { event.preventDefault(); first.focus({ preventScroll: true }); }
+            }
+          }}>
             <select aria-label="Playlist provider" value={provider} onChange={event => { setProvider(event.target.value); setActiveCategory("all"); }}>
               <option value="all">All playlists</option>
               {enabledPlaylists.map(playlist => <option key={playlist.id} value={playlist.id}>{playlist.name}</option>)}
@@ -400,7 +416,9 @@ export function LiveTvScreen() {
             <VirtualList items={categories.filter(category => category.id.startsWith("group:"))} estimate={56} itemKey={rowKey} label="Categories" renderItem={renderCategory} />
           </nav>
 
-          <main ref={listRef} className="livetv-list" aria-label={activeCategoryLabel} onKeyDown={(event) => {
+          <main ref={listRef} className="livetv-list" aria-label={activeCategoryLabel} onFocusCapture={event => {
+            if ((event.target as HTMLElement).closest(".livetv-guide-channel, .livetv-guide-block, .livetv-row-main, .tv-event-card")) setGroupsOpen(false);
+          }} onKeyDown={(event) => {
             if ((event.target as HTMLElement).closest("dialog")) return;
             if (event.key === "Escape" || (event.key === "ArrowLeft" && !(event.target as HTMLElement).closest(".livetv-guide-block"))) {
               if (!groupsOpen) { event.preventDefault(); setGroupsOpen(true); requestAnimationFrame(() => document.querySelector<HTMLElement>(".livetv-cats button.is-active")?.focus()); }
@@ -430,7 +448,7 @@ export function LiveTvScreen() {
             {renderedChannels.length === 0 && (
               <div className="livetv-list-empty">
                 <Search size={28} />
-                <p>No channels match {query.trim() ? `"${query.trim()}"` : "this category"}.</p>
+                <p>{resolvingSavedChannels && ["favorites", "recent"].includes(activeCategory) ? "Loading saved channels..." : `No channels match ${query.trim() ? `"${query.trim()}"` : "this category"}.`}</p>
                 {query.trim() && <button type="button" className="secondary" onClick={() => setQuery("")}>Clear search</button>}
               </div>
             )}
@@ -452,6 +470,7 @@ export function LiveTvScreen() {
               </div>
             ) : (
               <GuideGrid
+                key={`${provider}:${activeCategory}:${query}`}
                 channels={renderedChannels}
                 favorites={favoriteIds}
                 nowNext={iptvSnapshot.nowNext}
@@ -468,11 +487,11 @@ export function LiveTvScreen() {
           {activeCategory !== "sports" && <aside className="livetv-detail" aria-label="Channel details">
             {selectedChannel ? (
               <>
-                <div id="live-tv-player-dock" className="livetv-detail-art" aria-label="Live player">
+                <div id="live-tv-player-dock" className={`livetv-detail-art ${activeChannel ? "has-live-playback" : ""}`} aria-label="Live player">
                   <ChannelLogo channel={selectedChannel} size={48} />
                 </div>
                 <p className="livetv-detail-group">{selectedChannel.group || "Live TV"}</p>
-                <p className="livetv-channel-identity">{selectedChannel.name}{selectedChannel.qualityLabel ? ` · ${selectedChannel.qualityLabel}` : ""}</p>
+                <div className="livetv-channel-identity"><div className="tv-identity-logo"><ChannelLogo channel={selectedChannel} size={28} /></div><span>{selectedChannel.name}{selectedChannel.qualityLabel ? ` · ${selectedChannel.qualityLabel}` : ""}</span></div>
                 <h2>{selectedGuide?.now?.title || selectedChannel.name}</h2>
                 {selectedGuide?.now?.title ? (
                   <div className="livetv-program">
@@ -494,25 +513,27 @@ export function LiveTvScreen() {
                   </div>
                 )}
                 <div className="livetv-detail-actions">
-                  {favoriteIds.has(selectedChannel.id) && <><button className="secondary" type="button" title="Move favorite up" aria-label="Move favorite up" disabled={favorites.indexOf(selectedChannel.id) === 0} onClick={() => moveFavorite(selectedChannel.id, -1)}><ArrowUp size={17} /></button><button className="secondary" type="button" title="Move favorite down" aria-label="Move favorite down" disabled={favorites.indexOf(selectedChannel.id) === favorites.length - 1} onClick={() => moveFavorite(selectedChannel.id, 1)}><ArrowDown size={17} /></button></>}
+                  {favoriteIds.has(selectedChannel.id) && <><button className="secondary" type="button" title="Move favorite up" aria-label="Move favorite up" disabled={channelById.get(favorites[0])?.id === selectedChannel.id} onClick={() => moveFavorite(selectedChannel.id, -1)}><ArrowUp size={17} /></button><button className="secondary" type="button" title="Move favorite down" aria-label="Move favorite down" disabled={channelById.get(favorites[favorites.length - 1])?.id === selectedChannel.id} onClick={() => moveFavorite(selectedChannel.id, 1)}><ArrowDown size={17} /></button></>}
                   <button type="button" className="primary" onClick={() => watchChannel(selectedChannel)}><Play size={17} fill="currentColor" /> Watch</button>
                   <button type="button" className="secondary" onClick={() => openChannelExternally(selectedChannel, "vlc")}>
                     <ExternalLink size={17} /> VLC
                   </button>
                   <button
                     type="button"
-                    className={favorites.includes(selectedChannel.id) ? "secondary is-active" : "secondary"}
-                    aria-label={favorites.includes(selectedChannel.id) ? "Remove selected favorite" : "Add selected favorite"}
-                    title={favorites.includes(selectedChannel.id) ? "Remove favorite" : "Add favorite"}
+                    className={favoriteIds.has(selectedChannel.id) ? "secondary is-active" : "secondary"}
+                    aria-label={favoriteIds.has(selectedChannel.id) ? "Remove selected favorite" : "Add selected favorite"}
+                    title={favoriteIds.has(selectedChannel.id) ? "Remove favorite" : "Add favorite"}
                     onClick={() => toggleFavorite(selectedChannel.id)}
                   >
-                    <Star size={17} fill={favorites.includes(selectedChannel.id) ? "currentColor" : "none"} />
+                    <Star size={17} fill={favoriteIds.has(selectedChannel.id) ? "currentColor" : "none"} />
                   </button>
+                  {Boolean(selectedChannel.catchupDays) && <button type="button" className="secondary" aria-label="Show catch-up archive" aria-expanded={archiveOpen} onClick={() => setArchiveOpen(value => !value)}><History size={17} /> Catch-up</button>}
                 </div>
-                {catchup?.channelId === selectedChannel.id && (catchup.loading || catchup.programs.length > 0) && (
+                {archiveOpen && catchup?.channelId === selectedChannel.id && (
                   <div className="livetv-catchup">
                     <p className="livetv-catchup-head"><History size={14} /> Catch-up{selectedChannel.catchupDays ? ` · ${selectedChannel.catchupDays}d archive` : ""}</p>
                     {catchup.loading && <p className="livetv-detail-empty">Loading archive…</p>}
+                    {!catchup.loading && !catchup.programs.length && <p className="livetv-detail-empty">No archive available.</p>}
                     {catchup.programs.map((program) => (
                       <button
                         type="button"
@@ -601,20 +622,17 @@ function GuideGrid({ channels, favorites, nowNext, selectedId, onFocus, onVisibl
         <button type="button" title="Next four hours" aria-label="Next four hours" disabled={windowStart >= currentStart + 44 * 3_600_000} onClick={() => setManualStart(windowStart + 4 * 3_600_000)}><ChevronRight size={18} /></button>
         <span aria-live="polite">{new Intl.DateTimeFormat([], { weekday: "short", day: "numeric", month: "short" }).format(windowStart)} · {fmtTime(windowStart)}–{fmtTime(windowEnd)}</span>
       </div>
-      <div className="livetv-guide-scroll">
-        <div className="livetv-guide-inner" style={{ width: `${totalWidth + 232}px` }}>
-          <div className="livetv-guide-timebar">
+          <VirtualList items={channels} itemKey={rowKey} label="Guide channels" className="tv-guide-grid" contentWidth={`calc(${totalWidth}px + var(--guide-channel-width))`} preserveHorizontalFocus estimate={62} header={<div className="livetv-guide-timebar">
             <span className="livetv-guide-corner" />
             <div className="livetv-guide-ticks" style={{ width: `${totalWidth}px` }}>
               {ticks.map((tick) => (
                 <span key={tick} style={{ width: `${30 * GUIDE_PX_PER_MIN}px` }}>{fmtTime(tick)}</span>
               ))}
               {nowOffset >= 0 && nowOffset <= totalWidth && (
-                <i className="livetv-guide-nowline" style={{ left: `${nowOffset}px` }} />
+                <i className="livetv-guide-nowline" style={{ left: `${nowOffset}px` }}><b>{fmtTime(clock)}</b></i>
               )}
             </div>
-          </div>
-          <VirtualList items={channels} itemKey={rowKey} label="Guide channels" estimate={62} renderItem={(channel) => (
+          </div>} renderItem={(channel) => (
             <GuideRow
               key={channel.id}
               channel={channel}
@@ -631,8 +649,6 @@ function GuideGrid({ channels, favorites, nowNext, selectedId, onFocus, onVisibl
               onCatchup={(program) => onCatchup(channel, program)}
             />
           )} />
-        </div>
-      </div>
     </div>
   );
 }
@@ -677,7 +693,13 @@ function GuideRow({ channel, favorite, guide, selected, windowStart, windowEnd, 
   return (
     // onFocus mirrors ChannelRow: React's bubbling focus from the inner
     // channel button keeps the details pane in sync for D-pad/remote users.
-    <div ref={rowRef} className={`livetv-guide-row ${selected ? "is-selected" : ""}`} onMouseEnter={onFocus} onFocus={onFocus} role="row">
+    <div ref={rowRef} className={`livetv-guide-row ${selected ? "is-selected" : ""}`} onMouseEnter={onFocus} onFocus={onFocus} role="row" onKeyDown={event => {
+      if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+      const buttons = Array.from(event.currentTarget.querySelectorAll<HTMLButtonElement>("button"));
+      const index = buttons.indexOf(event.target as HTMLButtonElement);
+      const next = buttons[index + (event.key === "ArrowRight" ? 1 : -1)];
+      if (next) { event.preventDefault(); event.stopPropagation(); next.focus(); }
+    }}>
       <button type="button" className="livetv-guide-channel" onClick={onPlay} title={channel.name}>
         <small className="tv-guide-channel-number">{channel.number}</small>
         <span className="livetv-row-logo"><ChannelLogo channel={channel} size={16} /></span>

--- a/web/components/ui/VirtualList.tsx
+++ b/web/components/ui/VirtualList.tsx
@@ -4,9 +4,10 @@ import { defaultRangeExtractor, useVirtualizer } from "@tanstack/react-virtual";
 import { useCallback, useRef, useState, type ReactNode } from "react";
 
 /** Windowed list with a retained keyboard focus row and adjacent-row navigation. */
-export function VirtualList<T>({ items, itemKey, renderItem, estimate = 80, label, className = "" }: {
+export function VirtualList<T>({ items, itemKey, renderItem, estimate = 80, label, className = "", contentWidth, header, preserveHorizontalFocus = false }: {
   items: T[]; itemKey: (item: T) => string; renderItem: (item: T, index: number) => ReactNode;
   estimate?: number; label: string; className?: string;
+  contentWidth?: string; header?: ReactNode; preserveHorizontalFocus?: boolean;
 }) {
   const parent = useRef<HTMLDivElement>(null);
   const [focused, setFocused] = useState<{ key: string; index: number } | null>(null);
@@ -18,6 +19,7 @@ export function VirtualList<T>({ items, itemKey, renderItem, estimate = 80, labe
     useFlushSync: false,
     count: items.length, getScrollElement: () => parent.current,
     estimateSize, overscan: 5, getItemKey,
+    paddingStart: header ? 36 : 0,
     rangeExtractor: (range) => {
       const indices = defaultRangeExtractor(range);
       if (focusedIndex >= 0 && !indices.includes(focusedIndex)) indices.push(focusedIndex);
@@ -38,9 +40,16 @@ export function VirtualList<T>({ items, itemKey, renderItem, estimate = 80, labe
         event.preventDefault(); event.stopPropagation();
         setFocused({ key: itemKey(items[next]), index: next });
         virtual.scrollToIndex(next, { align: 'auto' });
-        requestAnimationFrame(() => parent.current?.querySelector<HTMLElement>(`[data-virtual-index="${next}"] button`)?.focus({ preventScroll: true }));
+        const x = (event.target as HTMLElement).getBoundingClientRect().left;
+        requestAnimationFrame(() => {
+          const buttons = Array.from(parent.current?.querySelectorAll<HTMLElement>(`[data-virtual-index="${next}"] button`) ?? []);
+          const target = preserveHorizontalFocus ? buttons.reduce<HTMLElement | undefined>((best, button) =>
+            !best || Math.abs(button.getBoundingClientRect().left - x) < Math.abs(best.getBoundingClientRect().left - x) ? button : best, undefined) : buttons[0];
+          target?.focus({ preventScroll: true });
+        });
       }}>
-      <div style={{ height: virtual.getTotalSize(), width: '100%', position: 'relative' }}>
+      <div style={{ height: virtual.getTotalSize(), width: contentWidth ?? '100%', minWidth: '100%', position: 'relative' }}>
+        {header}
         {virtual.getVirtualItems().map((row) => (
           <div key={row.key} data-index={row.index} data-virtual-index={row.index} ref={virtual.measureElement}
             onFocus={() => setFocused({ key: itemKey(items[row.index]), index: row.index })}

--- a/web/lib/cloud.ts
+++ b/web/lib/cloud.ts
@@ -2,6 +2,7 @@ import type { AuthClient } from "./auth";
 import { config, hasNetlifyBackendUrl } from "./config";
 import { parseHomeServerConnectionJson, serializeHomeServerConnectionJson } from "./homeserver";
 import { jsonRequest } from "./http";
+import { mergeTvSessions, normalizeTvSession } from "./iptvSession";
 import { normalizeIptvPlaylist as normalizeRuntimeIptvPlaylist } from "./iptv";
 import { tmdbImageUrl } from "./mediaImages";
 import type { TraktToken } from "./trakt";
@@ -523,7 +524,9 @@ function iptvFromAndroid(value: unknown, root?: RawPayload): Partial<AppSettings
           enabled: true
         }]
       : [];
-  const playlists = dedupeIptvPlaylists([
+  // An explicit per-profile playlist list is authoritative, including an empty
+  // one. Legacy mirrors can be stale or belong to a different profile.
+  const playlists = "playlists" in state ? profilePlaylists : dedupeIptvPlaylists([
     ...profilePlaylists,
     ...rootSettingsPlaylists,
     ...rootPlaylists,
@@ -532,6 +535,7 @@ function iptvFromAndroid(value: unknown, root?: RawPayload): Partial<AppSettings
   return {
     iptvPlaylists: playlists,
     favoriteChannelIds: value !== undefined ? stringArray(state.favoriteChannels) : stringArray(rootState.iptvFavoriteChannels),
+    iptvTvSession: normalizeTvSession((state as Record<string, unknown>).tvSession),
     favoriteGroupIds: value !== undefined ? stringArray(state.favoriteGroups) : stringArray(rootState.iptvFavoriteGroups),
     hiddenGroupIds: stringArray(state.hiddenGroups),
     lockedIptvGroupIds: stringArray(state.lockedGroups),
@@ -824,6 +828,7 @@ function androidIptvSettings(settings: AppSettings): Record<string, unknown> {
     stalkerPortalUrl: settings.iptvStalkerUrl,
     stalkerMacAddress: settings.iptvStalkerMac,
     favoriteChannels: settings.favoriteChannelIds,
+    tvSession: normalizeTvSession(settings.iptvTvSession),
     favoriteGroups: settings.favoriteGroupIds,
     hiddenGroups: settings.hiddenGroupIds,
     groupOrder: settings.groupOrder,
@@ -849,6 +854,10 @@ export function mergeIptvSettings(existing: Record<string, unknown>, settings: A
   const merged = { ...existing };
   for (const [field, value] of Object.entries(incoming)) {
     if (base && sameFieldValue(value, base[field])) continue;
+    if (field === "tvSession") {
+      merged[field] = mergeTvSessions(existing[field], value);
+      continue;
+    }
     merged[field] = base && field in existing && (field === "favoriteChannels" || field === "favoriteGroups")
       ? mergeFavoriteEdits(stringArray(existing[field]), stringArray(value), stringArray(base[field]))
       : value;

--- a/web/lib/iptv.ts
+++ b/web/lib/iptv.ts
@@ -885,6 +885,62 @@ function safeGuideImage(value: string): string | undefined {
   try { return value.length <= 2048 && ["https:", "http:"].includes(new URL(value).protocol) ? value : undefined; } catch { return undefined; }
 }
 
+const identityLoads = new Map<string, { expires: number; task: Promise<IptvChannel[]> }>();
+
+/** A single cached metadata request, never a stream probe or a request per channel. */
+export async function loadIptvChannelIdentities(playlists: IptvPlaylistEntry[], channels: IptvChannel[], options: IptvLoadOptions = {}) {
+  const replacements = new Map<string, IptvChannel>();
+  for (const playlist of normalizeIptvPlaylists(playlists).filter(p => p.enabled)) {
+    const scoped = channels.filter(c => c.id.startsWith(`${playlist.id}:xtream:`));
+    if (!scoped.length) continue;
+    const url = new URL(playlist.m3uUrl);
+    url.searchParams.set("output", "ts");
+    const key = `${playlist.id}:${url}`;
+    let cached = identityLoads.get(key);
+    if (!cached || cached.expires < Date.now()) {
+      const task = fetchPlaylistText(url.toString(), options)
+        .then(text => attachM3uChannelIdentities(scoped, text, playlist.id));
+      cached = { expires: Date.now() + PLAYLIST_TTL_MS, task };
+      identityLoads.set(key, cached);
+      // A provider failure must not become a render/retry loop.
+      void task.catch(() => { if (identityLoads.get(key) === cached) cached!.expires = Date.now() + 300_000; });
+      if (identityLoads.size > 12) identityLoads.delete(identityLoads.keys().next().value!);
+    }
+    try { for (const channel of await cached.task) replacements.set(channel.id, channel); }
+    catch { /* Keep API channels available when the optional identity bridge fails. */ }
+  }
+  return channels.map(channel => {
+    const identity = replacements.get(channel.id);
+    return identity?.cloudId ? { ...channel, cloudId: identity.cloudId, syncAliases: identity.syncAliases } : channel;
+  });
+}
+
+export async function attachM3uChannelIdentities(channels: IptvChannel[], text: string, playlistId: string) {
+  const byId = new Map(channels.map(c => [c.id, c]));
+  const replacements = new Map<string, IptvChannel>();
+  let epgId: string | undefined;
+  const lines = text.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    if (i > 0 && i % 500 === 0) await new Promise(resolve => setTimeout(resolve, 0));
+    const line = lines[i].trim();
+    if (line.startsWith("#EXTINF:")) { epgId = attr(line, "tvg-id"); continue; }
+    if (!line || line.startsWith("#")) continue;
+    const path = parseUrl(line)?.pathname;
+    const streamId = path?.match(/\/(\d+)(?:\.[a-z0-9]+)?$/i)?.[1];
+    const id = `${playlistId}:xtream:${streamId}`;
+    const channel = byId.get(id);
+    if (channel) {
+      const cloudId = `${playlistId}:${buildChannelId(line, epgId)}`;
+      const hlsAlias = `${playlistId}:${buildChannelId(line.replace(/\.ts(?=\?|$)/i, ".m3u8"), epgId)}`;
+      const previous = replacements.get(id);
+      replacements.set(id, { ...channel, cloudId: previous?.cloudId ?? cloudId,
+        syncAliases: [...new Set([...(previous?.syncAliases ?? []), cloudId, hlsAlias])] });
+    }
+    epgId = undefined;
+  }
+  return channels.map(channel => replacements.get(channel.id) ?? channel);
+}
+
 function parseXmltvTime(value: string) {
   const match = value.match(/^(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})\s*([+-]\d{4})?/);
   if (!match) return 0;

--- a/web/lib/iptvSession.ts
+++ b/web/lib/iptvSession.ts
@@ -1,0 +1,51 @@
+import type { IptvChannel, IptvTvSession } from "./types";
+
+export function normalizeTvSession(value: unknown): IptvTvSession {
+  let raw = value;
+  if (typeof raw === "string") { try { raw = JSON.parse(raw); } catch { raw = null; } }
+  const session = (raw && typeof raw === "object" ? raw : {}) as Partial<IptvTvSession>;
+  return {
+    lastChannelId: typeof session.lastChannelId === "string" ? session.lastChannelId : "",
+    lastGroupName: typeof session.lastGroupName === "string" ? session.lastGroupName : "",
+    lastFocusedZone: typeof session.lastFocusedZone === "string" ? session.lastFocusedZone : "GUIDE",
+    lastOpenedAt: Number.isFinite(session.lastOpenedAt) ? Math.max(0, session.lastOpenedAt!) : 0,
+    recentChannelIds: [...new Set(Array.isArray(session.recentChannelIds)
+      ? session.recentChannelIds.filter((id): id is string => typeof id === "string" && Boolean(id.trim())) : [])].slice(-40)
+  };
+}
+
+export function channelIdentityIndex(channels: IptvChannel[]): Map<string, IptvChannel> {
+  const index = new Map<string, IptvChannel>();
+  for (const channel of channels) {
+    index.set(channel.id, channel);
+    if (channel.cloudId) index.set(channel.cloudId, channel);
+    for (const alias of channel.syncAliases ?? []) index.set(alias, channel);
+  }
+  return index;
+}
+
+export function resolveChannelReferences(ids: string[], index: Map<string, IptvChannel>): IptvChannel[] {
+  const seen = new Set<string>();
+  return ids.flatMap(id => {
+    const channel = index.get(id);
+    if (!channel || seen.has(channel.id)) return [];
+    seen.add(channel.id);
+    return [channel];
+  });
+}
+
+export function recordTvPlayback(value: unknown, channel: IptvChannel, now = Date.now()): IptvTvSession {
+  const session = normalizeTvSession(value);
+  const id = channel.cloudId || channel.id;
+  const aliases = new Set([channel.id, id, ...(channel.syncAliases ?? [])]);
+  return { ...session, lastChannelId: id, lastGroupName: channel.group, lastFocusedZone: "GUIDE", lastOpenedAt: now,
+    recentChannelIds: [...session.recentChannelIds.filter(previous => !aliases.has(previous)), id].slice(-40) };
+}
+
+export function mergeTvSessions(remote: unknown, local: unknown): IptvTvSession {
+  const a = normalizeTvSession(remote), b = normalizeTvSession(local);
+  const [older, newer] = a.lastOpenedAt > b.lastOpenedAt ? [b, a] : [a, b];
+  // Preserve plays made on another device while this browser was offline.
+  return { ...newer, recentChannelIds: [...older.recentChannelIds.filter(id => !newer.recentChannelIds.includes(id)),
+    ...newer.recentChannelIds].slice(-40) };
+}

--- a/web/lib/store.tsx
+++ b/web/lib/store.tsx
@@ -15,7 +15,8 @@ import { playbackPlan } from "./streamCompatibility";
 import { prepareBrowserStream } from "./prepareBrowserStream";
 import { reportHomeServerPlayback } from "./homeServerPlayback";
 import { loadHomeServerRows } from "./homeserver";
-import { buildXtreamCatchupUrl, iptvPlaylistSignature, loadIptvGuideForChannels, loadIptvSnapshot, loadPlaylists, migrateXtreamFavoriteIds, savePlaylists } from "./iptv";
+import { buildXtreamCatchupUrl, iptvPlaylistSignature, loadIptvChannelIdentities, loadIptvGuideForChannels, loadIptvSnapshot, loadPlaylists, savePlaylists } from "./iptv";
+import { recordTvPlayback } from "./iptvSession";
 import { dedupeMedia, historyToItem, hydrateTraktItems, traktItemToMedia, traktPlaybackToMedia, traktUpNextToMedia } from "./mappers";
 import { loadStored, purgeLegacyStorage, removeStored, saveStored } from "./storage";
 import { getDetails, getSeasonEpisodes, loadCatalog, searchMedia, resolveTmdbId } from "./tmdb";
@@ -515,6 +516,7 @@ export interface AppStore {
   playStream: (stream: StreamSource, options?: { forceTranscode?: boolean; forceRemux?: boolean; forceBrowser?: boolean }) => void;
   playTrailer: (item: MediaItem) => Promise<void>;
   playChannel: (channel: IptvChannel) => void;
+  recordChannelPlayback: (channel: IptvChannel) => void;
   playCatchup: (channel: IptvChannel, program: IptvProgram) => void;
   closePlayer: () => void;
   installAddon: (url: string) => Promise<void>;
@@ -858,6 +860,7 @@ export function AppProvider({
           catalogs: mergeCatalogs(cloud.settings?.catalogs ?? currentSettings.catalogs, cloud.settings?.hiddenCatalogIds ?? currentSettings.hiddenCatalogIds),
           iptvPlaylists: cloud.settings?.iptvPlaylists ?? currentSettings.iptvPlaylists,
           favoriteChannelIds: cloud.settings?.favoriteChannelIds ?? currentSettings.favoriteChannelIds,
+          iptvTvSession: cloud.settings?.iptvTvSession ?? currentSettings.iptvTvSession,
           favoriteGroupIds: cloud.settings?.favoriteGroupIds ?? currentSettings.favoriteGroupIds,
           hiddenGroupIds: cloud.settings?.hiddenGroupIds ?? currentSettings.hiddenGroupIds,
           lockedIptvGroupIds: cloud.settings?.lockedIptvGroupIds ?? currentSettings.lockedIptvGroupIds,
@@ -1155,14 +1158,18 @@ export function AppProvider({
   }, []);
 
   useEffect(() => {
-    if (iptvSnapshot.signature !== iptvPlaylistSignature(settings.iptvPlaylists)) return;
-    const migrated = migrateXtreamFavoriteIds(settings.favoriteChannelIds, iptvSnapshot.allChannels ?? iptvSnapshot.channels);
-    if (migrated === settings.favoriteChannelIds) return;
-    setSettings((current) => ({
-      ...current,
-      favoriteChannelIds: migrateXtreamFavoriteIds(current.favoriteChannelIds, iptvSnapshot.allChannels ?? iptvSnapshot.channels)
-    }));
-  }, [iptvSnapshot, settings.iptvPlaylists, settings.favoriteChannelIds]);
+    const channels = iptvSnapshot.allChannels ?? iptvSnapshot.channels;
+    if (!channels.length || iptvSnapshot.identitiesLoaded || iptvSnapshot.signature !== iptvPlaylistSignature(settings.iptvPlaylists)) return;
+    let cancelled = false;
+    const profileId = activeProfileId;
+    void loadIptvChannelIdentities(settings.iptvPlaylists, channels, { userAgent: settings.customUserAgent }).then(enriched => {
+      if (cancelled || activeProfileIdRef.current !== profileId) return;
+      const byId = new Map(enriched.map(channel => [channel.id, channel]));
+      setIptvSnapshot(current => ({ ...current, identitiesLoaded: true, allChannels: enriched,
+        channels: current.channels.map(channel => byId.get(channel.id) ?? channel) }));
+    });
+    return () => { cancelled = true; };
+  }, [iptvSnapshot.allChannels, iptvSnapshot.channels, iptvSnapshot.signature, iptvSnapshot.identitiesLoaded, settings.iptvPlaylists, settings.customUserAgent, activeProfileId]);
 
   const loadIptvGuide = useCallback(async (channels: IptvChannel[]) => {
     if (!channels.length) return;
@@ -1792,6 +1799,10 @@ export function AppProvider({
     return true;
   }, []);
 
+  const recordChannelPlayback = useCallback((channel: IptvChannel) => {
+    setSettings(current => ({ ...current, iptvTvSession: recordTvPlayback(current.iptvTvSession, channel) }));
+  }, []);
+
   const playChannel = useCallback((channel: IptvChannel) => {
     playbackPreparation.current?.abort();
     stopOwnedPlayback();
@@ -1805,10 +1816,11 @@ export function AppProvider({
       description: channel.group,
       behaviorHints: { proxyHeaders: { request: channel.requestHeaders } }
     };
+    recordChannelPlayback(channel);
     if (openLiveExternally(stream, channel.name)) return;
     setActiveChannel(channel);
     setActiveStream(stream);
-  }, [openLiveExternally]);
+  }, [openLiveExternally, recordChannelPlayback]);
 
   // Catch-up plays a finished programme from the panel's archive. It is a
   // seekable VOD stream (no activeChannel → scrubber works), but the player
@@ -2485,6 +2497,7 @@ export function AppProvider({
     playStream,
     playTrailer,
     playChannel,
+    recordChannelPlayback,
     playCatchup,
     closePlayer,
     installAddon,
@@ -2514,7 +2527,7 @@ export function AppProvider({
     selectProfile, createProfile, updateProfileAction, deleteProfileAction, switchProfile, goToLogin, backToProfiles,
     section, categories, catalogConfigs, loadCatalogRow, homeServerRows, continueWatching, watchlist, isWatched, hero, heroPreview, selected, streams, selectedEpisode, loadEpisodeStreams, advanceEpisode, activeStream, activeChannel,
     addons, addonsReady, iptvSnapshot, query, results, searchState, settingsSyncState, settings, auth, traktConnected, mdblistConnected, simklConnected, trackingPreferences, deviceCode, simklDeviceCode, busy, toast,
-    updateSettings, refreshData, openDetails, closeDetails, playStream, playTrailer, playChannel, playCatchup, closePlayer,
+    updateSettings, refreshData, openDetails, closeDetails, playStream, playTrailer, playChannel, recordChannelPlayback, playCatchup, closePlayer,
     refreshIptv, loadIptvGuide,
     installAddon, removeAddon, setAddonsState, signIn, signOut, beginTrakt, pollTrakt, disconnectTrakt,
     connectMdblist, disconnectMdblist, beginSimkl, pollSimkl, disconnectSimkl, updateTrackingPreferences,

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -334,7 +334,19 @@ export interface IptvPlaylistEntry {
   enabled: boolean;
 }
 
+export interface IptvTvSession {
+  lastChannelId: string;
+  lastGroupName: string;
+  lastFocusedZone: string;
+  lastOpenedAt: number;
+  /** Android stores oldest first, most recently played last. */
+  recentChannelIds: string[];
+}
+
 export interface IptvChannel {
+  /** Exact provider-playlist identity used by Android cloud sync. */
+  cloudId?: string;
+  syncAliases?: string[];
   requestHeaders?: Record<string, string>;
   id: string;
   name: string;
@@ -370,6 +382,7 @@ export interface IptvNowNext {
 }
 
 export interface IptvSnapshot {
+  identitiesLoaded?: boolean;
   allChannels?: IptvChannel[];
   channels: IptvChannel[];
   grouped: Record<string, IptvChannel[]>;
@@ -490,6 +503,7 @@ export interface AppSettings {
   iptvStalkerUrl: string;
   iptvStalkerMac: string;
   favoriteChannelIds: string[];
+  iptvTvSession?: IptvTvSession;
   favoriteGroupIds: string[];
   hiddenGroupIds: string[];
   /** Read from cloud; locked IPTV groups are not exposed without a PIN flow. */

--- a/web/tests/browser-playback-integration.test.cjs
+++ b/web/tests/browser-playback-integration.test.cjs
@@ -222,7 +222,7 @@ function storeHarness(prepare, report = async () => {}, overrides = {}) {
     prepareBrowserStream: prepare, reportHomeServerPlayback: report,
     setActiveChannel: () => {}, setActiveStream: (value) => { state.active = value; state.accepted.push(value); },
     setToast: (value) => state.toasts.push(value),
-    openLiveExternally: () => false, buildXtreamCatchupUrl: () => 'https://iptv.example/archive.m3u8',
+    openLiveExternally: () => false, recordChannelPlayback: () => {}, buildXtreamCatchupUrl: () => 'https://iptv.example/archive.m3u8',
     window: { setTimeout: (fn) => { const id = state.timers.size + 1; state.timers.set(id, fn); return id; }, clearTimeout: (id) => state.timers.delete(id) },
     ...overrides
   };

--- a/web/tests/iptv-session.test.cjs
+++ b/web/tests/iptv-session.test.cjs
@@ -1,0 +1,46 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const { load, storage } = require('./load.cjs');
+const session = load('lib/iptvSession.ts');
+const iptv = load('lib/iptv.ts', { './storage': storage(), './http': {} });
+const plain = value => JSON.parse(JSON.stringify(value));
+const m3uId = (url, epg) => `list_1:m3u:${epg}:${url.length}-${crypto.createHash('sha1').update(url).digest('hex').slice(0,16)}`;
+
+test('custom provider stream paths resolve exactly without confusing HD variants or another provider', async () => {
+  const url = 'https://provider.invalid/custom/relay/live/user/pass/101.ts';
+  const channels = [{ id: 'list_1:xtream:101', name: 'NPO 1 HD' }, { id: 'list_1:xtream:102', name: 'NPO 1 UHD' }, { id: 'list_2:xtream:101', name: 'Other provider' }];
+  const enriched = await iptv.attachM3uChannelIdentities(channels, `#EXTM3U\n#EXTINF:-1 tvg-id="npo1.nl",NPO 1 HD\n${url}`, 'list_1');
+  const index = session.channelIdentityIndex(enriched);
+  const id = m3uId(url, 'npo1.nl');
+  assert.equal(index.get(id).id, 'list_1:xtream:101');
+  assert.equal(index.get(id).cloudId, id);
+  assert.equal(index.get(id.replace('list_1:', 'list_2:')), undefined);
+  assert.deepEqual(plain(session.resolveChannelReferences([id, channels[0].id, 'unavailable'], index)).map(c=>c.id), ['list_1:xtream:101']);
+  assert.equal(enriched[1].cloudId, undefined);
+});
+
+test('web playback uses Android identity, deduplicates aliases and keeps oldest-first history capped at 40', () => {
+  const channel = { id: 'list_1:xtream:10', cloudId: 'list_1:m3u:exact', group: 'Sports', syncAliases: ['list_1:m3u:old'] };
+  const result = session.recordTvPlayback({ recentChannelIds: ['one', channel.id, 'two', 'list_1:m3u:old'] }, channel, 200);
+  assert.deepEqual(plain(result.recentChannelIds), ['one', 'two', channel.cloudId]);
+  assert.equal(result.lastOpenedAt, 200);
+  assert.equal(result.lastChannelId, channel.cloudId);
+  const full = session.recordTvPlayback({recentChannelIds: Array.from({length:40},(_,i)=>String(i))},channel);
+  assert.equal(full.recentChannelIds.length, 40);
+  assert.equal(full.recentChannelIds[0], '1');
+});
+
+test('concurrent sessions keep both devices plays and the genuinely newest last channel', () => {
+  const remote = { lastChannelId: 'tv-new', lastOpenedAt: 300, recentChannelIds: ['shared','tv-new'] };
+  const local = { lastChannelId: 'web-new', lastOpenedAt: 200, recentChannelIds: ['shared','web-new'] };
+  const merged = session.mergeTvSessions(remote, local);
+  assert.equal(merged.lastChannelId, 'tv-new');
+  assert.deepEqual(plain(merged.recentChannelIds), ['web-new','shared','tv-new']);
+  assert.equal(session.mergeTvSessions(remote, undefined).lastChannelId, 'tv-new');
+});
+
+test('malformed TV history is normalized rather than crashing the guide', () => {
+  assert.deepEqual(plain(session.normalizeTvSession('{bad').recentChannelIds), []);
+  assert.deepEqual(plain(session.normalizeTvSession({recentChannelIds:[null,3,'a','a','']})).recentChannelIds, ['a']);
+});

--- a/web/tests/iptv-sync.test.cjs
+++ b/web/tests/iptv-sync.test.cjs
@@ -121,6 +121,26 @@ test('Settings mutations fetch fresh cloud data even after a cached pull', async
   assert.deepEqual(f.remote.iptvByProfile.arvind.favoriteChannels, ['tv-new']);
 });
 
+test('profile playlists override legacy mirrors, including deleted playlists and other profiles', async () => {
+  const current = playlist();
+  const f = fixture({ settings: { iptvPlaylists: [current, playlist('stale')] }, iptvM3uUrl: current.m3uUrl,
+    iptvByProfile: { arvind: { playlists: [current] }, child: { playlists: [] } } });
+  assert.deepEqual(Array.from((await f.cloud.pullCloudPayload(auth, 'arvind')).settings.iptvPlaylists, p => p.id), ['list_1']);
+  assert.deepEqual(Array.from((await f.cloud.pullCloudPayload(auth, 'child')).settings.iptvPlaylists), []);
+});
+
+test('Android recent history pulls and web playback round-trips without overwriting newer TV plays', async () => {
+  const remote = { lastChannelId: 'tv', lastOpenedAt: 300, recentChannelIds: ['old', 'tv'] };
+  const f = fixture({ iptvByProfile: { arvind: { playlists: [playlist()], tvSession: remote } } });
+  const pulled = (await f.cloud.pullCloudPayload(auth, 'arvind')).settings;
+  assert.equal(pulled.iptvTvSession.lastChannelId, 'tv');
+  assert.deepEqual(Array.from(pulled.iptvTvSession.recentChannelIds), ['old', 'tv']);
+  await f.cloud.saveCloudSettings(auth, settings({ iptvTvSession: { lastChannelId: 'web', lastOpenedAt: 200, recentChannelIds: ['old', 'web'] } }), [], 'arvind', [], settings());
+  assert.equal(f.remote.iptvByProfile.arvind.tvSession.lastChannelId, 'tv');
+  assert.ok(f.remote.iptvByProfile.arvind.tvSession.recentChannelIds.includes('web'));
+  assert.ok(f.remote.fieldUpdatedAt['i:arvind:tvSession'] > 0);
+});
+
 test('A HTTP 200 rejected cloud save stays in the durable outbox and succeeds on retry', async () => {
   const f = fixture();
   const outbox = load('lib/settingsOutbox.ts', { './storage': storage(), './cloud': f.cloud });

--- a/web/tests/load.cjs
+++ b/web/tests/load.cjs
@@ -8,7 +8,7 @@ exports.load = (relative, mocks = {}, globals = {}) => {
   const code = ts.transpileModule(fs.readFileSync(filename, 'utf8'), { compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022, esModuleInterop: true } }).outputText;
   const module = { exports: {} };
   vm.runInNewContext(code, {
-    module, exports: module.exports, require: (name) => { if (name in mocks) return mocks[name]; if (name.startsWith('node:') || ['ipaddr.js', 'undici'].includes(name)) return require(name); throw new Error(`Unmocked dependency ${name}`); },
+    module, exports: module.exports, require: (name) => { if (name in mocks) return mocks[name]; if (name === './iptvSession') return exports.load('lib/iptvSession.ts'); if (name.startsWith('node:') || ['ipaddr.js', 'undici'].includes(name)) return require(name); throw new Error(`Unmocked dependency ${name}`); },
     URL, URLSearchParams, Headers, Request, Response, ReadableStream, TextEncoder, TextDecoder, Uint8Array, Buffer, Date, Map, Set, AbortController, AbortSignal, structuredClone, setTimeout, clearTimeout, atob, btoa, crypto: crypto.webcrypto, console, process: { env: {} }, ...globals
   }, { filename });
   return module.exports;


### PR DESCRIPTION
## Summary
- Resolve exact Android M3U channel identities against the web Xtream catalog using one cached playlist-metadata bridge, with no channel stream probes.
- Read/write profile-scoped TV sessions and show Recently Watched, preserving concurrent device plays.
- Stop resurrecting legacy playlists alongside authoritative profile playlists.
- Align guide/sidebar layout with TV, keep channel names fixed during timeline scroll, preserve keyboard focus and add mobile drawer dismissal.
- Fetch catch-up archives only on request.

## Verification
- Real account/provider metadata resolves exactly 3 favorites and 12 recent channels, including HD/UHD variants.
- 558 web regression tests pass; TypeScript passes.
- Browser checks at desktop, 1024px tablet and 390px phone widths; favorite removal/reordering verified.
- 55,000-channel fixture: End navigation reaches final channel with 11 rendered rows.
- No TV controls used and no account favorites modified during testing.