### PR TITLE
feat(player): native YouTube trailer playback with clean UI and TV re…

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -436,6 +436,11 @@ ksp {
 
     baselineProfile(project(":benchmark"))
 
+    // YouTube player for trailers (official IFrame API wrapper)
+    implementation("com.pierfrancescosoffritti.androidyoutubeplayer:core:13.0.0") {
+        exclude(group = "androidx.lifecycle")
+    }
+
     // NanoHTTPD – lightweight HTTP server for QR-based AI key setup
     implementation("org.nanohttpd:nanohttpd:2.3.1")
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -246,3 +246,10 @@
 -keep class com.arflix.tv.util.Result$* { *; }
 -keep class com.arflix.tv.util.UiState { *; }
 -keep class com.arflix.tv.util.UiState$* { *; }
+
+# ============================================
+# android-youtube-player (IFrame API)
+# ============================================
+-keep class com.pierfrancescosoffritti.androidyoutubeplayer.** { *; }
+-keepnames class com.pierfrancescosoffritti.youtubeplayer.* { *; }
+-dontwarn com.pierfrancescosoffritti.androidyoutubeplayer.**

--- a/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncRepository.kt
+++ b/app/src/main/kotlin/com/arflix/tv/data/repository/CloudSyncRepository.kt
@@ -281,7 +281,7 @@ class CloudSyncRepository @Inject constructor(
         val autoPlayNext: Boolean = true,
         val autoPlaySingleSource: Boolean = true,
         val autoPlayMinQuality: String = "Any",
-        val trailerAutoPlay: Boolean = false,
+        val trailerAutoPlay: Boolean = true,
         val trailerSoundEnabled: Boolean = false,
         val trailerDelaySeconds: Int = 2,
         val trailerInCards: Boolean = true,
@@ -635,7 +635,7 @@ class CloudSyncRepository @Inject constructor(
                         defaultAudioLanguage = prefs[defaultAudioLanguageKeyFor(profile.id)] ?: "Auto (Original)",
                         contentLanguage = resolveAppLanguage(prefs, profile.id),
 
-                        trailerAutoPlay = prefs[trailerAutoPlayKeyFor(profile.id)] ?: false,
+                        trailerAutoPlay = prefs[trailerAutoPlayKeyFor(profile.id)] ?: true,
                         trailerSoundEnabled = prefs[trailerSoundEnabledKeyFor(profile.id)] ?: false,
                         trailerDelaySeconds = prefs[trailerDelayKeyFor(profile.id)]?.toIntOrNull() ?: 2,
                         trailerInCards = prefs[trailerInCardsKeyFor(profile.id)] ?: true,

--- a/app/src/main/kotlin/com/arflix/tv/ui/components/BackgroundTrailerPlayer.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/BackgroundTrailerPlayer.kt
@@ -1,0 +1,228 @@
+package com.arflix.tv.ui.components
+
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.WebView
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.PlayerConstants
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.YouTubePlayer
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.listeners.AbstractYouTubePlayerListener
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.options.IFramePlayerOptions
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.views.YouTubePlayerView
+import kotlinx.coroutines.delay
+
+private fun findWebView(view: View): WebView? {
+    if (view is WebView) return view
+    if (view is ViewGroup) {
+        for (i in 0 until view.childCount) {
+            val found = findWebView(view.getChildAt(i))
+            if (found != null) return found
+        }
+    }
+    return null
+}
+
+private fun disableCaptionsAndOverlays(view: View) {
+    findWebView(view)?.let { webView ->
+        val js = """
+            (function() {
+                try {
+                    if (typeof player !== 'undefined') {
+                        if (typeof player.unloadModule === 'function') {
+                            player.unloadModule('captions');
+                            player.unloadModule('cc');
+                        }
+                        if (typeof player.setOption === 'function') {
+                            player.setOption('captions', 'track', {});
+                            player.setOption('cc', 'track', {});
+                        }
+                    }
+                    var css = '.ytp-chrome-top, .ytp-chrome-bottom, .ytp-watermark, .ytp-youtube-button, .ytp-pause-overlay, .ytp-ce-element, .ytp-subtitles-player-content, .caption-window, .ytp-caption-window-bottom, .ytp-spinner { display: none !important; opacity: 0 !important; visibility: hidden !important; }';
+                    var head = document.head || document.getElementsByTagName('head')[0];
+                    if (head) {
+                        var style = document.createElement('style');
+                        style.type = 'text/css';
+                        style.appendChild(document.createTextNode(css));
+                        head.appendChild(style);
+                    }
+                } catch(e) {}
+            })();
+        """.trimIndent()
+        webView.evaluateJavascript(js, null)
+    }
+}
+
+/**
+ * Clean background YouTube trailer player for the Home screen hero backdrop.
+ *
+ * Key features for TV:
+ * - Completely unfocusable (FOCUS_BLOCK_DESCENDANTS) so TV remote D-pad navigation never gets trapped.
+ * - controls(0): pure video playback with NO time bar, play/pause buttons, or web overlays.
+ * - Delayed start: waits [delayMs] so fast scrolling past items does not trigger unnecessary video loads.
+ * - Smooth fade-in: stays transparent while buffering and fades in once PLAYING, preventing black flashes over backdrop art.
+ * - Lifecycle-aware: pauses and releases properly.
+ */
+@Composable
+fun BackgroundTrailerPlayer(
+    youtubeKey: String,
+    modifier: Modifier = Modifier,
+    delayMs: Long = 2000L,
+    soundEnabled: Boolean = false,
+    onPlayingChanged: (Boolean) -> Unit = {}
+) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    var shouldLoad by remember(youtubeKey) { mutableStateOf(false) }
+    var isPlaying by remember(youtubeKey) { mutableStateOf(false) }
+    var activePlayer by remember(youtubeKey) { mutableStateOf<YouTubePlayer?>(null) }
+
+    // Settle delay before initiating playback
+    LaunchedEffect(youtubeKey) {
+        shouldLoad = false
+        isPlaying = false
+        if (delayMs > 0L) {
+            delay(delayMs)
+        }
+        shouldLoad = true
+    }
+
+    // Sound control
+    LaunchedEffect(soundEnabled, activePlayer) {
+        activePlayer?.let { player ->
+            if (soundEnabled) {
+                player.unMute()
+            } else {
+                player.mute()
+            }
+        }
+    }
+
+    val animatedAlpha by animateFloatAsState(
+        targetValue = if (isPlaying) 1f else 0f,
+        animationSpec = tween(durationMillis = 800),
+        label = "trailerFadeIn"
+    )
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .clipToBounds()
+            .alpha(animatedAlpha)
+    ) {
+        if (shouldLoad) {
+            AndroidView(
+                factory = { ctx ->
+                    YouTubePlayerView(ctx).apply {
+                        enableAutomaticInitialization = false
+
+                        // Completely replace default UI (play/pause overlay, seekbar, etc.) with empty view
+                        setCustomPlayerUi(android.view.View(ctx).apply { visibility = android.view.View.GONE })
+
+                        // CRITICAL FOR TV: Block all focus so D-pad cannot focus or get trapped in the WebView
+                        isFocusable = false
+                        isFocusableInTouchMode = false
+                        descendantFocusability = ViewGroup.FOCUS_BLOCK_DESCENDANTS
+                        isClickable = false
+                        setOnTouchListener { _, _ -> true }
+
+                        val iFramePlayerOptions = IFramePlayerOptions.Builder(ctx)
+                            .controls(0)      // Hide all time bars and buttons
+                            .rel(0)           // Only related videos from same channel
+                            .ivLoadPolicy(3)  // Disable video annotations
+                            .ccLoadPolicy(0)  // Disable closed captions
+                            .fullscreen(0)
+                            .build()
+
+                        initialize(
+                            object : AbstractYouTubePlayerListener() {
+                                override fun onReady(youTubePlayer: YouTubePlayer) {
+                                    activePlayer = youTubePlayer
+                                    if (!soundEnabled) {
+                                        youTubePlayer.mute()
+                                    } else {
+                                        youTubePlayer.unMute()
+                                    }
+                                    disableCaptionsAndOverlays(this@apply)
+                                    youTubePlayer.loadVideo(youtubeKey, 0f)
+                                }
+
+                                override fun onStateChange(
+                                    youTubePlayer: YouTubePlayer,
+                                    state: PlayerConstants.PlayerState
+                                ) {
+                                    when (state) {
+                                        PlayerConstants.PlayerState.PLAYING -> {
+                                            disableCaptionsAndOverlays(this@apply)
+                                            isPlaying = true
+                                            onPlayingChanged(true)
+                                        }
+                                        PlayerConstants.PlayerState.ENDED,
+                                        PlayerConstants.PlayerState.PAUSED -> {
+                                            if (state == PlayerConstants.PlayerState.ENDED) {
+                                                isPlaying = false
+                                                onPlayingChanged(false)
+                                            }
+                                        }
+                                        else -> {}
+                                    }
+                                }
+
+                                override fun onError(
+                                    youTubePlayer: YouTubePlayer,
+                                    error: PlayerConstants.PlayerError
+                                ) {
+                                    isPlaying = false
+                                    onPlayingChanged(false)
+                                }
+                            },
+                            iFramePlayerOptions
+                        )
+                    }
+                },
+                modifier = Modifier.fillMaxSize(),
+                onRelease = { playerView ->
+                    playerView.release()
+                    activePlayer = null
+                    isPlaying = false
+                    onPlayingChanged(false)
+                }
+            )
+        }
+    }
+
+    // Lifecycle observer to pause/resume playback when activity is backgrounded
+    DisposableEffect(lifecycleOwner, activePlayer) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_PAUSE -> activePlayer?.pause()
+                Lifecycle.Event.ON_RESUME -> if (isPlaying) activePlayer?.play()
+                else -> {}
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+            onPlayingChanged(false)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/arflix/tv/ui/components/YouTubeTrailerModal.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/components/YouTubeTrailerModal.kt
@@ -1,0 +1,757 @@
+package com.arflix.tv.ui.components
+
+import android.content.Intent
+import android.net.Uri
+import android.os.SystemClock
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.WebView
+import android.widget.Toast
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.FastForward
+import androidx.compose.material.icons.filled.FastRewind
+import androidx.compose.material.icons.filled.OpenInNew
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.zIndex
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import com.arflix.tv.R
+import com.arflix.tv.ui.skin.ArvioSkin
+import com.arflix.tv.util.LocalDeviceType
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.PlayerConstants
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.YouTubePlayer
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.listeners.AbstractYouTubePlayerListener
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.options.IFramePlayerOptions
+import com.pierfrancescosoffritti.androidyoutubeplayer.core.player.views.YouTubePlayerView
+import kotlinx.coroutines.delay
+
+private fun findWebView(view: View): WebView? {
+    if (view is WebView) return view
+    if (view is ViewGroup) {
+        for (i in 0 until view.childCount) {
+            val found = findWebView(view.getChildAt(i))
+            if (found != null) return found
+        }
+    }
+    return null
+}
+
+private fun disableCaptionsAndOverlays(view: View) {
+    findWebView(view)?.let { webView ->
+        val js = """
+            (function() {
+                try {
+                    if (typeof player !== 'undefined') {
+                        if (typeof player.unloadModule === 'function') {
+                            player.unloadModule('captions');
+                            player.unloadModule('cc');
+                        }
+                        if (typeof player.setOption === 'function') {
+                            player.setOption('captions', 'track', {});
+                            player.setOption('cc', 'track', {});
+                        }
+                    }
+                    var css = '.ytp-chrome-top, .ytp-chrome-bottom, .ytp-watermark, .ytp-youtube-button, .ytp-pause-overlay, .ytp-pause-overlay-container, .ytp-ce-element, .ytp-ce-covering-overlay, .ytp-ce-expanding-overlay, .ytp-subtitles-player-content, .caption-window, .ytp-caption-window-bottom, .ytp-spinner, .ytp-gradient-top, .ytp-gradient-bottom, .ytp-impression-link, .ytp-title, .ytp-title-channel, .ytp-share-button, .ytp-share-panel, .ytp-menuitem, .ytp-contextmenu { display: none !important; opacity: 0 !important; visibility: hidden !important; pointer-events: none !important; }';
+                    var head = document.head || document.getElementsByTagName('head')[0];
+                    if (head) {
+                        var style = document.createElement('style');
+                        style.type = 'text/css';
+                        style.appendChild(document.createTextNode(css));
+                        head.appendChild(style);
+                    }
+                } catch(e) {}
+            })();
+        """.trimIndent()
+        webView.evaluateJavascript(js, null)
+    }
+}
+
+private fun formatTime(seconds: Float): String {
+    val totalSec = seconds.toInt().coerceAtLeast(0)
+    val minutes = totalSec / 60
+    val remSec = totalSec % 60
+    return "%02d:%02d".format(minutes, remSec)
+}
+
+private enum class IndicatorType {
+    PLAY, PAUSE, SEEK_BACK, SEEK_FORWARD
+}
+
+private data class TransientIndicator(
+    val type: IndicatorType,
+    val text: String,
+    val icon: ImageVector,
+    val timestamp: Long = SystemClock.uptimeMillis()
+)
+
+/**
+ * Clean cinema-grade YouTube trailer modal for TV and Mobile.
+ *
+ * Highlights:
+ * - Pure video canvas: strips YouTube's web title bar, share button, central pause overlay, and watermarks.
+ * - TV remote controls:
+ *   - [DPAD_CENTER] / [ENTER]: Play / Pause toggle
+ *   - [DPAD_LEFT] / [MediaRewind]: Seek backward 10s
+ *   - [DPAD_RIGHT] / [MediaFastForward]: Seek forward 10s
+ *   - [DPAD_UP]: Focus top action buttons (Close ✕ & Watch in YouTube)
+ *   - [DPAD_DOWN]: Focus video player canvas
+ *   - [BACK]: Dismiss modal cleanly and restore focus to Details
+ * - Auto-hiding HUD: fades out after 3.5s of playback, reappears on any remote key press or tap.
+ */
+@Composable
+fun YouTubeTrailerModal(
+    youtubeKey: String,
+    title: String = "",
+    onClose: () -> Unit
+) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val isMobile = LocalDeviceType.current.isTouchDevice()
+
+    val playerFocusRequester = remember { FocusRequester() }
+    val closeFocusRequester = remember { FocusRequester() }
+    val extFocusRequester = remember { FocusRequester() }
+
+    var isPlayerFocused by remember { mutableStateOf(false) }
+    var isCloseFocused by remember { mutableStateOf(false) }
+    var isExtFocused by remember { mutableStateOf(false) }
+
+    var activePlayer by remember(youtubeKey) { mutableStateOf<YouTubePlayer?>(null) }
+    var playerViewRef by remember { mutableStateOf<YouTubePlayerView?>(null) }
+    var playbackError by remember(youtubeKey) { mutableStateOf(false) }
+
+    var isPlaying by remember { mutableStateOf(false) }
+    var currentSecond by remember { mutableFloatStateOf(0f) }
+    var duration by remember { mutableFloatStateOf(0f) }
+
+    var showHud by remember { mutableStateOf(true) }
+    var lastInteractionTime by remember { mutableLongStateOf(SystemClock.uptimeMillis()) }
+    var transientIndicator by remember { mutableStateOf<TransientIndicator?>(null) }
+
+    // Intercept back key on TV and mobile exclusively
+    BackHandler(enabled = true) {
+        onClose()
+    }
+
+    // Auto-focus player container for direct remote interaction on start
+    LaunchedEffect(Unit) {
+        delay(150)
+        runCatching { playerFocusRequester.requestFocus() }
+    }
+
+    // Periodic check to strip late-injected YouTube web UI
+    LaunchedEffect(activePlayer) {
+        if (activePlayer != null) {
+            delay(500)
+            playerViewRef?.let { disableCaptionsAndOverlays(it) }
+            delay(1200)
+            playerViewRef?.let { disableCaptionsAndOverlays(it) }
+            delay(2500)
+            playerViewRef?.let { disableCaptionsAndOverlays(it) }
+        }
+    }
+
+    // Auto-hide HUD after 3.5s when playing and no buttons are focused
+    LaunchedEffect(showHud, isPlaying, lastInteractionTime, isCloseFocused, isExtFocused) {
+        if (showHud && isPlaying && !isCloseFocused && !isExtFocused) {
+            delay(3500)
+            showHud = false
+        }
+    }
+
+    // Transient indicator auto-clear
+    LaunchedEffect(transientIndicator) {
+        if (transientIndicator != null) {
+            delay(900)
+            transientIndicator = null
+        }
+    }
+
+    fun triggerIndicator(type: IndicatorType, text: String, icon: ImageVector) {
+        transientIndicator = TransientIndicator(type, text, icon)
+    }
+
+    fun openExternalYouTube() {
+        try {
+            val url = "https://www.youtube.com/watch?v=$youtubeKey"
+            context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            })
+            onClose()
+        } catch (_: Exception) {
+            Toast.makeText(context, R.string.trailer_open_failed, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.94f))
+            .zIndex(100f)
+            .onPreviewKeyEvent { event ->
+                if (event.key == Key.Back || event.key == Key.Escape) {
+                    if (event.type == KeyEventType.KeyUp) {
+                        onClose()
+                    }
+                    true
+                } else false
+            }
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null
+            ) {
+                if (isMobile) onClose()
+            },
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth(if (isMobile) 0.96f else 0.88f)
+                .widthIn(max = 1000.dp)
+                .padding(vertical = 12.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            // 16:9 Cinema Video Container
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(16f / 9f)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(Color.Black)
+                    .border(
+                        width = if (isPlayerFocused) 2.dp else 1.dp,
+                        color = if (isPlayerFocused) ArvioSkin.colors.focusOutline else Color.White.copy(alpha = 0.15f),
+                        shape = RoundedCornerShape(12.dp)
+                    )
+                    .focusRequester(playerFocusRequester)
+                    .onFocusChanged { isPlayerFocused = it.isFocused }
+                    .focusable()
+                    .onPreviewKeyEvent { event ->
+                        if (event.type == KeyEventType.KeyDown) {
+                            when (event.key) {
+                                Key.DirectionCenter, Key.Enter, Key.NumPadEnter, Key.MediaPlayPause -> {
+                                    if (isPlaying) {
+                                        activePlayer?.pause()
+                                        isPlaying = false
+                                        triggerIndicator(IndicatorType.PAUSE, "Paused", Icons.Default.Pause)
+                                    } else {
+                                        activePlayer?.play()
+                                        isPlaying = true
+                                        triggerIndicator(IndicatorType.PLAY, "Playing", Icons.Default.PlayArrow)
+                                    }
+                                    showHud = true
+                                    lastInteractionTime = SystemClock.uptimeMillis()
+                                    true
+                                }
+                                Key.MediaPlay -> {
+                                    activePlayer?.play()
+                                    isPlaying = true
+                                    triggerIndicator(IndicatorType.PLAY, "Playing", Icons.Default.PlayArrow)
+                                    showHud = true
+                                    lastInteractionTime = SystemClock.uptimeMillis()
+                                    true
+                                }
+                                Key.MediaPause -> {
+                                    activePlayer?.pause()
+                                    isPlaying = false
+                                    triggerIndicator(IndicatorType.PAUSE, "Paused", Icons.Default.Pause)
+                                    showHud = true
+                                    lastInteractionTime = SystemClock.uptimeMillis()
+                                    true
+                                }
+                                Key.DirectionLeft, Key.MediaRewind -> {
+                                    val target = (currentSecond - 10f).coerceAtLeast(0f)
+                                    activePlayer?.seekTo(target)
+                                    currentSecond = target
+                                    triggerIndicator(IndicatorType.SEEK_BACK, "-10s", Icons.Default.FastRewind)
+                                    showHud = true
+                                    lastInteractionTime = SystemClock.uptimeMillis()
+                                    true
+                                }
+                                Key.DirectionRight, Key.MediaFastForward -> {
+                                    val target = (currentSecond + 10f).coerceAtMost(duration)
+                                    activePlayer?.seekTo(target)
+                                    currentSecond = target
+                                    triggerIndicator(IndicatorType.SEEK_FORWARD, "+10s", Icons.Default.FastForward)
+                                    showHud = true
+                                    lastInteractionTime = SystemClock.uptimeMillis()
+                                    true
+                                }
+                                Key.DirectionUp -> {
+                                    showHud = true
+                                    lastInteractionTime = SystemClock.uptimeMillis()
+                                    closeFocusRequester.requestFocus()
+                                    true
+                                }
+                                Key.DirectionDown -> {
+                                    showHud = true
+                                    lastInteractionTime = SystemClock.uptimeMillis()
+                                    true
+                                }
+                                Key.Back, Key.Escape -> {
+                                    onClose()
+                                    true
+                                }
+                                else -> false
+                            }
+                        } else if (event.type == KeyEventType.KeyUp) {
+                            when (event.key) {
+                                Key.DirectionCenter, Key.Enter, Key.NumPadEnter,
+                                Key.DirectionLeft, Key.DirectionRight, Key.DirectionUp, Key.DirectionDown,
+                                Key.MediaPlayPause, Key.MediaPlay, Key.MediaPause,
+                                Key.MediaFastForward, Key.MediaRewind,
+                                Key.Back, Key.Escape -> true
+                                else -> false
+                            }
+                        } else false
+                    }
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null
+                    ) {
+                        showHud = !showHud
+                        lastInteractionTime = SystemClock.uptimeMillis()
+                    }
+            ) {
+                if (!playbackError) {
+                    AndroidView(
+                        factory = { ctx ->
+                            YouTubePlayerView(ctx).apply {
+                                enableAutomaticInitialization = false
+
+                                // Replace default UI (huge play/pause button, etc.) with empty view
+                                setCustomPlayerUi(android.view.View(ctx).apply { visibility = android.view.View.GONE })
+
+                                // Block touch and remote focus on WebView so Compose manages it
+                                isFocusable = false
+                                isFocusableInTouchMode = false
+                                descendantFocusability = ViewGroup.FOCUS_BLOCK_DESCENDANTS
+                                setOnTouchListener { _, _ -> true }
+
+                                val iFrameOptions = IFramePlayerOptions.Builder(ctx)
+                                    .controls(0) // Completely disable YouTube web controls
+                                    .rel(0)
+                                    .ivLoadPolicy(3)
+                                    .fullscreen(0)
+                                    .build()
+
+                                initialize(
+                                    object : AbstractYouTubePlayerListener() {
+                                        override fun onReady(youTubePlayer: YouTubePlayer) {
+                                            activePlayer = youTubePlayer
+                                            youTubePlayer.unMute()
+                                            youTubePlayer.loadVideo(youtubeKey, 0f)
+                                            disableCaptionsAndOverlays(this@apply)
+                                        }
+
+                                        override fun onStateChange(
+                                            youTubePlayer: YouTubePlayer,
+                                            state: PlayerConstants.PlayerState
+                                        ) {
+                                            when (state) {
+                                                PlayerConstants.PlayerState.PLAYING -> {
+                                                    isPlaying = true
+                                                    disableCaptionsAndOverlays(this@apply)
+                                                }
+                                                PlayerConstants.PlayerState.PAUSED -> {
+                                                    isPlaying = false
+                                                    showHud = true
+                                                }
+                                                PlayerConstants.PlayerState.ENDED -> {
+                                                    isPlaying = false
+                                                    showHud = true
+                                                }
+                                                else -> {}
+                                            }
+                                        }
+
+                                        override fun onCurrentSecond(
+                                            youTubePlayer: YouTubePlayer,
+                                            second: Float
+                                        ) {
+                                            currentSecond = second
+                                        }
+
+                                        override fun onVideoDuration(
+                                            youTubePlayer: YouTubePlayer,
+                                            durationSec: Float
+                                        ) {
+                                            duration = durationSec
+                                        }
+
+                                        override fun onError(
+                                            youTubePlayer: YouTubePlayer,
+                                            error: PlayerConstants.PlayerError
+                                        ) {
+                                            playbackError = true
+                                        }
+                                    },
+                                    iFrameOptions
+                                )
+                            }
+                        },
+                        update = { playerView ->
+                            playerViewRef = playerView
+                        },
+                        modifier = Modifier.fillMaxSize(),
+                        onRelease = { playerView ->
+                            playerView.release()
+                            activePlayer = null
+                            playerViewRef = null
+                        }
+                    )
+                } else {
+                    // Fallback UI when video cannot be embedded
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(24.dp),
+                        verticalArrangement = Arrangement.Center,
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(
+                            text = "This trailer cannot be embedded directly by YouTube.",
+                            style = ArvioSkin.typography.body.copy(color = Color.White.copy(alpha = 0.8f)),
+                            modifier = Modifier.padding(bottom = 16.dp)
+                        )
+                        var fallbackBtnFocused by remember { mutableStateOf(false) }
+                        Box(
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(8.dp))
+                                .background(if (fallbackBtnFocused) ArvioSkin.colors.focusOutline else Color(0xFFCC0000))
+                                .padding(horizontal = 20.dp, vertical = 10.dp)
+                                .onFocusChanged { fallbackBtnFocused = it.isFocused }
+                                .clickable { openExternalYouTube() }
+                        ) {
+                            Text(
+                                text = "Watch on YouTube",
+                                style = ArvioSkin.typography.button.copy(
+                                    fontWeight = FontWeight.Bold,
+                                    color = if (fallbackBtnFocused) Color.Black else Color.White
+                                )
+                            )
+                        }
+                    }
+                }
+
+                // Transient Feedback Badge (Play / Pause / Seek ±10s)
+                androidx.compose.animation.AnimatedVisibility(
+                    visible = transientIndicator != null,
+                    enter = fadeIn(),
+                    exit = fadeOut(),
+                    modifier = Modifier.align(Alignment.Center)
+                ) {
+                    transientIndicator?.let { ind ->
+                        Box(
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(24.dp))
+                                .background(Color.Black.copy(alpha = 0.78f))
+                                .border(1.dp, Color.White.copy(alpha = 0.2f), RoundedCornerShape(24.dp))
+                                .padding(horizontal = 18.dp, vertical = 10.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                Icon(
+                                    imageVector = ind.icon,
+                                    contentDescription = null,
+                                    tint = ArvioSkin.colors.focusOutline,
+                                    modifier = Modifier.size(24.dp)
+                                )
+                                Text(
+                                    text = ind.text,
+                                    style = ArvioSkin.typography.body.copy(
+                                        fontWeight = FontWeight.Bold,
+                                        fontSize = 15.sp,
+                                        color = Color.White
+                                    )
+                                )
+                            }
+                        }
+                    }
+                }
+
+                // Native TV & Cinema HUD (Top Header & Bottom Progress Controls)
+                androidx.compose.animation.AnimatedVisibility(
+                    visible = showHud || !isPlaying,
+                    enter = fadeIn(),
+                    exit = fadeOut(),
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    Box(modifier = Modifier.fillMaxSize()) {
+                        // Top Header with Title and Action buttons
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .align(Alignment.TopCenter)
+                                .background(
+                                    Brush.verticalGradient(
+                                        colors = listOf(
+                                            Color.Black.copy(alpha = 0.85f),
+                                            Color.Black.copy(alpha = 0.45f),
+                                            Color.Transparent
+                                        )
+                                    )
+                                )
+                                .padding(horizontal = 16.dp, vertical = 12.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Text(
+                                text = if (title.isNotBlank()) "$title - ${stringResource(R.string.trailer)}" else stringResource(R.string.trailer),
+                                style = ArvioSkin.typography.body.copy(
+                                    fontWeight = FontWeight.SemiBold,
+                                    fontSize = 16.sp,
+                                    color = Color.White
+                                ),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.weight(1f, fill = false)
+                            )
+
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(10.dp)
+                            ) {
+                                // Watch externally in YouTube App
+                                Box(
+                                    modifier = Modifier
+                                        .size(36.dp)
+                                        .clip(CircleShape)
+                                        .background(if (isExtFocused) ArvioSkin.colors.focusOutline else Color.White.copy(alpha = 0.15f))
+                                        .border(
+                                            width = if (isExtFocused) 2.dp else 1.dp,
+                                            color = if (isExtFocused) ArvioSkin.colors.focusOutline else Color.White.copy(alpha = 0.25f),
+                                            shape = CircleShape
+                                        )
+                                        .focusRequester(extFocusRequester)
+                                        .onFocusChanged { isExtFocused = it.isFocused }
+                                        .focusable()
+                                        .onPreviewKeyEvent { event ->
+                                            if (event.type == KeyEventType.KeyDown) {
+                                                when (event.key) {
+                                                    Key.DirectionDown -> {
+                                                        playerFocusRequester.requestFocus()
+                                                        true
+                                                    }
+                                                    Key.DirectionRight -> {
+                                                        closeFocusRequester.requestFocus()
+                                                        true
+                                                    }
+                                                    Key.DirectionCenter, Key.Enter, Key.NumPadEnter -> {
+                                                        openExternalYouTube()
+                                                        true
+                                                    }
+                                                    Key.Back, Key.Escape -> {
+                                                        onClose()
+                                                        true
+                                                    }
+                                                    else -> false
+                                                }
+                                            } else false
+                                        }
+                                        .clickable { openExternalYouTube() },
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Default.OpenInNew,
+                                        contentDescription = "Watch on YouTube",
+                                        tint = if (isExtFocused) Color.Black else Color.White,
+                                        modifier = Modifier.size(18.dp)
+                                    )
+                                }
+
+                                // Close Button (✕)
+                                Box(
+                                    modifier = Modifier
+                                        .size(36.dp)
+                                        .clip(CircleShape)
+                                        .background(if (isCloseFocused) ArvioSkin.colors.focusOutline else Color.White.copy(alpha = 0.18f))
+                                        .border(
+                                            width = if (isCloseFocused) 2.dp else 1.dp,
+                                            color = if (isCloseFocused) ArvioSkin.colors.focusOutline else Color.White.copy(alpha = 0.3f),
+                                            shape = CircleShape
+                                        )
+                                        .focusRequester(closeFocusRequester)
+                                        .onFocusChanged { isCloseFocused = it.isFocused }
+                                        .focusable()
+                                        .onPreviewKeyEvent { event ->
+                                            if (event.type == KeyEventType.KeyDown) {
+                                                when (event.key) {
+                                                    Key.DirectionDown -> {
+                                                        playerFocusRequester.requestFocus()
+                                                        true
+                                                    }
+                                                    Key.DirectionLeft -> {
+                                                        extFocusRequester.requestFocus()
+                                                        true
+                                                    }
+                                                    Key.DirectionCenter, Key.Enter, Key.NumPadEnter -> {
+                                                        onClose()
+                                                        true
+                                                    }
+                                                    Key.Back, Key.Escape -> {
+                                                        onClose()
+                                                        true
+                                                    }
+                                                    else -> false
+                                                }
+                                            } else false
+                                        }
+                                        .clickable { onClose() },
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Default.Close,
+                                        contentDescription = stringResource(R.string.close),
+                                        tint = if (isCloseFocused) Color.Black else Color.White,
+                                        modifier = Modifier.size(20.dp)
+                                    )
+                                }
+                            }
+                        }
+
+                        // Bottom Scrim & Progress Bar with Time and TV Remote Hints
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .align(Alignment.BottomCenter)
+                                .background(
+                                    Brush.verticalGradient(
+                                        colors = listOf(
+                                            Color.Transparent,
+                                            Color.Black.copy(alpha = 0.55f),
+                                            Color.Black.copy(alpha = 0.90f)
+                                        )
+                                    )
+                                )
+                                .padding(horizontal = 16.dp, vertical = 12.dp)
+                        ) {
+                            // Progress bar
+                            val progress = if (duration > 0f) (currentSecond / duration).coerceIn(0f, 1f) else 0f
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(4.dp)
+                                    .clip(RoundedCornerShape(2.dp))
+                                    .background(Color.White.copy(alpha = 0.25f))
+                            ) {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth(fraction = progress)
+                                        .height(4.dp)
+                                        .clip(RoundedCornerShape(2.dp))
+                                        .background(ArvioSkin.colors.focusOutline)
+                                )
+                            }
+
+                            Spacer(modifier = Modifier.height(8.dp))
+
+                            // Time and TV Remote Navigation Hints
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.SpaceBetween
+                            ) {
+                                Text(
+                                    text = "${formatTime(currentSecond)} / ${formatTime(duration)}",
+                                    style = ArvioSkin.typography.caption.copy(
+                                        fontFamily = FontFamily.Monospace,
+                                        fontWeight = FontWeight.Medium,
+                                        fontSize = 12.sp,
+                                        color = Color.White.copy(alpha = 0.9f)
+                                    )
+                                )
+
+                                Text(
+                                    text = if (isMobile) "Tap to show/hide controls" else "[OK] Play/Pause   ◄/► Seek 10s   ▲ Menu   Back Exit",
+                                    style = ArvioSkin.typography.caption.copy(
+                                        fontSize = 11.sp,
+                                        color = Color.White.copy(alpha = 0.65f)
+                                    )
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    DisposableEffect(lifecycleOwner, activePlayer) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_PAUSE -> activePlayer?.pause()
+                Lifecycle.Event.ON_RESUME -> activePlayer?.play()
+                else -> {}
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+            activePlayer?.pause()
+        }
+    }
+}

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/details/DetailsScreen.kt
@@ -174,7 +174,7 @@ import com.arflix.tv.ui.components.SidebarItem
 import com.arflix.tv.ui.components.SkeletonDetailsPage
 import com.arflix.tv.ui.components.SkeletonEpisodeCard
 import com.arflix.tv.ui.components.StreamSelector
-import com.arflix.tv.ui.components.OpenYouTubeTrailer
+import com.arflix.tv.ui.components.YouTubeTrailerModal
 import androidx.activity.compose.BackHandler
 import androidx.compose.material.icons.filled.ChevronLeft
 import androidx.compose.material.icons.filled.ChevronRight
@@ -540,12 +540,8 @@ fun DetailsScreen(
         }
     }
 
-    BackHandler(enabled = !showStreamSelector && !showEpisodeContextMenu && !showSeasonContextMenu && !uiState.showPersonModal) {
-        if (showTrailerPlayer) {
-            showTrailerPlayer = false
-        } else {
-            onBack()
-        }
+    BackHandler(enabled = !showStreamSelector && !showEpisodeContextMenu && !showSeasonContextMenu && !uiState.showPersonModal && !showTrailerPlayer) {
+        onBack()
     }
 
     // D-pad key handler — only used on TV (skipped on mobile/touch devices)
@@ -554,6 +550,10 @@ fun DetailsScreen(
         verticalMinRepeatIntervalMs = 112L
     )
     val keyModifier = if (isMobile) Modifier else Modifier.onPreviewKeyEvent { event ->
+                // Check if any modal is showing — let the modal handle all keys exclusively
+                if (showStreamSelector || showEpisodeContextMenu || showSeasonContextMenu || uiState.showPersonModal || showTrailerPlayer) {
+                    return@onPreviewKeyEvent false
+                }
                 if (event.type == KeyEventType.KeyUp && isArvioDpadNavigationKey(event.key)) {
                     dpadRepeatGate.reset()
                 }
@@ -576,10 +576,6 @@ fun DetailsScreen(
                     return@onPreviewKeyEvent true
                 }
                 if (event.type == KeyEventType.KeyDown) {
-                    // Check if any modal is showing
-                    if (showStreamSelector || showEpisodeContextMenu || showSeasonContextMenu || uiState.showPersonModal) {
-                        return@onPreviewKeyEvent false // Let the modal handle it
-                    }
 
                     val isRtl = isRtlLayoutDirection
                     val actualKey = event.key
@@ -593,8 +589,8 @@ fun DetailsScreen(
 
                     when (logicalKey) {
                         Key.Back, Key.Escape -> {
-                            if (showTrailerPlayer) { showTrailerPlayer = false; true }
-                            else { onBack(); true }
+                            onBack()
+                            true
                         }
                         Key.DirectionLeft -> {
                             if (isSidebarFocused) {
@@ -1015,7 +1011,14 @@ fun DetailsScreen(
         )
 
         if (showTrailerPlayer && uiState.trailerKey != null) {
-            OpenYouTubeTrailer(uiState.trailerKey!!) { showTrailerPlayer = false }
+            YouTubeTrailerModal(
+                youtubeKey = uiState.trailerKey!!,
+                title = uiState.item?.title ?: "",
+                onClose = {
+                    showTrailerPlayer = false
+                    runCatching { focusRequester.requestFocus() }
+                }
+            )
         }
         // Stream Selector Modal
         StreamSelector(

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeProfilePreferences.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeProfilePreferences.kt
@@ -28,7 +28,7 @@ internal fun readHomeProfilePreferences(
     val prefix = "profile_${profileId}_"
     val contentLang = resolveAppLanguage(preferences, profileId)
     return HomeProfilePreferences(
-        trailerAutoPlay = preferences[booleanPreferencesKey("${prefix}trailer_auto_play")] ?: false,
+        trailerAutoPlay = preferences[booleanPreferencesKey("${prefix}trailer_auto_play")] ?: true,
         trailerSoundEnabled = preferences[booleanPreferencesKey("${prefix}trailer_sound_enabled")] ?: false,
         trailerDelaySeconds = preferences[stringPreferencesKey("${prefix}trailer_delay_seconds")]
             ?.toIntOrNull() ?: 2,

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeScreen.kt
@@ -137,6 +137,7 @@ import com.arflix.tv.data.model.MediaItem
 import com.arflix.tv.data.model.MediaType
 import com.arflix.tv.data.model.isPortrait
 import com.arflix.tv.network.OkHttpProvider
+import com.arflix.tv.ui.components.BackgroundTrailerPlayer
 import com.arflix.tv.ui.components.FeaturedMediaCard
 import com.arflix.tv.ui.components.movieGenreNameRes
 import com.arflix.tv.ui.components.tvGenreNameRes
@@ -943,7 +944,10 @@ fun HomeScreen(
 
     var isTrailerPlaying by remember { mutableStateOf(false) }
     var trailerSuppressed by remember { mutableStateOf(false) }
-    LaunchedEffect(displayHeroItem?.id) { trailerSuppressed = false }
+    LaunchedEffect(displayHeroItem?.id) {
+        trailerSuppressed = false
+        isTrailerPlaying = false
+    }
     val heroRowIsContinueWatching = latestDisplayCategories
         .getOrNull(focusState.currentRowIndex)?.id == "continue_watching"
     val trailerOverlayAlpha = remember { Animatable(1f) }
@@ -1112,11 +1116,22 @@ fun HomeScreen(
                     )
                 }
 
+                // YouTube trailer auto-play on hero backdrop
+                if (heroVideoUrl == null && uiState.trailerAutoPlay && uiState.heroTrailerKey != null && !trailerSuppressed && !heroRowIsContinueWatching) {
+                    BackgroundTrailerPlayer(
+                        youtubeKey = uiState.heroTrailerKey!!,
+                        delayMs = uiState.trailerDelaySeconds * 1000L,
+                        soundEnabled = uiState.trailerSoundEnabled,
+                        onPlayingChanged = { playing -> isTrailerPlaying = playing },
+                        modifier = Modifier.fillMaxSize()
+                    )
+                }
 
                 // === SCRIM SYSTEM ===
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
+                        .graphicsLayer { alpha = trailerOverlayAlpha.value }
                         .drawWithCache {
                             val width = size.width
                             val height = size.height

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/home/HomeViewModel.kt
@@ -90,7 +90,7 @@ data class HomeUiState(
     val heroItem: MediaItem? = null,
     val heroLogoUrl: String? = null,
     val heroTrailerKey: String? = null,
-    val trailerAutoPlay: Boolean = false,
+    val trailerAutoPlay: Boolean = true,
     val trailerSoundEnabled: Boolean = false,
     val trailerDelaySeconds: Int = 2,
     val trailerInCards: Boolean = true,
@@ -1698,6 +1698,7 @@ class HomeViewModel @Inject constructor(
                     preferences = context.settingsDataStore.data
                 ).collect { preferences ->
                     val previousState = _uiState.value
+                    val autoplayJustEnabled = !previousState.trailerAutoPlay && preferences.trailerAutoPlay
                     mediaRepository.contentLanguage = preferences.contentLanguage
                     val normalizedLanguage = mediaRepository.contentLanguage
                     val langChanged = observedContentLanguage?.let { it != normalizedLanguage } ?: false
@@ -1708,7 +1709,7 @@ class HomeViewModel @Inject constructor(
                     observedIptvFavoritesOnHome = preferences.iptvFavoritesOnHome
 
                     _uiState.value = previousState.copy(
-                        trailerAutoPlay = false,
+                        trailerAutoPlay = preferences.trailerAutoPlay,
                         trailerSoundEnabled = preferences.trailerSoundEnabled,
                         trailerDelaySeconds = preferences.trailerDelaySeconds,
                         trailerInCards = preferences.trailerInCards,
@@ -1722,6 +1723,8 @@ class HomeViewModel @Inject constructor(
                         loadHomeData()
                     } else if (iptvFavoritesPlacementChanged) {
                         loadHomeData()
+                    } else if (autoplayJustEnabled) {
+                        _uiState.value.heroItem?.let(::hydrateHeroDetailsIfNeeded)
                     }
                 }
             } catch (e: Exception) {

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsScreen.kt
@@ -267,7 +267,7 @@ private fun tvGeneralRowsForSection(section: String): List<Int> {
         "language" -> listOf(0, 3, 1, 2)
         "subtitles" -> listOf(4, 5, 6, 7, 42, 8, 38, 39, 9)
         "ai_subtitles" -> listOf(28, 29, 30, 31, 32, 33)
-        "playback" -> listOf(10, 11, 12, 16, 15, 40, 27)
+        "playback" -> listOf(10, 11, 12, 13, 14, 34, 16, 15, 40, 27)
         "appearance" -> listOf(17, 18, 20, 21, 24, 23, 22, 41, 36)
         "profiles" -> listOf(19)
         "network" -> listOf(25, 26, 35)
@@ -4388,6 +4388,29 @@ private fun MobileSettingsSubPage(
                         onClick = { viewModel.cycleAutoPlayMinQuality() }
                     )
                     MobileSettingsRow(
+                        icon = Icons.Default.Movie,
+                        title = stringResource(R.string.trailer_auto_play),
+                        value = stringResource(if (uiState.trailerAutoPlay) R.string.on else R.string.off),
+                        toggleChecked = uiState.trailerAutoPlay,
+                        isFocused = false,
+                        onClick = { viewModel.setTrailerAutoPlay(!uiState.trailerAutoPlay) }
+                    )
+                    MobileSettingsRow(
+                        icon = Icons.Default.VolumeUp,
+                        title = stringResource(R.string.trailer_sound),
+                        value = stringResource(if (uiState.trailerSoundEnabled) R.string.on else R.string.off),
+                        toggleChecked = uiState.trailerSoundEnabled,
+                        isFocused = false,
+                        onClick = { viewModel.setTrailerSoundEnabled(!uiState.trailerSoundEnabled) }
+                    )
+                    MobileSettingsRow(
+                        icon = Icons.Default.Schedule,
+                        title = stringResource(R.string.trailer_delay),
+                        value = "${uiState.trailerDelaySeconds}s",
+                        isFocused = false,
+                        onClick = { viewModel.cycleTrailerDelay() }
+                    )
+                    MobileSettingsRow(
                         icon = Icons.Default.Settings,
                         title = stringResource(R.string.frame_rate),
                         value = uiState.frameRateMatchingMode,
@@ -5535,7 +5558,7 @@ private fun tvSettingsSectionPills(
         )
         "playback" -> listOf(
             stringResource(R.string.settings_pill_autoplay, if (uiState.autoPlaySingleSource) stringResource(R.string.settings_inline_on) else stringResource(R.string.settings_inline_off)),
-            stringResource(R.string.trailers_on_youtube),
+            stringResource(R.string.settings_pill_trailers, if (uiState.trailerAutoPlay) stringResource(R.string.settings_inline_on) else stringResource(R.string.settings_inline_off)),
             stringResource(R.string.settings_pill_min, localizeSettingValue(uiState.autoPlayMinQuality)),
         )
         "appearance" -> listOf(
@@ -5585,7 +5608,7 @@ private fun tvSettingsPanelFacts(
         )
         "playback" -> listOf(
             stringResource(R.string.settings_fact_autoplay) to if (uiState.autoPlaySingleSource) stringResource(R.string.on) else stringResource(R.string.off),
-            stringResource(R.string.settings_fact_trailers) to "YouTube",
+            stringResource(R.string.settings_fact_trailers) to if (uiState.trailerAutoPlay) stringResource(R.string.on) else stringResource(R.string.off),
             stringResource(R.string.settings_fact_frame_rate) to uiState.frameRateMatchingMode
         )
         "appearance" -> listOf(
@@ -5649,7 +5672,8 @@ private fun tvSettingsFocusedHelp(section: String, focusedIndex: Int): TvSetting
         "playback" -> when (focusedIndex) {
             0 -> TvSettingsHelp(stringResource(R.string.settings_help_next_autoplay), stringResource(R.string.settings_help_next_autoplay_desc))
             1 -> TvSettingsHelp(stringResource(R.string.settings_help_source_autoplay), stringResource(R.string.settings_help_source_autoplay_desc))
-            6 -> TvSettingsHelp(stringResource(R.string.volume_boost), stringResource(R.string.settings_help_volume_boost_desc))
+            in 3..5 -> TvSettingsHelp(stringResource(R.string.settings_help_trailers), stringResource(R.string.settings_help_trailers_desc))
+            9 -> TvSettingsHelp(stringResource(R.string.volume_boost), stringResource(R.string.settings_help_volume_boost_desc))
             else -> TvSettingsHelp(stringResource(R.string.playback), stringResource(R.string.settings_help_playback_desc))
         }
         "appearance" -> TvSettingsHelp(stringResource(R.string.interface_label), stringResource(R.string.settings_help_interface_desc))

--- a/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/arflix/tv/ui/screens/settings/SettingsViewModel.kt
@@ -167,7 +167,7 @@ data class SettingsUiState(
     val subtitleStylized: Boolean = true,
     val filterSubtitlesByLanguage: Boolean = true,
     val secondarySubtitle: String = "Off",
-    val trailerAutoPlay: Boolean = false,
+    val trailerAutoPlay: Boolean = true,
     val trailerSoundEnabled: Boolean = false,
     val trailerDelaySeconds: Int = 2,
     val trailerInCards: Boolean = true,
@@ -562,7 +562,7 @@ class SettingsViewModel @Inject constructor(
                 context.settingsDataStore.edit { it[autoPlayNextKey()] = true }
             }
             val autoPlayMinQuality = normalizeAutoPlayMinQuality(prefs[autoPlayMinQualityKey()])
-            val trailerAutoPlay = prefs[trailerAutoPlayKey()] ?: false
+            val trailerAutoPlay = prefs[trailerAutoPlayKey()] ?: true
             val trailerSoundEnabled = prefs[trailerSoundEnabledKey()] ?: false
             val trailerDelaySeconds = prefs[trailerDelayKey()]?.toIntOrNull() ?: 2
             val trailerInCards = prefs[trailerInCardsKey()] ?: true

--- a/app/src/test/kotlin/com/arflix/tv/ui/screens/home/HomeProfilePreferencesTest.kt
+++ b/app/src/test/kotlin/com/arflix/tv/ui/screens/home/HomeProfilePreferencesTest.kt
@@ -22,7 +22,11 @@ class HomeProfilePreferencesTest {
     @Test
     fun `delayed cloud restore enables trailer autoplay without recreating Home`() = runTest {
         val profileId = MutableStateFlow("primary")
-        val preferences = MutableStateFlow<Preferences>(mutablePreferencesOf())
+        val preferences = MutableStateFlow<Preferences>(
+            mutablePreferencesOf(
+                booleanPreferencesKey("profile_primary_trailer_auto_play") to false
+            )
+        )
 
         observeHomeProfilePreferences(profileId, preferences).test {
             assertThat(awaitItem().trailerAutoPlay).isFalse()
@@ -83,7 +87,7 @@ class HomeProfilePreferencesTest {
     fun `missing settings preserve Home defaults`() {
         val settings = readHomeProfilePreferences(mutablePreferencesOf(), "primary")
 
-        assertThat(settings.trailerAutoPlay).isFalse()
+        assertThat(settings.trailerAutoPlay).isTrue()
         assertThat(settings.trailerSoundEnabled).isFalse()
         assertThat(settings.trailerDelaySeconds).isEqualTo(2)
         assertThat(settings.trailerInCards).isTrue()


### PR DESCRIPTION
…mote controls

- Re-implemented YouTube trailer playback using android-youtube-player library (IFrame API)
- Added BackgroundTrailerPlayer for Home hero backdrop with auto-play, settle delay, sound settings, and smooth fade-out on playback
- Added YouTubeTrailerModal for Details screen with pure cinema video canvas (suppressed YouTube web title, share button, central pause overlay, and watermarks)
- Implemented native TV D-pad controls for trailer modal (Play/Pause, seek +/-10s, menu navigation, and auto-hiding HUD)
- Isolated key events in DetailsScreen when trailer modal is active to prevent background button leakage
- Restored trailer settings in Playback settings, CloudSyncRepository, and profile preferences