### PR TITLE
fix(web): prevent cloud hydration switching the selected profile

### DIFF
--- a/web/lib/profiles.ts
+++ b/web/lib/profiles.ts
@@ -1,5 +1,12 @@
 import type { Profile } from "./types";
 
+/** Cloud shares profiles, not which person is currently using this device. */
+export function hydratedProfileId(localId: string | null, profiles: Pick<Profile, "id">[], cloudId?: string | null): string | null {
+  if (localId && profiles.some(profile => profile.id === localId)) return localId;
+  if (cloudId && profiles.some(profile => profile.id === cloudId)) return cloudId;
+  return profiles[0]?.id ?? null;
+}
+
 /** Netflix-style profile colors — mirrors Android ProfileColors.colors (ARGB longs). */
 export const profileColors = [
   0xffe50914, // Netflix Red

--- a/web/lib/store.tsx
+++ b/web/lib/store.tsx
@@ -21,6 +21,7 @@ import { dedupeMedia, historyToItem, hydrateTraktItems, traktItemToMedia, traktP
 import { loadStored, purgeLegacyStorage, removeStored, saveStored } from "./storage";
 import { getDetails, getSeasonEpisodes, loadCatalog, searchMedia, resolveTmdbId } from "./tmdb";
 import { verifyProfilePin } from "./profilePin";
+import { hydratedProfileId } from "./profiles";
 import { flushSettingsOutbox, hasPendingSettings, queueSettings } from "./settingsOutbox";
 import type { MetadataProviderId, ProviderPriorityConfig } from "./metadata/types";
 import { TraktClient, type TraktDeviceCode } from "./trakt";
@@ -1377,13 +1378,12 @@ export function AppProvider({
         if (cloud.profiles.length) {
           setProfiles(cloud.profiles);
           setAvatarImages(cloud.avatarImages);
-          if (cloud.activeProfileId) {
-            setActiveProfileId(cloud.activeProfileId);
-            void refreshData(cloud.activeProfileId);
-          } else if (cloud.profiles[0]) {
-            setActiveProfileId(cloud.profiles[0].id);
-            void refreshData(cloud.profiles[0].id);
-          }
+          // Read the current selection when the request completes: a user may
+          // have chosen a profile while this older cloud snapshot was loading.
+          const selectedId = hydratedProfileId(activeProfileIdRef.current, cloud.profiles, cloud.activeProfileId);
+          activeProfileIdRef.current = selectedId;
+          setActiveProfileId(selectedId);
+          void refreshData(selectedId);
         } else {
           // New account with no cloud profiles yet. If the local profiles were
           // stamped for a DIFFERENT account, they leaked from a previous
@@ -1395,7 +1395,7 @@ export function AppProvider({
             saveStored(PROFILES_OWNER_KEY, currentAccountEmail());
             void refreshData(fresh[0].id);
           } else {
-            void refreshData(activeProfileId);
+            void refreshData(activeProfileIdRef.current);
           }
         }
         setCloudProfilesHydrated(true);
@@ -1406,7 +1406,7 @@ export function AppProvider({
     return () => {
       cancelled = true;
     };
-  }, [activeProfileId, auth, refreshData]);
+  }, [auth, refreshData]);
 
   useEffect(() => {
     let current = true;

--- a/web/tests/tv-polish.test.cjs
+++ b/web/tests/tv-polish.test.cjs
@@ -31,3 +31,13 @@ test('production build refuses masked values before starting Next', () => {
   assert.equal(result.status, 1);
   assert.match(result.stderr, /refusing production build/);
 });
+
+test('late cloud hydration keeps the profile selected on this device', () => {
+  const { hydratedProfileId } = load('lib/profiles.ts');
+  const profiles = [{ id: 'arvind' }, { id: 'shai' }];
+  assert.equal(hydratedProfileId('arvind', profiles, 'shai'), 'arvind');
+  assert.equal(hydratedProfileId('shai', profiles, 'arvind'), 'shai');
+  assert.equal(hydratedProfileId('deleted', profiles, 'shai'), 'shai');
+  assert.equal(hydratedProfileId(null, profiles, 'missing'), 'arvind');
+  assert.equal(hydratedProfileId('deleted', [], 'missing'), null);
+});


### PR DESCRIPTION
Live production testing found cloud hydration switching Arvind to the remote active Shai profile, leaving IPTV empty. Preserve the current device selection if it exists in the cloud profiles, read it at request completion, and avoid rehydrating profile selection on each click. Added regression coverage for both device choices and deleted-profile fallback. TypeScript and targeted tests pass.