### PR TITLE
feat(tv): restore fullscreen zapping and give the remote a TiviMate-style key plan

### DIFF
--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/FullscreenHud.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/FullscreenHud.kt
@@ -36,11 +36,13 @@ import androidx.compose.material.icons.filled.SkipPrevious
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -74,9 +76,9 @@ import java.util.Locale
 /**
  * Fullscreen playback HUD matching the full-width reference player layout.
  * Auto-hides 5s after the last `pokeSignal` bump; `hideSignal` dismisses it straight away (Back).
- * Focus lands on the central Play/Pause button only while `focusControls` is set — surfacing after a
- * channel zap is informational, so the arrow keys stay with playback until the user opens the
- * controls deliberately.
+ * With `showControls` off the seek bar and the button row are not composed at all: what surfaces on
+ * its own after a channel zap is then pure information with nothing focusable in it. With it on the
+ * controls are drawn and focused in the same breath, so anything visible is always operable.
  */
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
@@ -103,15 +105,21 @@ fun FullscreenHud(
     onOpenQuickZap: (() -> Unit)? = null,
     onVisibilityChanged: ((Boolean) -> Unit)? = null,
     hideSignal: Int = 0,
-    focusControls: Boolean = true,
+    showControls: Boolean = true,
     modifier: Modifier = Modifier,
 ) {
     var visible by remember { mutableStateOf(true) }
     var lastPoke by remember { mutableLongStateOf(System.currentTimeMillis()) }
 
-    androidx.compose.runtime.DisposableEffect(onVisibilityChanged) {
+    // Keyed on Unit, never on the callback: a caller that hands in a fresh
+    // lambda per recomposition would otherwise have this effect torn down and
+    // rebuilt constantly, reporting "hidden" each time. This HUD redraws every
+    // second for the clock, so that would fire relentlessly — and the caller
+    // uses the report to drop out of control mode.
+    val latestVisibilityChanged = rememberUpdatedState(onVisibilityChanged)
+    DisposableEffect(Unit) {
         onDispose {
-            onVisibilityChanged?.invoke(false)
+            latestVisibilityChanged.value?.invoke(false)
         }
     }
 
@@ -148,11 +156,11 @@ fun FullscreenHud(
         }
     }
 
-    // Take the focus ONLY once the caller says the user engaged the controls.
-    // Surfacing after a zap is informational, so the arrow keys must stay with
-    // playback instead of being swallowed by the button row.
-    LaunchedEffect(visible, focusControls) {
-        if (visible && focusControls && !initialFocusApplied) {
+    // Whenever the controls are on screen they are focused, so "visible" and
+    // "operable" can never disagree — showing buttons that ignore the remote is
+    // what the first device test rightly called broken.
+    LaunchedEffect(visible, showControls) {
+        if (visible && showControls && !initialFocusApplied) {
             initialFocusApplied = true
             delay(100)
             runCatching {
@@ -418,109 +426,115 @@ fun FullscreenHud(
                     }
                 }
 
-                // --- Row 2: Full-Width Seek Bar with Scrubber Ball ---
-                HudSeekBar(
-                    progress = progress,
-                    positionMs = elapsedShowMs,
-                    durationMs = totalShowMs,
-                    onSeekToPosition = onSeekToPosition,
-                    onOpenQuickZap = onOpenQuickZap,
-                )
+                // Seek bar and control buttons together are "the controls".
+                // On a remote they appear only once the user asks for them with
+                // OK, so that what surfaces on its own carries no focusable
+                // element at all and cannot look operable while it is not.
+                if (showControls) {
+                    // --- Row 2: Full-Width Seek Bar with Scrubber Ball ---
+                    HudSeekBar(
+                        progress = progress,
+                        positionMs = elapsedShowMs,
+                        durationMs = totalShowMs,
+                        onSeekToPosition = onSeekToPosition,
+                        onOpenQuickZap = onOpenQuickZap,
+                    )
 
-                // --- Row 3: Bottom Control Bar (Exact Centering & Time on Left) ---
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(56.dp),
-                ) {
-                    // Left Side: Time Text below Seek Bar
+                    // --- Row 3: Bottom Control Bar (Exact Centering & Time on Left) ---
                     Box(
-                        modifier = Modifier.align(Alignment.CenterStart),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(56.dp),
                     ) {
-                        Text(
-                            text = positionText,
-                            style = LiveType.TimeMono.copy(
-                                color = Color.White.copy(alpha = 0.85f),
-                                fontSize = 14.sp,
-                                fontWeight = FontWeight.Medium,
-                            ),
-                        )
-                    }
-
-                    // EXACT CENTER: Playback Controls Bar
-                    Row(
-                        modifier = Modifier.align(Alignment.Center),
-                        horizontalArrangement = Arrangement.spacedBy(16.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        // Previous channel (|<)
-                        HudIconButton(
-                            icon = Icons.Filled.SkipPrevious,
-                            contentDescription = stringResource(R.string.live_cd_previous_channel),
-                            onClick = { onPreviousCatchupClick?.invoke() },
-                        )
-
-                        // Rewind (<<)
-                        HudIconButton(
-                            icon = Icons.Filled.FastRewind,
-                            contentDescription = stringResource(R.string.live_cd_rewind),
-                            onClick = { onRewindClick?.invoke() },
-                        )
-
-                        // Central Play/Pause button (Instant local state toggle!)
-                        HudIconButton(
-                            icon = if (localIsPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
-                            contentDescription = stringResource(if (localIsPlaying) R.string.live_cd_pause else R.string.play),
-                            emphasis = true,
-                            focusRequester = playPauseFocusRequester,
-                            onClick = {
-                                localIsPlaying = !localIsPlaying
-                                onPlayPauseClick?.invoke()
-                            },
-                        )
-
-                        // Fast Forward (>>)
-                        HudIconButton(
-                            icon = Icons.Filled.FastForward,
-                            contentDescription = stringResource(R.string.live_cd_fast_forward),
-                            onClick = { onFastForwardClick?.invoke() },
-                        )
-
-                        // Next channel (>|)
-                        HudIconButton(
-                            icon = Icons.Filled.SkipNext,
-                            contentDescription = stringResource(R.string.live_cd_next_channel),
-                            onClick = { onNextCatchupClick?.invoke() },
-                        )
-                    }
-
-                    // Right Side: Replay, LIVE, GUIDE
-                    Row(
-                        modifier = Modifier.align(Alignment.CenterEnd),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        // Replay / Restart
-                        HudIconButton(
-                            icon = Icons.Filled.Replay,
-                            contentDescription = stringResource(R.string.live_cd_replay),
-                            onClick = { onReplayClick?.invoke() },
-                        )
-
-                        // LIVE button
-                        if (isCatchupMode) {
-                            HudActionButton(
-                                label = stringResource(R.string.live_badge_live),
-                                onClick = { onGoLiveClick?.invoke() },
+                        // Left Side: Time Text below Seek Bar
+                        Box(
+                            modifier = Modifier.align(Alignment.CenterStart),
+                        ) {
+                            Text(
+                                text = positionText,
+                                style = LiveType.TimeMono.copy(
+                                    color = Color.White.copy(alpha = 0.85f),
+                                    fontSize = 14.sp,
+                                    fontWeight = FontWeight.Medium,
+                                ),
                             )
                         }
 
-                        // Guide button at far right
-                        if (onGuideClick != null) {
-                            HudActionButton(
-                                label = stringResource(R.string.live_btn_guide),
-                                onClick = onGuideClick,
+                        // EXACT CENTER: Playback Controls Bar
+                        Row(
+                            modifier = Modifier.align(Alignment.Center),
+                            horizontalArrangement = Arrangement.spacedBy(16.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            // Previous channel (|<)
+                            HudIconButton(
+                                icon = Icons.Filled.SkipPrevious,
+                                contentDescription = stringResource(R.string.live_cd_previous_channel),
+                                onClick = { onPreviousCatchupClick?.invoke() },
                             )
+
+                            // Rewind (<<)
+                            HudIconButton(
+                                icon = Icons.Filled.FastRewind,
+                                contentDescription = stringResource(R.string.live_cd_rewind),
+                                onClick = { onRewindClick?.invoke() },
+                            )
+
+                            // Central Play/Pause button (Instant local state toggle!)
+                            HudIconButton(
+                                icon = if (localIsPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+                                contentDescription = stringResource(if (localIsPlaying) R.string.live_cd_pause else R.string.play),
+                                emphasis = true,
+                                focusRequester = playPauseFocusRequester,
+                                onClick = {
+                                    localIsPlaying = !localIsPlaying
+                                    onPlayPauseClick?.invoke()
+                                },
+                            )
+
+                            // Fast Forward (>>)
+                            HudIconButton(
+                                icon = Icons.Filled.FastForward,
+                                contentDescription = stringResource(R.string.live_cd_fast_forward),
+                                onClick = { onFastForwardClick?.invoke() },
+                            )
+
+                            // Next channel (>|)
+                            HudIconButton(
+                                icon = Icons.Filled.SkipNext,
+                                contentDescription = stringResource(R.string.live_cd_next_channel),
+                                onClick = { onNextCatchupClick?.invoke() },
+                            )
+                        }
+
+                        // Right Side: Replay, LIVE, GUIDE
+                        Row(
+                            modifier = Modifier.align(Alignment.CenterEnd),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            // Replay / Restart
+                            HudIconButton(
+                                icon = Icons.Filled.Replay,
+                                contentDescription = stringResource(R.string.live_cd_replay),
+                                onClick = { onReplayClick?.invoke() },
+                            )
+
+                            // LIVE button
+                            if (isCatchupMode) {
+                                HudActionButton(
+                                    label = stringResource(R.string.live_badge_live),
+                                    onClick = { onGoLiveClick?.invoke() },
+                                )
+                            }
+
+                            // Guide button at far right
+                            if (onGuideClick != null) {
+                                HudActionButton(
+                                    label = stringResource(R.string.live_btn_guide),
+                                    onClick = onGuideClick,
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/FullscreenHud.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/FullscreenHud.kt
@@ -73,8 +73,10 @@ import java.util.Locale
 
 /**
  * Fullscreen playback HUD matching the full-width reference player layout.
- * Auto-hides 5s after the last `pokeSignal` bump; parent bumps the counter on any DPAD key so the HUD re-surfaces.
- * Initial focus immediately lands on the central Play/Pause button when surfaced from hidden state.
+ * Auto-hides 5s after the last `pokeSignal` bump; `hideSignal` dismisses it straight away (Back).
+ * Focus lands on the central Play/Pause button only while `focusControls` is set — surfacing after a
+ * channel zap is informational, so the arrow keys stay with playback until the user opens the
+ * controls deliberately.
  */
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
@@ -100,6 +102,8 @@ fun FullscreenHud(
     onSeekToPosition: ((Long) -> Unit)? = null,
     onOpenQuickZap: (() -> Unit)? = null,
     onVisibilityChanged: ((Boolean) -> Unit)? = null,
+    hideSignal: Int = 0,
+    focusControls: Boolean = true,
     modifier: Modifier = Modifier,
 ) {
     var visible by remember { mutableStateOf(true) }
@@ -136,9 +140,19 @@ fun FullscreenHud(
     val playPauseFocusRequester = remember { FocusRequester() }
     var initialFocusApplied by remember { mutableStateOf(false) }
 
-    // Request initial focus ONLY when HUD first becomes visible from hidden state
-    LaunchedEffect(visible) {
-        if (visible && !initialFocusApplied) {
+    // Dismiss on request (Back), without leaving fullscreen.
+    LaunchedEffect(hideSignal) {
+        if (hideSignal > 0) {
+            visible = false
+            onVisibilityChanged?.invoke(false)
+        }
+    }
+
+    // Take the focus ONLY once the caller says the user engaged the controls.
+    // Surfacing after a zap is informational, so the arrow keys must stay with
+    // playback instead of being swallowed by the button row.
+    LaunchedEffect(visible, focusControls) {
+        if (visible && focusControls && !initialFocusApplied) {
             initialFocusApplied = true
             delay(100)
             runCatching {

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/FullscreenHud.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/FullscreenHud.kt
@@ -159,15 +159,33 @@ fun FullscreenHud(
     // Whenever the controls are on screen they are focused, so "visible" and
     // "operable" can never disagree — showing buttons that ignore the remote is
     // what the first device test rightly called broken.
+    //
+    // The flag records that focus actually *landed*, not that it was attempted,
+    // and it clears whenever the controls leave the screen. Both matter:
+    //  - Opening the controls from a bare screen flips `visible` and
+    //    `showControls` in the same breath, so this effect is relaunched a
+    //    second time while the first run still waits for the row to attach.
+    //    Marking the attempt up front made that second run believe the work was
+    //    done, while the cancelled first run never got to ask — the bar appeared
+    //    and ignored the remote. Opening it while the info bar was already up
+    //    changes only one key, so that path worked and hid the other one.
+    //  - Closing the controls with Back and opening them again leaves `visible`
+    //    untouched, so a flag that only cleared on `!visible` would have stayed
+    //    set and swallowed the second open the same way.
+    // Retrying costs nothing once focus has landed, and covers the row simply
+    // not being attached yet on the frame the HUD fades in.
     LaunchedEffect(visible, showControls) {
-        if (visible && showControls && !initialFocusApplied) {
-            initialFocusApplied = true
-            delay(100)
-            runCatching {
-                playPauseFocusRequester.requestFocus()
-            }
-        } else if (!visible) {
+        if (!visible || !showControls) {
             initialFocusApplied = false
+        } else {
+            var attempts = 0
+            while (!initialFocusApplied && attempts < ControlFocusAttempts) {
+                attempts++
+                delay(ControlFocusRetryMs)
+                if (runCatching { playPauseFocusRequester.requestFocus() }.isSuccess) {
+                    initialFocusApplied = true
+                }
+            }
         }
     }
 
@@ -727,3 +745,9 @@ private fun HudActionButton(
         )
     }
 }
+
+// The control row is asked for focus until it answers: on the frame the HUD
+// fades in from nothing the row may not be attached yet. Ten tries 50 ms apart
+// is half a second at the outside, and it stops at the first one that lands.
+private const val ControlFocusAttempts = 10
+private const val ControlFocusRetryMs = 50L

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvScreen.kt
@@ -165,6 +165,11 @@ private const val GuidePagedLoadStepRows = 192
 private const val GuideVisibleFirstRows = 28
 private const val GuideVisibleFirstRowsAllChannels = 18
 private const val CatchupSeekStepMs = 30_000L
+
+// Fullscreen zapping talks to the network on every step (stream resolve +
+// prepare), so a held or bouncing channel key must not turn into a burst of
+// requests. One step per this interval is still far faster than anyone zaps.
+private const val MinZapIntervalMs = 150L
 private const val CatchupUrlAnchorGranularityMs = 60_000L
 private const val IptvPlaybackUserAgent = "VLC/3.0.20 LibVLC/3.0.20"
 private const val VisibleGuidePastWindowMs = 48L * 60L * 60_000L
@@ -1077,6 +1082,12 @@ fun LiveTvScreen(
     // channel of the first non-empty category.
     val rememberedChannelByCategory = remember { mutableMapOf<String, String>() }
     var playingChannelId by rememberSaveable { mutableStateOf<String?>(initialChannelId) }
+    // The channel we were on before the current one. Tracked in a single place
+    // on purpose: five different paths change the channel (zapping, number
+    // entry, the quick-zap list, the guide and the HUD buttons), and a
+    // per-path copy would leave the toggle stale on whichever path was missed.
+    var previousChannelId by rememberSaveable { mutableStateOf<String?>(null) }
+    var lastTunedChannelId by rememberSaveable { mutableStateOf<String?>(initialChannelId) }
     KeepScreenOn(active = playingChannelId != null)
     // Treat the entire Live TV surface as latency-sensitive. Waiting until the
     // first channel starts leaves a gap where a large XMLTV backfill can claim
@@ -1856,6 +1867,22 @@ fun LiveTvScreen(
 
     var hudPokeSignal by remember { mutableStateOf(0) }
     var isHudVisible by remember { mutableStateOf(false) }
+    // Bumped to dismiss the HUD from outside, so Back can close it without
+    // leaving fullscreen.
+    var hudHideSignal by remember { mutableStateOf(0) }
+    // The HUD shows itself for a few seconds after a zap, but only OK hands it
+    // the focus. While it is not engaged the arrow keys stay with playback.
+    var hudEngaged by remember { mutableStateOf(false) }
+    var lastZapAtMs by remember { mutableLongStateOf(0L) }
+
+    // Dismissing the controls takes the focused button out of composition, so
+    // hand the focus back to the playback surface — otherwise the next key
+    // press lands nowhere and the remote looks dead.
+    LaunchedEffect(isHudVisible) {
+        if (!isHudVisible && isFullScreen && !fullscreenGuideOpen && !quickZapOpen) {
+            runCatching { fsFocus.requestFocus() }
+        }
+    }
     var guideOpenedFromQuickZap by remember { mutableStateOf(false) }
     var guideChannel by remember { mutableStateOf<EnrichedChannel?>(null) }
     val fullscreenGuideChannelId = (guideChannel ?: playingChannel)?.id
@@ -1969,24 +1996,52 @@ fun LiveTvScreen(
         }
     }
 
+    // Single source for the previous channel: every path that changes the
+    // channel ends up writing playingChannelId, so observing it here keeps the
+    // toggle correct no matter which one was used.
+    LaunchedEffect(playingChannelId) {
+        val current = playingChannelId ?: return@LaunchedEffect
+        val last = lastTunedChannelId
+        if (last != null && last != current) {
+            previousChannelId = last
+        }
+        lastTunedChannelId = current
+    }
+
+    // Tune straight to a channel without leaving fullscreen. Shared by zapping
+    // and by the previous-channel jump so both leave the same state behind.
+    fun tuneToDisplayChannel(channel: EnrichedChannel) {
+        noteGuideUserNavigation()
+        playingChannelId = channel.id
+        focusedChannelId = channel.id
+        epgPrefetchAnchorId = channel.id
+        rememberedChannelByCategory[categoryScope] = channel.id
+        playingCatchupProgram = null
+        catchupPlaybackOffsetMs = 0L
+        fullscreenGuideOpen = false
+    }
+
     // Prev/next zapping across the full enriched list (not the filtered
     // category) per user spec. Wraps around.
     fun zap(delta: Int) {
-        noteGuideUserNavigation()
         val all = allDisplayChannels
         if (all.isEmpty()) return
         val currentDisplayId = displayChannelIdFor(playingChannelId, visibleEnrichedState.value.index.byId, variantGroups)
         val currentIdx = currentDisplayId?.let { id -> all.indexOfFirst { channel -> channel.id == id } } ?: -1
         val start = if (currentIdx >= 0) currentIdx else 0
         val size = all.size
-        val nextIdx = ((start + delta) % size + size) % size
-        playingChannelId = all[nextIdx].id
-        focusedChannelId = all[nextIdx].id
-        epgPrefetchAnchorId = all[nextIdx].id
-        rememberedChannelByCategory[categoryScope] = all[nextIdx].id
-        playingCatchupProgram = null
-        catchupPlaybackOffsetMs = 0L
-        fullscreenGuideOpen = false
+        tuneToDisplayChannel(all[((start + delta) % size + size) % size])
+    }
+
+    // Jump back to the channel that was playing before this one, so the right
+    // arrow toggles between the last two. Returns false when there is no
+    // previous channel yet or it has dropped out of the visible list.
+    fun tunePreviousChannel(): Boolean {
+        val target = previousChannelId
+            ?.let { id -> allDisplayChannels.firstOrNull { channel -> channel.id == id } }
+            ?: return false
+        tuneToDisplayChannel(target)
+        return true
     }
 
     fun focusPlaylistSearch() {
@@ -3126,7 +3181,10 @@ fun LiveTvScreen(
         fullscreenGuideOpen = false
     }
     BackHandler(enabled = !searchOpen && isFullScreen && !fullscreenGuideOpen) {
-        if (playingCatchupProgram != null) {
+        if (hudEngaged) {
+            hudEngaged = false
+            hudHideSignal++
+        } else if (playingCatchupProgram != null) {
             returnCatchupToLive()
         } else {
             exitFullScreenPlayback()
@@ -3617,7 +3675,10 @@ fun LiveTvScreen(
                         fullscreenGuideOpen = false
                         hudPokeSignal++
                     } else if (!quickZapOpen) {
-                        if (playingCatchupProgram != null) {
+                        if (hudEngaged) {
+                            hudEngaged = false
+                            hudHideSignal++
+                        } else if (playingCatchupProgram != null) {
                             returnCatchupToLive()
                         } else {
                             exitFullScreenPlayback()
@@ -3684,17 +3745,63 @@ fun LiveTvScreen(
                                     hudPokeSignal++
                                     return@onPreviewKeyEvent handleChannelNumberDigit(digit)
                                 }
-                                if (!isHudVisible) {
-                                    if (ev.key in listOf(Key.DirectionUp, Key.DirectionDown, Key.DirectionLeft, Key.DirectionRight, Key.DirectionCenter, Key.Enter)) {
+                            }
+
+                            // Up/Down and the remote's channel keys zap straight
+                            // away — no overlay, no extra press. In catchup the
+                            // arrows stay with the HUD instead, because there the
+                            // user wants to seek inside the recording rather than
+                            // leave it; the channel keys still zap and drop back
+                            // to live, which is what leaving a recording means.
+                            val zapDelta = when (ev.key) {
+                                Key.ChannelUp -> -1
+                                Key.ChannelDown -> 1
+                                Key.DirectionUp -> if (playingCatchupProgram == null) -1 else 0
+                                Key.DirectionDown -> if (playingCatchupProgram == null) 1 else 0
+                                else -> 0
+                            }
+                            if (zapDelta != 0) {
+                                if (firstPress) {
+                                    val nowMs = System.currentTimeMillis()
+                                    if (nowMs - lastZapAtMs >= MinZapIntervalMs) {
+                                        lastZapAtMs = nowMs
+                                        zap(zapDelta)
+                                        hudPokeSignal++
+                                    }
+                                }
+                                return@onPreviewKeyEvent true
+                            }
+
+                            // Left, Right and OK belong to playback until the user
+                            // hands the HUD the focus with OK; from then on they
+                            // drive its button row instead.
+                            if (firstPress && !hudEngaged) {
+                                when (ev.key) {
+                                    Key.DirectionLeft -> {
+                                        quickZapOpen = true
+                                        return@onPreviewKeyEvent true
+                                    }
+                                    Key.DirectionRight -> {
+                                        if (tunePreviousChannel()) hudPokeSignal++
+                                        return@onPreviewKeyEvent true
+                                    }
+                                    Key.DirectionCenter, Key.Enter -> {
+                                        hudEngaged = true
                                         hudPokeSignal++
                                         return@onPreviewKeyEvent true
                                     }
+                                    else -> Unit
                                 }
                             }
+
                             when (ev.key) {
                                 Key.Back, Key.Escape -> {
                                     if (firstPress) {
-                                        if (playingCatchupProgram != null) {
+                                        if (hudEngaged) {
+                                            // Put the controls away and keep watching.
+                                            hudEngaged = false
+                                            hudHideSignal++
+                                        } else if (playingCatchupProgram != null) {
                                             returnCatchupToLive()
                                         } else {
                                             exitFullScreenPlayback()
@@ -3716,7 +3823,9 @@ fun LiveTvScreen(
                             }
                         } else if (isFullScreen && !fullscreenGuideOpen && !quickZapOpen) {
                             Modifier.onPreviewKeyEvent { ev ->
-                                if (ev.type == KeyEventType.KeyDown) {
+                                // Keep the HUD alive while it is on screen, but
+                                // never summon it: OK opens it, Back closes it.
+                                if (ev.type == KeyEventType.KeyDown && isHudVisible) {
                                     hudPokeSignal++
                                 }
                                 false
@@ -3842,7 +3951,12 @@ fun LiveTvScreen(
                             quickZapOpen = true
                             isHudVisible = false
                         },
-                        onVisibilityChanged = { isHudVisible = it },
+                        onVisibilityChanged = { visible ->
+                            isHudVisible = visible
+                            if (!visible) hudEngaged = false
+                        },
+                        hideSignal = hudHideSignal,
+                        focusControls = hudEngaged,
                         modifier = Modifier,
                     )
                 }
@@ -3898,8 +4012,9 @@ fun LiveTvScreen(
                     selectedCategoryId = selectedCategoryId,
                     onCategorySelected = { selectedCategoryId = it },
                     onDismiss = {
+                        // Back from the list goes straight back to plain
+                        // fullscreen — no HUD in the way.
                         quickZapOpen = false
-                        hudPokeSignal++
                     },
                     onChannelSelect = { channel ->
                         playingChannelId = channel.id

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/tv/live/LiveTvScreen.kt
@@ -3747,17 +3747,24 @@ fun LiveTvScreen(
                                 }
                             }
 
+                            // Everything below is the remote's fullscreen key plan.
+                            // Touch devices drive playback by tapping and keep the
+                            // behaviour they have always had.
+                            if (isTouchDevice) return@onPreviewKeyEvent false
+
                             // Up/Down and the remote's channel keys zap straight
-                            // away — no overlay, no extra press. In catchup the
+                            // away — no overlay, no extra press. Up and CH+ go to
+                            // the next channel, the way a television has always
+                            // answered CH+. In catchup the
                             // arrows stay with the HUD instead, because there the
                             // user wants to seek inside the recording rather than
                             // leave it; the channel keys still zap and drop back
                             // to live, which is what leaving a recording means.
                             val zapDelta = when (ev.key) {
-                                Key.ChannelUp -> -1
-                                Key.ChannelDown -> 1
-                                Key.DirectionUp -> if (playingCatchupProgram == null) -1 else 0
-                                Key.DirectionDown -> if (playingCatchupProgram == null) 1 else 0
+                                Key.ChannelUp -> 1
+                                Key.ChannelDown -> -1
+                                Key.DirectionUp -> if (playingCatchupProgram == null) 1 else 0
+                                Key.DirectionDown -> if (playingCatchupProgram == null) -1 else 0
                                 else -> 0
                             }
                             if (zapDelta != 0) {
@@ -3956,7 +3963,10 @@ fun LiveTvScreen(
                             if (!visible) hudEngaged = false
                         },
                         hideSignal = hudHideSignal,
-                        focusControls = hudEngaged,
+                        // On a remote the controls wait for OK; on a touch device
+                        // a tap is the only way to reach them, so they stay part
+                        // of what a tap brings up, exactly as before.
+                        showControls = isTouchDevice || hudEngaged,
                         modifier = Modifier,
                     )
                 }


### PR DESCRIPTION
Fullscreen live TV on the remote had two problems, and this addresses both plus the key plan around them.

**The regression.** `Key.DirectionUp -> zap(-1)` was added on 22 Apr (`0251e6b8`) and dropped in the HUD redesign on 08 Aug (`972ceb94`, #538). `zap()` has been sitting there uncalled ever since — the last release it worked in was `v1.9.983`. **The remote's CH+/CH− keys were never wired at all**, which is what was reported.

**What this changes, TV remote only — nothing on phone or tablet** (guarded by `isTouchDevice`):

| Key | Before | After |
|---|---|---|
| Up / Down | showed the HUD | switch channel |
| CH+ / CH− | nothing | switch channel |
| Left | showed the HUD | open the channel list |
| Right | showed the HUD | jump to the previous channel |
| OK | showed the HUD | open the control bar **with focus** |
| Back, control bar open | left fullscreen | closes the bar, playback continues |

**Two deliberate reversals, called out on purpose:**
1. **Direction is flipped** — Up/CH+ now goes to the *next* channel, the way a TV answers CH+. The original choice was the opposite; happy to flip it back, it is two characters.
2. **Info and controls are now two overlays, not one.** What appears on its own (zapping, entering fullscreen) is an info bar with no buttons; the button row from #538 appears only on OK. This came out of device testing: showing buttons that deliberately refuse focus reads as broken.

**Known and intentional:** zapping runs across the full channel list rather than the current category. That was the original intent — the April plan lists it as *"Fix 6 (up/down zap across all channels)"* (`50e830cc`; the plan file itself was removed from the tree later, in `1be60644`). The quick-zap list still follows the category. Catch-up is excluded from zapping so seeking inside a recording still works.

**Screenshots — the two overlays.** Captured on a phone in TV mode rather than off the television, so the aspect and resolution look different from a TV grab; the overlays themselves are the same ones the remote drives.

1. Right after a zap — information only, nothing focusable in it.
2. After pressing OK — the control bar, with focus on play/pause.

<img width="2400" height="1080" alt="Screenshot_20260911-082910" src="https://github.com/user-attachments/assets/9146b105-a6b5-439a-8365-dae5340d0769" />

<img width="2400" height="1080" alt="Screenshot_20260911-082916" src="https://github.com/user-attachments/assets/3fbfb0a0-bcdc-4347-8cda-c1590148785c" />


Tested on a TCL C7K with the remote.

---
created by Claude (Anthropic) on behalf of @ReichiMD