### PR TITLE
fix(web): keep navigation available during docked live playback

### DIFF
--- a/web/app/tv-guide.css
+++ b/web/app/tv-guide.css
@@ -1,4 +1,5 @@
 /* TV workspace: shared charcoal surfaces, independent selected/focused states. */
+.app-shell:has(.player-overlay:not(.player-docked)) > :is(.sidebar, .mobile-header, .mobile-bottom-nav) { visibility: hidden; pointer-events: none; }
 .player-overlay.player-docked { z-index: 40; border-radius: 4px; overflow: hidden; background: #080808; }
 .player-overlay.player-docked > .player-top, .player-overlay.player-docked > .player-controls,
 .player-overlay.player-docked > .player-panel { display: none; }

--- a/web/components/shell/AppShell.tsx
+++ b/web/components/shell/AppShell.tsx
@@ -30,7 +30,7 @@ const ACCENTS: Record<string, string> = {
 };
 
 export function AppShell() {
-  const { view, section, settings, selected, activeStream } = useApp();
+  const { view, section, settings, selected, activeStream, activeChannel } = useApp();
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
@@ -88,7 +88,7 @@ export function AppShell() {
       className={`app-shell ${settings.oledBlack ? "oled" : ""} ${settings.spoilerBlur ? "spoiler-blur" : ""}`}
       style={{ ["--accent" as string]: accent }}
     >
-      {!activeStream && <TopNav />}
+      {(!activeStream || (section === "tv" && activeChannel)) && <TopNav />}
 
       <section className="content">
         {selected ? (


### PR DESCRIPTION
Follow-up to #680: retain the shared navigation while a live TV channel plays in the dock. Full-screen player mode hides the navigation and removes it from keyboard access using visibility:hidden. Existing VOD navigation behavior is unchanged. TypeScript validation passes.